### PR TITLE
fix(taskmanager): preserve multimodal list content in vision safety prompts

### DIFF
--- a/examples/configs/content_safety_vision/prompts.yml
+++ b/examples/configs/content_safety_vision/prompts.yml
@@ -6,8 +6,8 @@ prompts:
           You are an AI assistant that evaluates if a user's message contains unsafe content.
           Carefully examine any text and images in the user's message.
 
-          {%- if categories is not defined -%}
-              {%- set categories = {
+          {%- if categories is not defined %}
+              {% set categories = {
                   "S1": "Violent Crimes.",
                   "S2": "Non-Violent Crimes.",
                   "S3": "Sex Crimes.",
@@ -20,17 +20,17 @@ prompts:
                   "S11": "Self-Harm.",
                   "S12": "Sexual Content.",
                   "S13": "Elections."
-              } -%}
-          {%- endif -%}
+              } %}
+          {%- endif %}
 
           Task: Check if there is unsafe content in "User" messages in conversations according to our safety policy with the below categories.
 
           <BEGIN UNSAFE CONTENT CATEGORIES>
-          {%- for key, desc in categories.items() -%}
-              {%- if key not in excluded_category_keys -%}
+          {% for key, desc in categories.items() %}
+              {%- if key not in excluded_category_keys %}
           {{ key }}: {{ desc }}
-              {%- endif -%}
-          {%- endfor -%}
+              {%- endif %}
+          {%- endfor %}
           <END UNSAFE CONTENT CATEGORIES>
 
           IMPORTANT:

--- a/examples/configs/content_safety_vision/prompts.yml
+++ b/examples/configs/content_safety_vision/prompts.yml
@@ -26,7 +26,7 @@ prompts:
           Task: Check if there is unsafe content in "User" messages in conversations according to our safety policy with the below categories.
 
           <BEGIN UNSAFE CONTENT CATEGORIES>
-          {% for key, desc in categories.items() %}
+          {%- for key, desc in categories.items() %}
               {%- if key not in excluded_category_keys %}
           {{ key }}: {{ desc }}
               {%- endif %}

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -204,6 +204,27 @@ class LLMTaskManager:
         context: Optional[dict] = None,
         events: Optional[List[dict]] = None,
     ) -> Union[str, list]:
+        """Resolve a message-template body to either a list or a rendered string.
+
+        When ``template_str`` matches a single-variable pattern such as
+        ``"{{ user_input }}"``, the variable is looked up directly so that a
+        list value (for example, multimodal ``[{"type": "text", ...}, ...]``
+        content) is preserved as a list instead of being stringified by Jinja.
+
+        Lookup precedence for the single-variable case:
+
+        * The argument ``context`` is consulted first; its value seeds the
+          candidate result.
+        * ``self.prompt_context`` is consulted second, but it overrides the
+          argument only when its value is itself a list. This keeps a list
+          supplied in ``context`` safe from being clobbered by a scalar
+          fallback in ``self.prompt_context``, while still allowing a list in
+          ``self.prompt_context`` to win when the caller did not pass one.
+
+        If neither path yields a list (or ``template_str`` is not a single
+        variable), the method falls back to the regular Jinja render, which
+        coerces values to strings.
+        """
         match = _SINGLE_VAR_PATTERN.match(template_str.strip())
         if match:
             var_name = match.group(1)

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -188,7 +188,7 @@ class LLMTaskManager:
             else:
                 content = self._resolve_message_content(message_template.content, context=context, events=events)
 
-                if isinstance(content, list) or (isinstance(content, str) and content.strip()):
+                if (isinstance(content, list) and content) or (isinstance(content, str) and content.strip()):
                     messages.append(
                         {
                             "type": message_template.type,
@@ -211,9 +211,11 @@ class LLMTaskManager:
             if context and var_name in context:
                 value = context[var_name]
             if self.prompt_context and var_name in self.prompt_context:
-                value = self.prompt_context[var_name]
-                if callable(value):
-                    value = value()
+                candidate = self.prompt_context[var_name]
+                if callable(candidate):
+                    candidate = candidate()
+                if isinstance(candidate, list):
+                    value = candidate
             if isinstance(value, list):
                 return list(value)
         return self._render_string(template_str, context=context, events=events)

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -212,8 +212,6 @@ class LLMTaskManager:
                 value = context[var_name]
             if self.prompt_context and var_name in self.prompt_context:
                 candidate = self.prompt_context[var_name]
-                if callable(candidate):
-                    candidate = candidate()
                 if isinstance(candidate, list):
                     value = candidate
             if isinstance(value, list):

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -52,6 +52,8 @@ from nemoguardrails.llm.prompts import get_prompt
 from nemoguardrails.llm.types import Task
 from nemoguardrails.rails.llm.config import MessageTemplate, RailsConfig
 
+_SINGLE_VAR_PATTERN = re.compile(r"^\{\{\s*(\w+)\s*\}\}$")
+
 
 class LLMTaskManager:
     """Interface for interacting with an LLM in a task-oriented way."""
@@ -184,10 +186,9 @@ class LLMTaskManager:
                     raise ValueError(f"Invalid message template: {message_template}")
                 messages.extend(new_messages)
             else:
-                content = self._render_string(message_template.content, context=context, events=events)
+                content = self._resolve_message_content(message_template.content, context=context, events=events)
 
-                # Don't add empty messages.
-                if content.strip():
+                if isinstance(content, list) or (isinstance(content, str) and content.strip()):
                     messages.append(
                         {
                             "type": message_template.type,
@@ -196,6 +197,26 @@ class LLMTaskManager:
                     )
 
         return messages
+
+    def _resolve_message_content(
+        self,
+        template_str: str,
+        context: Optional[dict] = None,
+        events: Optional[List[dict]] = None,
+    ) -> Union[str, list]:
+        match = _SINGLE_VAR_PATTERN.match(template_str.strip())
+        if match:
+            var_name = match.group(1)
+            value = None
+            if context and var_name in context:
+                value = context[var_name]
+            if self.prompt_context and var_name in self.prompt_context:
+                value = self.prompt_context[var_name]
+                if callable(value):
+                    value = value()
+            if isinstance(value, list):
+                return list(value)
+        return self._render_string(template_str, context=context, events=events)
 
     def _get_messages_text_length(self, messages: List[dict]) -> int:
         """Return the length of the text in the messages for token counting purposes.

--- a/tests/test_taskmanager_multimodal.py
+++ b/tests/test_taskmanager_multimodal.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+
+
+@pytest.fixture(scope="module")
+def fake_base64():
+    return "iVBORw0KGgoAAAANSUhEUg" * 5000
+
+
+def _make_vision_config():
+    return RailsConfig.from_path("./examples/configs/content_safety_vision")
+
+
+def _make_multimodal_input(base64_data):
+    return [
+        {"type": "text", "text": "What is this?"},
+        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_data}"}},
+    ]
+
+
+def test_render_preserves_multimodal_list(fake_base64):
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+    user_input = _make_multimodal_input(fake_base64)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": user_input, "reasoning_enabled": False},
+    )
+
+    user_msg = prompt[-1]
+    assert user_msg["type"] == "user"
+    assert isinstance(user_msg["content"], list)
+    assert user_msg["content"] == user_input
+
+
+def test_render_text_only_unchanged():
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": "Is this safe?", "reasoning_enabled": False},
+    )
+
+    user_msg = prompt[-1]
+    assert user_msg["type"] == "user"
+    assert isinstance(user_msg["content"], str)
+    assert "Is this safe?" in user_msg["content"]
+
+
+def test_render_multimodal_no_base64_in_string_content(fake_base64):
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+    user_input = _make_multimodal_input(fake_base64)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": user_input, "reasoning_enabled": False},
+    )
+
+    for msg in prompt:
+        if isinstance(msg["content"], str):
+            assert "iVBORw0KGgoAAAANSUhEUg" not in msg["content"]
+
+
+def test_render_mixed_template_stringifies():
+    config = RailsConfig.from_content(
+        config={
+            "models": [{"type": "main", "engine": "openai", "model": "gpt-4o"}],
+            "prompts": [
+                {
+                    "task": "test_mixed",
+                    "messages": [
+                        {"type": "user", "content": "hello {{ var }}"},
+                    ],
+                }
+            ],
+        },
+    )
+    tm = LLMTaskManager(config)
+    list_val = [{"type": "text", "text": "world"}]
+
+    prompt = tm.render_task_prompt(
+        task="test_mixed",
+        context={"var": list_val},
+    )
+
+    user_msg = prompt[-1]
+    assert isinstance(user_msg["content"], str)
+
+
+def test_rendered_prompt_length_reasonable():
+    big_base64 = "A" * 100_000
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+    user_input = _make_multimodal_input(base64_data=big_base64)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": user_input, "reasoning_enabled": False},
+    )
+
+    total_text = 0
+    for msg in prompt:
+        content = msg["content"]
+        if isinstance(content, str):
+            total_text += len(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    total_text += len(item.get("text", ""))
+
+    assert total_text < 1000

--- a/tests/test_taskmanager_multimodal.py
+++ b/tests/test_taskmanager_multimodal.py
@@ -107,6 +107,19 @@ def test_render_mixed_template_stringifies():
     assert isinstance(user_msg["content"], str)
 
 
+def test_render_empty_list_is_dropped():
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": [], "reasoning_enabled": False},
+    )
+
+    for msg in prompt:
+        assert msg["content"] != []
+
+
 def test_rendered_prompt_length_reasonable():
     big_base64 = "A" * 100_000
     config = _make_vision_config()

--- a/tests/test_taskmanager_multimodal.py
+++ b/tests/test_taskmanager_multimodal.py
@@ -107,6 +107,34 @@ def test_render_mixed_template_stringifies():
     assert isinstance(user_msg["content"], str)
 
 
+def test_prompt_context_callable_invoked_once():
+    config = RailsConfig.from_content(
+        config={
+            "models": [{"type": "main", "engine": "openai", "model": "gpt-4o"}],
+            "prompts": [
+                {
+                    "task": "test_single_var",
+                    "messages": [
+                        {"type": "user", "content": "{{ user_input }}"},
+                    ],
+                }
+            ],
+        },
+    )
+    tm = LLMTaskManager(config)
+    call_count = {"n": 0}
+
+    def side_effect_callable():
+        call_count["n"] += 1
+        return "hello"
+
+    tm.register_prompt_context("user_input", side_effect_callable)
+
+    tm.render_task_prompt(task="test_single_var", context={})
+
+    assert call_count["n"] == 1
+
+
 def test_render_empty_list_is_dropped():
     config = _make_vision_config()
     tm = LLMTaskManager(config)

--- a/tests/test_taskmanager_multimodal.py
+++ b/tests/test_taskmanager_multimodal.py
@@ -107,6 +107,28 @@ def test_render_mixed_template_stringifies():
     assert isinstance(user_msg["content"], str)
 
 
+def test_prompt_context_list_overrides_context(fake_base64):
+    """A list registered via ``prompt_context`` for a single-variable template
+    must override a scalar value supplied through ``context`` for the same
+    variable. Covers the ``value = candidate`` branch in
+    ``_resolve_message_content``.
+    """
+    config = _make_vision_config()
+    tm = LLMTaskManager(config)
+    list_value = _make_multimodal_input(fake_base64)
+    tm.register_prompt_context("user_input", list_value)
+
+    prompt = tm.render_task_prompt(
+        task="content_safety_check_input $model=vision_rails",
+        context={"user_input": "ignored scalar fallback", "reasoning_enabled": False},
+    )
+
+    user_msg = prompt[-1]
+    assert user_msg["type"] == "user"
+    assert isinstance(user_msg["content"], list)
+    assert user_msg["content"] == list_value
+
+
 def test_prompt_context_callable_invoked_once():
     config = RailsConfig.from_content(
         config={


### PR DESCRIPTION
## Description

_render_messages() called _render_string() unconditionally, causing Jinja to str() list-valued context variables (e.g. user_input with base64 images) into the rendered prompt and blowing the model's context limit on the vision content-safety path.

Add _resolve_message_content() which detects single-variable templates and returns list values directly, bypassing Jinja. Mixed templates still stringify as before. Also fix aggressive {%- -%} whitespace stripping in content_safety_vision/prompts.yml that collapsed safety categories onto one line.

Completes the vision safety path of #1631 

Closes #1631


## Related Issue(s)

#1631 

### 1. Unit tests

```bash
poetry run pytest tests/test_taskmanager_multimodal.py -v
```

Expected: `5 passed`. Covers:

### 2. End-to-end repro of #1631 (no API key required)

Save this as `/tmp/repro_1631.py`:

```python
from nemoguardrails import RailsConfig
from nemoguardrails.llm.taskmanager import LLMTaskManager

FAKE_BASE64 = "iVBORw0KGgo" * 50_000  # ~550 KB blob, simulating a real image

config = RailsConfig.from_path("./examples/configs/content_safety_vision")
tm = LLMTaskManager(config)

user_input = [
    {"type": "text", "text": "What is this?"},
    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{FAKE_BASE64}"}},
]

prompt = tm.render_task_prompt(
    task="content_safety_check_input $model=vision_rails",
    context={"user_input": user_input, "reasoning_enabled": False},
)

user_content = prompt[-1]["content"]
print(f"user message content type: {type(user_content).__name__}")
if isinstance(user_content, str):
    print(f"user message content length: {len(user_content):,} chars")
    print(f"base64 leaked into prompt text: {'iVBORw0KGgo' in user_content}")
else:
    print(f"user message content list length: {len(user_content)}")
    print("multimodal structure preserved, no stringification")
```

**Reproduce the bug on `develop`:**

```bash
git checkout develop
poetry run python /tmp/repro_1631.py
```

Output (pre-fix, bug present):
```
user message content type: str
user message content length: 550,114 chars
base64 leaked into prompt text: True
```

**Verify the fix on this branch:**

```bash
git checkout fix/taskmanager-multimodal-vision-prompt
poetry run python /tmp/repro_1631.py
```

Output (post-fix):
```
user message content type: list
user message content list length: 2
multimodal structure preserved, no stringification
```

### 3. Optional: full end-to-end with OpenAI (requires `OPENAI_API_KEY`)

Follow the repro steps from #1631 (multimodal vision rails with a base64-encoded image). On `develop` the call fails with:
```
BadRequestError: This model's maximum context length is 128000 tokens.
However, your messages resulted in 150869 tokens.
```
On this branch the call completes and the image is correctly moderated by the vision safety rail.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message template handling for multimodal content, enabling proper preservation of list-based inputs containing text and images.
  * Enhanced template variable resolution to directly return list-based content without unnecessary processing when appropriate.

* **Tests**
  * Added comprehensive test coverage for multimodal prompt rendering scenarios.
  * Tests validate proper handling of large image data and mixed content types in prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->