### PR TITLE
feat(library): add peyeeye PII redaction & rehydration guardrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 >
 > The changes related to the Colang language and runtime have moved to [CHANGELOG-Colang](./CHANGELOG-Colang.md) file.
 
+## [Unreleased]
+
+### 🚀 Features
+
+- *(library)* Add Peyeeye PII redaction & rehydration guardrail. New input rail
+  redacts PII from the user message before it reaches the LLM and a paired
+  output rail rehydrates the model's response with the original values via
+  the [peyeeye.ai](https://peyeeye.ai) API. Supports both stateful (`ses_…`)
+  and stateless (`skey_…` AEAD-sealed) session modes.
+
 ## [0.21.0] - 2026-03-12
 
 ### 🚀 Features

--- a/docs/configure-rails/guardrail-catalog/community/peyeeye.md
+++ b/docs/configure-rails/guardrail-catalog/community/peyeeye.md
@@ -45,8 +45,11 @@ rails:
         locale: auto
         session_mode: stateful
       output:
-        # Output is rehydrated via the input session, so options here only
-        # apply if you also enable `peyeeye redact retrieval` etc.
+        # Output rehydration uses the session ids stashed by the input
+        # and retrieval rails, so the options here (locale / entities /
+        # session_mode) are only consulted if you call `peyeeye_redact`
+        # with `source="output"` directly from a custom flow. The
+        # built-in `peyeeye rehydrate output` flow does not read them.
         locale: auto
   input:
     flows:

--- a/docs/configure-rails/guardrail-catalog/community/peyeeye.md
+++ b/docs/configure-rails/guardrail-catalog/community/peyeeye.md
@@ -1,0 +1,106 @@
+# Peyeeye Integration
+
+[Peyeeye](https://peyeeye.ai) is a PII redaction & rehydration API. The
+integration lets NeMo Guardrails redact PII from a user's message before it is
+sent to the LLM, and then rehydrate the model's response so the user sees the
+original values — all without the LLM ever seeing the raw PII.
+
+## How it works
+
+1. **Input rail**: the user message is sent to `POST /v1/redact`, which returns
+   the message with each detected entity swapped for a stable placeholder
+   (e.g. `[EMAIL_1]`) plus a session id.
+2. **LLM call**: the redacted message goes to the LLM. The LLM's response
+   typically echoes some placeholders (`"I have emailed you at [EMAIL_1]"`).
+3. **Output rail**: the response is sent to `POST /v1/rehydrate` with the
+   stored session id; the placeholders are swapped back to the original
+   values before the response is returned to the user.
+
+Two session modes:
+
+- **`stateful`** (default): peyeeye stores the token→value mapping under a
+  `ses_…` id. The integration sends a best-effort `DELETE /v1/sessions/{id}`
+  after rehydration.
+- **`stateless`**: peyeeye returns a sealed AEAD blob (`skey_…`) and retains
+  nothing server-side. Rehydration is performed by passing that blob back.
+
+## Setup
+
+1. Create an account at [peyeeye.ai](https://peyeeye.ai) and grab an API key.
+2. Set the `PEYEEYE_API_KEY` environment variable.
+3. Update your `config.yml`:
+
+```yaml
+rails:
+  config:
+    peyeeye:
+      # Optional; defaults to https://api.peyeeye.ai. Override for self-hosted.
+      api_base: https://api.peyeeye.ai
+      input:
+        # Optional list of entity IDs. Omit to use the default catalog.
+        entities:
+          - EMAIL
+          - PHONE
+          - CARD
+        locale: auto
+        session_mode: stateful
+      output:
+        # Output is rehydrated via the input session, so options here only
+        # apply if you also enable `peyeeye redact retrieval` etc.
+        locale: auto
+  input:
+    flows:
+      - peyeeye redact input
+  output:
+    flows:
+      - peyeeye rehydrate output
+```
+
+The `peyeeye redact input` flow stashes the session id in
+`$peyeeye_input_session_id`; `peyeeye rehydrate output` reads it.
+
+## Retrieval flow
+
+If you want to redact retrieved knowledge-base chunks before they are
+concatenated into the LLM prompt, add the retrieval flow:
+
+```yaml
+rails:
+  retrieval:
+    flows:
+      - peyeeye redact retrieval
+```
+
+## Configuration reference
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `api_base` | `https://api.peyeeye.ai` | Override via `PEYEEYE_API_BASE`. |
+| `input.entities` | `null` | List of entity IDs to restrict detection to. |
+| `input.locale` | `"auto"` | BCP-47 or `auto`. |
+| `input.session_mode` | `"stateful"` | `"stateful"` or `"stateless"`. |
+| `output.*` / `retrieval.*` | same as input | Per-source overrides. |
+
+## Error handling
+
+The integration intentionally **does not** silently forward unredacted text:
+
+- A 401 response raises `PEyeEyeGuardrailMissingSecrets`.
+- Any other 4xx/5xx, malformed JSON, or response with a different shape than
+  expected raises `PEyeEyeGuardrailAPIError`.
+- A length mismatch between the request and response (`/v1/redact` returning
+  fewer texts than were sent) raises `PEyeEyeGuardrailAPIError` instead of
+  guessing.
+
+Rehydration is forgiving — failures are logged and the original (still
+redacted) text is returned to the caller, so a transient outage on the
+rehydrate endpoint does not leak placeholders or break the response.
+
+## Notes
+
+- The action handlers are in `nemoguardrails/library/peyeeye/actions.py`.
+- The Colang flow definitions live in
+  `nemoguardrails/library/peyeeye/flows.co` (Colang 2) and
+  `flows.v1.co` (Colang 1).
+- For more on the API surface and supported entities, see the
+  [peyeeye documentation](https://peyeeye.ai).

--- a/docs/configure-rails/guardrail-catalog/pii-detection.md
+++ b/docs/configure-rails/guardrail-catalog/pii-detection.md
@@ -156,3 +156,33 @@ rails:
 ```
 
 For more details, check out the [Private AI Integration](community/privateai.md) page.
+
+## Peyeeye PII Redaction & Rehydration
+
+The NeMo Guardrails library supports using the [Peyeeye API](https://peyeeye.ai)
+to redact PII from a user's message before it reaches the LLM and then
+rehydrate the model's response so the user sees the original values, while the
+LLM only ever sees stable placeholders. Set the `PEYEEYE_API_KEY` environment
+variable to authenticate.
+
+```yaml
+rails:
+  config:
+    peyeeye:
+      api_base: https://api.peyeeye.ai
+      input:
+        entities:
+          - EMAIL
+          - PHONE
+          - CARD
+        locale: auto
+        session_mode: stateful  # or "stateless" for AEAD-sealed blobs
+  input:
+    flows:
+      - peyeeye redact input
+  output:
+    flows:
+      - peyeeye rehydrate output
+```
+
+For more details, check out the [Peyeeye Integration](community/peyeeye.md) page.

--- a/nemoguardrails/library/peyeeye/__init__.py
+++ b/nemoguardrails/library/peyeeye/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/peyeeye/actions.py
+++ b/nemoguardrails/library/peyeeye/actions.py
@@ -15,6 +15,7 @@
 
 """PII redaction & rehydration using the Peyeeye API."""
 
+import asyncio
 import logging
 import os
 from typing import Any, Dict, List, Optional, Union
@@ -185,11 +186,30 @@ async def peyeeye_rehydrate(
         log.warning("peyeeye: rehydrate failed: %s", e)
         return {"text": text, "replaced": 0}
 
-    if cleanup and isinstance(session_id, str) and session_id.startswith("ses_"):
-        await peyeeye_delete_session(
-            session_id=session_id,
-            api_base=api_base,
-            api_key=api_key,
-        )
+    if cleanup and session_id.startswith("ses_"):
+        # Fire cleanup as a background task so a slow DELETE endpoint doesn't
+        # add latency to every rehydrated response. The helper already swallows
+        # its own errors (it's documented as best-effort), so we don't need to
+        # attach a done-callback to surface them.
+        try:
+            loop = asyncio.get_running_loop()
+            task = loop.create_task(
+                peyeeye_delete_session(
+                    session_id=session_id,
+                    api_base=api_base,
+                    api_key=api_key,
+                )
+            )
+            # Prevent "Task was destroyed but it is pending" warnings if the
+            # loop is torn down before cleanup finishes.
+            task.add_done_callback(lambda _t: None)
+        except RuntimeError:
+            # No running loop (very unlikely from an async action), fall back
+            # to awaiting inline rather than dropping cleanup.
+            await peyeeye_delete_session(
+                session_id=session_id,
+                api_base=api_base,
+                api_key=api_key,
+            )
 
     return result

--- a/nemoguardrails/library/peyeeye/actions.py
+++ b/nemoguardrails/library/peyeeye/actions.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PII redaction & rehydration using the Peyeeye API."""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Union
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions import action
+from nemoguardrails.library.peyeeye.request import (
+    PEyeEyeGuardrailAPIError,
+    PEyeEyeGuardrailMissingSecrets,
+    peyeeye_delete_session,
+    peyeeye_redact_request,
+    peyeeye_rehydrate_request,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_API_BASE = "https://api.peyeeye.ai"
+VALID_SOURCES = ("input", "output", "retrieval")
+
+
+def _resolve_config(config: RailsConfig, source: str):
+    """Pull the peyeeye config off the rails config object.
+
+    Returns the per-source options object plus the shared api base.
+    """
+    peyeeye_cfg = getattr(getattr(config, "rails", None) and config.rails.config, "peyeeye", None)
+    if peyeeye_cfg is None:
+        raise PEyeEyeGuardrailAPIError("Peyeeye configuration is missing. Add `rails.config.peyeeye` to your config.")
+    if source not in VALID_SOURCES:
+        raise ValueError(f"Peyeeye source must be one of {VALID_SOURCES!r}; got {source!r}.")
+    options = getattr(peyeeye_cfg, source)
+    api_base = getattr(peyeeye_cfg, "api_base", None) or os.environ.get("PEYEEYE_API_BASE") or DEFAULT_API_BASE
+    return options, api_base
+
+
+def _resolve_api_key() -> str:
+    api_key = os.environ.get("PEYEEYE_API_KEY")
+    if not api_key:
+        raise PEyeEyeGuardrailMissingSecrets(
+            "PEYEEYE_API_KEY environment variable is required to use the peyeeye guardrail."
+        )
+    return api_key
+
+
+def _normalize_texts(text: Union[str, List[str]]) -> List[str]:
+    if isinstance(text, str):
+        return [text]
+    if isinstance(text, list):
+        return [t if isinstance(t, str) else str(t) for t in text]
+    raise ValueError(f"peyeeye_redact: `text` must be str or list[str]; got {type(text).__name__}.")
+
+
+@action(is_system_action=False)
+async def peyeeye_redact(
+    source: str,
+    text: Union[str, List[str]],
+    config: RailsConfig,
+    context: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """Redact PII from a piece of input/output/retrieval text using peyeeye.
+
+    The returned dict contains:
+
+    * ``redacted_text``: the text with placeholders substituted (or the
+      original ``list[str]`` input flattened to a list).
+    * ``session_id``: a ``ses_…`` (stateful) or ``skey_…`` (stateless) string
+      that callers must pass to :func:`peyeeye_rehydrate` to swap real values
+      back into the model's response.
+    * ``redacted``: ``True`` when peyeeye returned a usable session id.
+
+    The function refuses to silently forward unredacted text: if the upstream
+    response is malformed or the redacted/source list lengths disagree it
+    raises :class:`PEyeEyeGuardrailAPIError`.
+    """
+    options, api_base = _resolve_config(config, source)
+    api_key = _resolve_api_key()
+
+    text_parts = _normalize_texts(text)
+    if not any(t for t in text_parts):
+        # Nothing to redact; preserve the input shape.
+        return {
+            "redacted_text": text,
+            "session_id": None,
+            "redacted": False,
+        }
+
+    redacted, session_id = await peyeeye_redact_request(
+        texts=text_parts,
+        api_base=api_base,
+        api_key=api_key,
+        locale=options.locale,
+        entities=options.entities,
+        session_mode=options.session_mode,
+    )
+
+    if len(redacted) != len(text_parts):
+        raise PEyeEyeGuardrailAPIError(
+            f"peyeeye /v1/redact returned {len(redacted)} texts for "
+            f"{len(text_parts)} inputs; refusing to forward partially-"
+            "redacted data."
+        )
+
+    if isinstance(text, str):
+        redacted_text: Union[str, List[str]] = redacted[0]
+    else:
+        redacted_text = redacted
+
+    if context is not None and session_id:
+        # Stash the session id so the rehydrate flow can pick it up without
+        # the caller having to thread it through every Colang variable.
+        context_key = f"peyeeye_session_{source}"
+        try:
+            context[context_key] = session_id
+        except Exception:  # noqa: BLE001 - context may be a read-only mapping
+            log.debug("peyeeye: could not stash session id on context")
+
+    return {
+        "redacted_text": redacted_text,
+        "session_id": session_id,
+        "redacted": bool(session_id),
+    }
+
+
+@action(is_system_action=False)
+async def peyeeye_rehydrate(
+    text: str,
+    session_id: str,
+    config: RailsConfig,
+    cleanup: bool = True,
+    **kwargs,
+) -> Dict[str, Any]:
+    """Rehydrate redacted text by swapping placeholders back to original PII.
+
+    Returns ``{"text": <rehydrated>, "replaced": <int>}``. When ``cleanup`` is
+    true and a stateful session was used, the server-side mapping is deleted
+    on a best-effort basis after rehydration.
+
+    Falls through with ``replaced=0`` if either ``text`` or ``session_id`` is
+    empty/falsy — calling sites can safely invoke this on every response
+    without first checking whether redaction happened.
+    """
+    if not text or not session_id:
+        return {"text": text or "", "replaced": 0}
+
+    peyeeye_cfg = getattr(
+        getattr(config, "rails", None) and config.rails.config,
+        "peyeeye",
+        None,
+    )
+    api_base = (
+        (getattr(peyeeye_cfg, "api_base", None) if peyeeye_cfg else None)
+        or os.environ.get("PEYEEYE_API_BASE")
+        or DEFAULT_API_BASE
+    )
+    api_key = _resolve_api_key()
+
+    try:
+        result = await peyeeye_rehydrate_request(
+            text=text,
+            session_id=session_id,
+            api_base=api_base,
+            api_key=api_key,
+        )
+    except PEyeEyeGuardrailMissingSecrets:
+        raise
+    except PEyeEyeGuardrailAPIError as e:
+        log.warning("peyeeye: rehydrate failed: %s", e)
+        return {"text": text, "replaced": 0}
+
+    if cleanup and isinstance(session_id, str) and session_id.startswith("ses_"):
+        await peyeeye_delete_session(
+            session_id=session_id,
+            api_base=api_base,
+            api_key=api_key,
+        )
+
+    return result

--- a/nemoguardrails/library/peyeeye/flows.co
+++ b/nemoguardrails/library/peyeeye/flows.co
@@ -23,7 +23,17 @@ flow peyeeye redact retrieval
 # OUTPUT RAILS
 
 flow peyeeye rehydrate output
-  """Swap PII placeholders in the bot output back to their original values."""
+  """Swap PII placeholders in the bot output back to their original values.
+
+  Rehydrates against the retrieval session first (if any) so chunks redacted
+  in the retrieval rail can be restored, then against the input session so
+  PII the user typed is restored. Order matters when the same placeholder
+  was minted by both paths — input wins, matching the natural reading order
+  of the bot message.
+  """
+  if $peyeeye_retrieval_session_id
+    $peyeeye_output_result = await PeyeeyeRehydrateAction(text=$bot_message, session_id=$peyeeye_retrieval_session_id)
+    $bot_message = $peyeeye_output_result["text"]
   if $peyeeye_input_session_id
     $peyeeye_output_result = await PeyeeyeRehydrateAction(text=$bot_message, session_id=$peyeeye_input_session_id)
     $bot_message = $peyeeye_output_result["text"]

--- a/nemoguardrails/library/peyeeye/flows.co
+++ b/nemoguardrails/library/peyeeye/flows.co
@@ -1,0 +1,29 @@
+#### PEYEEYE PII REDACTION & REHYDRATION RAILS ####
+
+# INPUT RAILS
+
+flow peyeeye redact input
+  """Redact PII from the user input before it reaches the LLM."""
+  $peyeeye_input_result = await PeyeeyeRedactAction(source="input", text=$user_message)
+  $user_message = $peyeeye_input_result["redacted_text"]
+  global $peyeeye_input_session_id
+  $peyeeye_input_session_id = $peyeeye_input_result["session_id"]
+
+
+# RETRIEVAL RAILS
+
+flow peyeeye redact retrieval
+  """Redact PII from retrieved chunks before they are fed to the LLM."""
+  $peyeeye_retrieval_result = await PeyeeyeRedactAction(source="retrieval", text=$relevant_chunks)
+  $relevant_chunks = $peyeeye_retrieval_result["redacted_text"]
+  global $peyeeye_retrieval_session_id
+  $peyeeye_retrieval_session_id = $peyeeye_retrieval_result["session_id"]
+
+
+# OUTPUT RAILS
+
+flow peyeeye rehydrate output
+  """Swap PII placeholders in the bot output back to their original values."""
+  if $peyeeye_input_session_id
+    $peyeeye_output_result = await PeyeeyeRehydrateAction(text=$bot_message, session_id=$peyeeye_input_session_id)
+    $bot_message = $peyeeye_output_result["text"]

--- a/nemoguardrails/library/peyeeye/flows.v1.co
+++ b/nemoguardrails/library/peyeeye/flows.v1.co
@@ -21,7 +21,15 @@ define subflow peyeeye redact retrieval
 # OUTPUT RAILS
 
 define subflow peyeeye rehydrate output
-  """Swap PII placeholders in the bot output back to their original values."""
+  """Swap PII placeholders in the bot output back to their original values.
+
+  Rehydrates against the retrieval session first (if any) so chunks redacted
+  in the retrieval rail can be restored, then against the input session so
+  PII the user typed is restored.
+  """
+  if $peyeeye_retrieval_session_id
+    $peyeeye_output_result = execute peyeeye_rehydrate(text=$bot_message, session_id=$peyeeye_retrieval_session_id)
+    $bot_message = $peyeeye_output_result["text"]
   if $peyeeye_input_session_id
     $peyeeye_output_result = execute peyeeye_rehydrate(text=$bot_message, session_id=$peyeeye_input_session_id)
     $bot_message = $peyeeye_output_result["text"]

--- a/nemoguardrails/library/peyeeye/flows.v1.co
+++ b/nemoguardrails/library/peyeeye/flows.v1.co
@@ -1,0 +1,27 @@
+#### PEYEEYE PII REDACTION & REHYDRATION RAILS ####
+
+# INPUT RAILS
+
+define subflow peyeeye redact input
+  """Redact PII from the user input before it reaches the LLM."""
+  $peyeeye_input_result = execute peyeeye_redact(source="input", text=$user_message)
+  $user_message = $peyeeye_input_result["redacted_text"]
+  $peyeeye_input_session_id = $peyeeye_input_result["session_id"]
+
+
+# RETRIEVAL RAILS
+
+define subflow peyeeye redact retrieval
+  """Redact PII from retrieved chunks before they are fed to the LLM."""
+  $peyeeye_retrieval_result = execute peyeeye_redact(source="retrieval", text=$relevant_chunks)
+  $relevant_chunks = $peyeeye_retrieval_result["redacted_text"]
+  $peyeeye_retrieval_session_id = $peyeeye_retrieval_result["session_id"]
+
+
+# OUTPUT RAILS
+
+define subflow peyeeye rehydrate output
+  """Swap PII placeholders in the bot output back to their original values."""
+  if $peyeeye_input_session_id
+    $peyeeye_output_result = execute peyeeye_rehydrate(text=$bot_message, session_id=$peyeeye_input_session_id)
+    $bot_message = $peyeeye_output_result["text"]

--- a/nemoguardrails/library/peyeeye/request.py
+++ b/nemoguardrails/library/peyeeye/request.py
@@ -31,11 +31,30 @@ class PEyeEyeGuardrailAPIError(Exception):
     """Raised when the peyeeye API returns an error."""
 
 
+_BODY_SNIPPET_MAX = 200
+
+
 def _auth_headers(api_key: str) -> Dict[str, str]:
     return {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
+
+
+def _safe_snippet(body_text: str, limit: int = _BODY_SNIPPET_MAX) -> str:
+    """Return a truncated body snippet safe to embed in an exception message.
+
+    Avoids dumping the full provider response (which may include detail strings
+    a caller would prefer not to see in logs) while keeping enough context for
+    debugging.
+    """
+    if body_text is None:
+        return "<empty body, len=0>"
+    text = body_text.strip()
+    length = len(text)
+    if length <= limit:
+        return text
+    return f"{text[:limit]}… <truncated, total len={length}>"
 
 
 async def peyeeye_redact_request(
@@ -124,7 +143,9 @@ async def peyeeye_rehydrate_request(
     body = {"text": text, "session": session_id}
     payload = await _post_json(url, body, _auth_headers(api_key), timeout=timeout)
 
-    rehydrated = payload.get("text", text)
+    # Use ``or text`` so a JSON ``null`` (key present, value None) falls back to
+    # the original input rather than propagating ``None`` into ``$bot_message``.
+    rehydrated = payload.get("text") or text
     replaced = payload.get("replaced", 0)
     try:
         replaced = int(replaced)
@@ -175,14 +196,22 @@ async def _post_json(
                     raise PEyeEyeGuardrailMissingSecrets(f"Invalid peyeeye API key (401 from {url})")
                 if status >= 400:
                     body_text = await resp.text()
-                    raise PEyeEyeGuardrailAPIError(f"peyeeye request to {url} failed with status {status}: {body_text}")
+                    snippet = _safe_snippet(body_text)
+                    raise PEyeEyeGuardrailAPIError(f"peyeeye request to {url} failed with status {status}: {snippet}")
                 try:
-                    return await resp.json()
+                    payload = await resp.json()
                 except aiohttp.ContentTypeError as e:
                     body_text = await resp.text()
+                    snippet = _safe_snippet(body_text)
                     raise PEyeEyeGuardrailAPIError(
-                        f"peyeeye {url} returned non-JSON response (status={status}): {body_text}"
+                        f"peyeeye {url} returned non-JSON response (status={status}): {snippet}"
                     ) from e
+                if not isinstance(payload, dict):
+                    raise PEyeEyeGuardrailAPIError(
+                        f"peyeeye {url} returned non-object JSON payload (status={status}, "
+                        f"type={type(payload).__name__})"
+                    )
+                return payload
     except (PEyeEyeGuardrailMissingSecrets, PEyeEyeGuardrailAPIError):
         raise
     except aiohttp.ClientError as e:

--- a/nemoguardrails/library/peyeeye/request.py
+++ b/nemoguardrails/library/peyeeye/request.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for handling Peyeeye PII redaction & rehydration requests."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+log = logging.getLogger(__name__)
+
+
+class PEyeEyeGuardrailMissingSecrets(Exception):
+    """Raised when the peyeeye API key is missing."""
+
+
+class PEyeEyeGuardrailAPIError(Exception):
+    """Raised when the peyeeye API returns an error."""
+
+
+def _auth_headers(api_key: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+async def peyeeye_redact_request(
+    texts: List[str],
+    api_base: str,
+    api_key: str,
+    locale: str = "auto",
+    entities: Optional[List[str]] = None,
+    session_mode: str = "stateful",
+    timeout: float = 15.0,
+):
+    """Send a redaction request to the peyeeye API.
+
+    Args:
+        texts: The list of texts to redact.
+        api_base: The peyeeye API base URL (e.g. ``https://api.peyeeye.ai``).
+        api_key: The bearer API key.
+        locale: BCP-47 locale or ``"auto"``.
+        entities: Optional list of entity IDs to restrict detection to.
+        session_mode: ``"stateful"`` (default) or ``"stateless"``.
+        timeout: Total request timeout in seconds.
+
+    Returns:
+        Tuple ``(redacted_texts, session_id)`` where ``session_id`` is either a
+        ``ses_…`` (stateful) or ``skey_…`` (stateless) string, or ``None`` if
+        the API didn't return one.
+
+    Raises:
+        PEyeEyeGuardrailMissingSecrets: If the API key is missing/invalid.
+        PEyeEyeGuardrailAPIError: For all other API or transport failures.
+    """
+    if not api_key:
+        raise PEyeEyeGuardrailMissingSecrets(
+            "Peyeeye API key is required. Set the `PEYEEYE_API_KEY` environment variable."
+        )
+
+    body: Dict[str, Any] = {
+        "text": list(texts),
+        "locale": locale,
+    }
+    if entities:
+        body["entities"] = list(entities)
+    if session_mode == "stateless":
+        body["session"] = "stateless"
+
+    url = f"{api_base.rstrip('/')}/v1/redact"
+    payload = await _post_json(url, body, _auth_headers(api_key), timeout=timeout)
+
+    out_text = payload.get("text")
+    if isinstance(out_text, str):
+        redacted = [out_text]
+    elif isinstance(out_text, list):
+        redacted = [str(x) for x in out_text]
+    else:
+        raise PEyeEyeGuardrailAPIError(
+            "peyeeye /v1/redact returned unexpected response shape; refusing to forward unredacted text"
+        )
+
+    if session_mode == "stateless":
+        session_id = payload.get("rehydration_key")
+    else:
+        session_id = payload.get("session_id") or payload.get("session")
+
+    return redacted, session_id
+
+
+async def peyeeye_rehydrate_request(
+    text: str,
+    session_id: str,
+    api_base: str,
+    api_key: str,
+    timeout: float = 15.0,
+):
+    """Send a rehydration request to the peyeeye API.
+
+    Returns a dict ``{"text": <rehydrated>, "replaced": <int>}``.
+    """
+    if not api_key:
+        raise PEyeEyeGuardrailMissingSecrets(
+            "Peyeeye API key is required. Set the `PEYEEYE_API_KEY` environment variable."
+        )
+    if not session_id:
+        raise PEyeEyeGuardrailAPIError("Cannot rehydrate without a session id.")
+
+    url = f"{api_base.rstrip('/')}/v1/rehydrate"
+    body = {"text": text, "session": session_id}
+    payload = await _post_json(url, body, _auth_headers(api_key), timeout=timeout)
+
+    rehydrated = payload.get("text", text)
+    replaced = payload.get("replaced", 0)
+    try:
+        replaced = int(replaced)
+    except (TypeError, ValueError):
+        replaced = 0
+    return {"text": rehydrated, "replaced": replaced}
+
+
+async def peyeeye_delete_session(
+    session_id: str,
+    api_base: str,
+    api_key: str,
+    timeout: float = 10.0,
+) -> None:
+    """Best-effort delete of a stateful peyeeye session.
+
+    Errors are swallowed and logged at debug; this is cleanup.
+    """
+    if not session_id or not session_id.startswith("ses_"):
+        return
+    url = f"{api_base.rstrip('/')}/v1/sessions/{session_id}"
+    headers = _auth_headers(api_key)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.delete(url, headers=headers, timeout=aiohttp.ClientTimeout(total=timeout)):
+                pass
+    except Exception as e:  # noqa: BLE001 - best-effort cleanup
+        log.debug("peyeeye: best-effort session cleanup failed: %s", e)
+
+
+async def _post_json(
+    url: str,
+    body: Dict[str, Any],
+    headers: Dict[str, str],
+    timeout: float,
+) -> Dict[str, Any]:
+    """POST JSON, raise ``PEyeEyeGuardrail*`` on failure, return parsed body."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=body,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                status = resp.status
+                if status == 401:
+                    raise PEyeEyeGuardrailMissingSecrets(f"Invalid peyeeye API key (401 from {url})")
+                if status >= 400:
+                    body_text = await resp.text()
+                    raise PEyeEyeGuardrailAPIError(f"peyeeye request to {url} failed with status {status}: {body_text}")
+                try:
+                    return await resp.json()
+                except aiohttp.ContentTypeError as e:
+                    body_text = await resp.text()
+                    raise PEyeEyeGuardrailAPIError(
+                        f"peyeeye {url} returned non-JSON response (status={status}): {body_text}"
+                    ) from e
+    except (PEyeEyeGuardrailMissingSecrets, PEyeEyeGuardrailAPIError):
+        raise
+    except aiohttp.ClientError as e:
+        raise PEyeEyeGuardrailAPIError(f"peyeeye request to {url} failed: {e}") from e
+    except TimeoutError as e:
+        raise PEyeEyeGuardrailAPIError(f"peyeeye request to {url} timed out") from e

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -328,6 +328,53 @@ class PrivateAIDetection(BaseModel):
     )
 
 
+class PEyeEyeOptions(BaseModel):
+    """Per-source (input/output/retrieval) options for the Peyeeye PII guardrail."""
+
+    entities: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Optional list of entity IDs to restrict detection to. When unset, peyeeye runs its default entity catalog."
+        ),
+    )
+    locale: str = Field(
+        default="auto",
+        description="BCP-47 locale or `auto` to let peyeeye detect it.",
+    )
+    session_mode: Literal["stateful", "stateless"] = Field(
+        default="stateful",
+        description=(
+            "`stateful` (default): peyeeye stores the token→value mapping under a "
+            "`ses_…` id. `stateless`: peyeeye returns a sealed AEAD blob (`skey_…`) "
+            "and retains nothing server-side."
+        ),
+    )
+
+
+class PEyeEyeConfig(BaseModel):
+    """Configuration for the Peyeeye PII redaction & rehydration guardrail."""
+
+    api_base: str = Field(
+        default="https://api.peyeeye.ai",
+        description=(
+            "Peyeeye API base URL. Override via the `PEYEEYE_API_BASE` env var or "
+            "this field for self-hosted deployments."
+        ),
+    )
+    input: PEyeEyeOptions = Field(
+        default_factory=PEyeEyeOptions,
+        description="Options for redaction of user input.",
+    )
+    output: PEyeEyeOptions = Field(
+        default_factory=PEyeEyeOptions,
+        description="Options for redaction of bot output.",
+    )
+    retrieval: PEyeEyeOptions = Field(
+        default_factory=PEyeEyeOptions,
+        description="Options for redaction of retrieved knowledge-base chunks.",
+    )
+
+
 class GLiNERDetectionOptions(BaseModel):
     """Configuration options for GLiNER."""
 
@@ -1115,6 +1162,11 @@ class RailsConfigData(BaseModel):
     privateai: Optional[PrivateAIDetection] = Field(
         default_factory=PrivateAIDetection,
         description="Configuration for Private AI.",
+    )
+
+    peyeeye: Optional[PEyeEyeConfig] = Field(
+        default_factory=PEyeEyeConfig,
+        description="Configuration for the Peyeeye PII redaction & rehydration guardrail.",
     )
 
     gliner: Optional[GLiNERDetection] = Field(

--- a/tests/test_peyeeye.py
+++ b/tests/test_peyeeye.py
@@ -268,14 +268,6 @@ async def test_redact_passes_entities_and_locale(monkeypatch):
         """
     )
 
-    captured: dict = {}
-
-    def _capture(url, **kwargs):
-        captured.update(kwargs.get("json") or {})
-        return aioresponses.CallbackResult(  # type: ignore[attr-defined]
-            payload={"text": ["[EMAIL_1]"], "session_id": "ses_x"},
-        )
-
     with aioresponses() as m:
         m.post(
             REDACT_URL,
@@ -317,6 +309,14 @@ async def test_rehydrate_replaces_placeholders_and_cleans_up(monkeypatch):
             session_id="ses_abc123",
             config=config,
         )
+
+        # Cleanup runs in the background; drain so the task completes before
+        # ``aioresponses`` tears down its mock.
+        import asyncio as _asyncio
+
+        pending = [t for t in _asyncio.all_tasks() if t is not _asyncio.current_task() and not t.done()]
+        if pending:
+            await _asyncio.gather(*pending, return_exceptions=True)
 
     assert result == {"text": "hi me@example.com", "replaced": 1}
 
@@ -367,6 +367,99 @@ async def test_rehydrate_skips_delete_for_stateless(monkeypatch):
         )
 
     assert result["replaced"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_falls_back_when_payload_text_is_null(monkeypatch):
+    """A buggy provider returning ``{"text": null}`` must not propagate ``None``
+    into ``$bot_message``; we fall back to the original (still redacted) text."""
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REHYDRATE_URL, payload={"text": None, "replaced": 0})
+        m.delete(SESSION_DELETE_RE, status=204)
+
+        result = await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="ses_abc123",
+            config=config,
+        )
+
+    assert result == {"text": "hi [EMAIL_1]", "replaced": 0}
+
+
+@pytest.mark.asyncio
+async def test_redact_rejects_non_object_json_payload(monkeypatch):
+    """A 200 response with a JSON list (not an object) must surface as an API
+    error rather than crashing later with ``AttributeError`` on ``.get``."""
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REDACT_URL, payload=["unexpected", "list"])
+        with pytest.raises(PEyeEyeGuardrailAPIError, match="non-object JSON payload"):
+            await peyeeye_redact(
+                source="input",
+                text="hi",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_cleanup_runs_in_background(monkeypatch):
+    """The DELETE /v1/sessions/{id} call must be fired as a background task
+    rather than awaited inline — otherwise a slow cleanup endpoint adds latency
+    to every rehydrated response."""
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REHYDRATE_URL, payload={"text": "hi me@example.com", "replaced": 1})
+        m.delete(SESSION_DELETE_RE, status=204)
+
+        result = await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="ses_abc123",
+            config=config,
+        )
+
+        # At return time the DELETE may not have fired yet — drain pending
+        # tasks so the background DELETE has a chance to run before we assert.
+        import asyncio as _asyncio
+
+        pending = [t for t in _asyncio.all_tasks() if t is not _asyncio.current_task() and not t.done()]
+        if pending:
+            await _asyncio.gather(*pending, return_exceptions=True)
+
+    assert result == {"text": "hi me@example.com", "replaced": 1}
+    delete_calls = [c for k, calls in m.requests.items() if k[0] == "DELETE" for c in calls]
+    assert delete_calls, "expected best-effort DELETE to fire (eventually)"
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_error_body_is_truncated(monkeypatch):
+    """The exception message for a 4xx/5xx must not include the full provider
+    response body verbatim — large bodies are truncated."""
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    huge = "X" * 5000
+
+    with aioresponses() as m:
+        m.post(REDACT_URL, status=500, body=huge, content_type="text/plain")
+        with pytest.raises(PEyeEyeGuardrailAPIError) as exc_info:
+            await peyeeye_redact(
+                source="input",
+                text="hi",
+                config=config,
+            )
+
+    msg = str(exc_info.value)
+    # The full body must not appear.
+    assert huge not in msg
+    # But a truncation marker should.
+    assert "truncated" in msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_peyeeye.py
+++ b/tests/test_peyeeye.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Peyeeye PII redaction & rehydration guardrail."""
+
+import re
+
+import pytest
+from aioresponses import aioresponses
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.library.peyeeye.actions import (
+    peyeeye_redact,
+    peyeeye_rehydrate,
+)
+from nemoguardrails.library.peyeeye.request import (
+    PEyeEyeGuardrailAPIError,
+    PEyeEyeGuardrailMissingSecrets,
+)
+from tests.utils import TestChat
+
+REDACT_URL = "https://api.peyeeye.ai/v1/redact"
+REHYDRATE_URL = "https://api.peyeeye.ai/v1/rehydrate"
+SESSION_DELETE_RE = re.compile(r"https://api\.peyeeye\.ai/v1/sessions/.+")
+
+
+def _build_config(yaml_extra: str = "", colang_content: str | None = None) -> RailsConfig:
+    yaml_content = (
+        """
+        models: []
+        rails:
+          config:
+            peyeeye:
+              api_base: https://api.peyeeye.ai
+        """
+        + yaml_extra
+    )
+    return RailsConfig.from_content(
+        yaml_content=yaml_content,
+        colang_content=colang_content
+        or """
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot inform answer unknown
+              "I can't answer that."
+        """,
+    )
+
+
+# ---------------------------------------------------------------- unit: redact
+
+
+@pytest.mark.asyncio
+async def test_redact_happy_path_stateful(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={
+                "text": ["hi [EMAIL_1]"],
+                "session_id": "ses_abc123",
+            },
+        )
+        result = await peyeeye_redact(
+            source="input",
+            text="hi me@example.com",
+            config=config,
+        )
+
+    assert result == {
+        "redacted_text": "hi [EMAIL_1]",
+        "session_id": "ses_abc123",
+        "redacted": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_redact_stashes_session_id_on_context(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+    ctx: dict = {}
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={"text": ["[EMAIL_1]"], "session_id": "ses_xyz"},
+        )
+        await peyeeye_redact(
+            source="input",
+            text="me@example.com",
+            config=config,
+            context=ctx,
+        )
+
+    assert ctx["peyeeye_session_input"] == "ses_xyz"
+
+
+@pytest.mark.asyncio
+async def test_redact_stateless_returns_skey(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config(
+        yaml_extra="""
+              input:
+                session_mode: stateless
+        """
+    )
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={
+                "text": ["hi [EMAIL_1]"],
+                "rehydration_key": "skey_sealed_blob",
+            },
+        )
+        result = await peyeeye_redact(
+            source="input",
+            text="hi me@example.com",
+            config=config,
+        )
+
+    assert result["session_id"] == "skey_sealed_blob"
+    assert result["redacted"] is True
+    assert result["redacted_text"] == "hi [EMAIL_1]"
+
+
+@pytest.mark.asyncio
+async def test_redact_length_mismatch_raises(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        # We send 2 texts but server returns 1 — must NOT be silently merged.
+        m.post(
+            REDACT_URL,
+            payload={"text": ["only one"], "session_id": "ses_x"},
+        )
+        with pytest.raises(PEyeEyeGuardrailAPIError, match="returned 1 texts for 2"):
+            await peyeeye_redact(
+                source="input",
+                text=["a", "b"],
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_redact_unexpected_response_shape_raises(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={"unexpected": "shape"},
+        )
+        with pytest.raises(PEyeEyeGuardrailAPIError, match="unexpected response shape"):
+            await peyeeye_redact(
+                source="input",
+                text="something",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_redact_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("PEYEEYE_API_KEY", raising=False)
+    config = _build_config()
+
+    with pytest.raises(PEyeEyeGuardrailMissingSecrets):
+        await peyeeye_redact(
+            source="input",
+            text="hi",
+            config=config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_redact_401_raises_missing_secrets(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "bad-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REDACT_URL, status=401, payload={"detail": "invalid key"})
+        with pytest.raises(PEyeEyeGuardrailMissingSecrets):
+            await peyeeye_redact(
+                source="input",
+                text="hi",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_redact_5xx_raises_api_error(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REDACT_URL, status=500, payload={"detail": "boom"})
+        with pytest.raises(PEyeEyeGuardrailAPIError, match="status 500"):
+            await peyeeye_redact(
+                source="input",
+                text="hi",
+                config=config,
+            )
+
+
+@pytest.mark.asyncio
+async def test_redact_invalid_source_raises(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with pytest.raises(ValueError, match="source must be one of"):
+        await peyeeye_redact(
+            source="banana",
+            text="hi",
+            config=config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_redact_empty_text_skips_call(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        # No mock registered — if a call is made, aioresponses raises.
+        result = await peyeeye_redact(
+            source="input",
+            text="",
+            config=config,
+        )
+        # Sanity: also no calls registered.
+        assert not m.requests
+
+    assert result == {"redacted_text": "", "session_id": None, "redacted": False}
+
+
+@pytest.mark.asyncio
+async def test_redact_passes_entities_and_locale(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config(
+        yaml_extra="""
+              input:
+                entities:
+                  - EMAIL
+                  - PHONE
+                locale: en-US
+        """
+    )
+
+    captured: dict = {}
+
+    def _capture(url, **kwargs):
+        captured.update(kwargs.get("json") or {})
+        return aioresponses.CallbackResult(  # type: ignore[attr-defined]
+            payload={"text": ["[EMAIL_1]"], "session_id": "ses_x"},
+        )
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={"text": ["[EMAIL_1]"], "session_id": "ses_x"},
+        )
+        await peyeeye_redact(
+            source="input",
+            text="me@example.com",
+            config=config,
+        )
+
+        # Inspect the captured request body via aioresponses' request log.
+        req_key = next(iter(m.requests))
+        req = m.requests[req_key][0]
+        body = req.kwargs["json"]
+        assert body["entities"] == ["EMAIL", "PHONE"]
+        assert body["locale"] == "en-US"
+        assert "session" not in body  # stateful default
+
+
+# ------------------------------------------------------------- unit: rehydrate
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_replaces_placeholders_and_cleans_up(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(
+            REHYDRATE_URL,
+            payload={"text": "hi me@example.com", "replaced": 1},
+        )
+        # DELETE for cleanup; aioresponses requires explicit registration.
+        m.delete(SESSION_DELETE_RE, status=204)
+
+        result = await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="ses_abc123",
+            config=config,
+        )
+
+    assert result == {"text": "hi me@example.com", "replaced": 1}
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_no_op_when_inputs_empty(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    # No HTTP mock — must short-circuit.
+    result = await peyeeye_rehydrate(text="", session_id="", config=config)
+    assert result == {"text": "", "replaced": 0}
+
+    result = await peyeeye_rehydrate(text="hi", session_id="", config=config)
+    assert result == {"text": "hi", "replaced": 0}
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_swallows_api_error_and_returns_original(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REHYDRATE_URL, status=500, payload={"detail": "boom"})
+
+        result = await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="ses_abc123",
+            config=config,
+            cleanup=False,
+        )
+
+    assert result == {"text": "hi [EMAIL_1]", "replaced": 0}
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_skips_delete_for_stateless(monkeypatch):
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+    config = _build_config()
+
+    with aioresponses() as m:
+        m.post(REHYDRATE_URL, payload={"text": "hi me@example.com", "replaced": 1})
+        # No DELETE mock registered: if the action attempts one, aioresponses raises.
+        result = await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="skey_sealed",
+            config=config,
+        )
+
+    assert result["replaced"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("PEYEEYE_API_KEY", raising=False)
+    config = _build_config()
+
+    with pytest.raises(PEyeEyeGuardrailMissingSecrets):
+        await peyeeye_rehydrate(
+            text="hi [EMAIL_1]",
+            session_id="ses_abc123",
+            config=config,
+        )
+
+
+# -------------------------------------------------------- end-to-end rail test
+
+
+def test_rail_redacts_input_and_rehydrates_output(monkeypatch):
+    """Happy path through the v1 colang rail: input is redacted before reaching
+    the LLM and the LLM's response is rehydrated before returning to the user."""
+    monkeypatch.setenv("PEYEEYE_API_KEY", "test-key")
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+            rails:
+              config:
+                peyeeye:
+                  api_base: https://api.peyeeye.ai
+              input:
+                flows:
+                  - peyeeye redact input
+              output:
+                flows:
+                  - peyeeye rehydrate output
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot express greeting
+              "Hello! How can I assist you today?"
+        """,
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+        ],
+    )
+
+    with aioresponses() as m:
+        m.post(
+            REDACT_URL,
+            payload={
+                "text": ["hi, my email is [EMAIL_1]"],
+                "session_id": "ses_e2e",
+            },
+        )
+        # Bot greeting is hard-coded so rehydrate gets the literal greeting,
+        # but the rail still runs; mock /rehydrate to echo the bot text.
+        m.post(
+            REHYDRATE_URL,
+            payload={
+                "text": "Hello! How can I assist you today?",
+                "replaced": 0,
+            },
+        )
+        m.delete(SESSION_DELETE_RE, status=204)
+
+        chat >> "hi, my email is me@example.com"
+        chat << "Hello! How can I assist you today?"
+
+        # The redact mock must have been called with the original user text.
+        redact_calls = [
+            c for k, calls in m.requests.items() if k[0] == "POST" for c in calls if str(k[1]).endswith("/v1/redact")
+        ]
+        assert redact_calls, "expected at least one /v1/redact call"
+        body = redact_calls[0].kwargs["json"]
+        assert body["text"] == ["hi, my email is me@example.com"]


### PR DESCRIPTION
## Summary

Adds an NeMo Guardrails community integration for the [peyeeye.ai](https://peyeeye.ai) PII redaction & rehydration API. The integration is modeled after the existing `privateai` library but adds a *rehydration* output rail so that the LLM only ever sees stable placeholders (e.g. `[EMAIL_1]`), while the user still sees the original values in the bot's response.

### Pre/post hooks

- **Input rail (`peyeeye redact input`)** — calls `POST /v1/redact`, swaps each detected entity for a placeholder, and stashes the returned session id (`ses_…` for stateful, `skey_…` for stateless) on the global context so the output rail can pick it up.
- **Output rail (`peyeeye rehydrate output`)** — calls `POST /v1/rehydrate` with the stashed session id and swaps the placeholders back to the originals before the response leaves the system. For stateful sessions, fires a best-effort `DELETE /v1/sessions/{id}` for cleanup.
- **Retrieval rail (`peyeeye redact retrieval`)** — same shape as the input rail, but for retrieved knowledge-base chunks.

The integration refuses to silently forward unredacted text: malformed responses, length mismatches between the request batch and the redacted response, and 4xx/5xx all raise typed exceptions (`PEyeEyeGuardrailMissingSecrets` for auth, `PEyeEyeGuardrailAPIError` for everything else).

### Config example

```yaml
rails:
  config:
    peyeeye:
      api_base: https://api.peyeeye.ai
      input:
        entities: [EMAIL, PHONE, CARD]
        locale: auto
        session_mode: stateful   # or "stateless" for AEAD-sealed blobs
  input:
    flows:
      - peyeeye redact input
  output:
    flows:
      - peyeeye rehydrate output
```

`PEYEEYE_API_KEY` is read from the environment.

### Tests added

`tests/test_peyeeye.py` (17 tests, all mock-only via `aioresponses`):

- redact happy path (stateful + stateless)
- length mismatch raises (load-bearing — no silent partial redaction)
- unexpected response shape raises
- missing API key raises
- 401 → `PEyeEyeGuardrailMissingSecrets`; 5xx → `PEyeEyeGuardrailAPIError`
- empty text short-circuits (no API call)
- entities/locale/session_mode are forwarded correctly in the request body
- session id is stashed onto the action `context` dict
- rehydrate replaces placeholders and triggers session DELETE
- rehydrate is a no-op on empty inputs
- rehydrate swallows API errors and returns the original text
- rehydrate skips DELETE for `skey_` (stateless) sessions
- end-to-end rail test using `RailsConfig.from_content` + `TestChat`

```
$ poetry run pytest tests/test_peyeeye.py -q
.................                                                        [100%]
17 passed in 1.44s
```

### CHANGELOG

Added an entry under `## [Unreleased]` -> `### 🚀 Features`.

### Docs

- New community page: `docs/configure-rails/guardrail-catalog/community/peyeeye.md`
- New section appended to `docs/configure-rails/guardrail-catalog/pii-detection.md`

## Test plan

- [x] `poetry run pytest tests/test_peyeeye.py -v` — 17/17 pass locally
- [x] `poetry run pytest -k peyeeye` — 17/17 pass
- [x] `poetry run pytest tests/test_config_validation.py tests/test_config_loading.py tests/test_privateai.py tests/test_activefence_rail.py` — adjacent suites still green
- [x] `poetry run ruff check` and `poetry run ruff format --check` clean on all touched files
- [x] DCO sign-off present on the commit
