### PR TITLE
chore(jailbreak-detection): update transformers and torch

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/requirements.txt
+++ b/nemoguardrails/library/jailbreak_detection/requirements.txt
@@ -4,8 +4,8 @@ fastapi>=0.103.1
 starlette>=0.27.0
 typer>=0.7.0
 uvicorn>=0.23.2
-transformers>=4.32.1
-torch>=2.1.1
+transformers>=4.56.0
+torch>=2.8.0
 nemoguardrails>=0.7.0
 numpy==1.23.5
 scikit-learn==1.2.2


### PR DESCRIPTION
Bump transformers to >=4.56.0 and torch to >=2.8.0 to resolve high severity vulns
