### PR TITLE
fix: normalize OpenAI multi-part content in _get_events_for_messages

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -598,6 +598,23 @@ class LLMRails:
                 kwargs = esp_config.parameters
                 return self.embedding_search_providers[esp_config.name](**kwargs)
 
+    @staticmethod
+    def _extract_text_content(content) -> str:
+        """Normalize an OpenAI message content value to a plain string.
+
+        The OpenAI spec allows ``content`` to be either a plain string or a list
+        of content parts (e.g. ``[{"type": "text", "text": "…"}, …]``).  When a
+        list is received, extract and join all ``text`` parts so the rest of the
+        pipeline always operates on a regular string.
+        """
+        if isinstance(content, list):
+            return " ".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+        return content if content is not None else ""
+
     def _get_events_for_messages(self, messages: List[dict], state: Any):
         """Return the list of events corresponding to the provided messages.
 
@@ -635,10 +652,11 @@ class LLMRails:
             for idx in range(p, len(messages)):
                 msg = messages[idx]
                 if msg["role"] == "user":
+                    user_text = self._extract_text_content(msg["content"])
                     events.append(
                         {
                             "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
+                            "final_transcript": user_text,
                         }
                     )
 
@@ -647,7 +665,7 @@ class LLMRails:
                         events.append(
                             {
                                 "type": "UserMessage",
-                                "text": msg["content"],
+                                "text": user_text,
                             }
                         )
 
@@ -682,7 +700,7 @@ class LLMRails:
                         user_message = None
                         for prev_msg in reversed(messages[:idx]):
                             if prev_msg["role"] == "user":
-                                user_message = prev_msg["content"]
+                                user_message = self._extract_text_content(prev_msg["content"])
                                 break
 
                         if user_message:
@@ -717,7 +735,7 @@ class LLMRails:
                     events.append(
                         {
                             "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
+                            "final_transcript": self._extract_text_content(msg["content"]),
                         }
                     )
 

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1476,3 +1476,90 @@ def test_embedding_model_no_backfill_when_no_embeddings_model():
     assert "embedding_engine" not in rails.config.core.embedding_search_provider.parameters
     assert "embedding_model" not in rails.config.knowledge_base.embedding_search_provider.parameters
     assert "embedding_engine" not in rails.config.knowledge_base.embedding_search_provider.parameters
+
+
+# ---------------------------------------------------------------------------
+# Tests for multi-part (OpenAI spec) content normalization — issue #1741
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_content_string():
+    """Plain strings should be returned unchanged."""
+    config = RailsConfig.from_content(config={"models": []})
+    rails = LLMRails(config=config, llm=FakeLLM(responses=[]))
+
+    assert rails._extract_text_content("hello") == "hello"
+    assert rails._extract_text_content("") == ""
+    assert rails._extract_text_content(None) == ""
+
+
+def test_extract_text_content_list_single_text_part():
+    """A single-part list with type=text should return the text string."""
+    config = RailsConfig.from_content(config={"models": []})
+    rails = LLMRails(config=config, llm=FakeLLM(responses=[]))
+
+    content = [{"type": "text", "text": "Hello there"}]
+    assert rails._extract_text_content(content) == "Hello there"
+
+
+def test_extract_text_content_list_multiple_text_parts():
+    """Multiple text parts should be joined with a space."""
+    config = RailsConfig.from_content(config={"models": []})
+    rails = LLMRails(config=config, llm=FakeLLM(responses=[]))
+
+    content = [
+        {"type": "text", "text": "First part."},
+        {"type": "text", "text": "Second part."},
+    ]
+    assert rails._extract_text_content(content) == "First part. Second part."
+
+
+def test_extract_text_content_list_skips_image_parts():
+    """Image parts should be silently ignored; only text parts are returned."""
+    config = RailsConfig.from_content(config={"models": []})
+    rails = LLMRails(config=config, llm=FakeLLM(responses=[]))
+
+    content = [
+        {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+        {"type": "text", "text": "Describe this image."},
+    ]
+    assert rails._extract_text_content(content) == "Describe this image."
+
+
+@pytest.mark.asyncio
+async def test_generate_async_multipart_user_content(rails_config):
+    """generate_async must not crash when content is an OpenAI multi-part list."""
+    llm = FakeLLM(responses=["  express greeting"])
+    llm_rails = LLMRails(config=rails_config, llm=llm)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Hello!"}],
+        }
+    ]
+    # Before the fix this raised TypeError; after the fix it should succeed.
+    result = await llm_rails.generate_async(messages=messages)
+    assert result["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_generate_async_multipart_multi_turn_no_type_error(rails_config):
+    """Multi-turn conversations with multi-part content must not raise TypeError."""
+    llm = FakeLLM(
+        responses=[
+            "  express greeting",
+            "  express greeting",
+        ]
+    )
+    llm_rails = LLMRails(config=rails_config, llm=llm)
+
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Hello!"}]},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": [{"type": "text", "text": "Hello again"}]},
+    ]
+    # Before the fix, get_colang_history() would crash with:
+    #   TypeError: must be str or None, not list
+    result = await llm_rails.generate_async(messages=messages)
+    assert result["role"] == "assistant"


### PR DESCRIPTION
Fixes #1741

## Problem

When the OpenAI chat completions API sends messages with multi-part content (e.g. `"content": [{"type": "text", "text": "Hello"}]`), `llmrails.py` stored the raw list directly in event text fields without normalizing to a string. This caused two failures:

1. **Garbled prompts** — self-check and intent-matching prompts received the Python repr of the list (`[{'type': 'text', 'text': '...'}]`) instead of the actual user text.
2. **`TypeError` crash** — in multi-turn conversations where `mask_prev_user_message` fires, `get_colang_history()` called `rsplit()` on the list and raised `TypeError: must be str or None, not list`.

Root cause: `_get_events_for_messages` set `"final_transcript": msg["content"]` and `"text": msg["content"]` without checking whether `content` is a list.

## Solution

Add a static helper method `LLMRails._extract_text_content(content)` that:
- Returns plain strings unchanged.
- For list content, joins all `{"type": "text"}` parts with a space (image and other non-text parts are silently ignored, consistent with how the rest of the codebase handles multimodal content).

Apply the helper to every user-message content assignment in `_get_events_for_messages` for both the Colang 1.0 and 2.0 code paths.

## Testing

- Added unit tests for `_extract_text_content` (plain string, single text part, multiple text parts, image parts ignored).
- Added integration tests verifying that `generate_async` no longer crashes with single-turn and multi-turn multi-part content.
- All 6 new tests pass; existing `test_llmrails.py` tests unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-part message content formats to prevent crashes and enhance compatibility with OpenAI messages
* **Tests**
  * Added comprehensive test coverage for message content normalization across various input formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->