### PR TITLE
fix(llmrails): scope no main LLM warning to generation path

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -457,7 +457,7 @@ class LLMRails:
                 self.runtime.register_action_param("llm", self.llm)
 
             else:
-                log.warning("No main LLM specified in the config and no LLM provided via constructor.")
+                log.info("No main LLM specified in the config and no LLM provided via constructor.")
 
         llms = dict()
 
@@ -837,6 +837,10 @@ class LLMRails:
         # Save the generation options in the current async context.
         # At this point, gen_options is either None or GenerationOptions
         generation_options_var.set(gen_options)
+
+        needs_llm = gen_options is None or gen_options.rails.dialog is not False
+        if needs_llm and not self.llm:
+            log.warning("No main LLM specified in the config and no LLM provided via constructor.")
 
         if streaming_handler:
             streaming_handler_var.set(streaming_handler)

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from typing import Optional
 from unittest.mock import patch
@@ -22,6 +23,7 @@ import pytest
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.rails.llm.options import GenerationOptions
 from tests.conftest import REASONING_TRACE_MOCK_PATH
 from tests.utils import FakeLLMModel, clean_events, event_sequence_conforms
 
@@ -1475,3 +1477,71 @@ def test_embedding_model_no_backfill_when_no_embeddings_model():
     assert "embedding_engine" not in rails.config.core.embedding_search_provider.parameters
     assert "embedding_model" not in rails.config.knowledge_base.embedding_search_provider.parameters
     assert "embedding_engine" not in rails.config.knowledge_base.embedding_search_provider.parameters
+
+
+@pytest.fixture
+def no_main_llm_config():
+    return RailsConfig.from_content(
+        """
+        define flow input rail
+          if $user_message == "block"
+            bot refuse to respond
+            stop
+
+        define flow output rail
+          if $bot_message == "block output"
+            bot refuse to respond
+            stop
+        """,
+        """
+        rails:
+            input:
+                flows:
+                    - input rail
+            output:
+                flows:
+                    - output rail
+        """,
+    )
+
+
+def _count_no_llm_warnings(caplog):
+    return sum(
+        1 for record in caplog.records if record.levelno == logging.WARNING and NO_MAIN_LLM_WARNING in record.message
+    )
+
+
+USER_MSG = [{"role": "user", "content": "hello"}]
+USER_ASSISTANT_MSG = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+
+NO_MAIN_LLM_WARNING = "No main LLM specified in the config and no LLM provided via constructor."
+
+
+class TestGenerateAsyncNoMainLLMWarning:
+    @pytest.mark.parametrize(
+        "options, has_llm, messages, expected_warnings",
+        [
+            pytest.param(None, False, USER_MSG, 1, id="no-options-warns"),
+            pytest.param(GenerationOptions(), False, USER_MSG, 1, id="default-options-warns"),
+            pytest.param({"rails": ["input", "dialog"]}, False, USER_MSG, 1, id="dialog-in-list-warns"),
+            pytest.param(
+                {"rails": ["input", "output", "retrieval", "dialog"]}, False, USER_MSG, 1, id="all-rails-warns"
+            ),
+            pytest.param({"rails": ["input"]}, False, USER_MSG, 0, id="input-only-no-warn"),
+            pytest.param({"rails": ["output"]}, False, USER_ASSISTANT_MSG, 0, id="output-only-no-warn"),
+            pytest.param({"rails": ["input", "output"]}, False, USER_ASSISTANT_MSG, 0, id="input-output-no-warn"),
+            pytest.param(None, True, USER_MSG, 0, id="llm-no-options-no-warn"),
+            pytest.param({"rails": ["input", "dialog"]}, True, USER_MSG, 0, id="llm-dialog-enabled-no-warn"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_warning_behavior(self, no_main_llm_config, caplog, options, has_llm, messages, expected_warnings):
+        llm = FakeLLMModel(responses=["Hello!"]) if has_llm else None
+        rails = LLMRails(no_main_llm_config, llm=llm)
+        with caplog.at_level(logging.WARNING, logger="nemoguardrails.rails.llm.llmrails"):
+            if expected_warnings > 0:
+                with pytest.raises(Exception):
+                    await rails.generate_async(messages=messages, options=options)
+            else:
+                await rails.generate_async(messages=messages, options=options)
+        assert _count_no_llm_warnings(caplog) == expected_warnings

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
@@ -533,3 +535,63 @@ class TestCheckAsyncExplicitRails:
         ]
         result = mock_rails.check(messages, rail_types=None)
         assert result.status == RailStatus.BLOCKED
+
+
+@pytest.fixture
+def no_main_llm_config():
+    return RailsConfig.from_content(
+        """
+        define flow input rail
+          if $user_message == "block"
+            bot refuse to respond
+            stop
+
+        define flow output rail
+          if $bot_message == "block output"
+            bot refuse to respond
+            stop
+        """,
+        """
+        rails:
+            input:
+                flows:
+                    - input rail
+            output:
+                flows:
+                    - output rail
+        """,
+    )
+
+
+USER_MSG = [{"role": "user", "content": "hello"}]
+ASSISTANT_MSG = [{"role": "assistant", "content": "hello"}]
+USER_ASSISTANT_MSG = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+
+NO_MAIN_LLM_WARNING = "No main LLM specified in the config and no LLM provided via constructor."
+
+
+class TestNoMainLLMWarning:
+    def test_init_logs_info_not_warning(self, no_main_llm_config, caplog):
+        with caplog.at_level(logging.INFO, logger="nemoguardrails.rails.llm.llmrails"):
+            LLMRails(no_main_llm_config)
+        matches = [r for r in caplog.records if NO_MAIN_LLM_WARNING in r.message]
+        assert len(matches) == 1
+        assert matches[0].levelno == logging.INFO
+
+    @pytest.mark.parametrize(
+        "messages, rail_types",
+        [
+            pytest.param(USER_MSG, None, id="auto-input"),
+            pytest.param(ASSISTANT_MSG, None, id="auto-output"),
+            pytest.param(USER_ASSISTANT_MSG, None, id="auto-both"),
+            pytest.param(USER_MSG, [RailType.INPUT], id="explicit-input"),
+            pytest.param(ASSISTANT_MSG, [RailType.OUTPUT], id="explicit-output"),
+            pytest.param(USER_ASSISTANT_MSG, [RailType.INPUT, RailType.OUTPUT], id="explicit-both"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_check_async_does_not_warn(self, no_main_llm_config, caplog, messages, rail_types):
+        rails = LLMRails(no_main_llm_config)
+        with caplog.at_level(logging.WARNING, logger="nemoguardrails.rails.llm.llmrails"):
+            await rails.check_async(messages, rail_types=rail_types)
+        assert NO_MAIN_LLM_WARNING not in caplog.text


### PR DESCRIPTION
## Description

Previously LLMRails emitted a WARNING at init whenever no main LLM was configured, even for check-only configs where the main LLM is intentionally absent. The message looked like a misconfiguration error and fired on every check_async test run.

The warning is now emitted lazily from generate_async when a generation that actually needs the main LLM is attempted (dialog rails enabled and no LLM available via constructor or config). The init-time log is downgraded to INFO so the information remains available for debugging without false-positive noise.

Fixes NGUARD-718


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved logging behavior during LLM engine initialization when no main language model is configured.
  * Added conditional warning messages during text generation to better reflect when LLM availability is critical.

* **Tests**
  * Added comprehensive test coverage for initialization and generation workflows in scenarios without a configured main language model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->