### PR TITLE
docs: fix jira 407

### DIFF
--- a/docs/configure-rails/guardrail-catalog/fact-checking.md
+++ b/docs/configure-rails/guardrail-catalog/fact-checking.md
@@ -23,6 +23,8 @@ The NeMo Guardrails library uses the concept of **relevant chunks** (which are s
 
 ```{important}
 The performance of this rail is strongly dependent on the capability of the LLM to follow the instructions in the `self_check_facts` prompt.
+
+If your LLM does not reliably follow this prompt, consider a model purpose-built for hallucination detection instead. See [AlignScore-based Fact-Checking](#alignscore-based-fact-checking) or [Patronus Lynx-based RAG Hallucination Detection](#patronus-lynx-based-rag-hallucination-detection) on this page.
 ```
 
 ### Usage

--- a/docs/configure-rails/guardrail-catalog/self-check.md
+++ b/docs/configure-rails/guardrail-catalog/self-check.md
@@ -25,6 +25,8 @@ The goal of the input self-checking rail is to determine if the input from the u
 
 ```{important}
 The performance of this rail is strongly dependent on the capability of the LLM to follow the instructions in the `self_check_input` prompt.
+
+If your LLM does not reliably follow this prompt, consider a purpose-built input safety model instead. See [Content Safety](content-safety.md) for Nemotron Content Safety, Llama Guard 3, and ShieldGemma alternatives.
 ```
 
 ### Usage
@@ -131,6 +133,8 @@ The goal of the output self-checking rail is to determine if the output from the
 
 ```{important}
 The performance of this rail is strongly dependent on the capability of the LLM to follow the instructions in the `self_check_output` prompt.
+
+If your LLM does not reliably follow this prompt, consider a purpose-built output safety model instead. See [Content Safety](content-safety.md) for Nemotron Content Safety, Llama Guard 3, and ShieldGemma alternatives.
 ```
 
 ### Usage


### PR DESCRIPTION
## Description

closes NGUARD-407

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Enhanced guidance on selecting purpose-built hallucination-detection models when default LLMs cannot reliably follow configured prompts
- Added recommendations for alternative content safety models in input and output validation sections
- Included cross-references to alternative solutions including Nemotron Content Safety, Llama Guard 3, and ShieldGemma

<!-- end of auto-generated comment: release notes by coderabbit.ai -->