### PR TITLE
fix(generation): use correct task enum for stop tokens in generate_value

### DIFF
--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -787,7 +787,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             },
         )
 
-        stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_USER_INTENT_FROM_USER_ACTION)
+        stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_VALUE_FROM_INSTRUCTION)
 
         result = await llm_call(generation_llm, prompt, stop=stop, llm_params={"temperature": 0.1})
 


### PR DESCRIPTION
## Summary

In the `generate_value` action, the prompt is correctly rendered for `Task.GENERATE_VALUE_FROM_INSTRUCTION` (line 779), but the stop tokens are fetched for `Task.GENERATE_USER_INTENT_FROM_USER_ACTION` (line 790). This task enum mismatch means the LLM receives stop tokens intended for a completely different task, which can cause generation to terminate at incorrect boundaries — either cutting off valid output or failing to stop where it should.

## Fix

Change the `get_stop_tokens` call on line 790 to use `Task.GENERATE_VALUE_FROM_INSTRUCTION`, matching the task used for prompt rendering and output parsing.

## Test plan

- Test `generate_value` action with instructions that produce multi-line or structured output
- Verify stop tokens now match the task and generation terminates correctly
- Check that the parsed output from `GENERATE_VALUE_FROM_INSTRUCTION` is well-formed
- Run existing test suite to check for regressions