### PR TITLE
feat(iorails): Telemetry - saturation metrics and end-to-end request metrics

### DIFF
--- a/nemoguardrails/guardrails/async_work_queue.py
+++ b/nemoguardrails/guardrails/async_work_queue.py
@@ -57,6 +57,12 @@ class AsyncWorkQueue(Generic[T]):
         """Returns the number of workers currently executing a task."""
         return self._busy_count
 
+    def num_pending(self) -> int:
+        """Number of items buffered in the queue, waiting for a worker.
+        Pairs with :meth:`num_busy_workers` — together they cover the two states a
+        WorkItem can be in."""
+        return self._queue.qsize()
+
     def is_queue_full(self) -> bool:
         """Returns True if the queue is currently full."""
         return self._queue.full()

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -145,6 +145,17 @@ class IORails:
             except BaseException:
                 log.exception("engine_registry rollback failed during IORails.start()")
             raise
+
+        # Queue is now live; register the state-observing ObservableGauges.
+        # ``lambda: self._running`` is checked at collect time so the gauges
+        # report empty lists once the engine has been stopped.
+        if self._metrics_enabled and not self._gauges_registered:
+            register_nonstream_saturation_gauges(
+                self._generate_async_queue,
+                is_running=lambda: self._running,
+            )
+            self._gauges_registered = True
+
         self._running = True
 
     async def stop(self) -> None:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -49,6 +49,7 @@ from nemoguardrails.guardrails.telemetry import (
     record_span_error,
     record_stream_rejected,
     register_nonstream_saturation_gauges,
+    request_metrics,
     stream_active_metric,
     traced_request,
 )
@@ -188,24 +189,34 @@ class IORails:
         (``NONSTREAM_MAX_CONCURRENCY`` workers draining up to
         ``NONSTREAM_QUEUE_DEPTH`` pending items).  Callers receive
         ``asyncio.QueueFull`` when the admission buffer is full and
-        ``guardrails.nonstream.rejections`` increments if metrics are enabled
+        ``guardrails.nonstream.rejections`` increments if metrics are enabled.
+
+        Request-level metrics (``guardrails.requests``,
+        ``guardrails.request.duration``, ``guardrails.requests.errors``)
+        wrap the queue submission, so duration includes queue-wait time
+        (OTEL HTTP semconv).  A ``QueueFull`` rejection shows up in BOTH
+        ``requests.errors{error.type=QueueFull}`` and
+        ``nonstream.rejections`` — honest dual-signal reporting.
         """
         await self.start()
-        try:
-            return await self._generate_async_queue.submit(self._run_generate, messages, **kwargs)
-        except asyncio.QueueFull:
-            if self._metrics_enabled:
-                record_nonstream_rejected()
-            raise
+        metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
+        with metrics_ctx:
+            try:
+                return await self._generate_async_queue.submit(self._run_generate, messages, **kwargs)
+            except asyncio.QueueFull:
+                if self._metrics_enabled:
+                    record_nonstream_rejected()
+                raise
 
     async def _run_generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Runs inside a queue worker task.  Wraps the pipeline in
-        ``traced_request`` so each request gets its own span / metrics
-        lifecycle, then delegates to ``_do_generate`` for the actual
-        input rails → LLM → output rails flow.
+        ``traced_request`` so each request gets its own span + request ID,
+        then delegates to ``_do_generate`` for the actual input rails →
+        LLM → output rails flow.  Metrics are emitted at the outer
+        lifecycle scope by ``generate_async``, not here.
         """
         tracer = self._tracer if self._tracing_enabled else None
-        with traced_request(tracer, self._metrics_enabled) as (_, req_id):
+        with traced_request(tracer) as (_, req_id):
             t0 = time.monotonic()
             try:
                 result = await self._do_generate(messages, req_id, **kwargs)
@@ -373,65 +384,75 @@ class IORails:
                 log.info("[%s] generation task completed time=%.1fms", req_id, elapsed_ms)
 
         async def _wrapped_iterator():
-            """Wrap the base iterator with semaphore-based concurrency control."""
-            # Ensure engines are running (idempotent if already started).
-            await self.start()
+            """Wrap the base iterator with semaphore-based concurrency control.
 
-            # Non-blocking acquire; raises immediately if all slots are taken.
-            # locked() returns True when the semaphore value is 0.  Because there
-            # is no await between the check and acquire(), no other coroutine can
-            # interleave in asyncio's cooperative model, so this is race-free.
-            if self._stream_semaphore.locked():
-                if self._metrics_enabled:
-                    record_stream_rejected()
-                raise asyncio.QueueFull("Streaming concurrency limit reached")
-            await self._stream_semaphore.acquire()
+            Request-level metrics (``guardrails.requests``,
+            ``guardrails.request.duration``, ``guardrails.requests.errors``)
+            wrap the entire stream lifecycle, so a ``QueueFull`` on the
+            semaphore check bumps BOTH ``stream.rejections`` and
+            ``requests.errors{error.type=QueueFull}`` — dual-signal
+            semantics matching the non-streaming path.
+            """
+            metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
+            with metrics_ctx:
+                # Ensure engines are running (idempotent if already started).
+                await self.start()
 
-            tracer = self._tracer if self._tracing_enabled else None
-            # Track this stream as active while it holds the semaphore
-            # permit; the CM decrements in its finally, just before the
-            # outer ``semaphore.release()`` below.
-            stream_active_ctx = stream_active_metric() if self._metrics_enabled else nullcontext()
-            try:
-                with stream_active_ctx:
-                    # traced_request is entered inside the async generator so the
-                    # request span is the current OTEL context when create_task()
-                    # below snapshots contextvars — that's what makes rail / LLM
-                    # spans raised inside _generation_task attach as children.
-                    with traced_request(tracer, self._metrics_enabled) as (request_span, req_id):
-                        t0 = time.monotonic()
-                        try:
-                            log.info("[%s] stream_async called", req_id)
-                            log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
+                # Non-blocking acquire; raises immediately if all slots are taken.
+                # locked() returns True when the semaphore value is 0.  Because there
+                # is no await between the check and acquire(), no other coroutine can
+                # interleave in asyncio's cooperative model, so this is race-free.
+                if self._stream_semaphore.locked():
+                    if self._metrics_enabled:
+                        record_stream_rejected()
+                    raise asyncio.QueueFull("Streaming concurrency limit reached")
+                await self._stream_semaphore.acquire()
 
-                            task = asyncio.create_task(_generation_task(request_span))
+                tracer = self._tracer if self._tracing_enabled else None
+                # Track this stream as active while it holds the semaphore
+                # permit; the CM decrements in its finally, just before the
+                # outer ``semaphore.release()`` below.
+                stream_active_ctx = stream_active_metric() if self._metrics_enabled else nullcontext()
+                try:
+                    with stream_active_ctx:
+                        # traced_request is entered inside the async generator so the
+                        # request span is the current OTEL context when create_task()
+                        # below snapshots contextvars — that's what makes rail / LLM
+                        # spans raised inside _generation_task attach as children.
+                        with traced_request(tracer) as (request_span, req_id):
+                            t0 = time.monotonic()
                             try:
-                                # Determine base iterator: with or without output rails
-                                if self._has_streaming_output_rails:
-                                    base_iterator = self._run_output_rails_in_streaming(
-                                        streaming_handler=streaming_handler,
-                                        messages=messages,
-                                    )
-                                else:
-                                    base_iterator = streaming_handler
+                                log.info("[%s] stream_async called", req_id)
+                                log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
 
-                                async for chunk in base_iterator:
-                                    if chunk is not None:
-                                        yield chunk
+                                task = asyncio.create_task(_generation_task(request_span))
+                                try:
+                                    # Determine base iterator: with or without output rails
+                                    if self._has_streaming_output_rails:
+                                        base_iterator = self._run_output_rails_in_streaming(
+                                            streaming_handler=streaming_handler,
+                                            messages=messages,
+                                        )
+                                    else:
+                                        base_iterator = streaming_handler
+
+                                    async for chunk in base_iterator:
+                                        if chunk is not None:
+                                            yield chunk
+                                finally:
+                                    if not task.done():
+                                        task.cancel()
+                                    with suppress(asyncio.CancelledError):
+                                        await task
+                            except Exception:
+                                elapsed_ms = (time.monotonic() - t0) * 1000
+                                log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+                                raise
                             finally:
-                                if not task.done():
-                                    task.cancel()
-                                with suppress(asyncio.CancelledError):
-                                    await task
-                        except Exception:
-                            elapsed_ms = (time.monotonic() - t0) * 1000
-                            log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
-                            raise
-                        finally:
-                            elapsed_ms = (time.monotonic() - t0) * 1000
-                            log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
-            finally:
-                self._stream_semaphore.release()
+                                elapsed_ms = (time.monotonic() - t0) * 1000
+                                log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
+                finally:
+                    self._stream_semaphore.release()
 
         return _wrapped_iterator()
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -48,6 +48,7 @@ from nemoguardrails.guardrails.telemetry import (
     record_request_error,
     record_span_error,
     record_stream_rejected,
+    register_nonstream_saturation_gauges,
     stream_active_metric,
     traced_request,
 )
@@ -114,6 +115,10 @@ class IORails:
 
         # Semaphore for streaming concurrency control / load shedding
         self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
+
+        # ObservableGauges are created lazily on first ``start()`` because
+        # they need a reference to an AsyncWorkQueue which has been started.
+        self._gauges_registered = False
 
     @property
     def _has_streaming_output_rails(self) -> bool:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -173,11 +173,24 @@ class IORails:
         await self.stop()
 
     def generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
-        """Synchronous version of generate_async."""
+        """Synchronous version of generate_async.
+
+        Telemetry is disabled for the ephemeral IORails object used for
+        the ``generate()`` call. For production use, use the asynchronous
+        `generate_async()` and `stream_async()` methods for non-streaming
+        and streaming requests respectively.
+        """
+
+        # Disable tracing and metrics for synchronous generation calls
+        sync_config = self.config.model_copy(deep=True)
+        if sync_config.tracing is not None:
+            sync_config.tracing.enabled = False
+        if sync_config.metrics is not None:
+            sync_config.metrics.enabled = False
 
         async def _run_sync_iorails():
             """Spin up a short-lived IORails engine for one synchronous generate call."""
-            async with IORails(self.config) as iorails_engine:
+            async with IORails(sync_config) as iorails_engine:
                 return await iorails_engine.generate_async(messages, **kwargs)
 
         return asyncio.run(_run_sync_iorails())

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -393,11 +393,13 @@ class IORails:
             ``requests.errors{error.type=QueueFull}`` — dual-signal
             semantics matching the non-streaming path.
             """
+            # Ensure engines are running (idempotent if already started).
+            # Kept outside ``request_metrics`` so duration matches the
+            # non-streaming path (excludes one-time engine startup cost).
+            await self.start()
+
             metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
             with metrics_ctx:
-                # Ensure engines are running (idempotent if already started).
-                await self.start()
-
                 # Non-blocking acquire; raises immediately if all slots are taken.
                 # locked() returns True when the semaphore value is 0.  Because there
                 # is no await between the check and acquire(), no other coroutine can

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -25,7 +25,7 @@ import json
 import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from typing import Optional, Union
 
 from nemoguardrails.exceptions import StreamingNotSupportedError
@@ -46,6 +46,8 @@ from nemoguardrails.guardrails.telemetry import (
     record_request_blocked,
     record_request_error,
     record_span_error,
+    record_stream_rejected,
+    stream_active_metric,
     traced_request,
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -368,47 +370,54 @@ class IORails:
             # is no await between the check and acquire(), no other coroutine can
             # interleave in asyncio's cooperative model, so this is race-free.
             if self._stream_semaphore.locked():
+                if self._metrics_enabled:
+                    record_stream_rejected()
                 raise asyncio.QueueFull("Streaming concurrency limit reached")
             await self._stream_semaphore.acquire()
 
             tracer = self._tracer if self._tracing_enabled else None
+            # Track this stream as active while it holds the semaphore
+            # permit; the CM decrements in its finally, just before the
+            # outer ``semaphore.release()`` below.
+            stream_active_ctx = stream_active_metric() if self._metrics_enabled else nullcontext()
             try:
-                # traced_request is entered inside the async generator so the
-                # request span is the current OTEL context when create_task()
-                # below snapshots contextvars — that's what makes rail / LLM
-                # spans raised inside _generation_task attach as children.
-                with traced_request(tracer, self._metrics_enabled) as (request_span, req_id):
-                    t0 = time.monotonic()
-                    try:
-                        log.info("[%s] stream_async called", req_id)
-                        log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
-
-                        task = asyncio.create_task(_generation_task(request_span))
+                with stream_active_ctx:
+                    # traced_request is entered inside the async generator so the
+                    # request span is the current OTEL context when create_task()
+                    # below snapshots contextvars — that's what makes rail / LLM
+                    # spans raised inside _generation_task attach as children.
+                    with traced_request(tracer, self._metrics_enabled) as (request_span, req_id):
+                        t0 = time.monotonic()
                         try:
-                            # Determine base iterator: with or without output rails
-                            if self._has_streaming_output_rails:
-                                base_iterator = self._run_output_rails_in_streaming(
-                                    streaming_handler=streaming_handler,
-                                    messages=messages,
-                                )
-                            else:
-                                base_iterator = streaming_handler
+                            log.info("[%s] stream_async called", req_id)
+                            log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
 
-                            async for chunk in base_iterator:
-                                if chunk is not None:
-                                    yield chunk
+                            task = asyncio.create_task(_generation_task(request_span))
+                            try:
+                                # Determine base iterator: with or without output rails
+                                if self._has_streaming_output_rails:
+                                    base_iterator = self._run_output_rails_in_streaming(
+                                        streaming_handler=streaming_handler,
+                                        messages=messages,
+                                    )
+                                else:
+                                    base_iterator = streaming_handler
+
+                                async for chunk in base_iterator:
+                                    if chunk is not None:
+                                        yield chunk
+                            finally:
+                                if not task.done():
+                                    task.cancel()
+                                with suppress(asyncio.CancelledError):
+                                    await task
+                        except Exception:
+                            elapsed_ms = (time.monotonic() - t0) * 1000
+                            log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+                            raise
                         finally:
-                            if not task.done():
-                                task.cancel()
-                            with suppress(asyncio.CancelledError):
-                                await task
-                    except Exception:
-                        elapsed_ms = (time.monotonic() - t0) * 1000
-                        log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
-                        raise
-                    finally:
-                        elapsed_ms = (time.monotonic() - t0) * 1000
-                        log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
+                            elapsed_ms = (time.monotonic() - t0) * 1000
+                            log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
             finally:
                 self._stream_semaphore.release()
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -43,6 +43,7 @@ from nemoguardrails.guardrails.telemetry import (
     are_metrics_enabled,
     get_tracer,
     is_tracing_enabled,
+    record_nonstream_rejected,
     record_request_blocked,
     record_request_error,
     record_span_error,
@@ -181,10 +182,16 @@ class IORails:
         The queue enforces non-streaming concurrency limits
         (``NONSTREAM_MAX_CONCURRENCY`` workers draining up to
         ``NONSTREAM_QUEUE_DEPTH`` pending items).  Callers receive
-        ``asyncio.QueueFull`` when the admission buffer is full.
+        ``asyncio.QueueFull`` when the admission buffer is full and
+        ``guardrails.nonstream.rejections`` increments if metrics are enabled
         """
         await self.start()
-        return await self._generate_async_queue.submit(self._run_generate, messages, **kwargs)
+        try:
+            return await self._generate_async_queue.submit(self._run_generate, messages, **kwargs)
+        except asyncio.QueueFull:
+            if self._metrics_enabled:
+                record_nonstream_rejected()
+            raise
 
     async def _run_generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Runs inside a queue worker task.  Wraps the pipeline in

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -57,7 +57,7 @@ _OTEL_AVAILABLE: bool
 if TYPE_CHECKING:
     from opentelemetry import metrics as otel_metrics
     from opentelemetry import trace
-    from opentelemetry.metrics import Counter, Histogram, Meter
+    from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
     from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer, format_trace_id
 
     from nemoguardrails.rails.llm.config import MetricsConfig, TracingConfig
@@ -122,16 +122,26 @@ class RequestInstruments:
     """Request-level OTEL instruments for the IORails engine.
 
     Field names mirror the emitted metric names (minus the ``guardrails.``
-    prefix): ``requests`` → ``guardrails.requests``, ``errors`` →
-    ``guardrails.requests.errors``, ``blocked`` →
-    ``guardrails.requests.blocked``, ``duration`` →
-    ``guardrails.request.duration``.
+    prefix).  The saturation-metric group covers the full request lifecycle:
+
+    * Aggregate: ``requests_active`` (``guardrails.requests.active``)
+    * Non-streaming path: ``nonstream_rejections``
+      (``guardrails.nonstream.rejections``); the two gauges
+      ``nonstream.queued`` and ``nonstream.active`` are registered
+      separately via ``register_nonstream_saturation_gauges`` because
+      ObservableGauges need a live queue reference.
+    * Streaming path: ``stream_active`` (``guardrails.stream.active``)
+      and ``stream_rejections`` (``guardrails.stream.rejections``).
     """
 
     requests: "Counter"
     errors: "Counter"
     blocked: "Counter"
     duration: "Histogram"
+    requests_active: "UpDownCounter"
+    nonstream_rejections: "Counter"
+    stream_active: "UpDownCounter"
+    stream_rejections: "Counter"
 
 
 def get_meter() -> Optional["Meter"]:
@@ -208,6 +218,28 @@ def _ensure_request_instruments() -> Optional[RequestInstruments]:
                     7.5,
                     10.0,
                 ],
+            ),
+            requests_active=meter.create_up_down_counter(
+                MetricNames.REQUESTS_ACTIVE,
+                description=(
+                    "Guardrails requests currently in flight (aggregate across admission queue, workers, and streams)"
+                ),
+                unit="1",
+            ),
+            nonstream_rejections=meter.create_counter(
+                MetricNames.NONSTREAM_REJECTIONS,
+                description="Non-streaming requests rejected because the admission queue was full",
+                unit="1",
+            ),
+            stream_active=meter.create_up_down_counter(
+                MetricNames.STREAM_ACTIVE,
+                description="Streaming requests currently holding a concurrency permit",
+                unit="1",
+            ),
+            stream_rejections=meter.create_counter(
+                MetricNames.STREAM_REJECTIONS,
+                description="Streaming requests rejected because the concurrency limit was reached",
+                unit="1",
             ),
         )
     return _request_instruments

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -556,6 +556,19 @@ def record_stream_rejected() -> None:
     instruments.stream_rejections.add(1)
 
 
+def record_nonstream_rejected() -> None:
+    """Increment ``guardrails.nonstream.rejections`` by 1.
+
+    Called from the non-streaming path when the admission queue rejects a
+    submission with ``asyncio.QueueFull`` (the queue's ``reject_on_full``
+    behaviour, triggered when ``NONSTREAM_QUEUE_DEPTH`` is exceeded).
+    """
+    instruments = _ensure_request_instruments()
+    if instruments is None:
+        return
+    instruments.nonstream_rejections.add(1)
+
+
 @contextmanager
 def stream_active_metric() -> Generator[None, None, None]:
     """Context manager that tracks a stream as active for its full lifetime.

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -652,11 +652,20 @@ def stream_active_metric() -> Generator[None, None, None]:
 def request_metrics() -> Generator[None, None, None]:
     """Emit request-level OTEL metrics around the wrapped block.
 
-    Increments ``guardrails.requests`` on entry, records
-    ``guardrails.request.duration`` in seconds on exit, and increments
-    ``guardrails.requests.errors`` with an ``error.type`` attribute when
-    the block raises.  Instruments are created lazily on first use.  No-op
-    when the OTEL API is not installed or instruments cannot be created.
+    Increments ``guardrails.requests`` on entry, bumps
+    ``guardrails.requests.active`` (UpDownCounter) for the duration of
+    the block, records ``guardrails.request.duration`` in seconds on
+    exit, and increments ``guardrails.requests.errors`` with an
+    ``error.type`` attribute when the block raises.
+
+    ``requests.active`` covers both non-streaming (queue-wait + execution)
+     and streaming (semaphore hold) requests.
+     Summing the per-path saturation metrics
+    (``nonstream.queued``, ``nonstream.active``, ``stream.active``)
+    should approximate this value at any collection instant.
+
+    Instruments are created lazily on first use.  No-op when the OTEL
+    API is not installed or instruments cannot be created.
     """
     instruments = _ensure_request_instruments()
     if instruments is None:
@@ -664,12 +673,14 @@ def request_metrics() -> Generator[None, None, None]:
         return
     t0 = time.monotonic()
     instruments.requests.add(1)
+    instruments.requests_active.add(1)
     try:
         yield
     except Exception as exc:
         record_request_error(exc)
         raise
     finally:
+        instruments.requests_active.add(-1)
         duration_s = time.monotonic() - t0
         instruments.duration.record(duration_s)
 

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -29,7 +29,7 @@ import logging
 import secrets
 import time
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Generator, Iterable, NamedTuple, Optional, Tuple
 
@@ -675,19 +675,17 @@ def request_metrics() -> Generator[None, None, None]:
 
 
 @contextmanager
-def traced_request(tracer: Optional["Tracer"], metrics_enabled: bool = False) -> Generator[TracedRequest, None, None]:
-    """Unified request context: sets request ID, optionally creates a span
-    and/or emits request-level metrics.
-
-    The two signals are gated **independently**:
+def traced_request(tracer: Optional["Tracer"]) -> Generator[TracedRequest, None, None]:
+    """Unified request context: sets the request ID and optionally creates
+    a ``guardrails.request`` SERVER span.
 
     * ``tracer is not None`` → a live ``guardrails.request`` SERVER span
       is created and the request ID is derived from its trace ID.
-    * ``metrics_enabled=True`` → emit request-level OTEL metrics
+    * ``tracer is None`` → a fresh request ID is generated locally.
 
-    All four combinations are valid.  Metrics-only (``tracer=None,
-    metrics_enabled=True``) is a supported setup for customers running
-    cheap SLO dashboards without full trace export.
+    Metrics are emitted separately via :func:`request_metrics` at the
+    full-lifecycle scope (around queue submission / stream semaphore
+    acquisition).
 
     Yields a :class:`TracedRequest` (``span``, ``request_id``).  Callers
     that want to mark the request span ERROR from a deeply-nested scope
@@ -700,18 +698,16 @@ def traced_request(tracer: Optional["Tracer"], metrics_enabled: bool = False) ->
     :func:`_cleanup_request_id`, which tolerates the expected
     cross-context ``ValueError`` that async-generator cleanup can raise.
     """
-    metrics_ctx = request_metrics() if metrics_enabled else nullcontext()
     if tracer is not None:
-        with metrics_ctx, request_span(tracer) as (span, req_id):
+        with request_span(tracer) as (span, req_id):
             token = _set_request_id(req_id)
             try:
                 yield TracedRequest(span, req_id)
             finally:
                 _cleanup_request_id(token)
     else:
-        with metrics_ctx:
-            token = set_new_request_id()
-            try:
-                yield TracedRequest(None, get_request_id())
-            finally:
-                _cleanup_request_id(token)
+        token = set_new_request_id()
+        try:
+            yield TracedRequest(None, get_request_id())
+        finally:
+            _cleanup_request_id(token)

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -31,7 +31,7 @@ import time
 import warnings
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generator, NamedTuple, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Generator, Iterable, NamedTuple, Optional, Tuple
 
 from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
@@ -57,9 +57,10 @@ _OTEL_AVAILABLE: bool
 if TYPE_CHECKING:
     from opentelemetry import metrics as otel_metrics
     from opentelemetry import trace
-    from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
+    from opentelemetry.metrics import CallbackOptions, Counter, Histogram, Meter, Observation, UpDownCounter
     from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer, format_trace_id
 
+    from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
     from nemoguardrails.rails.llm.config import MetricsConfig, TracingConfig
 
     _OTEL_AVAILABLE = True
@@ -67,6 +68,7 @@ else:
     try:
         from opentelemetry import metrics as otel_metrics
         from opentelemetry import trace
+        from opentelemetry.metrics import CallbackOptions, Observation
         from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
         _OTEL_AVAILABLE = True
@@ -243,6 +245,64 @@ def _ensure_request_instruments() -> Optional[RequestInstruments]:
             ),
         )
     return _request_instruments
+
+
+def register_nonstream_saturation_gauges(
+    queue: "AsyncWorkQueue",
+    is_running: Callable[[], bool],
+) -> None:
+    """Register ``guardrails.nonstream.queued`` + ``guardrails.nonstream.active``
+    ObservableGauges on the module-level Meter.
+
+    ObservableGauges read live state at collection time, so both metrics
+    reflect the *current* non-streaming queue + worker occupancy with no
+    drift risk vs. an UpDownCounter lineage.
+
+    ``is_running`` is a zero-arg callable returning ``bool``, deferred
+    so each collection re-reads the current state (passing the bool
+    directly would bake its start-time value into the closure).  The
+    callbacks return an empty observation list when it returns ``False``
+    — the state the flag holds after ``IORails.stop()`` flips
+    ``self._running`` back to False.  OTEL Python has no public
+    unregister API for observable instruments, so this "no data points"
+    fallback is the only way to stop a dead IORails instance from
+    polluting collection.
+
+    No-op when the OTEL API is unavailable or no MeterProvider is
+    configured.
+    """
+    meter = get_meter()
+    if meter is None:
+        return
+
+    def _queued_callback(options: "CallbackOptions") -> Iterable["Observation"]:
+        """Observe current backlog: items in the admission queue not yet
+        picked up by a worker.  Returns ``[]`` after ``IORails.stop()``
+        so a dead instance emits no data points."""
+        if not is_running():
+            return []
+        return [Observation(queue.num_pending())]
+
+    def _active_callback(options: "CallbackOptions") -> Iterable["Observation"]:
+        """Observe current occupancy: workers currently executing a
+        WorkItem.  Returns ``[]`` after ``IORails.stop()``, same
+        rationale as :func:`_queued_callback`."""
+        if not is_running():
+            return []
+        return [Observation(queue.num_busy_workers())]
+
+    meter.create_observable_gauge(
+        MetricNames.NONSTREAM_QUEUED,
+        callbacks=[_queued_callback],
+        description="Non-streaming requests buffered, not actively executing on a workernot yet picked up by a worker",
+        unit="1",
+    )
+    meter.create_observable_gauge(
+        MetricNames.NONSTREAM_ACTIVE,
+        callbacks=[_active_callback],
+        description="Non-streaming requests currently executing on a worker",
+        unit="1",
+    )
 
 
 _INVALID_TRACE_ID = 0

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -228,17 +228,17 @@ def _ensure_request_instruments() -> Optional[RequestInstruments]:
             ),
             nonstream_rejections=meter.create_counter(
                 MetricNames.NONSTREAM_REJECTIONS,
-                description="Count of rejected non-streaming requests (because the queue was full)",
+                description="Rejected non-streaming requests",
                 unit="1",
             ),
             stream_active=meter.create_up_down_counter(
                 MetricNames.STREAM_ACTIVE,
-                description="Count of streaming requests currently in-progress",
+                description="In-progress streaming requests",
                 unit="1",
             ),
             stream_rejections=meter.create_counter(
                 MetricNames.STREAM_REJECTIONS,
-                description="Count of streaming requests rejected due to concurrency limit",
+                description="Rejected streaming requests",
                 unit="1",
             ),
         )
@@ -292,13 +292,13 @@ def register_nonstream_saturation_gauges(
     meter.create_observable_gauge(
         MetricNames.NONSTREAM_QUEUED,
         callbacks=[_queued_callback],
-        description="Count of non-streaming requests pending in the queue",
+        description="Non-streaming requests buffered in the admission queue",
         unit="1",
     )
     meter.create_observable_gauge(
         MetricNames.NONSTREAM_ACTIVE,
         callbacks=[_active_callback],
-        description="Count of non-streaming requests actively running",
+        description="Non-streaming requests currently executing on a worker",
         unit="1",
     )
 

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -192,7 +192,7 @@ def _ensure_request_instruments() -> Optional[RequestInstruments]:
             ),
             errors=meter.create_counter(
                 MetricNames.REQUESTS_ERRORS,
-                description="Guardrails requests that ended in an unhandled error",
+                description="Guardrails requests ending in an unhandled error",
                 unit="1",
             ),
             blocked=meter.create_counter(
@@ -223,24 +223,22 @@ def _ensure_request_instruments() -> Optional[RequestInstruments]:
             ),
             requests_active=meter.create_up_down_counter(
                 MetricNames.REQUESTS_ACTIVE,
-                description=(
-                    "Guardrails requests currently in flight (aggregate across admission queue, workers, and streams)"
-                ),
+                description=("Guardrails requests currently in flight"),
                 unit="1",
             ),
             nonstream_rejections=meter.create_counter(
                 MetricNames.NONSTREAM_REJECTIONS,
-                description="Non-streaming requests rejected because the admission queue was full",
+                description="Count of rejected non-streaming requests (because the queue was full)",
                 unit="1",
             ),
             stream_active=meter.create_up_down_counter(
                 MetricNames.STREAM_ACTIVE,
-                description="Streaming requests currently holding a concurrency permit",
+                description="Count of streaming requests currently in-progress",
                 unit="1",
             ),
             stream_rejections=meter.create_counter(
                 MetricNames.STREAM_REJECTIONS,
-                description="Streaming requests rejected because the concurrency limit was reached",
+                description="Count of streaming requests rejected due to concurrency limit",
                 unit="1",
             ),
         )
@@ -294,13 +292,13 @@ def register_nonstream_saturation_gauges(
     meter.create_observable_gauge(
         MetricNames.NONSTREAM_QUEUED,
         callbacks=[_queued_callback],
-        description="Non-streaming requests buffered, not actively executing on a workernot yet picked up by a worker",
+        description="Count of non-streaming requests pending in the queue",
         unit="1",
     )
     meter.create_observable_gauge(
         MetricNames.NONSTREAM_ACTIVE,
         callbacks=[_active_callback],
-        description="Non-streaming requests currently executing on a worker",
+        description="Count of non-streaming requests actively running",
         unit="1",
     )
 

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -544,6 +544,37 @@ def record_request_error(exc: BaseException) -> None:
     instruments.errors.add(1, attributes={"error.type": type(exc).__name__})
 
 
+def record_stream_rejected() -> None:
+    """Increment ``guardrails.stream.rejections`` by 1.
+
+    Called from the streaming path when a request arrives while the stream
+    concurrency semaphore is fully occupied (``_stream_semaphore.locked()``).
+    """
+    instruments = _ensure_request_instruments()
+    if instruments is None:
+        return
+    instruments.stream_rejections.add(1)
+
+
+@contextmanager
+def stream_active_metric() -> Generator[None, None, None]:
+    """Context manager that tracks a stream as active for its full lifetime.
+
+    ``+1`` on enter / ``-1`` on exit (``finally``) on
+    ``guardrails.stream.active`` (UpDownCounter).  No-op when metrics are
+    unavailable.  Wrap the block where the stream holds a semaphore permit.
+    """
+    instruments = _ensure_request_instruments()
+    if instruments is None:
+        yield
+        return
+    instruments.stream_active.add(1)
+    try:
+        yield
+    finally:
+        instruments.stream_active.add(-1)
+
+
 @contextmanager
 def request_metrics() -> Generator[None, None, None]:
     """Emit request-level OTEL metrics around the wrapped block.

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -167,7 +167,17 @@ class MetricNames:
     REQUESTS = "guardrails.requests"
     REQUESTS_ERRORS = "guardrails.requests.errors"
     REQUESTS_BLOCKED = "guardrails.requests.blocked"
+    REQUESTS_ACTIVE = "guardrails.requests.active"
     REQUEST_DURATION = "guardrails.request.duration"
+
+    # Non-streaming (AsyncWorkQueue) saturation signals
+    NONSTREAM_QUEUED = "guardrails.nonstream.queued"
+    NONSTREAM_ACTIVE = "guardrails.nonstream.active"
+    NONSTREAM_REJECTIONS = "guardrails.nonstream.rejections"
+
+    # Streaming (semaphore) saturation signals
+    STREAM_ACTIVE = "guardrails.stream.active"
+    STREAM_REJECTIONS = "guardrails.stream.rejections"
 
 
 class OperationNames:

--- a/tests/guardrails/async_helpers.py
+++ b/tests/guardrails/async_helpers.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared async test helpers.
+
+Primitives for tests that coordinate with asyncio-backed components.
+Centralised here so the polling / timeout patterns are consistent across
+``test_async_work_queue.py``, ``test_iorails_telemetry.py``, and other
+tests that need to observe state transitions mid-flight.
+"""
+
+import asyncio
+
+from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
+
+
+async def wait_for_queue_state(
+    queue: AsyncWorkQueue,
+    busy: int,
+    pending: int,
+    timeout: float = 1.0,
+) -> None:
+    """Poll ``queue`` until it reaches ``(busy, pending)`` or time out.
+
+    Replaces fixed ``asyncio.sleep(<magic>)`` spins in tests that need the
+    worker pool to reach a known state before asserting on it.  Yielding
+    via ``sleep(0)`` re-runs the scheduler each iteration, so the helper
+    returns the moment the state is correct rather than after a full
+    fixed delay.
+
+    Raises ``AssertionError`` on timeout, carrying the last observed
+    state in the message for faster debugging of flaky setups.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while (queue.num_busy_workers(), queue.num_pending()) != (busy, pending):
+        if loop.time() > deadline:
+            raise AssertionError(
+                f"timed out waiting for queue state busy={busy} pending={pending}; "
+                f"last seen busy={queue.num_busy_workers()} pending={queue.num_pending()}"
+            )
+        await asyncio.sleep(0)

--- a/tests/guardrails/async_helpers.py
+++ b/tests/guardrails/async_helpers.py
@@ -24,6 +24,7 @@ tests that need to observe state transitions mid-flight.
 import asyncio
 
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
+from nemoguardrails.guardrails.iorails import IORails
 
 
 async def wait_for_queue_state(
@@ -52,3 +53,16 @@ async def wait_for_queue_state(
                 f"last seen busy={queue.num_busy_workers()} pending={queue.num_pending()}"
             )
         await asyncio.sleep(0)
+
+
+def saturate_stream_semaphore(iorails: IORails) -> None:
+    """Force ``iorails._stream_semaphore`` into a fully-occupied state by
+    swapping in a zero-permit semaphore.  Any subsequent
+    ``stream_async()`` call trips ``Semaphore.locked() == True`` and is
+    rejected with ``asyncio.QueueFull``.
+
+    Cheaper and more future-proof than draining all
+    ``STREAM_MAX_CONCURRENCY`` permits one-by-one — the test no longer
+    breaks silently if that constant grows.
+    """
+    iorails._stream_semaphore = asyncio.Semaphore(0)

--- a/tests/guardrails/metric_helpers.py
+++ b/tests/guardrails/metric_helpers.py
@@ -51,6 +51,29 @@ def _point_value(data_point) -> float:
     return getattr(data_point, "count", 0)
 
 
+def collect_histogram_sum(reader: InMemoryMetricReader, metric_name: str) -> float:
+    """Return the aggregated ``sum`` across all data points of a histogram.
+
+    ``collect_metric_points`` flattens histograms to their *count* (number
+    of recordings) — fine for "did it fire?" tests.  When a test also
+    cares about the magnitude (e.g. asserting duration includes queue-
+    wait), it needs ``sum``.  Returns ``0.0`` if the metric hasn't been
+    recorded yet.
+    """
+    data = reader.get_metrics_data()
+    if data is None:
+        return 0.0
+    total = 0.0
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                if metric.name != metric_name:
+                    continue
+                for data_point in metric.data.data_points:
+                    total += getattr(data_point, "sum", 0.0) or 0.0
+    return total
+
+
 def collect_metric_points(reader: InMemoryMetricReader) -> Dict[str, List[MetricPoint]]:
     """Flatten SDK-collected metric data into ``{metric_name: [MetricPoint, ...]}``.
 

--- a/tests/guardrails/test_async_work_queue.py
+++ b/tests/guardrails/test_async_work_queue.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
+from tests.guardrails.async_helpers import wait_for_queue_state
 
 
 class TestBasicFunctionality:
@@ -612,7 +613,7 @@ class TestQueueStatusMethods:
 
             # Wait for task to start executing
             await started.wait()
-            await asyncio.sleep(0.01)  # Give time for busy_count to update
+            await wait_for_queue_state(queue, busy=1, pending=0)
 
             # Should have 1 busy worker
             assert queue.num_busy_workers() == 1
@@ -623,7 +624,7 @@ class TestQueueStatusMethods:
             assert result == 1
 
             # Worker should be idle again
-            await asyncio.sleep(0.01)
+            await wait_for_queue_state(queue, busy=0, pending=0)
             assert queue.num_busy_workers() == 0
 
     @pytest.mark.asyncio
@@ -642,7 +643,7 @@ class TestQueueStatusMethods:
             tasks = [asyncio.create_task(queue.submit(concurrent_task, i)) for i in range(3)]
 
             # Wait for all tasks to start
-            await asyncio.sleep(0.1)
+            await wait_for_queue_state(queue, busy=3, pending=0)
 
             # Should have 3 busy workers (up to max_concurrency)
             assert queue.num_busy_workers() == 3
@@ -653,7 +654,7 @@ class TestQueueStatusMethods:
             assert results == [0, 1, 2]
 
             # All workers should be idle
-            await asyncio.sleep(0.01)
+            await wait_for_queue_state(queue, busy=0, pending=0)
             assert queue.num_busy_workers() == 0
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -34,6 +34,7 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, Rai
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import SystemConstants
+from tests.guardrails.async_helpers import wait_for_queue_state
 from tests.guardrails.metric_helpers import collect_metric_points
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 from tests.guardrails.test_telemetry import _is_valid_hex_string
@@ -1410,3 +1411,159 @@ class TestIndependentTracingAndMetrics:
         assert any(s.name == "guardrails.request" for s in spans)
         points = collect_metric_points(metric_reader)
         assert points == {}
+
+
+class TestNonstreamStateGauges:
+    """IORails-level integration tests for the ``nonstream.queued`` +
+    ``nonstream.active`` ObservableGauges.
+
+    Each test constructs IORails *after* ``metric_reader`` has installed its
+    test-local Meter — the gauges are registered in ``IORails.start()``,
+    so the Meter in effect at startup time is what the reader sees.  The
+    ``iorails_tracing`` / ``iorails_no_tracing`` fixtures set up the Meter
+    too late for gauges, which is why these tests build IORails inline.
+    """
+
+    @pytest.mark.asyncio
+    async def test_gauges_registered_and_read_zero_at_rest(self, metric_reader):
+        """A freshly-started IORails with no pending work → both gauges read 0."""
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+        async with iorails:
+            points = collect_metric_points(metric_reader)
+            assert points["guardrails.nonstream.queued"][0].value == 0
+            assert points["guardrails.nonstream.active"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_nonstream_active_reads_one_while_worker_is_busy(self, metric_reader):
+        """A pipeline blocked on an Event → ``nonstream.active == 1`` during
+        the block, 0 after the Event is set and the worker finishes.
+        """
+        gate = asyncio.Event()
+
+        async def blocking_generate(messages, req_id, **kwargs):
+            await gate.wait()
+            return {"role": "assistant", "content": "done"}
+
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+        async with iorails:
+            iorails._do_generate = blocking_generate
+
+            task = asyncio.create_task(iorails.generate_async([{"role": "user", "content": "hi"}]))
+            # Wait for the worker to pick up the item and enter
+            # ``blocking_generate`` (busy_count=1, pending=0).
+            await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=0)
+
+            mid = collect_metric_points(metric_reader)
+            assert mid["guardrails.nonstream.active"][0].value == 1
+            assert mid["guardrails.nonstream.queued"][0].value == 0
+
+            gate.set()
+            await task
+
+            final = collect_metric_points(metric_reader)
+            assert final["guardrails.nonstream.active"][0].value == 0
+            assert final["guardrails.nonstream.queued"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_nonstream_queued_reflects_backlog_past_worker_capacity(self, metric_reader):
+        """With a single worker occupied and extras pending, ``nonstream.queued``
+        reports the backlog size while ``nonstream.active == 1``.
+        """
+        gate = asyncio.Event()
+
+        async def blocking_generate(messages, req_id, **kwargs):
+            await gate.wait()
+            return {"role": "assistant", "content": "done"}
+
+        # Patch module-level budgets so the backlog test doesn't need to
+        # spin up 256 workers.
+        with (
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_MAX_CONCURRENCY", 1),
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_QUEUE_DEPTH", 8),
+        ):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+            async with iorails:
+                iorails._do_generate = blocking_generate
+
+                tasks = [
+                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    for i in range(3)
+                ]
+                # Wait for one worker to pick up an item and the other two
+                # to sit in the queue (busy=1, pending=2).
+                await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=2)
+
+                mid = collect_metric_points(metric_reader)
+                assert mid["guardrails.nonstream.active"][0].value == 1
+                assert mid["guardrails.nonstream.queued"][0].value == 2
+
+                gate.set()
+                await asyncio.gather(*tasks)
+
+                final = collect_metric_points(metric_reader)
+                assert final["guardrails.nonstream.active"][0].value == 0
+                assert final["guardrails.nonstream.queued"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_gauges_not_registered_when_metrics_disabled(self, metric_reader):
+        """Metrics disabled in config → ``start()`` does not register gauges
+        and they never appear in collection output.
+        """
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            iorails = IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        async with iorails:
+            points = collect_metric_points(metric_reader)
+            assert "guardrails.nonstream.queued" not in points
+            assert "guardrails.nonstream.active" not in points
+
+    @pytest.mark.asyncio
+    async def test_gauges_soft_disabled_after_stop(self, metric_reader):
+        """``stop()`` flips ``self._running`` to False; the gauge callbacks
+        return ``[]`` on subsequent collection (soft-disable).  Needed
+        because OTEL Python has no public unregister API — an always-alive
+        callback would leak dead-IORails state across tests and long-running
+        processes.
+        """
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+        await iorails.start()
+        try:
+            alive = collect_metric_points(metric_reader)
+            assert alive["guardrails.nonstream.queued"][0].value == 0
+            assert alive["guardrails.nonstream.active"][0].value == 0
+        finally:
+            await iorails.stop()
+
+        stopped = collect_metric_points(metric_reader)
+        # Either the metric is absent (SDK-dependent when callbacks return [])
+        # or present with no data points — both mean "no observation".
+        assert stopped.get("guardrails.nonstream.queued", []) == []
+        assert stopped.get("guardrails.nonstream.active", []) == []
+
+    @pytest.mark.asyncio
+    async def test_stop_then_start_resumes_gauge_observations(self, metric_reader):
+        """``stop()`` → ``start()`` cycle must re-enable observations without
+        re-registering (the ``_gauges_registered`` flag remains True across
+        the cycle; ``self._running`` flipping back to True is what
+        re-enables the callbacks).
+        """
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+
+        await iorails.start()
+        assert iorails._gauges_registered is True
+        await iorails.stop()
+
+        # Restart — must NOT re-register (flag still True) but must resume
+        # reporting because ``self._running`` flips back to True.
+        await iorails.start()
+        try:
+            assert iorails._gauges_registered is True
+            resumed = collect_metric_points(metric_reader)
+            assert resumed["guardrails.nonstream.queued"][0].value == 0
+            assert resumed["guardrails.nonstream.active"][0].value == 0
+        finally:
+            await iorails.stop()

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -34,7 +34,7 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, Rai
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import SystemConstants
-from tests.guardrails.async_helpers import wait_for_queue_state
+from tests.guardrails.async_helpers import saturate_stream_semaphore, wait_for_queue_state
 from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 from tests.guardrails.test_telemetry import _is_valid_hex_string
@@ -1234,19 +1234,9 @@ class TestStreamAsyncRequestMetrics:
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
-        # Acquire all the available semaphores (any more requests should be rejected)
-        acquired = 0
-        while not iorails._stream_semaphore.locked():
-            await iorails._stream_semaphore.acquire()
-            acquired += 1
-
-        # Make a `stream_async()` call with no sempohores left to use
-        try:
-            with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
-                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
-        finally:
-            for _ in range(acquired):
-                iorails._stream_semaphore.release()
+        saturate_stream_semaphore(iorails)
+        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+            [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.stream.rejections"][0].value == 1
@@ -1268,17 +1258,9 @@ class TestStreamAsyncRequestMetrics:
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
-        acquired = 0
-        while not iorails._stream_semaphore.locked():
-            await iorails._stream_semaphore.acquire()
-            acquired += 1
-
-        try:
-            with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
-                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
-        finally:
-            for _ in range(acquired):
-                iorails._stream_semaphore.release()
+        saturate_stream_semaphore(iorails)
+        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+            [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.stream.rejections"][0].value == 1
@@ -1347,18 +1329,9 @@ class TestStreamAsyncRequestMetrics:
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
-        # Drain permits so the next stream is rejected.
-        acquired = 0
-        while not iorails._stream_semaphore.locked():
-            await iorails._stream_semaphore.acquire()
-            acquired += 1
-
-        try:
-            with pytest.raises(asyncio.QueueFull):
-                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
-        finally:
-            for _ in range(acquired):
-                iorails._stream_semaphore.release()
+        saturate_stream_semaphore(iorails)
+        with pytest.raises(asyncio.QueueFull):
+            [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)
         assert "guardrails.stream.active" not in points

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1087,6 +1087,39 @@ class TestGenerateAsyncRequestMetrics:
         points = collect_metric_points(metric_reader)
         assert points == {}
 
+    @pytest.mark.asyncio
+    async def test_nonstream_rejections_counter_on_queue_full(self, iorails_tracing, metric_reader):
+        """When the admission queue raises ``asyncio.QueueFull``,
+        ``generate_async`` catches the exception, increments
+        ``guardrails.nonstream.rejections``, and re-raises.
+
+        The queue's overflow semantics are covered in
+        ``test_async_work_queue.py``; here we stub ``submit`` to raise
+        directly so the test stays fast and focused on the counter wiring.
+        """
+        _stub_safe_pipeline(iorails_tracing)
+        iorails_tracing._generate_async_queue.submit = AsyncMock(side_effect=asyncio.QueueFull("admission queue full"))
+
+        with pytest.raises(asyncio.QueueFull, match="admission queue full"):
+            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        points = collect_metric_points(metric_reader)
+        assert points["guardrails.nonstream.rejections"][0].value == 1
+
+    @pytest.mark.asyncio
+    async def test_no_nonstream_rejections_counter_when_metrics_disabled(self, iorails_no_tracing, metric_reader):
+        """Metrics disabled → even a QueueFull raise doesn't emit the counter."""
+        _stub_safe_pipeline(iorails_no_tracing)
+        iorails_no_tracing._generate_async_queue.submit = AsyncMock(
+            side_effect=asyncio.QueueFull("admission queue full")
+        )
+
+        with pytest.raises(asyncio.QueueFull):
+            await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        points = collect_metric_points(metric_reader)
+        assert "guardrails.nonstream.rejections" not in points
+
 
 class TestStreamAsyncRequestMetrics:
     """Streaming path also emits request-level metrics via the shared

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1010,8 +1010,14 @@ def metric_reader():
 
 
 class TestGenerateAsyncRequestMetrics:
+    """Non-streaming path emits ``guardrails.requests`` /
+    ``guardrails.request.duration`` / ``guardrails.requests.errors`` and
+    nets ``guardrails.requests.active`` to zero on completion."""
+
     @pytest.mark.asyncio
     async def test_emits_counter_and_duration_on_safe_request(self, iorails_tracing, metric_reader):
+        """Happy-path generate_async → counter +1, duration recorded once,
+        no errors, requests.active back to 0."""
         _stub_safe_pipeline(iorails_tracing)
 
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
@@ -1079,6 +1085,8 @@ class TestGenerateAsyncRequestMetrics:
 
     @pytest.mark.asyncio
     async def test_no_blocked_counter_emitted_when_tracing_disabled(self, iorails_no_tracing, metric_reader):
+        """With metrics disabled, a blocked-by-input-rail request emits no
+        ``requests.blocked`` data point."""
         _stub_safe_pipeline(iorails_no_tracing)
         iorails_no_tracing.rails_manager.is_input_safe = AsyncMock(
             return_value=RailResult(is_safe=False, reason="unsafe")
@@ -1151,6 +1159,8 @@ class TestGenerateAsyncRequestMetrics:
         gate = asyncio.Event()
 
         async def blocking_generate(messages, req_id, **kwargs):
+            """Stub pipeline that blocks until ``gate`` is set, so the test can
+            observe queue/worker state mid-flight."""
             await gate.wait()
             return {"role": "assistant", "content": "done"}
 
@@ -1206,6 +1216,8 @@ class TestStreamAsyncRequestMetrics:
 
     @pytest.mark.asyncio
     async def test_emits_counter_and_duration_on_safe_stream(self, iorails_streaming_input_only_tracing, metric_reader):
+        """Happy-path stream_async → counter +1, duration recorded once,
+        no errors, stream.active back to 0, no rejections."""
         iorails = iorails_streaming_input_only_tracing
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
@@ -1525,6 +1537,8 @@ class TestNonstreamStateGauges:
         gate = asyncio.Event()
 
         async def blocking_generate(messages, req_id, **kwargs):
+            """Stub pipeline that blocks until ``gate`` is set, so the test can
+            observe queue/worker state mid-flight."""
             await gate.wait()
             return {"role": "assistant", "content": "done"}
 
@@ -1557,6 +1571,8 @@ class TestNonstreamStateGauges:
         gate = asyncio.Event()
 
         async def blocking_generate(messages, req_id, **kwargs):
+            """Stub pipeline that blocks until ``gate`` is set, so the test can
+            observe queue/worker state mid-flight."""
             await gate.wait()
             return {"role": "assistant", "content": "done"}
 
@@ -1676,6 +1692,8 @@ class TestRequestsActiveAggregate:
         gate = asyncio.Event()
 
         async def blocking_generate(messages, req_id, **kwargs):
+            """Stub pipeline that blocks until ``gate`` is set, so the test can
+            observe queue/worker state mid-flight."""
             await gate.wait()
             return {"role": "assistant", "content": "done"}
 
@@ -1740,6 +1758,8 @@ class TestRequestsActiveAggregate:
         nonstream_gate = asyncio.Event()
 
         async def blocking_generate(messages, req_id, **kwargs):
+            """Stub pipeline that blocks until ``nonstream_gate`` is set, so the
+            test can observe queue/worker state mid-flight."""
             await nonstream_gate.wait()
             return {"role": "assistant", "content": "done"}
 

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1105,6 +1105,120 @@ class TestStreamAsyncRequestMetrics:
         assert points["guardrails.requests"][0].value == 1
         assert points["guardrails.request.duration"][0].value == 1
         assert "guardrails.requests.errors" not in points
+        # Saturation: stream.active nets to 0 after the stream completes;
+        # stream.rejections never fires on the happy path.
+        assert points["guardrails.stream.active"][0].value == 0
+        assert "guardrails.stream.rejections" not in points
+
+    @pytest.mark.asyncio
+    async def test_stream_rejections_counter_on_semaphore_full(
+        self, iorails_streaming_input_only_tracing, metric_reader
+    ):
+        """A stream that arrives while the semaphore is fully occupied is
+        rejected with ``asyncio.QueueFull`` and the ``stream.rejections``
+        counter increments.
+        """
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        # Acquire all the available semaphores (any more requests should be rejected)
+        acquired = 0
+        while not iorails._stream_semaphore.locked():
+            await iorails._stream_semaphore.acquire()
+            acquired += 1
+
+        # Make a `stream_async()` call with no sempohores left to use
+        try:
+            with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        finally:
+            for _ in range(acquired):
+                iorails._stream_semaphore.release()
+
+        points = collect_metric_points(metric_reader)
+        assert points["guardrails.stream.rejections"][0].value == 1
+        # Active counter untouched — the semaphore was never acquired by the
+        # rejected stream, so the UpDownCounter never saw a +1 and emits no
+        # data point (UpDownCounters only export points after first ``.add()``).
+        assert "guardrails.stream.active" not in points
+
+    @pytest.mark.asyncio
+    async def test_stream_active_is_one_mid_flight(self, iorails_streaming_input_only_tracing, metric_reader):
+        """Observe the UpDownCounter mid-flight: after the first chunk is
+        pulled (semaphore acquired, stream body running), ``stream.active``
+        reads 1; after the iterator is consumed, it reads 0.
+        """
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        iterator = iorails.stream_async([{"role": "user", "content": "hi"}]).__aiter__()
+
+        # Before any chunk is pulled, nothing has touched the UpDownCounter
+        # yet, so no data point is emitted (semantically equivalent to 0).
+        before = collect_metric_points(metric_reader)
+        assert "guardrails.stream.active" not in before
+
+        # During: pull the first chunk → semaphore acquired, counter at +1.
+        first = await iterator.__anext__()
+        assert first == "Hello"
+        mid = collect_metric_points(metric_reader)
+        assert mid["guardrails.stream.active"][0].value == 1
+
+        # Drain the rest.
+        rest = [c async for c in iterator]
+        assert rest == [" ", "world"]
+
+        # After: counter back to 0 (net of +1 / -1).
+        final = collect_metric_points(metric_reader)
+        assert final["guardrails.stream.active"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_active_nets_to_zero_on_stream_failure(
+        self, iorails_streaming_input_only_tracing, metric_reader
+    ):
+        """Even when the LLM raises mid-stream, ``stream.active`` decrements
+        on exit — the ``stream_active_metric`` context manager's ``finally``
+        guarantees the -1.
+        """
+        iorails = iorails_streaming_input_only_tracing
+        _stub_deep_streaming_pipeline(iorails, main_stream=_engine_failing_stream)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        # Stream failure was converted to an error-payload chunk.
+        assert any(c.startswith('{"error"') for c in chunks)
+
+        points = collect_metric_points(metric_reader)
+        assert points["guardrails.stream.active"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_no_stream_saturation_metrics_when_metrics_disabled(
+        self, iorails_streaming_no_tracing, metric_reader
+    ):
+        """Tracing + metrics disabled → ``stream.active`` and
+        ``stream.rejections`` don't emit, even on rejection path.
+        """
+        iorails = iorails_streaming_no_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        # Drain permits so the next stream is rejected.
+        acquired = 0
+        while not iorails._stream_semaphore.locked():
+            await iorails._stream_semaphore.acquire()
+            acquired += 1
+
+        try:
+            with pytest.raises(asyncio.QueueFull):
+                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        finally:
+            for _ in range(acquired):
+                iorails._stream_semaphore.release()
+
+        points = collect_metric_points(metric_reader)
+        assert "guardrails.stream.active" not in points
+        assert "guardrails.stream.rejections" not in points
 
     @pytest.mark.asyncio
     async def test_emits_errors_counter_on_stream_failure(self, iorails_streaming_input_only_tracing, metric_reader):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -35,7 +35,7 @@ from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import SystemConstants
 from tests.guardrails.async_helpers import wait_for_queue_state
-from tests.guardrails.metric_helpers import collect_metric_points
+from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 from tests.guardrails.test_telemetry import _is_valid_hex_string
 
@@ -1094,6 +1094,11 @@ class TestGenerateAsyncRequestMetrics:
         ``generate_async`` catches the exception, increments
         ``guardrails.nonstream.rejections``, and re-raises.
 
+        Note: the rejection also propagates through the outer
+        ``request_metrics()`` wrapper, so ``requests.errors`` and
+        ``request.duration`` fire too — covered by the dedicated
+        dual-signal test below.
+
         The queue's overflow semantics are covered in
         ``test_async_work_queue.py``; here we stub ``submit`` to raise
         directly so the test stays fast and focused on the counter wiring.
@@ -1106,6 +1111,77 @@ class TestGenerateAsyncRequestMetrics:
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.nonstream.rejections"][0].value == 1
+
+    @pytest.mark.asyncio
+    async def test_queuefull_bumps_both_errors_and_nonstream_rejections(self, iorails_tracing, metric_reader):
+        """Dual-signal semantics: a ``QueueFull`` rejection is BOTH a
+        saturation signal (``nonstream.rejections``) AND a request error
+        (``requests.errors{error.type=QueueFull}``).  Dashboards can
+        count either one.  Also bumps the ``requests`` counter and
+        records into the duration histogram — the request ran through
+        the full lifecycle, even if only briefly.
+        """
+        _stub_safe_pipeline(iorails_tracing)
+        iorails_tracing._generate_async_queue.submit = AsyncMock(side_effect=asyncio.QueueFull("admission queue full"))
+
+        with pytest.raises(asyncio.QueueFull):
+            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        points = collect_metric_points(metric_reader)
+        assert points["guardrails.nonstream.rejections"][0].value == 1
+        assert points["guardrails.requests.errors"][0].value == 1
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "QueueFull"
+        assert points["guardrails.requests"][0].value == 1
+        assert points["guardrails.request.duration"][0].value == 1
+
+    @pytest.mark.asyncio
+    async def test_request_duration_includes_queue_wait(self, metric_reader):
+        """``request.duration`` measures the full ``generate_async``
+        lifecycle (OTEL HTTP semconv), so the time a request spends
+        waiting in the admission queue is included.
+
+        With a single worker and two submitted requests, the second
+        request sits in the queue for the duration of the first.  The
+        histogram's aggregate sum therefore captures at least one
+        queue-wait period — if duration were worker-scope the waiting
+        request would contribute ~0 to the sum.
+        """
+        gate = asyncio.Event()
+
+        async def blocking_generate(messages, req_id, **kwargs):
+            await gate.wait()
+            return {"role": "assistant", "content": "done"}
+
+        block_seconds = 0.05
+
+        with (
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_MAX_CONCURRENCY", 1),
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_QUEUE_DEPTH", 4),
+        ):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+            async with iorails:
+                iorails._do_generate = blocking_generate
+
+                tasks = [
+                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    for i in range(2)
+                ]
+                # Wait until exactly one is executing and one is queued.
+                await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=1)
+                # Hold this state for a measurable duration so the queued
+                # request accumulates queue-wait time.
+                await asyncio.sleep(block_seconds)
+                gate.set()
+                await asyncio.gather(*tasks)
+
+        # The sum of both recorded durations must exceed one block period.
+        # A worker-scope duration would sum to ~block_seconds (the first
+        # request held a worker, the second ran trivially after pickup);
+        # full-lifecycle duration also covers the queued request's wait,
+        # lifting the sum near 2×block.
+        duration_sum = collect_histogram_sum(metric_reader, "guardrails.request.duration")
+        assert duration_sum >= block_seconds * 1.5
 
     @pytest.mark.asyncio
     async def test_no_nonstream_rejections_counter_when_metrics_disabled(self, iorails_no_tracing, metric_reader):
@@ -1176,6 +1252,38 @@ class TestStreamAsyncRequestMetrics:
         # rejected stream, so the UpDownCounter never saw a +1 and emits no
         # data point (UpDownCounters only export points after first ``.add()``).
         assert "guardrails.stream.active" not in points
+
+    @pytest.mark.asyncio
+    async def test_stream_queuefull_bumps_both_errors_and_stream_rejections(
+        self, iorails_streaming_input_only_tracing, metric_reader
+    ):
+        """Streaming equivalent of the non-streaming dual-signal test: a
+        ``QueueFull`` on the semaphore check is BOTH a saturation signal
+        (``stream.rejections``) AND a request error
+        (``requests.errors{error.type=QueueFull}``)
+        """
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        acquired = 0
+        while not iorails._stream_semaphore.locked():
+            await iorails._stream_semaphore.acquire()
+            acquired += 1
+
+        try:
+            with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+                [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        finally:
+            for _ in range(acquired):
+                iorails._stream_semaphore.release()
+
+        points = collect_metric_points(metric_reader)
+        assert points["guardrails.stream.rejections"][0].value == 1
+        assert points["guardrails.requests.errors"][0].value == 1
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "QueueFull"
+        assert points["guardrails.requests"][0].value == 1
+        assert points["guardrails.request.duration"][0].value == 1
 
     @pytest.mark.asyncio
     async def test_stream_active_is_one_mid_flight(self, iorails_streaming_input_only_tracing, metric_reader):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1021,6 +1021,8 @@ class TestGenerateAsyncRequestMetrics:
         # Histogram value is the recording count, not the duration itself.
         assert points["guardrails.request.duration"][0].value == 1
         assert "guardrails.requests.errors" not in points
+        # Aggregate saturation counter nets to 0 after a completed request.
+        assert points["guardrails.requests.active"][0].value == 0
 
     @pytest.mark.asyncio
     async def test_emits_errors_counter_on_exception(self, iorails_tracing, metric_reader):
@@ -1675,3 +1677,144 @@ class TestNonstreamStateGauges:
             assert resumed["guardrails.nonstream.active"][0].value == 0
         finally:
             await iorails.stop()
+
+
+class TestRequestsActiveAggregate:
+    """End-to-end coverage for ``guardrails.requests.active`` — the path-
+    agnostic aggregate that counts both non-streaming and streaming
+    in-flight requests.
+
+    The invariant this metric set satisfies at any collection instant:
+
+        requests.active  ≈  nonstream.queued + nonstream.active + stream.active
+
+    IORails is built inline so ``metric_reader`` installs its test Meter
+    before ``start()`` registers the saturation ObservableGauges (same
+    rationale as :class:`TestNonstreamStateGauges`).
+    """
+
+    @pytest.mark.asyncio
+    async def test_captures_queued_nonstream_request_mid_flight(self, metric_reader):
+        """A request stuck in the admission queue contributes to
+        ``requests.active`` — the full-lifecycle scope means queue-wait
+        counts, not just worker time.  With one worker busy and one
+        queued, ``requests.active`` reads 2.
+        """
+        gate = asyncio.Event()
+
+        async def blocking_generate(messages, req_id, **kwargs):
+            await gate.wait()
+            return {"role": "assistant", "content": "done"}
+
+        with (
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_MAX_CONCURRENCY", 1),
+            patch("nemoguardrails.guardrails.iorails.NONSTREAM_QUEUE_DEPTH", 4),
+        ):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
+            async with iorails:
+                iorails._do_generate = blocking_generate
+                tasks = [
+                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    for i in range(2)
+                ]
+                await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=1)
+
+                mid = collect_metric_points(metric_reader)
+                assert mid["guardrails.requests.active"][0].value == 2
+
+                gate.set()
+                await asyncio.gather(*tasks)
+
+                final = collect_metric_points(metric_reader)
+                assert final["guardrails.requests.active"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_captures_streaming_request_mid_flight(self, iorails_streaming_input_only_tracing, metric_reader):
+        """A streaming request holding a semaphore permit contributes to
+        ``requests.active``.  Mid-stream, the counter reads 1; after the
+        iterator drains, it nets to 0.
+        """
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        iterator = iorails.stream_async([{"role": "user", "content": "hi"}]).__aiter__()
+
+        # Pull the first chunk → semaphore acquired, stream body running.
+        first = await iterator.__anext__()
+        assert first == "Hello"
+        mid = collect_metric_points(metric_reader)
+        assert mid["guardrails.requests.active"][0].value == 1
+
+        # Drain and check net-to-zero.
+        rest = [c async for c in iterator]
+        assert rest == [" ", "world"]
+        final = collect_metric_points(metric_reader)
+        assert final["guardrails.requests.active"][0].value == 0
+
+    @pytest.mark.asyncio
+    async def test_invariant_aggregate_equals_component_sum(self, metric_reader):
+        """Core payoff check: with M non-streaming executing, N queued,
+        and S streaming simultaneously, the aggregate counter matches
+        the component-wise sum.
+
+        Uses a single IORails instance: M=1 executing + N=1 queued +
+        S=1 streaming → ``requests.active == 3``, each of the per-path
+        metrics reads its own value, and the sum of the three equals
+        the aggregate.
+        """
+        nonstream_gate = asyncio.Event()
+
+        async def blocking_generate(messages, req_id, **kwargs):
+            await nonstream_gate.wait()
+            return {"role": "assistant", "content": "done"}
+
+        # Drop output rails so ``stream_async`` doesn't trip the
+        # StreamingNotSupportedError path (matches the ``_INPUT_ONLY_*``
+        # configs used by the streaming-path fixtures above).
+        invariant_config = copy.deepcopy(NEMOGUARDS_CONFIG)
+        invariant_config["rails"]["output"] = {"flows": []}
+        invariant_config["metrics"] = {"enabled": True}
+
+        with patch("nemoguardrails.guardrails.iorails.NONSTREAM_MAX_CONCURRENCY", 1):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                iorails = IORails(RailsConfig.from_content(config=invariant_config))
+            async with iorails:
+                iorails._do_generate = blocking_generate
+                iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+                iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+                # Launch one executing + one queued non-streaming request.
+                nonstream_tasks = [
+                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"n{i}"}]))
+                    for i in range(2)
+                ]
+                await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=1)
+
+                # Launch one streaming request and pull the first chunk
+                # to force semaphore acquisition + stream-body execution.
+                stream_iter = iorails.stream_async([{"role": "user", "content": "s0"}]).__aiter__()
+                first = await stream_iter.__anext__()
+                assert first == "Hello"
+
+                mid = collect_metric_points(metric_reader)
+                aggregate = mid["guardrails.requests.active"][0].value
+                nonstream_active = mid["guardrails.nonstream.active"][0].value
+                nonstream_queued = mid["guardrails.nonstream.queued"][0].value
+                stream_active = mid["guardrails.stream.active"][0].value
+
+                assert nonstream_active == 1
+                assert nonstream_queued == 1
+                assert stream_active == 1
+                assert aggregate == 3
+                # The invariant itself.
+                assert aggregate == nonstream_active + nonstream_queued + stream_active
+
+                # Drain everything so the fixture teardown is clean.
+                nonstream_gate.set()
+                [_ async for _ in stream_iter]
+                await asyncio.gather(*nonstream_tasks)
+
+                final = collect_metric_points(metric_reader)
+                assert final["guardrails.requests.active"][0].value == 0

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -21,7 +21,6 @@ from unittest.mock import patch
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
-from opentelemetry.sdk.trace import TracerProvider
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
@@ -37,7 +36,6 @@ from nemoguardrails.guardrails.telemetry import (
     register_nonstream_saturation_gauges,
     request_metrics,
     stream_active_metric,
-    traced_request,
 )
 from nemoguardrails.rails.llm.config import MetricsConfig
 from nemoguardrails.tracing.constants import SystemConstants
@@ -65,13 +63,6 @@ def meter_reader():
         schema_url="https://opentelemetry.io/schemas/1.26.0",
     )
     yield reader
-
-
-@pytest.fixture
-def tracer():
-    """Provide a real Tracer (no exporter — tests here care about metrics, not spans)."""
-    provider = TracerProvider()
-    return provider.get_tracer("test")
 
 
 class TestGetMeter:
@@ -169,72 +160,6 @@ class TestRequestMetrics:
             with request_metrics():
                 pass
             # Just verify no crash; there's no reader to check against.
-
-
-class TestTracedRequestMetrics:
-    """``traced_request(tracer, metrics_enabled)`` gates the two signals
-    independently.  All four combinations exercised here.
-    """
-
-    def test_both_enabled_emits_metrics(self, meter_reader, tracer):
-        with traced_request(tracer, metrics_enabled=True):
-            pass
-        points = collect_metric_points(meter_reader)
-        assert points["guardrails.requests"][0].value == 1
-        assert points["guardrails.request.duration"][0].value == 1
-
-    def test_metrics_only_emits_metrics(self, meter_reader):
-        """tracer=None, metrics_enabled=True — the cost-optimized setup."""
-        with traced_request(None, metrics_enabled=True):
-            pass
-        points = collect_metric_points(meter_reader)
-        assert points["guardrails.requests"][0].value == 1
-        assert points["guardrails.request.duration"][0].value == 1
-
-    def test_tracing_only_emits_no_metrics(self, meter_reader, tracer):
-        """tracer!=None, metrics_enabled=False — span emits (not asserted
-        here; see span tests) but no metric data points are recorded.
-        """
-        with traced_request(tracer, metrics_enabled=False):
-            pass
-        points = collect_metric_points(meter_reader)
-        assert points == {}
-
-    def test_both_disabled_emits_nothing(self, meter_reader):
-        with traced_request(None, metrics_enabled=False):
-            pass
-        points = collect_metric_points(meter_reader)
-        assert points == {}
-
-    def test_errors_counter_on_exception_metrics_only(self, meter_reader):
-        """Exception through a metrics-only traced_request still bumps the
-        errors counter — the errors counter follows metrics_enabled, not
-        tracer presence.
-        """
-        with pytest.raises(ValueError):
-            with traced_request(None, metrics_enabled=True):
-                raise ValueError("boom")
-        points = collect_metric_points(meter_reader)
-        assert points["guardrails.requests.errors"][0].value == 1
-        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "ValueError"
-
-    def test_errors_counter_on_exception_both_enabled(self, meter_reader, tracer):
-        with pytest.raises(ValueError):
-            with traced_request(tracer, metrics_enabled=True):
-                raise ValueError("boom")
-        points = collect_metric_points(meter_reader)
-        assert points["guardrails.requests.errors"][0].value == 1
-        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "ValueError"
-
-    def test_no_errors_counter_when_metrics_disabled(self, meter_reader, tracer):
-        """Exception through tracing-only traced_request does NOT bump the
-        errors counter — metrics are off.
-        """
-        with pytest.raises(ValueError):
-            with traced_request(tracer, metrics_enabled=False):
-                raise ValueError("boom")
-        points = collect_metric_points(meter_reader)
-        assert points == {}
 
 
 class TestNoMeterProviderConfigured:

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -30,7 +30,9 @@ from nemoguardrails.guardrails.telemetry import (
     get_meter,
     record_request_blocked,
     record_request_error,
+    record_stream_rejected,
     request_metrics,
+    stream_active_metric,
     traced_request,
 )
 from nemoguardrails.rails.llm.config import MetricsConfig
@@ -322,3 +324,50 @@ class TestAreMetricsEnabled:
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             with pytest.warns(UserWarning, match="opentelemetry-api package is not installed"):
                 assert are_metrics_enabled(MetricsConfig(enabled=True)) is False
+
+
+class TestRecordStreamRejected:
+    def test_increments_counter(self, meter_reader):
+        record_stream_rejected()
+        record_stream_rejected()
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.stream.rejections"][0].value == 2
+
+    def test_no_op_when_otel_unavailable(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._meter = None
+            telemetry._request_instruments = None
+            record_stream_rejected()  # must not raise
+
+
+class TestStreamActiveMetric:
+    def test_nets_to_zero_after_completed_scope(self, meter_reader):
+        """UpDownCounter +1 on enter, -1 on exit → net 0 for a completed scope."""
+        with stream_active_metric():
+            pass
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.stream.active"][0].value == 0
+
+    def test_nets_to_zero_after_exception(self, meter_reader):
+        """Exception path still decrements — -1 lives in ``finally``."""
+        with pytest.raises(ValueError):
+            with stream_active_metric():
+                raise ValueError("boom")
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.stream.active"][0].value == 0
+
+    def test_reflects_concurrent_streams_mid_flight(self, meter_reader):
+        """Observe mid-flight: two overlapping streams → counter reads 2."""
+        with stream_active_metric():
+            with stream_active_metric():
+                mid = collect_metric_points(meter_reader)
+                assert mid["guardrails.stream.active"][0].value == 2
+        final = collect_metric_points(meter_reader)
+        assert final["guardrails.stream.active"][0].value == 0
+
+    def test_no_op_when_otel_unavailable(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._meter = None
+            telemetry._request_instruments = None
+            with stream_active_metric():
+                pass  # must not raise

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -85,12 +85,19 @@ class TestGetMeter:
 
 
 class TestEnsureRequestInstruments:
-    def test_creates_three_instruments(self, meter_reader):
+    def test_creates_all_instruments(self, meter_reader):
         result = _ensure_request_instruments()
         assert result is not None
+        # Core request-level metrics
         assert result.requests is not None
         assert result.errors is not None
+        assert result.blocked is not None
         assert result.duration is not None
+        # Saturation metrics
+        assert result.requests_active is not None
+        assert result.nonstream_rejections is not None
+        assert result.stream_active is not None
+        assert result.stream_rejections is not None
 
     def test_returns_same_instruments_on_second_call(self, meter_reader):
         first = _ensure_request_instruments()

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -15,6 +15,7 @@
 
 """Unit tests for the OTEL metrics API in nemoguardrails.guardrails.telemetry."""
 
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +24,7 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 
 from nemoguardrails.guardrails import telemetry
+from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.guardrails_types import RailDirection
 from nemoguardrails.guardrails.telemetry import (
     _ensure_request_instruments,
@@ -32,6 +34,7 @@ from nemoguardrails.guardrails.telemetry import (
     record_request_blocked,
     record_request_error,
     record_stream_rejected,
+    register_nonstream_saturation_gauges,
     request_metrics,
     stream_active_metric,
     traced_request,
@@ -387,3 +390,99 @@ class TestStreamActiveMetric:
             telemetry._request_instruments = None
             with stream_active_metric():
                 pass  # must not raise
+
+
+class _FakeQueue:
+    """Stand-in for AsyncWorkQueue used by gauge-registration unit tests.
+
+    The real ``AsyncWorkQueue`` needs an asyncio event loop to start; the
+    gauge callbacks only need ``num_pending()`` and ``num_busy_workers()``,
+    so a tiny stub keeps these tests synchronous.
+    """
+
+    def __init__(self, queued: int = 0, active: int = 0) -> None:
+        self._queued = queued
+        self._active = active
+
+    def num_pending(self) -> int:
+        return self._queued
+
+    def num_busy_workers(self) -> int:
+        return self._active
+
+
+class TestRegisterNonstreamSaturationGauges:
+    def test_registers_both_gauges(self, meter_reader):
+        fake = _FakeQueue(queued=0, active=0)
+        register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: True)
+        points = collect_metric_points(meter_reader)
+        assert "guardrails.nonstream.queued" in points
+        assert "guardrails.nonstream.active" in points
+
+    def test_gauges_reflect_live_queue_state(self, meter_reader):
+        """Callbacks re-read the queue on each collection — bumping the
+        fake's counters between collections shows up immediately."""
+        fake = _FakeQueue(queued=3, active=7)
+        register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: True)
+
+        first = collect_metric_points(meter_reader)
+        assert first["guardrails.nonstream.queued"][0].value == 3
+        assert first["guardrails.nonstream.active"][0].value == 7
+
+        fake._queued = 11
+        fake._active = 2
+        second = collect_metric_points(meter_reader)
+        assert second["guardrails.nonstream.queued"][0].value == 11
+        assert second["guardrails.nonstream.active"][0].value == 2
+
+    def test_disabled_flag_suppresses_observations(self, meter_reader):
+        """When ``is_running()`` returns False the callbacks return [] and
+        no data points are exported (soft-disable behaviour used after
+        ``IORails.stop()``)."""
+        fake = _FakeQueue(queued=5, active=5)
+        enabled = True
+        register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: enabled)
+
+        enabled_points = collect_metric_points(meter_reader)
+        assert enabled_points["guardrails.nonstream.queued"][0].value == 5
+        assert enabled_points["guardrails.nonstream.active"][0].value == 5
+
+        enabled = False
+        disabled_points = collect_metric_points(meter_reader)
+        # Callback returned [] — the SDK may either omit the metric entirely
+        # or include it with zero data points.  Assert "no observations",
+        # which is what consumers actually care about.
+        assert disabled_points.get("guardrails.nonstream.queued", []) == []
+        assert disabled_points.get("guardrails.nonstream.active", []) == []
+
+    def test_flag_flip_back_on_resumes_observations(self, meter_reader):
+        """After soft-disable, flipping the flag back to True resumes
+        collection on the same callbacks — matches the stop → start cycle."""
+        fake = _FakeQueue(queued=1, active=0)
+        enabled = False
+        register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: enabled)
+
+        off = collect_metric_points(meter_reader)
+        # SDK omits gauges entirely when callbacks return [] (no data points
+        # → no metric in the export).  Assert "no observations" defensively
+        # so the test doesn't depend on which of the two shapes the SDK picks.
+        assert off.get("guardrails.nonstream.queued", []) == []
+
+        enabled = True
+        on = collect_metric_points(meter_reader)
+        assert on["guardrails.nonstream.queued"][0].value == 1
+
+    def test_no_op_when_meter_is_none(self):
+        """No MeterProvider configured → no registration, no exception."""
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._meter = None
+            fake = _FakeQueue()
+            register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: True)  # must not raise
+
+    def test_accepts_real_async_work_queue(self):
+        """Smoke test: the helper accepts an actual ``AsyncWorkQueue`` — no
+        asyncio loop needed for registration, only for start/stop."""
+        real_queue = AsyncWorkQueue(name="t", max_queue_size=4, max_concurrency=2)
+        # No meter_reader fixture — we only care that registration doesn't
+        # raise on the real class.  Skipped when no meter is configured.
+        register_nonstream_saturation_gauges(real_queue, is_running=lambda: False)

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -28,6 +28,7 @@ from nemoguardrails.guardrails.telemetry import (
     _ensure_request_instruments,
     are_metrics_enabled,
     get_meter,
+    record_nonstream_rejected,
     record_request_blocked,
     record_request_error,
     record_stream_rejected,
@@ -338,6 +339,21 @@ class TestRecordStreamRejected:
             telemetry._meter = None
             telemetry._request_instruments = None
             record_stream_rejected()  # must not raise
+
+
+class TestRecordNonstreamRejected:
+    def test_increments_counter(self, meter_reader):
+        record_nonstream_rejected()
+        record_nonstream_rejected()
+        record_nonstream_rejected()
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.nonstream.rejections"][0].value == 3
+
+    def test_no_op_when_otel_unavailable(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._meter = None
+            telemetry._request_instruments = None
+            record_nonstream_rejected()  # must not raise
 
 
 class TestStreamActiveMetric:

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -82,7 +82,12 @@ class TestGetMeter:
 
 
 class TestEnsureRequestInstruments:
+    """``_ensure_request_instruments()`` lazily creates and caches the full
+    set of OTEL instruments used by the request lifecycle."""
+
     def test_creates_all_instruments(self, meter_reader):
+        """First call returns a populated ``RequestInstruments`` with every
+        core + saturation instrument set."""
         result = _ensure_request_instruments()
         assert result is not None
         # Core request-level metrics
@@ -108,6 +113,10 @@ class TestEnsureRequestInstruments:
 
 
 class TestRequestMetrics:
+    """``request_metrics()`` context manager increments the requests
+    counter on entry, records duration on exit, and bumps the errors
+    counter (split by ``error.type``) on exception."""
+
     def test_requests_counter_increments_on_entry(self, meter_reader):
         with request_metrics():
             pass
@@ -137,6 +146,8 @@ class TestRequestMetrics:
         assert points["guardrails.requests.errors"][0].attributes["error.type"] == "ValueError"
 
     def test_errors_counter_labels_split_by_error_type(self, meter_reader):
+        """Errors counter splits into separate series keyed by
+        ``error.type`` attribute."""
         with pytest.raises(ValueError):
             with request_metrics():
                 raise ValueError("a")
@@ -148,6 +159,8 @@ class TestRequestMetrics:
         assert error_types == {"ValueError", "RuntimeError"}
 
     def test_duration_still_recorded_on_exception(self, meter_reader):
+        """Duration histogram fires from ``finally``, so a raising scope
+        still produces a recording."""
         with pytest.raises(ValueError):
             with request_metrics():
                 raise ValueError("boom")
@@ -181,6 +194,8 @@ class TestRequestMetrics:
         assert final["guardrails.requests.active"][0].value == 0
 
     def test_no_metrics_when_otel_unavailable(self):
+        """``request_metrics()`` is a silent no-op when OTEL isn't installed —
+        the context manager must not raise."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None
             with request_metrics():
@@ -267,28 +282,37 @@ class TestAreMetricsEnabled:
     """
 
     def test_returns_true_when_config_enabled(self):
+        """``MetricsConfig(enabled=True)`` with OTEL available → metrics on."""
         assert are_metrics_enabled(MetricsConfig(enabled=True)) is True
 
     def test_returns_false_when_config_disabled(self):
+        """``MetricsConfig(enabled=False)`` → metrics off."""
         assert are_metrics_enabled(MetricsConfig(enabled=False)) is False
 
     def test_returns_false_when_config_none(self):
+        """Missing ``MetricsConfig`` → metrics off."""
         assert are_metrics_enabled(None) is False
 
     def test_returns_false_when_otel_unavailable(self):
+        """Even with ``enabled=True``, metrics stay off and a UserWarning
+        fires when the OTEL API package isn't installed."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             with pytest.warns(UserWarning, match="opentelemetry-api package is not installed"):
                 assert are_metrics_enabled(MetricsConfig(enabled=True)) is False
 
 
 class TestRecordStreamRejected:
+    """``record_stream_rejected()`` bumps the stream-rejections counter."""
+
     def test_increments_counter(self, meter_reader):
+        """Each call increments ``guardrails.stream.rejections`` by 1."""
         record_stream_rejected()
         record_stream_rejected()
         points = collect_metric_points(meter_reader)
         assert points["guardrails.stream.rejections"][0].value == 2
 
     def test_no_op_when_otel_unavailable(self):
+        """Silent no-op when OTEL isn't installed — must not raise."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None
             telemetry._request_instruments = None
@@ -296,7 +320,10 @@ class TestRecordStreamRejected:
 
 
 class TestRecordNonstreamRejected:
+    """``record_nonstream_rejected()`` bumps the nonstream-rejections counter."""
+
     def test_increments_counter(self, meter_reader):
+        """Each call increments ``guardrails.nonstream.rejections`` by 1."""
         record_nonstream_rejected()
         record_nonstream_rejected()
         record_nonstream_rejected()
@@ -304,6 +331,7 @@ class TestRecordNonstreamRejected:
         assert points["guardrails.nonstream.rejections"][0].value == 3
 
     def test_no_op_when_otel_unavailable(self):
+        """Silent no-op when OTEL isn't installed — must not raise."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None
             telemetry._request_instruments = None
@@ -311,6 +339,9 @@ class TestRecordNonstreamRejected:
 
 
 class TestStreamActiveMetric:
+    """``stream_active_metric()`` context manager nets to zero across
+    completed and failed scopes and reflects concurrent streams."""
+
     def test_nets_to_zero_after_completed_scope(self, meter_reader):
         """UpDownCounter +1 on enter, -1 on exit → net 0 for a completed scope."""
         with stream_active_metric():
@@ -336,6 +367,7 @@ class TestStreamActiveMetric:
         assert final["guardrails.stream.active"][0].value == 0
 
     def test_no_op_when_otel_unavailable(self):
+        """Silent no-op when OTEL isn't installed — must not raise."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None
             telemetry._request_instruments = None
@@ -352,18 +384,27 @@ class _FakeQueue:
     """
 
     def __init__(self, queued: int = 0, active: int = 0) -> None:
+        """Initialize with fixed counts the gauge callbacks will read back."""
         self._queued = queued
         self._active = active
 
     def num_pending(self) -> int:
+        """Return the configured queued-item count."""
         return self._queued
 
     def num_busy_workers(self) -> int:
+        """Return the configured busy-worker count."""
         return self._active
 
 
 class TestRegisterNonstreamSaturationGauges:
+    """``register_nonstream_saturation_gauges()`` wires the
+    ``nonstream.queued`` / ``nonstream.active`` ObservableGauges to a
+    queue and an ``is_running`` flag."""
+
     def test_registers_both_gauges(self, meter_reader):
+        """After registration, both gauge series exist in the collected
+        metric points."""
         fake = _FakeQueue(queued=0, active=0)
         register_nonstream_saturation_gauges(cast(AsyncWorkQueue, fake), is_running=lambda: True)
         points = collect_metric_points(meter_reader)

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -154,6 +154,32 @@ class TestRequestMetrics:
         points = collect_metric_points(meter_reader)
         assert points["guardrails.request.duration"][0].value == 1
 
+    def test_requests_active_nets_to_zero_after_completed_scope(self, meter_reader):
+        """+1 on entry, -1 on exit → net 0 for a completed scope."""
+        with request_metrics():
+            pass
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.requests.active"][0].value == 0
+
+    def test_requests_active_nets_to_zero_after_exception(self, meter_reader):
+        """Exception path still decrements — -1 lives in ``finally``."""
+        with pytest.raises(ValueError):
+            with request_metrics():
+                raise ValueError("boom")
+        points = collect_metric_points(meter_reader)
+        assert points["guardrails.requests.active"][0].value == 0
+
+    def test_requests_active_reflects_concurrent_scopes_mid_flight(self, meter_reader):
+        """Two overlapping ``request_metrics()`` scopes → counter reads 2
+        mid-flight.  Simulates mid-flight observation without actually
+        running two real requests."""
+        with request_metrics():
+            with request_metrics():
+                mid = collect_metric_points(meter_reader)
+                assert mid["guardrails.requests.active"][0].value == 2
+        final = collect_metric_points(meter_reader)
+        assert final["guardrails.requests.active"][0].value == 0
+
     def test_no_metrics_when_otel_unavailable(self):
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None


### PR DESCRIPTION
## Description

**Stacked PR on top of #1817**

Adds saturation metrics to measure how "full" the service is with work. This includes for non-streaming requests how many are buffered in the queue, and how many are being actively worked on by the worker-pool. And for streaming requests how many are active (streaming requests are not buffered).

Moves the existing request-level metric boundary from being popped out of the non-streaming work queue to completion to being pushed into the work queue to completion. This requires the AsyncWorkQueue to be inside IORails to keep metrics self-contained, hence this PR is stacked on top of #1817.

Here's a table of the metrics, any changes, and what they measure

  | Metric | Instrument | Status | What it measures |
  |---|---|---|---|
  | `guardrails.requests` | Counter | scope changed | Total requests entering the full lifecycle (was: worker pickup). |
  | `guardrails.requests.errors` | Counter (labelled by `error.type`) | scope changed | Requests that ended in an unhandled error. Now also fires with `error.type=QueueFull` for admission rejections. |
  | `guardrails.requests.blocked` | Counter (labelled by `rail.type`) | unchanged | Requests blocked by an input or output rail. |
  | `guardrails.request.duration` | Histogram (seconds) | scope changed | End-to-end lifecycle duration. Now includes queue-wait (OTEL HTTP semconv). |
  | `guardrails.requests.active` | UpDownCounter | new | Aggregate in-flight requests across both paths. Invariant: `≈ nonstream.queued + nonstream.active + stream.active`. |
  | `guardrails.nonstream.queued` | ObservableGauge | new | Non-streaming requests buffered in the admission queue, not yet picked up by a worker. |
  | `guardrails.nonstream.active` | ObservableGauge | new | Non-streaming requests currently executing on a worker. |
  | `guardrails.nonstream.rejections` | Counter | new | Non-streaming requests rejected with `QueueFull` because the admission queue was full. |
  | `guardrails.stream.active` | UpDownCounter | new | Streaming requests currently holding a concurrency permit. |
  | `guardrails.stream.rejections` | Counter | new | Streaming requests rejected with `QueueFull` because the semaphore was fully occupied. |

## Related Issue(s)

**Stacked PR**
* #1817 : Pre-requisite to move AsyncWorkQueue into IORails to consolidate metrics at that layer
* #1819 <- This PR

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```


### Unit-test
```
$ poetry run pytest -q
Grea.......................ssss.........................................................................................s......................................................................................................................... [  6%]
.............................................................................................................................................................................................................................................. [ 13%]
.............................................................................................................................................................................................................................................. [ 19%]
..............................................................................................................................................s......ss...................sssssss............................................................. [ 26%]
..................................................................s.......s................................................................................................................................................................... [ 32%]
.............................................................................................................................................................................................................................................. [ 39%]
....ss...........................s...............s.......sssss.................................................s..........................................ss........ss...ss............................................s...................... [ 46%]
...............................s............s................................................................................................................................................................................................. [ 52%]
................................................................................................................................sssss......ssssssssssssssssss..........sssss.................................................................. [ 59%]
..................s...........ss...................................sssssssss.ssssssssss.......................................s...................................................s....s...................................................... [ 65%]
..ssssssss..............sss...ss...ss.....ssssssssssssss......................................................................................................................................s............................................... [ 72%]
...............................................................s....................ssssssss.........ss...................................................................................................................................ssss [ 78%]
sss.............................................................s............................................................................................................................................................................. [ 85%]
.............................................................................................................................................................................................................................................. [ 92%]
.......................s...................................................................................................................................................................................................................... [ 98%]
..............................................                                                                                                                                                                                                 [100%]
3477 passed, 139 skipped in 126.10s (0:02:06)
```


### Integration-test (todo)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability metrics for request saturation and rejection tracking across streaming and non-streaming paths
  * Introduced metrics for active requests, pending queue items, and rejection counters
  * New method to query pending items in the work queue
  * Enhanced telemetry to track queue wait times and admission failures

* **Tests**
  * Expanded test coverage for queue state assertions and saturation metrics
  * Added integration tests for observable gauge behavior and metric consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->