### PR TITLE
refactor(deps): make server-only dependencies optional

### DIFF
--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -251,6 +251,7 @@ def action_server(
     """Start a NeMo Guardrails actions server."""
 
     try:
+        import fastapi  # noqa: F401
         import uvicorn
     except ImportError:
         typer.secho(

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -20,11 +20,8 @@ from enum import Enum
 from typing import List, Literal, Optional
 
 import typer
-import uvicorn
-from fastapi import FastAPI
 
 from nemoguardrails import __version__
-from nemoguardrails.actions_server import actions_server
 from nemoguardrails.cli.chat import run_chat
 from nemoguardrails.cli.migration import migrate
 from nemoguardrails.cli.providers import _list_providers, select_provider_with_type
@@ -149,6 +146,16 @@ def server(
     """Start a NeMo Guardrails server."""
 
     try:
+        import uvicorn
+        from fastapi import FastAPI as _FastAPI
+    except ImportError:
+        typer.secho(
+            "Server dependencies are missing. Install them with: pip install nemoguardrails[server]",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    try:
         from nemoguardrails.server import api
     except ImportError:
         typer.secho(
@@ -183,7 +190,7 @@ def server(
         setattr(api.app, "auto_reload", True)
 
     if prefix:
-        server_app = FastAPI()
+        server_app = _FastAPI()
         server_app.mount(prefix, api.app)
     else:
         server_app = api.app
@@ -242,6 +249,17 @@ def action_server(
     port: int = typer.Option(default=8001, help="The port that the server should listen on. "),
 ):
     """Start a NeMo Guardrails actions server."""
+
+    try:
+        import uvicorn
+    except ImportError:
+        typer.secho(
+            "Server dependencies are missing. Install them with: pip install nemoguardrails[server]",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    from nemoguardrails.actions_server import actions_server
 
     uvicorn.run(actions_server.app, port=port, log_level="info", host="0.0.0.0")
 

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -147,7 +147,7 @@ def server(
 
     try:
         import uvicorn
-        from fastapi import FastAPI as _FastAPI
+        from fastapi import FastAPI
     except ImportError:
         typer.secho(
             "Server dependencies are missing. Install them with: pip install nemoguardrails[server]",
@@ -190,7 +190,7 @@ def server(
         setattr(api.app, "auto_reload", True)
 
     if prefix:
-        server_app = _FastAPI()
+        server_app = FastAPI()
         server_app.mount(prefix, api.app)
     else:
         server_app = api.app

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -159,7 +159,7 @@ def server(
         from nemoguardrails.server import api
     except ImportError:
         typer.secho(
-            "The 'openai' package is required to run the server. Install it with: pip install nemoguardrails[server]",
+            "Server dependencies are missing. Install them with: pip install nemoguardrails[server]",
             fg=typer.colors.RED,
         )
         raise typer.Exit(1)
@@ -251,16 +251,15 @@ def action_server(
     """Start a NeMo Guardrails actions server."""
 
     try:
-        import fastapi  # noqa: F401
         import uvicorn
+
+        from nemoguardrails.actions_server import actions_server
     except ImportError:
         typer.secho(
             "Server dependencies are missing. Install them with: pip install nemoguardrails[server]",
             fg=typer.colors.RED,
         )
         raise typer.Exit(1)
-
-    from nemoguardrails.actions_server import actions_server
 
     uvicorn.run(actions_server.app, port=port, log_level="info", host="0.0.0.0")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,7 +231,7 @@ save = ["vl-convert-python (>=1.7.0)"]
 name = "annotated-doc"
 version = "0.0.3"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580"},
@@ -1004,7 +1004,7 @@ robust-downloader = ">=0.0.2"
 name = "fastapi"
 version = "0.121.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106"},
@@ -1479,6 +1479,8 @@ files = [
     {file = "greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f47617f698838ba98f4ff4189aef02e7343952df3a615f847bb575c3feb177a7"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af41be48a4f60429d5cad9d22175217805098a9ef7c40bfef44f7669fb9d74d8"},
     {file = "greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c"},
     {file = "greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2"},
     {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246"},
@@ -1488,6 +1490,8 @@ files = [
     {file = "greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5"},
     {file = "greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9"},
     {file = "greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd"},
     {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb"},
@@ -1497,6 +1501,8 @@ files = [
     {file = "greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d"},
     {file = "greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02"},
     {file = "greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31"},
     {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945"},
@@ -1506,6 +1512,8 @@ files = [
     {file = "greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929"},
     {file = "greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b"},
     {file = "greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f"},
@@ -1513,6 +1521,8 @@ files = [
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681"},
     {file = "greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01"},
     {file = "greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c"},
     {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d"},
@@ -1522,6 +1532,8 @@ files = [
     {file = "greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:28a3c6b7cd72a96f61b0e4b2a36f681025b60ae4779cc73c1535eb5f29560b10"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be"},
     {file = "greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b"},
     {file = "greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb"},
     {file = "greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d"},
@@ -6900,7 +6912,7 @@ files = [
 cffi = ["cffi (>=1.17)"]
 
 [extras]
-all = ["aiofiles", "fast-langdetect", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "openai", "opentelemetry-api", "presidio-analyzer", "presidio-anonymizer", "streamlit", "tqdm", "yara-python"]
+all = ["aiofiles", "fast-langdetect", "fastapi", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "openai", "opentelemetry-api", "presidio-analyzer", "presidio-anonymizer", "starlette", "streamlit", "tqdm", "uvicorn", "watchdog", "yara-python"]
 eval = ["numpy", "numpy", "numpy", "numpy", "streamlit", "tornado", "tqdm"]
 gcp = ["google-cloud-language"]
 jailbreak = ["yara-python"]
@@ -6908,10 +6920,10 @@ multilingual = ["fast-langdetect"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 openai = ["langchain-openai"]
 sdd = ["presidio-analyzer", "presidio-anonymizer"]
-server = ["aiofiles", "openai"]
+server = ["aiofiles", "fastapi", "openai", "starlette", "uvicorn", "watchdog"]
 tracing = ["aiofiles", "opentelemetry-api"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "525873b52b3cf098f1e41cbed55c75ed4ab5fcdbb6c11e872cc393791a1363bd"
+content-hash = "9a9b4eaff9948a0102af7cddecf77c1eec6fde375e1d4e3e31d68009735a1131"

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,7 +231,7 @@ save = ["vl-convert-python (>=1.7.0)"]
 name = "annotated-doc"
 version = "0.0.3"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580"},
@@ -1004,7 +1004,7 @@ robust-downloader = ">=0.0.2"
 name = "fastapi"
 version = "0.121.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106"},
@@ -6926,4 +6926,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "9a9b4eaff9948a0102af7cddecf77c1eec6fde375e1d4e3e31d68009735a1131"
+content-hash = "7115b4c5a1a6e44e637ceca647abe9efb598db578eb66fda3f8479b78b06b661"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7410,4 +7410,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "066d34fb2e969dc7f2ff1d132afae3aa59ecd021122776c7579ad21764de8750"
+content-hash = "b2962d12d3e7dc04c8ce8c1b79e63869f579d4231e22b09ffca67df107e738ef"

--- a/poetry.lock
+++ b/poetry.lock
@@ -265,7 +265,7 @@ save = ["vl-convert-python (>=1.8.0)"]
 name = "annotated-doc"
 version = "0.0.4"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -265,7 +265,7 @@ save = ["vl-convert-python (>=1.8.0)"]
 name = "annotated-doc"
 version = "0.0.4"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
@@ -7396,7 +7396,7 @@ files = [
 cffi = ["cffi (>=1.17,<2.0)", "cffi (>=2.0.0b)"]
 
 [extras]
-all = ["aiofiles", "fast-langdetect", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "openai", "opentelemetry-api", "presidio-analyzer", "presidio-anonymizer", "streamlit", "tqdm", "yara-python"]
+all = ["aiofiles", "fast-langdetect", "fastapi", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "openai", "opentelemetry-api", "presidio-analyzer", "presidio-anonymizer", "starlette", "streamlit", "tqdm", "uvicorn", "watchdog", "yara-python"]
 eval = ["numpy", "numpy", "numpy", "numpy", "streamlit", "tornado", "tqdm"]
 gcp = ["google-cloud-language"]
 jailbreak = ["yara-python"]
@@ -7404,7 +7404,7 @@ multilingual = ["fast-langdetect"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 openai = ["langchain-openai"]
 sdd = ["presidio-analyzer", "presidio-anonymizer"]
-server = ["aiofiles", "openai"]
+server = ["aiofiles", "fastapi", "openai", "starlette", "uvicorn", "watchdog"]
 tracing = ["aiofiles", "opentelemetry-api"]
 
 [metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ python = ">=3.10,<3.14"
 aiohttp = ">=3.10.11"
 aiohttp-retry = ">=2.9.0"
 annoy = ">=1.17.3"
-fastapi = ">=0.103.0,"
+fastapi = { version = ">=0.103.0", optional = true }
 fastembed = [{ version = ">=0.2.2", python = ">=3.10,<3.14" }]
 httpx = ">=0.24.1"
 jinja2 = ">=3.1.6"
@@ -68,10 +68,10 @@ pydantic = ">=1.10"
 pyyaml = ">=6.0"
 rich = ">=13.5.2"
 simpleeval = ">=0.9.13,"
-starlette = ">=0.49.1"
+starlette = { version = ">=0.49.1", optional = true }
 typer = ">=0.8"
-uvicorn = ">=0.23"
-watchdog = ">=3.0.0,"
+uvicorn = { version = ">=0.23", optional = true }
+watchdog = { version = ">=3.0.0", optional = true }
 openai = { version = ">=1.0.0,<3.0.0", optional = true }
 
 # tracing
@@ -119,7 +119,7 @@ tracing = ["opentelemetry-api", "aiofiles"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 jailbreak = ["yara-python"]
 multilingual = ["fast-langdetect"]
-server = ["aiofiles", "openai"]
+server = ["aiofiles", "openai", "fastapi", "starlette", "uvicorn", "watchdog"]
 # Poetry does not support recursive dependencies, so we need to add all the dependencies here.
 # I also support their decision. There is no PEP for recursive dependencies, but it has been supported in pip since version 21.2.
 # It is here for backward compatibility.
@@ -137,6 +137,10 @@ all = [
   "langchain-nvidia-ai-endpoints",
   "yara-python",
   "fast-langdetect",
+  "fastapi",
+  "starlette",
+  "uvicorn",
+  "watchdog",
 ]
 
 [tool.poetry.group.dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,11 @@ opentelemetry-api = "^1.34.1"
 opentelemetry-sdk = "^1.34.1"
 fast-langdetect = ">=1.0.0"
 openai = ">=1.0.0,<3.0.0"
+# server (optional at runtime, required for tests/server/)
+fastapi = ">=0.103.0"
+uvicorn = ">=0.23"
+starlette = ">=0.49.1"
+watchdog = ">=3.0.0"
 pyright = "^1.1.405"
 ruff = "0.14.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ python = ">=3.10,<3.14"
 aiohttp = ">=3.10.11"
 aiohttp-retry = ">=2.9.0"
 annoy = ">=1.17.3"
-fastapi = ">=0.103.0,"
+fastapi = { version = ">=0.103.0", optional = true }
 fastembed = [{ version = ">=0.2.2", python = ">=3.10,<3.14" }]
 # onnxruntime 1.24+ dropped Python 3.10 wheels; cap it for that version
 onnxruntime = [
@@ -73,10 +73,10 @@ pydantic = ">=1.10"
 pyyaml = ">=6.0"
 rich = ">=13.5.2"
 simpleeval = ">=0.9.13,"
-starlette = ">=0.49.1"
+starlette = { version = ">=0.49.1", optional = true }
 typer = ">=0.8"
-uvicorn = ">=0.23"
-watchdog = ">=3.0.0,"
+uvicorn = { version = ">=0.23", optional = true }
+watchdog = { version = ">=3.0.0", optional = true }
 openai = { version = ">=1.0.0,<3.0.0", optional = true }
 
 # tracing
@@ -124,7 +124,7 @@ tracing = ["opentelemetry-api", "aiofiles"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 jailbreak = ["yara-python"]
 multilingual = ["fast-langdetect"]
-server = ["aiofiles", "openai"]
+server = ["aiofiles", "openai", "fastapi", "starlette", "uvicorn", "watchdog"]
 # Poetry does not support recursive dependencies, so we need to add all the dependencies here.
 # I also support their decision. There is no PEP for recursive dependencies, but it has been supported in pip since version 21.2.
 # It is here for backward compatibility.
@@ -142,6 +142,10 @@ all = [
   "langchain-nvidia-ai-endpoints",
   "yara-python",
   "fast-langdetect",
+  "fastapi",
+  "starlette",
+  "uvicorn",
+  "watchdog",
 ]
 
 [tool.poetry.group.dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,11 @@ opentelemetry-api = "^1.34.1"
 opentelemetry-sdk = "^1.34.1"
 fast-langdetect = ">=1.0.0"
 openai = ">=1.0.0,<3.0.0"
+# server (optional at runtime, required for tests/server/)
+fastapi = ">=0.103.0"
+uvicorn = ">=0.23"
+starlette = ">=0.49.1"
+watchdog = ">=3.0.0"
 pyright = "^1.1.405"
 ruff = "0.14.6"
 


### PR DESCRIPTION
Related to https://github.com/NVIDIA-NeMo/Guardrails/discussions/1580

- move `fastapi`, `starlette`, `uvicorn`, and `watchdog` from required to optional dependencies under the `[server]` extra
- Lazy import these packages in `cli/__init__.py` so non-server commands (`chat`, `convert`, `find-providers`) work without them
- reduces the default install footprint for users who only need the core guardrails library

## Test plan
- [x] `poetry install` (without extras) succeeds and `nemoguardrails chat` works
- [x] `poetry install --extras server` succeeds and `nemoguardrails server` works
- [x] `poetry install --extras all` succeeds
- [x] Existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server dependencies are now optional and installed separately via `pip install nemoguardrails[server]`, reducing the base installation size.

* **Improvements**
  * Enhanced error messages guide users to install missing server dependencies when attempting to use server commands without the optional package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->