### PR TITLE
refactor(registry): make Registry and Singleton thread-safe

### DIFF
--- a/nemoguardrails/registry.py
+++ b/nemoguardrails/registry.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Any, Iterator, List
@@ -24,13 +25,15 @@ class Registry(ABC, metaclass=Singleton):
     def __init__(self, enable_validation: bool = True) -> None:
         self.items = defaultdict(str)
         self.enable_validation = enable_validation
+        self._lock = threading.RLock()
 
     @abstractmethod
     def validate(self, name: str, item: Any) -> None:
         pass
 
     def reset(self):
-        self.items = defaultdict(str)
+        with self._lock:
+            self.items = defaultdict(str)
 
     def add(self, name: str, item: Any):
         """Add an item to the registry.
@@ -42,11 +45,12 @@ class Registry(ABC, metaclass=Singleton):
         Raises:
             ValueError: If the item name already exists in the registry.
         """
-        if name in self.items:
-            raise ValueError(f"{name} already exists in the registry")
-        if self.enable_validation:
-            self.validate(name, item)
-        self.items[name] = item
+        with self._lock:
+            if name in self.items:
+                raise ValueError(f"{name} already exists in the registry")
+            if self.enable_validation:
+                self.validate(name, item)
+            self.items[name] = item
 
     def get(self, name: str) -> Any:
         """Get an item by name.
@@ -59,9 +63,10 @@ class Registry(ABC, metaclass=Singleton):
         """
         if name is None:
             raise ValueError("name cannot be None")
-        if name not in self.items:
-            raise KeyError(f"{name} does not exist in the registry")
-        return self.items.get(name)
+        with self._lock:
+            if name not in self.items:
+                raise KeyError(f"{name} does not exist in the registry")
+            return self.items.get(name)
 
     def list(self) -> List[str]:
         """List all items in the registry.
@@ -69,19 +74,24 @@ class Registry(ABC, metaclass=Singleton):
         Returns:
             List[str]: A list of all item names.
         """
-        return list(self.items.keys())
+        with self._lock:
+            return list(self.items.keys())
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(items={self.items.keys()})"
+        with self._lock:
+            return f"{self.__class__.__name__}(items={list(self.items.keys())})"
 
     def __len__(self) -> int:
-        return len(self.items)
+        with self._lock:
+            return len(self.items)
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self.items)
+        with self._lock:
+            return iter(list(self.items))
 
     def __contains__(self, name: str) -> bool:
-        return name in self.items
+        with self._lock:
+            return name in self.items
 
     def __getitem__(self, name: str) -> Any:
         return self.get(name)

--- a/nemoguardrails/singleton.py
+++ b/nemoguardrails/singleton.py
@@ -16,6 +16,7 @@
 """The singleton metaclass for ensuring only one instance of a class."""
 
 import abc
+import threading
 
 
 class Singleton(abc.ABCMeta, type):
@@ -23,10 +24,12 @@ class Singleton(abc.ABCMeta, type):
     Singleton metaclass for ensuring only one instance of a class.
     """
 
-    _instances = {}
+    _instances: dict = {}
+    _lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
-        """Call method for the singleton metaclass."""
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            with cls._lock:
+                if cls not in cls._instances:
+                    cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,16 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+import time
 from typing import Any
 
 import pytest
 
 from nemoguardrails.registry import Registry
+from nemoguardrails.singleton import Singleton
 
 
 class StubRegistry(Registry):
     def validate(self, name: str, item: Any) -> None:
         pass
+
+
+class SlowValidateRegistry(Registry):
+    def validate(self, name: str, item: Any) -> None:
+        time.sleep(0.005)
 
 
 @pytest.fixture()
@@ -78,3 +86,95 @@ def test_reset(registry):
     registry.add("item1", "value1")
     registry.reset()
     assert len(registry) == 0
+
+
+class TestThreadSafety:
+    def test_singleton_under_concurrent_construction(self):
+        class _SlowSingleton(metaclass=Singleton):
+            construction_count = 0
+
+            def __init__(self):
+                time.sleep(0.01)
+                type(self).construction_count += 1
+
+        Singleton._instances.pop(_SlowSingleton, None)
+
+        start = threading.Event()
+        instances = []
+
+        def worker():
+            start.wait()
+            instances.append(_SlowSingleton())
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join()
+
+        assert len(instances) == 16
+        assert all(inst is instances[0] for inst in instances)
+        assert _SlowSingleton.construction_count == 1
+
+    def test_concurrent_add_no_duplicates(self):
+        Singleton._instances.pop(SlowValidateRegistry, None)
+        reg = SlowValidateRegistry(enable_validation=True)
+        reg.reset()
+
+        start = threading.Event()
+        succeeded = []
+        duplicate_rejected = []
+
+        def worker():
+            start.wait()
+            try:
+                reg.add("contested", "value")
+                succeeded.append(True)
+            except ValueError:
+                duplicate_rejected.append(True)
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join()
+
+        assert len(succeeded) == 1
+        assert len(duplicate_rejected) == 15
+
+    def test_iter_during_concurrent_mutation(self, registry):
+        registry.reset()
+        for i in range(50):
+            registry.add(f"initial-{i}", i)
+
+        stop = threading.Event()
+        errors = []
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                try:
+                    registry.add(f"w-{i}", i)
+                except ValueError:
+                    pass
+                i += 1
+
+        def reader():
+            try:
+                for _ in range(100):
+                    for _name in registry:
+                        pass
+            except Exception as e:
+                errors.append(e)
+
+        w = threading.Thread(target=writer)
+        r = threading.Thread(target=reader)
+        w.start()
+        r.start()
+        r.join()
+        stop.set()
+        w.join()
+
+        assert errors == []


### PR DESCRIPTION
## Description

`Singleton` and `Registry` have TOCTOU (time-of-check-time-of-use) races.

- **`Singleton.__call__`**: two threads racing `MyRegistry()` can both see the class missing from `_instances` and both construct an instance thus producing multiple "singleton" objects. Only one wins the final assignment; work already in flight on the loser holds a stale reference.
- **`Registry.add`**: two threads racing `reg.add("x", ...)` can both see `"x" not in items` and both assign so silently accepting duplicate registrations instead of raising `ValueError`.
- **`Registry` iteration**: a reader iterating `for name in reg:` while another thread calls `reg.add(...)` raises `RuntimeError: dictionary changed size during iteration`.

Impact: duplicate httpx connection pools in `LLMFrameworkRegistry`, silently lost registrations, crashes in concurrent read/write paths. Affects every consumer of this shared infrastructure — `LogAdapterRegistry`, `EmbeddingProviderRegistry`, and the incoming `LLMFrameworkRegistry`.

## Fix

- **`Singleton`**: double checked locking on `__call__` using a shared `threading.Lock`. 
- **`Registry`**: instance level `threading.RLock` guards `add`, `get`, `reset`, and the read paths (`list`, `__len__`, `__iter__`, `__contains__`, `__repr__`). `__iter__` returns a snapshot (`iter(list(self.items))`) so iteration is stable even if writers mutates concurrently.

## Test plan

Three new tests in `tests/test_registry.py::TestThreadSafety`: Each test uses a slow path in the vulnerable critical section (sleep in `__init__` / `validate`) to widen the race window so the bug is deterministically reproducible.

### Before the fix

Reverting the production code and running the new tests (10 consecutive runs):


```
FAILED TestThreadSafety::test_singleton_under_concurrent_construction
FAILED TestThreadSafety::test_concurrent_add_no_duplicates
FAILED TestThreadSafety::test_iter_during_concurrent_mutation
3 failed ( all 3 fail reliably on every run)
```

### After the fix

```
tests/test_registry.py ........... [100%]
11 passed in 0.56s
```

Consistent across 5 consecutive runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety mechanisms in core components.

* **Tests**
  * Added comprehensive concurrency test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->