### PR TITLE
fix(actions): guard bot message extraction against composite specs

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -177,7 +177,10 @@ class LLMGenerationActions:
             else cast(Dict, spec_op.spec)
         )
 
-        if not spec["name"] or spec["name"] != "UtteranceUserActionFinished" or "script" not in spec["arguments"]:
+        if spec.get("_type") in ("spec_or", "spec_and"):
+            return
+
+        if not spec.get("name") or spec["name"] != "UtteranceBotAction" or "script" not in spec.get("arguments", {}):
             return
 
         # Extract the message and remove the double quotes

--- a/tests/v2_x/test_bot_flow_composite_spec.py
+++ b/tests/v2_x/test_bot_flow_composite_spec.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from tests.utils import TestChat
+
+BASE_CONFIG = textwrap.dedent("""
+    colang_version: "2.x"
+""")
+
+OR_BOT_FLOW_COLANG = textwrap.dedent("""
+    import core
+
+    flow main
+        activate greeting
+
+    flow greeting
+        user said "hi"
+        bot inform about service
+
+    flow bot inform about service
+        bot say "You can ask me anything!"
+            or bot say "Just ask me something!"
+""")
+
+AND_BOT_FLOW_COLANG = textwrap.dedent("""
+    import core
+
+    flow main
+        activate greeting
+
+    flow greeting
+        user said "hi"
+        bot express greeting
+
+    flow bot express greeting
+        bot say "Hello!"
+            and bot say "Welcome!"
+""")
+
+
+def _make_chat(colang: str) -> TestChat:
+    from nemoguardrails import RailsConfig
+
+    config = RailsConfig.from_content(yaml_content=BASE_CONFIG, colang_content=colang)
+    return TestChat(config, llm_completions=[])
+
+
+def test_llmrails_init_handles_spec_or_in_bot_flow():
+    chat = _make_chat(OR_BOT_FLOW_COLANG)
+    assert "bot inform about service" not in chat.app.llm_generation_actions.bot_messages
+
+
+def test_llmrails_init_handles_spec_and_in_bot_flow():
+    chat = _make_chat(AND_BOT_FLOW_COLANG)
+    assert "bot express greeting" not in chat.app.llm_generation_actions.bot_messages


### PR DESCRIPTION
## Description

`_extract_bot_message_example` unconditionally accessed `spec["name"]`, which raises `KeyError` for SpecOr / SpecAnd composite dicts produced by Colang v2.x or / and operators on bot flows. This crashed `LLMRails.__init__` for any config using that standard v2.x syntax, including the official interaction_loop and multi_modal tutorials.

Restore the pre-#1361 safety: return early for composite `_type` and revert the identifier from the copy-pasted `UtteranceUserActionFinished` back to `UtteranceBotAction`.

Regression introduced in 67de94723 (#1361).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot message extraction to correctly handle composite specifications using `or` and `and` operators in bot flows.

* **Tests**
  * Added test coverage for composite bot flow specifications to ensure proper validation and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->