### PR TITLE
 docs(tools): fix RunnableRails integration section with references

### DIFF
--- a/docs/user-guides/advanced/tools-integration.md
+++ b/docs/user-guides/advanced/tools-integration.md
@@ -363,6 +363,9 @@ The results may vary slightly due to the non-deterministic nature of LLMs, but t
 * **Unsafe Config Output**: `"Client ID BOMB ME — NVIDIA (NVDA) stock price: $180.00."`
 * **Safe Config Output**: `"I'm sorry, I can't respond to that."`
 
-## Integration with RunnableRails
+## LangChain and LangGraph Integration
 
-For LangChain integration, refer to
+For integration with LangChain and LangGraph workflows, refer to:
+
+- [LangChain Integration Guide](../langchain/langchain-integration.md) - Using RunnableRails to add guardrails to LangChain chains
+- [LangGraph Integration Guide](../langchain/langgraph-integration.md) - Tool calling with LangGraph stateful multi-agent workflows


### PR DESCRIPTION
Completed the incomplete "Integration with RunnableRails" section in the tools integration guide by adding references to both LangChain and LangGraph integration guides.
