### PR TITLE
ci: prevent duplicate runs on PR updates

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,8 +1,6 @@
 name: PR Tests
 
 on:
-  push:
-
   pull_request:
     # we don't ignore markdkowns to run pre-commits
     paths-ignore:


### PR DESCRIPTION
Remove the push trigger from the PR Tests workflow to avoid duplicate runs when a pull request is updated. The workflow will now only run on pull_request events, ensuring a single execution per PR update.

