### PR TITLE
fix(logging): add "Tool" type to message sender labeling

### DIFF
--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -109,6 +109,8 @@ class LoggingCallbackHandler(AsyncCallbackHandler, StdOutCallbackHandler):
                     if msg.type == "human"
                     else "Bot"
                     if msg.type == "ai"
+                    else "Tool"
+                    if msg.type == "tool"
                     else "System"
                 )
                 + "[/]"


### PR DESCRIPTION
## Description

Previously, messages of type "tool" were not distinctly labeled in the LoggingCallbackHandler output, causing them to be grouped under "System".
This change adds explicit handling for "tool" messages, labeling them as "Tool" in the logs for improved clarity and debugging.

