### PR TITLE
fix(llm): drop stop param for OpenAI reasoning models

### DIFF
--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -110,6 +110,15 @@ def _infer_provider_from_module(llm: Any) -> Optional[str]:
     return None
 
 
+def _is_reasoning_model(model_name: str) -> bool:
+    name = model_name.lower()
+    if name in ("o1", "o3") or name.startswith(("o1-", "o3-")):
+        return True
+    if name == "gpt-5" or name.startswith("gpt-5-"):
+        return "chat" not in name
+    return False
+
+
 _BASE_URL_ATTRIBUTES = [
     "base_url",
     "endpoint_url",
@@ -149,32 +158,14 @@ class LangChainLLMAdapter:
             return str(client.base_url)
         return None
 
-    def _filter_reasoning_model_params(self, params: Optional[dict]) -> Optional[dict]:
-        if not params or "temperature" not in params:
-            return params
-
-        model_name = _infer_model_name(self._llm).lower()
-
-        is_openai_reasoning_model = (
-            model_name.startswith("o1")
-            or model_name.startswith("o3")
-            or (model_name.startswith("gpt-5") and "chat" not in model_name)
-        )
-
-        if is_openai_reasoning_model:
-            filtered = params.copy()
-            filtered.pop("temperature", None)
-            log.debug("Stripped 'temperature' for reasoning model '%s'", model_name)
-            return filtered
-
+    def _prepare_call_params(self, stop: Optional[List[str]], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        params = dict(kwargs)
+        if stop is not None:
+            params["stop"] = stop
+        if _is_reasoning_model(self.model_name):
+            params.pop("temperature", None)
+            params.pop("stop", None)
         return params
-
-    def _prepare_llm(self, kwargs: dict):
-        kwargs = self._filter_reasoning_model_params(kwargs) or {}
-        llm = self._llm
-        if kwargs:
-            llm = llm.bind(**kwargs)
-        return llm
 
     def _to_langchain_input(self, prompt):
         if isinstance(prompt, list):
@@ -192,9 +183,10 @@ class LangChainLLMAdapter:
         stop: Optional[List[str]] = None,
         **kwargs,
     ) -> LLMResponse:
-        llm = self._prepare_llm(kwargs)
+        params = self._prepare_call_params(stop, kwargs)
+        llm = self._llm.bind(**params) if params else self._llm
         messages = self._to_langchain_input(prompt)
-        response = await llm.ainvoke(messages, stop=stop)
+        response = await llm.ainvoke(messages)
         return _langchain_response_to_llm_response(response)
 
     async def stream_async(
@@ -204,12 +196,13 @@ class LangChainLLMAdapter:
         stop: Optional[List[str]] = None,
         **kwargs,
     ) -> AsyncIterator[LLMResponseChunk]:
-        llm = self._prepare_llm(kwargs)
+        params = self._prepare_call_params(stop, kwargs)
+        llm = self._llm.bind(**params) if params else self._llm
         messages = self._to_langchain_input(prompt)
 
         tool_call_acc: Dict[int, Dict[str, Any]] = {}
 
-        async for chunk in llm.astream(messages, stop=stop):
+        async for chunk in llm.astream(messages):
             for tc_chunk in getattr(chunk, "tool_call_chunks", None) or []:
                 idx = tc_chunk.get("index", 0)
                 if idx not in tool_call_acc:

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -110,7 +110,7 @@ def _infer_provider_from_module(llm: Any) -> Optional[str]:
     return None
 
 
-def _is_reasoning_model(model_name: str) -> bool:
+def _is_openai_reasoning_model(model_name: str) -> bool:
     name = model_name.lower()
     if name in ("o1", "o3", "o4") or name.startswith(("o1-", "o3-", "o4-")):
         return True
@@ -164,7 +164,7 @@ class LangChainLLMAdapter:
         params = dict(kwargs)
         if stop is not None:
             params["stop"] = stop
-        if _is_reasoning_model(self.model_name):
+        if _is_openai_reasoning_model(self.model_name):
             params.pop("temperature", None)
             params.pop("stop", None)
         return params

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -112,7 +112,7 @@ def _infer_provider_from_module(llm: Any) -> Optional[str]:
 
 def _is_reasoning_model(model_name: str) -> bool:
     name = model_name.lower()
-    if name in ("o1", "o3") or name.startswith(("o1-", "o3-")):
+    if name in ("o1", "o3", "o4") or name.startswith(("o1-", "o3-", "o4-")):
         return True
     if name == "gpt-5" or name.startswith("gpt-5-"):
         return "chat" not in name

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -116,6 +116,8 @@ def _is_reasoning_model(model_name: str) -> bool:
         return True
     if name == "gpt-5" or name.startswith("gpt-5-"):
         return "chat" not in name
+    if name.startswith(("gpt-5.", "gpt-6")):
+        return True
     return False
 
 

--- a/tests/integrations/langchain/test_actions_llm_utils.py
+++ b/tests/integrations/langchain/test_actions_llm_utils.py
@@ -273,13 +273,16 @@ async def test_llm_call_stop_tokens_passed_without_llm_params(llm_params):
 
     from nemoguardrails.actions.llm.utils import llm_call
 
-    mock_llm = AsyncMock()
-    mock_llm.ainvoke.return_value = MagicMock(content="response")
+    mock_llm = MagicMock()
+    mock_llm.model_name = "gpt-4"
+    bound_llm = AsyncMock()
+    bound_llm.ainvoke.return_value = MagicMock(content="response")
+    mock_llm.bind.return_value = bound_llm
 
     wrapped = LangChainLLMAdapter(mock_llm)
     await llm_call(wrapped, "prompt", stop=["User:"], llm_params=llm_params)
 
-    assert mock_llm.ainvoke.call_args[1]["stop"] == ["User:"]
+    mock_llm.bind.assert_called_once_with(stop=["User:"])
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -312,6 +312,13 @@ class TestPrepareCallParams:
             ("o4-mini", ["User:"], {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
             ("o4-mini-2025-04-16", ["User:"], {"temperature": 0.5}, {}),
             ("o4", ["User:"], {"temperature": 0.5}, {}),
+            # gpt-5.1+ and gpt-6: fully reasoning, no chat escape
+            ("gpt-5.1", ["User:"], {"temperature": 0.5}, {}),
+            ("gpt-5.1-chat-latest", ["User:"], {"temperature": 0.5}, {}),
+            ("gpt-5.2-2025-12-11", ["User:"], {}, {}),
+            ("gpt-5.4-mini", ["User:"], {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
+            ("gpt-6", ["User:"], {"temperature": 0.5}, {}),
+            ("gpt-6-mini", ["User:"], {}, {}),
             # no stop, no temperature, unchanged
             ("o1-preview", None, {"max_tokens": 100}, {"max_tokens": 100}),
             ("o1-preview", None, {}, {}),

--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -309,7 +309,10 @@ class TestPrepareCallParams:
             ("gpt-5", ["User:"], {"temperature": 0.001}, {}),
             ("gpt-5-mini", ["User:"], {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
             ("gpt-5-nano", ["User:"], {}, {}),
-            # no stop, no temperature — unchanged
+            ("o4-mini", ["User:"], {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
+            ("o4-mini-2025-04-16", ["User:"], {"temperature": 0.5}, {}),
+            ("o4", ["User:"], {"temperature": 0.5}, {}),
+            # no stop, no temperature, unchanged
             ("o1-preview", None, {"max_tokens": 100}, {"max_tokens": 100}),
             ("o1-preview", None, {}, {}),
         ],

--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -90,7 +90,7 @@ class TestLangChainLLMAdapter:
 
         assert isinstance(result, LLMResponse)
         assert result.content == "hello world"
-        mock_llm.ainvoke.assert_called_once_with("say hello", stop=None)
+        mock_llm.ainvoke.assert_called_once_with("say hello")
 
     @pytest.mark.asyncio
     async def test_generate_with_chat_message_list(self):
@@ -194,7 +194,7 @@ class TestLangChainLLMAdapter:
         result = await adapter.generate_async("prompt", temperature=0.5, max_tokens=100)
 
         mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
-        bound_llm.ainvoke.assert_called_once_with("prompt", stop=None)
+        bound_llm.ainvoke.assert_called_once_with("prompt")
         assert result.content == "bound response"
 
     @pytest.mark.asyncio
@@ -221,6 +221,39 @@ class TestLangChainLLMAdapter:
 
         mock_llm.bind.assert_called_once_with(max_tokens=100)
         assert result.content == "reasoning response"
+
+    @pytest.mark.asyncio
+    async def test_generate_drops_stop_for_reasoning_model(self):
+        mock_llm = AsyncMock()
+        mock_llm.model_name = "gpt-5-mini"
+        mock_llm.ainvoke.return_value = AIMessage(content="ok")
+        adapter = LangChainLLMAdapter(mock_llm)
+
+        await adapter.generate_async("prompt", stop=["User:"])
+
+        mock_llm.bind.assert_not_called()
+        _, kwargs = mock_llm.ainvoke.call_args
+        assert "stop" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_stream_drops_stop_for_reasoning_model(self):
+        mock_llm = MagicMock()
+        mock_llm.model_name = "gpt-5-mini"
+        astream_kwargs = {}
+
+        async def mock_astream(*args, **kwargs):
+            astream_kwargs.update(kwargs)
+            for c in [MagicMock(content="ok", response_metadata=None, usage_metadata=None, generation_info=None)]:
+                yield c
+
+        mock_llm.astream = mock_astream
+        adapter = LangChainLLMAdapter(mock_llm)
+
+        async for _ in adapter.stream_async("prompt", stop=["User:"]):
+            pass
+
+        mock_llm.bind.assert_not_called()
+        assert "stop" not in astream_kwargs
 
     def test_satisfies_llm_model_protocol(self):
         mock_llm = MagicMock()
@@ -254,45 +287,43 @@ class TestLangChainFramework:
         )
 
 
-class TestFilterReasoningModelParams:
+class TestPrepareCallParams:
     def _make_adapter(self, model_name):
         mock_llm = MagicMock()
         mock_llm.model_name = model_name
         return LangChainLLMAdapter(mock_llm)
 
     @pytest.mark.parametrize(
-        "model,params,expected",
+        "model,stop,kwargs,expected",
         [
-            ("gpt-4", {"temperature": 0.5, "max_tokens": 100}, {"temperature": 0.5, "max_tokens": 100}),
-            ("gpt-4o", {"temperature": 0.7}, {"temperature": 0.7}),
-            ("gpt-4o-mini", {"temperature": 0.3, "max_tokens": 50}, {"temperature": 0.3, "max_tokens": 50}),
-            ("gpt-5-chat", {"temperature": 0.5}, {"temperature": 0.5}),
-            ("o1-preview", {"temperature": 0.001, "max_tokens": 100}, {"max_tokens": 100}),
-            ("o1-mini", {"temperature": 0.5}, {}),
-            ("o3", {"temperature": 0.001, "max_tokens": 200}, {"max_tokens": 200}),
-            ("o3-mini", {"temperature": 0.1}, {}),
-            ("gpt-5", {"temperature": 0.001}, {}),
-            ("gpt-5-mini", {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
-            ("gpt-5-nano", {"temperature": 0.001}, {}),
-            ("o1-preview", {"max_tokens": 100}, {"max_tokens": 100}),
-            ("o1-preview", {}, {}),
+            # non-reasoning models: stop and temperature both pass through
+            ("gpt-4", None, {"temperature": 0.5, "max_tokens": 100}, {"temperature": 0.5, "max_tokens": 100}),
+            ("gpt-4o", ["User:"], {"temperature": 0.7}, {"temperature": 0.7, "stop": ["User:"]}),
+            ("gpt-4o-mini", ["User:"], {}, {"stop": ["User:"]}),
+            ("gpt-5-chat", ["User:"], {"temperature": 0.5}, {"temperature": 0.5, "stop": ["User:"]}),
+            # reasoning models: both temperature and stop stripped
+            ("o1-preview", ["User:"], {"temperature": 0.001, "max_tokens": 100}, {"max_tokens": 100}),
+            ("o1-mini", ["User:"], {"temperature": 0.5}, {}),
+            ("o3", None, {"temperature": 0.001, "max_tokens": 200}, {"max_tokens": 200}),
+            ("o3-mini", ["User:"], {"temperature": 0.1}, {}),
+            ("gpt-5", ["User:"], {"temperature": 0.001}, {}),
+            ("gpt-5-mini", ["User:"], {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
+            ("gpt-5-nano", ["User:"], {}, {}),
+            # no stop, no temperature — unchanged
+            ("o1-preview", None, {"max_tokens": 100}, {"max_tokens": 100}),
+            ("o1-preview", None, {}, {}),
         ],
     )
-    def test_filter_params(self, model, params, expected):
+    def test_prepare_call_params(self, model, stop, kwargs, expected):
         adapter = self._make_adapter(model)
-        result = adapter._filter_reasoning_model_params(params)
+        result = adapter._prepare_call_params(stop, kwargs)
         assert result == expected
 
-    def test_returns_none_when_params_is_none(self):
-        adapter = self._make_adapter("gpt-4")
-        result = adapter._filter_reasoning_model_params(None)
-        assert result is None
-
-    def test_does_not_modify_original_params(self):
+    def test_does_not_modify_original_kwargs(self):
         adapter = self._make_adapter("o1-preview")
-        params = {"temperature": 0.5, "max_tokens": 100}
-        adapter._filter_reasoning_model_params(params)
-        assert params == {"temperature": 0.5, "max_tokens": 100}
+        kwargs = {"temperature": 0.5, "max_tokens": 100}
+        adapter._prepare_call_params(["User:"], kwargs)
+        assert kwargs == {"temperature": 0.5, "max_tokens": 100}
 
 
 class TestConversionHelpers:


### PR DESCRIPTION
## Description

After #1760 activated the LangChainLLMAdapter path, stop was forwarded unconditionally to llm.ainvoke() and llm.astream(), causing HTTP 400 from gpt-5*, o3 (non-mini) and o4-mini which reject the stop parameter.

Unify stop and temperature filtering into a single _prepare_call_params method
## Test Plan
Extend TestPrepareCallParams to parametrize over stop as well as temperature, and add two call-site regression tests that assert generate_async / stream_async do not leak stop to the underlying LLM for reasoning models. Both regression tests fail against the pre-fix adapter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect stop token and temperature parameter handling for reasoning-model variants like o1, o3, and gpt-5.
  * Improved LangChain integration to ensure reasoning models function properly with correct parameter passing and configuration.
  * Enhanced parameter management to handle model-specific requirements while maintaining backward compatibility with standard models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->