### PR TITLE
docs: fix inaccurate statement about nested asyncio loop support

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ This page provides solutions to issues you may encounter while using NeMo Guardr
 
 ## Nested AsyncIO Loop
 
-NeMo Guardrails is an async-first toolkit, i.e., the core functionality is implemented using async functions. To provide a blocking API, the toolkit must invoke async functions inside synchronous code using `asyncio.run`. However, the current Python implementation for `asyncio` does not allow "nested event loops". This issue is being discussed by the Python core team and, most likely, support will be added (see [GitHub Issue 66435](https://github.com/python/cpython/issues/66435) and [Pull Request 93338](https://github.com/python/cpython/pull/93338)).
+NeMo Guardrails is an async-first toolkit, i.e., the core functionality is implemented using async functions. To provide a blocking API, the toolkit must invoke async functions inside synchronous code using `asyncio.run`. However, the current Python implementation for `asyncio` does not allow "nested event loops". This issue is being discussed by the Python core team and, most likely, support will not be added (see [GitHub Issue 66435](https://github.com/python/cpython/issues/66435) and [Pull Request 93338](https://github.com/python/cpython/pull/93338)).
 
 Meanwhile, NeMo Guardrails makes use of [nest_asyncio](https://github.com/erdewit/nest_asyncio). The patching is applied when the `nemoguardrails` package is loaded the first time.
 


### PR DESCRIPTION
Fixes #1445

## Problem

The troubleshooting documentation incorrectly stated:

> This issue is being discussed by the Python core team and, most likely, support **will be added**

However, both the referenced CPython issue ([#66435](https://github.com/python/cpython/issues/66435), 11 years old) and the PR ([#93338](https://github.com/python/cpython/pull/93338), 3 years old) have been closed without adding support for nested event loops. The statement should reflect that support will **not** be added.

## Solution

Changed "support will be added" to "support will not be added" to accurately reflect the current state of the CPython discussion and the closed references.

## Testing

Documentation-only change; no code is affected.

Signed-off-by: Octopus <liyuan851277048@icloud.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Nested AsyncIO Loop" troubleshooting guide with clarified information regarding Python's support for nested event loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->