### PR TITLE
Bot action parsing fixes

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -534,6 +534,23 @@ def get_first_user_intent(strings: List[str]) -> Optional[str]:
     return None
 
 
+def quote_bot_say(line: str) -> str:
+    if line.startswith("bot say "):
+        message = line[len("bot say "):]
+        return f"{line}\nbot say \"{message}\""
+    return line
+
+
+def correct_bot_action(line: str) -> str:
+    match = re.search(r'"(.*)"', line, re.DOTALL)
+    if match:
+        message = match.group(1).strip()
+        return f'bot say "{message}"'
+    else:
+        # fallback: no quoted part, return as-is or handle differently
+        return f'bot say "{line.strip()}"'
+
+
 def get_first_bot_intent(strings: List[str]) -> Optional[str]:
     """Returns first bot intent."""
     for string in strings:
@@ -545,8 +562,11 @@ def get_first_bot_intent(strings: List[str]) -> Optional[str]:
 def get_first_bot_action(strings: List[str]) -> Optional[str]:
     """Returns first bot action."""
     action_started = False
+    fallback_action: str = ""
     action: str = ""
+
     for string in strings:
+        fallback_action = string
         if string.startswith("bot action: "):
             if action != "":
                 action += "\n"
@@ -561,7 +581,12 @@ def get_first_bot_action(strings: List[str]) -> Optional[str]:
             continue
         elif action != "":
             return action
-    return action
+
+    result = action if action != "" else fallback_action
+
+    result = correct_bot_action(result)
+
+    return result
 
 
 def escape_flow_name(name: str) -> str:


### PR DESCRIPTION
## Description

The LLM is returning the bot action inconsistently. When it returns something in a format the system does not expect, a colang parsing error happens and the application errors out.

Some examples of bot actions that were returned to me were:

`bot responds with "You can call the number at 123-456-7891"`

`bot says You can call the number at 123-456-7891`

`bot provides information on "You can call the number at 123-456-7891"`

All of these caused the bot to error out and crash.

These changes ensure that the bot action is a "bot say" in the proper format. There may be some edge cases I am missing but these changes have made my application way more stable. I have been testing my application for the past 30 or so minutes and have yet to see any colang parsing errors.

## Related Issue(s)

- Fixes #1026 

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [X] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
