### PR TITLE
refactor(llm): use Registry pattern for framework registry

### DIFF
--- a/nemoguardrails/llm/frameworks/__init__.py
+++ b/nemoguardrails/llm/frameworks/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 from nemoguardrails.llm.frameworks.registry import (
-    _areset_frameworks,
-    _reset_frameworks,
     get_default_framework,
     get_framework,
     register_framework,
@@ -23,8 +21,6 @@ from nemoguardrails.llm.frameworks.registry import (
 )
 
 __all__ = [
-    "_areset_frameworks",
-    "_reset_frameworks",
     "get_default_framework",
     "get_framework",
     "register_framework",

--- a/nemoguardrails/llm/frameworks/registry.py
+++ b/nemoguardrails/llm/frameworks/registry.py
@@ -16,55 +16,78 @@
 import asyncio
 import logging
 import os
-from typing import Dict
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
 
+from nemoguardrails.registry import Registry
 from nemoguardrails.types import LLMFramework
 
 log = logging.getLogger(__name__)
 
-_frameworks: Dict[str, LLMFramework] = {}
-_default_framework: str = os.environ.get("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
+
+def _default_factory() -> LLMFramework:
+    from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+    return DefaultFramework()
+
+
+def _langchain_factory() -> LLMFramework:
+    from nemoguardrails.integrations.langchain.llm_adapter import LangChainFramework
+
+    return LangChainFramework()
+
+
+class LLMFrameworkRegistry(Registry):
+    _factories: Mapping[str, Callable[[], LLMFramework]] = MappingProxyType(
+        {
+            "default": _default_factory,
+            "langchain": _langchain_factory,
+        }
+    )
+    _active_name: str = os.environ.get("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
+
+    def validate(self, name: str, item: Any) -> None:
+        if not isinstance(item, LLMFramework):
+            raise TypeError(f"{name!r} does not implement LLMFramework")
+        if not asyncio.iscoroutinefunction(getattr(item, "reset", None)):
+            raise TypeError(f"{name!r}.reset must be an async coroutine function")
+
+    def get(self, name: str) -> LLMFramework:
+        if name not in self.items and name in self._factories:
+            self.add(name, self._factories[name]())
+        return super().get(name)
+
+    @property
+    def active(self) -> str:
+        return type(self)._active_name
+
+    @active.setter
+    def active(self, name: str) -> None:
+        if name not in self.items and name not in self._factories:
+            known = sorted(set(self.list()) | set(self._factories))
+            raise KeyError(f"Unknown framework {name!r}. Available: {known}")
+        type(self)._active_name = name
 
 
 def register_framework(name: str, framework: LLMFramework) -> None:
-    if name in _frameworks:
-        raise ValueError(f"Framework '{name}' is already registered.")
-    _frameworks[name] = framework
+    LLMFrameworkRegistry().add(name, framework)
 
 
 def get_framework(name: str) -> LLMFramework:
-    if name not in _frameworks:
-        if name == "langchain":
-            from nemoguardrails.integrations.langchain.llm_adapter import LangChainFramework
-
-            _frameworks["langchain"] = LangChainFramework()
-        elif name == "default":
-            from nemoguardrails.llm.frameworks.default import DefaultFramework
-
-            _frameworks["default"] = DefaultFramework()
-        else:
-            available = list(_frameworks.keys())
-            raise KeyError(f"Unknown framework '{name}'. Available frameworks: {available}")
-    return _frameworks[name]
-
-
-_LAZY_FRAMEWORKS = {"langchain", "default"}
+    return LLMFrameworkRegistry().get(name)
 
 
 def set_default_framework(name: str) -> None:
-    if name not in _frameworks and name not in _LAZY_FRAMEWORKS:
-        raise KeyError(f"Unknown framework '{name}'. Register it first or use one of: {sorted(_LAZY_FRAMEWORKS)}")
-    global _default_framework
-    _default_framework = name
+    LLMFrameworkRegistry().active = name
 
 
 def get_default_framework() -> str:
-    return _default_framework
+    return LLMFrameworkRegistry().active
 
 
 async def _areset_frameworks() -> None:
-    global _default_framework
-    frameworks_to_close = list(_frameworks.values())
+    registry = LLMFrameworkRegistry()
+    frameworks_to_close = list(registry.items.values())
     try:
         for fw in frameworks_to_close:
             reset = getattr(fw, "reset", None)
@@ -75,9 +98,15 @@ async def _areset_frameworks() -> None:
             except Exception as exc:
                 log.warning("Error resetting framework %r: %s", fw, exc)
     finally:
-        _frameworks.clear()
-        _default_framework = os.environ.get("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
+        registry.reset()
+        type(registry)._active_name = os.environ.get("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
 
 
 def _reset_frameworks() -> None:
+    """Synchronous teardown helper. Must NOT be called from a running event loop.
+
+    Wraps :func:`_areset_frameworks` in :func:`asyncio.run`, which raises
+    ``RuntimeError`` if a loop is already running on the current thread.
+    Async callers should ``await _areset_frameworks()`` directly.
+    """
     asyncio.run(_areset_frameworks())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,8 @@ def reset_reasoning_trace_var():
 
 @pytest.fixture
 def langchain_framework():
-    from nemoguardrails.llm.frameworks import _reset_frameworks, set_default_framework
+    from nemoguardrails.llm.frameworks import set_default_framework
+    from nemoguardrails.llm.frameworks.registry import _reset_frameworks
 
     _reset_frameworks()
     set_default_framework("langchain")

--- a/tests/llm/frameworks/test_registry.py
+++ b/tests/llm/frameworks/test_registry.py
@@ -19,13 +19,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails.llm.frameworks import (
-    _areset_frameworks,
-    _reset_frameworks,
     get_default_framework,
     get_framework,
     register_framework,
     set_default_framework,
 )
+from nemoguardrails.llm.frameworks.registry import _areset_frameworks, _reset_frameworks
 from nemoguardrails.llm.providers import (
     get_chat_provider_names,
     get_llm_provider_names,
@@ -48,6 +47,12 @@ class FakeFramework:
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
 
+    def register_provider(self, name, provider_cls):
+        pass
+
+    def get_provider_names(self):
+        return []
+
     async def reset(self):
         return
 
@@ -60,11 +65,11 @@ class TestRegistry:
 
     def test_register_duplicate_raises_valueerror(self):
         register_framework("dup", FakeFramework())
-        with pytest.raises(ValueError, match="already registered"):
+        with pytest.raises(ValueError, match="already exists"):
             register_framework("dup", FakeFramework())
 
     def test_get_unregistered_raises_keyerror(self):
-        with pytest.raises(KeyError, match="Unknown framework"):
+        with pytest.raises(KeyError, match="does not exist"):
             get_framework("nonexistent")
 
     def test_langchain_lazy_auto_registration(self):
@@ -104,6 +109,12 @@ class _ResetSpyFramework:
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
 
+    def register_provider(self, name, provider_cls):
+        pass
+
+    def get_provider_names(self):
+        return []
+
     async def reset(self):
         self.reset_count += 1
 
@@ -130,17 +141,18 @@ class TestAresetFrameworks:
             _reset_frameworks()
 
 
-class _FrameworkWithoutReset:
-    def create_model(self, model_name, provider_name, model_kwargs=None):
-        return MagicMock(spec=LLMModel)
-
-
 class _RaisingFramework:
     def __init__(self, exc=None):
         self._exc = exc or RuntimeError("boom")
 
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
+
+    def register_provider(self, name, provider_cls):
+        pass
+
+    def get_provider_names(self):
+        return []
 
     async def reset(self):
         raise self._exc
@@ -163,18 +175,52 @@ class TestResetFrameworksErrorIsolation:
             get_framework("bad_only")
 
 
-class TestResetFrameworksMissingResetMethod:
-    def test_framework_without_reset_does_not_crash(self):
-        register_framework("no_reset", _FrameworkWithoutReset())
-        _reset_frameworks()
-        with pytest.raises(KeyError):
-            get_framework("no_reset")
+class TestRegisterFrameworkProtocolEnforcement:
+    """Registry validates the LLMFramework protocol on add().
 
-    def test_framework_without_reset_resets_default(self, monkeypatch):
-        monkeypatch.setenv("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
-        register_framework("no_reset_2", _FrameworkWithoutReset())
-        _reset_frameworks()
-        assert get_default_framework() == "default"
+    Frameworks lacking required methods (create_model / register_provider /
+    get_provider_names / reset) are rejected at registration time, replacing
+    the older silent-skip behaviour of the previous dict-based registry.
+    """
+
+    def test_framework_missing_reset_is_rejected(self):
+        class _NoReset:
+            def create_model(self, model_name, provider_name, model_kwargs=None):
+                return MagicMock(spec=LLMModel)
+
+            def register_provider(self, name, provider_cls):
+                pass
+
+            def get_provider_names(self):
+                return []
+
+        with pytest.raises(TypeError, match="does not implement LLMFramework"):
+            register_framework("no_reset", _NoReset())
+
+    def test_framework_with_sync_reset_is_rejected(self):
+        """A protocol-compliant class with a sync reset() must not be accepted.
+
+        runtime_checkable Protocols only verify attribute existence, not that
+        an attribute is async. Without the explicit coroutine check, a sync
+        reset would pass validation and crash later inside _areset_frameworks
+        when the loop tries to await it.
+        """
+
+        class _SyncReset:
+            def create_model(self, model_name, provider_name, model_kwargs=None):
+                return MagicMock(spec=LLMModel)
+
+            def register_provider(self, name, provider_cls):
+                pass
+
+            def get_provider_names(self):
+                return []
+
+            def reset(self):
+                pass
+
+        with pytest.raises(TypeError, match="reset must be an async coroutine function"):
+            register_framework("sync_reset", _SyncReset())
 
 
 class FakeChatProvider:


### PR DESCRIPTION
## Description
Migrates `nemoguardrails/llm/frameworks.py` from an ad-hoc module-level dict and state globals to an `LLMFrameworkRegistry(Registry)` subclass, matching the pattern used by `LogAdapterRegistry` and `EmbeddingProviderRegistry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the framework registration and retrieval system with stricter validation of framework implementations to ensure protocol compliance.

* **Tests**
  * Enhanced test coverage to enforce framework protocol requirements and updated error validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->