### PR TITLE
fix: pass constructed prompt instead of raw user_message in passthrough LLM action

### DIFF
--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -447,7 +447,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         generation_llm_params = generation_options and generation_options.llm_params
         text = await llm_call(
             llm,
-            user_message,
+            prompt,
             streaming_handler=streaming_handler,
             llm_params=generation_llm_params,
         )


### PR DESCRIPTION
## Summary

In `passthrough_llm_action`, the function carefully constructs a `prompt` variable from the raw LLM request (lines 421-438), handling both string and list prompt formats, and substituting any user text that may have been altered by input rails.

However, the actual `llm_call` on line 450 passes `user_message` (the original function parameter) instead of the constructed `prompt`. This makes the entire prompt construction block dead code — any modifications made by input rails are silently ignored, and the raw user message is sent to the LLM instead.

## Fix

Change the `llm_call` argument from `user_message` to `prompt` so that the constructed prompt (with input rail modifications applied) is actually used.

## Test plan

- Configure a guardrails app with input rails that modify user text in passthrough mode
- Verify that the modified text is now correctly forwarded to the LLM
- Verify that both string and list prompt formats work correctly
- Run existing test suite to check for regressions