### PR TITLE
fix:(llmrails): pre-initialize LLMRails.kb to prevent AttributeError on init failure

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -321,6 +321,8 @@ class LLMRails:
         self.runtime.register_actions(self.llm_generation_actions, override=False)
 
         # Next, we initialize the Knowledge Base
+        # Pre-initialize to None so the attribute always exists, even if _init_kb fails.
+        self.kb = None
         # There are still some edge cases not covered by nest_asyncio.
         # Using a separate thread always for now.
         loop = get_or_create_event_loop()


### PR DESCRIPTION
Fixes #1665

## Problem

When `LLMRails` is initialized, it calls `_init_kb()` in a background thread via `asyncio.run()`. If the background thread fails (e.g., `asyncio.run()` raises a `RuntimeError` before the coroutine body starts), the thread exits silently — `threading.Thread.join()` does not propagate thread exceptions. As a result, `self.kb` is never set on the `LLMRails` instance.

Any subsequent access to `self.kb` (including `self.runtime.register_action_param("kb", self.kb)` at the end of `__init__`) then raises:

```
AttributeError: 'LLMRails' object has no attribute 'kb'
```

This has been reported for Python 3.12+ in LangGraph/LangChain integration scenarios.

## Solution

Pre-initialize `self.kb = None` immediately before launching the background thread. This ensures:

1. The attribute always exists on the `LLMRails` instance, even if `_init_kb()` never runs.
2. Behavior is consistent with `_init_kb()` itself, which already sets `self.kb = None` as its very first statement before any conditional logic.

## Testing

- Existing tests continue to pass (no functional logic changed).
- The fix is purely defensive initialization that mirrors what `_init_kb()` already does.

Signed-off-by: Octopus <liyuan851277048@icloud.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge base initialization reliability to prevent potential startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->