### PR TITLE
fix: make RunnableRails.atransform return AsyncIterator

### DIFF
--- a/nemoguardrails/integrations/langchain/runnable_rails.py
+++ b/nemoguardrails/integrations/langchain/runnable_rails.py
@@ -852,24 +852,30 @@ class RunnableRails(Runnable[Input, Output]):
 
     def transform(
         self,
-        input: Input,
+        input: Iterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Output:
+    ) -> Iterator[Output]:
         """Transform the input.
 
-        This is just an alias for invoke.
+        Consumes the input iterator and yields the result of invoke for each
+        item.  For RunnableRails the entire input must be collected before
+        processing, so streaming granularity matches invoke.
         """
-        return self.invoke(input, config, **kwargs)
+        for item in input:
+            yield self.invoke(item, config, **kwargs)
 
     async def atransform(
         self,
-        input: Input,
+        input: AsyncIterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Output:
+    ) -> AsyncIterator[Output]:
         """Transform the input asynchronously.
 
-        This is just an alias for ainvoke.
+        Consumes the async input iterator and yields the result of ainvoke for
+        each item.  For RunnableRails the entire input must be collected before
+        processing, so streaming granularity matches ainvoke.
         """
-        return await self.ainvoke(input, config, **kwargs)
+        async for item in input:
+            yield await self.ainvoke(item, config, **kwargs)

--- a/nemoguardrails/integrations/langchain/runnable_rails.py
+++ b/nemoguardrails/integrations/langchain/runnable_rails.py
@@ -852,7 +852,7 @@ class RunnableRails(Runnable[Input, Output]):
 
     def transform(
         self,
-        input: Iterator[Input],
+        input_stream: Iterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
     ) -> Iterator[Output]:
@@ -862,12 +862,12 @@ class RunnableRails(Runnable[Input, Output]):
         item.  For RunnableRails the entire input must be collected before
         processing, so streaming granularity matches invoke.
         """
-        for item in input:
+        for item in input_stream:
             yield self.invoke(item, config, **kwargs)
 
     async def atransform(
         self,
-        input: AsyncIterator[Input],
+        input_stream: AsyncIterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
     ) -> AsyncIterator[Output]:
@@ -877,5 +877,5 @@ class RunnableRails(Runnable[Input, Output]):
         each item.  For RunnableRails the entire input must be collected before
         processing, so streaming granularity matches ainvoke.
         """
-        async for item in input:
+        async for item in input_stream:
             yield await self.ainvoke(item, config, **kwargs)

--- a/tests/runnable_rails/test_atransform_async_iter.py
+++ b/tests/runnable_rails/test_atransform_async_iter.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that RunnableRails.atransform returns an AsyncIterator (fixes #1692)."""
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from langchain_core.runnables import RunnableLambda
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails
+
+
+@pytest.fixture
+def passthrough_rails():
+    """Create a minimal passthrough RunnableRails instance."""
+    config = RailsConfig.from_content(yaml_content="models: []")
+    return RunnableRails(config, passthrough=True)
+
+
+def test_transform_returns_iterator(passthrough_rails):
+    """transform() should yield results, not return a single value."""
+    result = passthrough_rails.transform(iter(["hello"]))
+    assert isinstance(result, Iterator)
+    items = list(result)
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_atransform_returns_async_iterator(passthrough_rails):
+    """atransform() should yield results as an async iterator."""
+
+    async def _aiter():
+        yield "hello"
+
+    result = passthrough_rails.atransform(_aiter())
+    assert isinstance(result, AsyncIterator)
+    items = []
+    async for item in result:
+        items.append(item)
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_astream_through_pipeline(passthrough_rails):
+    """RunnableRails should work in a pipeline with astream (reproduces #1692)."""
+    pipeline = RunnableLambda(lambda x: x) | passthrough_rails
+
+    items = []
+    async for chunk in pipeline.astream("hello"):
+        items.append(chunk)
+
+    # Should get at least one result without TypeError
+    assert len(items) >= 1

--- a/tests/runnable_rails/test_atransform_async_iter.py
+++ b/tests/runnable_rails/test_atransform_async_iter.py
@@ -15,7 +15,6 @@
 
 """Tests that RunnableRails.atransform returns an AsyncIterator (fixes #1692)."""
 
-import asyncio
 from collections.abc import AsyncIterator, Iterator
 
 import pytest


### PR DESCRIPTION
## Summary

Fixes #1692 — `RunnableRails.atransform()` was returning a coroutine (via `ainvoke`) instead of an `AsyncIterator`, causing a `TypeError: 'async for' requires an object with __aiter__ method, got coroutine` when `RunnableRails` was used inside a `RunnableSequence` pipeline with `astream()`.

## Problem

The `atransform` method signature should match LangChain's `Runnable.atransform` protocol, which takes an `AsyncIterator[Input]` and returns an `AsyncIterator[Output]`. The previous implementation was:

```python
async def atransform(self, input, config=None, **kwargs):
    return await self.ainvoke(input, config, **kwargs)
```

This returned a single awaited value (a coroutine result), not an async iterator. The same issue affected the synchronous `transform` method.

## Fix

Both `transform` and `atransform` now:
- Accept an iterator/async-iterator as input (matching the Runnable protocol)
- Yield results via generator/async-generator syntax
- Properly consume input items and process each through invoke/ainvoke

## Tests

Added `tests/runnable_rails/test_atransform_async_iter.py` with three tests:
- `test_transform_returns_iterator`: Verifies `transform()` returns an `Iterator`
- `test_atransform_returns_async_iterator`: Verifies `atransform()` returns an `AsyncIterator`
- `test_astream_through_pipeline`: Reproduces the exact bug from #1692 — `RunnableRails` in a pipeline with `astream()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LangChain integration now supports streaming batch processing of multiple inputs simultaneously.
  * Transform methods can consume streams of data and yield results iteratively, enabling efficient pipeline integration.

* **Tests**
  * Added comprehensive test coverage for stream processing functionality in pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->