### PR TITLE
refactor(iorails): Return LLMResponse(Chunk) from ModelEngine

### DIFF
--- a/nemoguardrails/guardrails/actions/content_safety_action.py
+++ b/nemoguardrails/guardrails/actions/content_safety_action.py
@@ -55,7 +55,9 @@ class ContentSafetyInputAction(RailAction):
         if stop:
             kwargs["stop"] = stop
 
-        response_text = await self._get_llm_response(model_type, prompt, **kwargs)
+        # Extract content string from structured LLMResponse
+        llm_response = await self._get_llm_response(model_type, prompt, **kwargs)
+        response_text = llm_response.content
 
         # Parse via LLMTaskManager's registered output parser
         return self.task_manager.parse_task_output(task=prompt_task_key, output=response_text)  # type: ignore[arg-type]
@@ -103,7 +105,7 @@ class ContentSafetyOutputAction(RailAction):
         if stop:
             kwargs["stop"] = stop
 
-        response_text = await self._get_llm_response(model_type, prompt, **kwargs)
+        response_text = (await self._get_llm_response(model_type, prompt, **kwargs)).content
         return self.task_manager.parse_task_output(task=prompt_task_key, output=response_text)  # type: ignore[arg-type]
 
     def _parse_response(self, response: Any) -> RailResult:

--- a/nemoguardrails/guardrails/actions/topic_safety_action.py
+++ b/nemoguardrails/guardrails/actions/topic_safety_action.py
@@ -57,7 +57,9 @@ class TopicSafetyInputAction(RailAction):
         if stop:
             kwargs["stop"] = stop
 
-        return await self._get_llm_response(model_type, prompt, **kwargs)
+        # Extract content string from structured LLMResponse
+        llm_response = await self._get_llm_response(model_type, prompt, **kwargs)
+        return llm_response.content
 
     def _parse_response(self, response: Any) -> RailResult:
         if response.lower().strip() == "off-topic":

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -29,6 +29,7 @@ from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.telemetry import api_call_span, llm_call_span
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -139,8 +140,12 @@ class EngineRegistry:
             raise TypeError(f"Engine '{name}' is {type(engine).__name__}, expected {expected_type.__name__}")
         return engine
 
-    async def model_call(self, model_type: str, messages: list[dict], **kwargs: Any) -> str:
+    async def model_call(self, model_type: str, messages: list[dict], **kwargs: Any) -> LLMResponse:
         """Route a chat completion request to the named model engine.
+
+        Returns the structured ``LLMResponse`` from the engine — content,
+        reasoning (when the provider exposes it), usage, finish reason.
+        Callers that only want the assistant text should access ``.content``.
 
         Raises:
             KeyError: If no engine is registered with the given name.
@@ -158,12 +163,13 @@ class EngineRegistry:
 
     async def stream_model_call(
         self, model_type: str, messages: list[dict], **kwargs: Any
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[LLMResponseChunk, None]:
         """Stream chat completion chunks from the named model engine.
 
-        The surrounding ``llm_call_span`` wraps the full generator lifetime:
-        it opens before the first chunk and closes when the generator
-        exhausts or raises.
+        Yields ``LLMResponseChunk`` objects. The surrounding
+        ``llm_call_span`` wraps the full generator lifetime: it opens
+        before the first chunk and closes when the generator exhausts or
+        raises.
 
         Raises:
             KeyError: If no engine is registered with the given name.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -385,7 +385,10 @@ class IORails:
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
 
-                # Step 2: Stream main LLM content from structured response
+                # Step 2: Stream main LLM content from structured response.
+                # TODO: Only delta_content is forwarded.
+                #  Reasoning-only chunks (delta_reasoning set but delta_content is None)
+                #  and tool-call deltas will be routed through in a follow-up PR
                 log.info("[%s] Streaming main LLM", req_id)
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
                     if chunk.delta_content:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -285,7 +285,8 @@ class IORails:
         if isinstance(options, GenerationOptions) and options.llm_params:
             llm_kwargs = options.llm_params
 
-        response_text = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        # Extract content string from structured LLMResponse.
+        response_text = (await self.engine_registry.model_call("main", messages, **llm_kwargs)).content
         log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
 
         # Step 3: Check output rails
@@ -384,10 +385,11 @@ class IORails:
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
 
-                # Step 2: Stream main LLM
+                # Step 2: Stream main LLM content from structured response
                 log.info("[%s] Streaming main LLM", req_id)
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
-                    await streaming_handler.push_chunk(chunk)
+                    if chunk.delta_content:
+                        await streaming_handler.push_chunk(chunk.delta_content)
 
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
             except Exception as e:

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails._http import (
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, get_request_id, truncate
 from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +59,82 @@ class _RequestParams(NamedTuple):
     url: str
     headers: dict[str, str]
     body: dict[str, Any]
+
+
+def _parse_usage(usage_dict: dict) -> UsageInfo:
+    """Build UsageInfo from an OpenAI-format usage dict.
+
+    Picks up reasoning_tokens from completion_tokens_details (OpenAI reasoning
+    models) and cached_tokens from prompt_tokens_details when present.
+    """
+    completion_details = usage_dict.get("completion_tokens_details") or {}
+    prompt_details = usage_dict.get("prompt_tokens_details") or {}
+    return UsageInfo(
+        input_tokens=usage_dict.get("prompt_tokens", 0),
+        output_tokens=usage_dict.get("completion_tokens", 0),
+        total_tokens=usage_dict.get("total_tokens", 0),
+        reasoning_tokens=completion_details.get("reasoning_tokens"),
+        cached_tokens=prompt_details.get("cached_tokens"),
+    )
+
+
+def _parse_chat_completion(response: dict) -> LLMResponse:
+    """Convert a /v1/chat/completions response dict into an LLMResponse.
+
+    Reasoning is read from ``message.reasoning_content`` when the provider
+    exposes it (NIM, DeepSeek-style). Tool calls are out of scope for this
+    PR series and are not currently surfaced.
+    """
+    try:
+        choice = response["choices"][0]
+        message = choice["message"]
+        content = message["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ValueError(f"Unexpected /v1/chat/completions response shape: {exc}") from exc
+
+    if not isinstance(content, str):
+        raise ValueError(f"Expected string content, got {type(content).__name__}")
+
+    reasoning = message.get("reasoning_content") or None
+
+    usage = _parse_usage(response["usage"]) if response.get("usage") else None
+
+    return LLMResponse(
+        content=content,
+        reasoning=reasoning,
+        model=response.get("model"),
+        finish_reason=choice.get("finish_reason"),
+        request_id=response.get("id"),
+        usage=usage,
+    )
+
+
+def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
+    """Build an LLMResponseChunk from an SSE chunk dict.
+
+    Returns None for chunks that carry no content or reasoning delta —
+    role-only first events, finish-only events, or empty-choices events
+    are skipped, preserving current stream_call behavior.
+    """
+    choices = chunk.get("choices") or []
+    if not choices:
+        return None
+
+    choice = choices[0]
+    delta = choice.get("delta") or {}
+    delta_content = delta.get("content")
+    delta_reasoning = delta.get("reasoning_content")
+
+    if not delta_content and not delta_reasoning:
+        return None
+
+    return LLMResponseChunk(
+        delta_content=delta_content,
+        delta_reasoning=delta_reasoning,
+        model=chunk.get("model"),
+        finish_reason=choice.get("finish_reason"),
+        request_id=chunk.get("id"),
+    )
 
 
 class ModelEngineError(Exception):
@@ -230,18 +307,21 @@ class ModelEngine(BaseEngine):
         self,
         messages: LLMMessages,
         **kwargs: Any,
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[LLMResponseChunk, None]:
         """Make a streaming POST request to the /v1/chat/completions endpoint.
 
-        Sends ``stream=True`` and yields content-delta strings as they arrive
-        via SSE.  Retries are handled by the RetryClient (same as ``call()``).
+        Sends ``stream=True`` and yields one ``LLMResponseChunk`` per SSE
+        event that carries a content or reasoning delta. Role-only,
+        finish-only, and empty-choices events are skipped. Retries are
+        handled by the RetryClient (same as ``call()``).
 
         Args:
             messages: List of message dicts in OpenAI format.
             **kwargs: Additional parameters for the request body (temperature, max_tokens, etc.)
 
         Yields:
-            Content-delta strings from each streamed chunk.
+            ``LLMResponseChunk`` objects with ``delta_content`` and/or
+            ``delta_reasoning`` populated.
 
         Raises:
             ModelEngineError: If the request fails after all retries.
@@ -287,18 +367,14 @@ class ModelEngine(BaseEngine):
                         break
 
                     try:
-                        chunk = json.loads(payload)
+                        raw_chunk = json.loads(payload)
                     except json.JSONDecodeError:
                         log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
                         continue
 
-                    choices = chunk.get("choices") or []
-                    if not choices:
-                        continue
-                    delta = choices[0].get("delta") or {}
-                    content = delta.get("content")
-                    if content:
-                        yield content
+                    parsed_chunk = _parse_chat_completion_chunk(raw_chunk)
+                    if parsed_chunk is not None:
+                        yield parsed_chunk
 
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.debug("[%s] Stream completed time=%.1fms", req_id, elapsed_ms)
@@ -308,35 +384,32 @@ class ModelEngine(BaseEngine):
         except Exception as exc:
             raise self._wrap_exception(exc, req_id, t0, label="Stream request") from exc
 
-    async def chat_completion(self, messages: LLMMessages, **kwargs: Any) -> str:
-        """Generate a chat completion and return the response content string.
+    async def chat_completion(self, messages: LLMMessages, **kwargs: Any) -> LLMResponse:
+        """Generate a chat completion and return a structured ``LLMResponse``.
 
-        Calls the /v1/chat/completions endpoint and extracts the assistant
-        message content from the OpenAI-format response.
+        Calls the /v1/chat/completions endpoint and parses the OpenAI-format
+        response into an ``LLMResponse`` carrying content, reasoning (when the
+        provider exposes ``reasoning_content``), usage, finish reason, and
+        request id.
 
         Raises:
             ModelEngineError: If the request fails or the response format is unexpected.
         """
         response = await self.call(messages, **kwargs)
         try:
-            content = response["choices"][0]["message"]["content"]
-        except (KeyError, IndexError, TypeError) as exc:
+            return _parse_chat_completion(response)
+        except ValueError as exc:
             raise ModelEngineError(
                 f"Unexpected response format from model '{self.model_name}': {exc}",
                 model_name=self.model_name,
             ) from exc
-        if not isinstance(content, str):
-            raise ModelEngineError(
-                f"Expected string content from model '{self.model_name}', got {type(content).__name__}",
-                model_name=self.model_name,
-            )
-        return content
 
-    async def stream_chat_completion(self, messages: LLMMessages, **kwargs: Any) -> AsyncGenerator[str, None]:
-        """Stream a chat completion and yield content-delta strings.
+    async def stream_chat_completion(
+        self, messages: LLMMessages, **kwargs: Any
+    ) -> AsyncGenerator[LLMResponseChunk, None]:
+        """Stream a chat completion and yield ``LLMResponseChunk`` objects.
 
-        Calls the /v1/chat/completions endpoint with streaming enabled and
-        yields content strings as they arrive.
+        Thin pass-through over ``stream_call``.
 
         Raises:
             ModelEngineError: If the request fails after all retries.

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -93,6 +93,10 @@ def _parse_chat_completion(response: dict) -> LLMResponse:
         raise ValueError(f"Unexpected /v1/chat/completions response shape: {exc}") from exc
 
     if not isinstance(content, str):
+        if content is None and message.get("tool_calls"):
+            raise ValueError(
+                "Tool-call-only responses are not yet supported by IORails (message contains tool_calls but no content)"
+            )
         raise ValueError(f"Expected string content, got {type(content).__name__}")
 
     reasoning = message.get("reasoning_content") or None

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -123,7 +123,7 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
     choice = choices[0]
     delta = choice.get("delta") or {}
     delta_content = delta.get("content")
-    delta_reasoning = delta.get("reasoning_content")
+    delta_reasoning = delta.get("reasoning_content") or None
 
     if not delta_content and not delta_reasoning:
         return None

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -36,6 +36,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.telemetry import action_span, record_span_error
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
+from nemoguardrails.types import LLMResponse
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -151,8 +152,8 @@ class RailAction(ABC):
         model_type: Optional[str],
         messages: list[dict],
         **kwargs: Any,
-    ) -> str:
-        """Call an LLM via EngineRegistry and return the response text."""
+    ) -> LLMResponse:
+        """Call an LLM via EngineRegistry and return the structured response."""
         if not model_type:
             raise RuntimeError("model_type is required for LLM calls")
         return await self.engine_registry.model_call(model_type, messages, **kwargs)

--- a/tests/guardrails/test_content_safety_iorails_actions.py
+++ b/tests/guardrails/test_content_safety_iorails_actions.py
@@ -27,8 +27,10 @@ from nemoguardrails.guardrails.actions.content_safety_action import (
 )
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, CONTENT_SAFETY_INPUT_PROMPT, CONTENT_SAFETY_OUTPUT_PROMPT
 
 FLOW_INPUT = "content safety check input $model=content_safety"
@@ -195,14 +197,14 @@ class TestContentSafetyInputRun:
 
     @pytest.mark.asyncio
     async def test_safe_input(self, input_action):
-        input_action.engine_registry.model_call = AsyncMock(return_value=SAFE_JSON)
+        input_action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=SAFE_JSON))
         result = await input_action.run(FLOW_INPUT, MESSAGES)
         assert result.is_safe
         input_action.engine_registry.model_call.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unsafe_input(self, input_action):
-        input_action.engine_registry.model_call = AsyncMock(return_value=UNSAFE_JSON)
+        input_action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=UNSAFE_JSON))
         result = await input_action.run(FLOW_INPUT, MESSAGES)
         assert not result.is_safe
         assert "S1: Violence" in result.reason
@@ -220,13 +222,13 @@ class TestContentSafetyOutputRun:
 
     @pytest.mark.asyncio
     async def test_safe_output(self, output_action):
-        output_action.engine_registry.model_call = AsyncMock(return_value=SAFE_OUTPUT_JSON)
+        output_action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=SAFE_OUTPUT_JSON))
         result = await output_action.run(FLOW_OUTPUT, MESSAGES, bot_response=BOT_RESPONSE)
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_unsafe_output(self, output_action):
-        output_action.engine_registry.model_call = AsyncMock(return_value=UNSAFE_OUTPUT_JSON)
+        output_action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON))
         result = await output_action.run(FLOW_OUTPUT, MESSAGES, bot_response=BOT_RESPONSE)
         assert not result.is_safe
         assert "S17: Malware" in result.reason
@@ -282,7 +284,7 @@ class TestContentSafetyStopTokens:
         task_manager = LLMTaskManager(config)
         engine_registry = EngineRegistry(config.models, config.rails.config)
         action = ContentSafetyInputAction(engine_registry, task_manager)
-        action.engine_registry.model_call = AsyncMock(return_value=SAFE_JSON)
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=SAFE_JSON))
 
         await action.run(FLOW_INPUT, MESSAGES)
 
@@ -309,9 +311,77 @@ class TestContentSafetyStopTokens:
         task_manager = LLMTaskManager(config)
         engine_registry = EngineRegistry(config.models, config.rails.config)
         action = ContentSafetyOutputAction(engine_registry, task_manager)
-        action.engine_registry.model_call = AsyncMock(return_value=SAFE_OUTPUT_JSON)
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=SAFE_OUTPUT_JSON))
 
         await action.run(FLOW_OUTPUT, MESSAGES, bot_response=BOT_RESPONSE)
 
         call_kwargs = action.engine_registry.model_call.call_args.kwargs
         assert call_kwargs["stop"] == ["</s>"]
+
+
+class TestContentSafetyEndToEnd:
+    """Full chain: raw HTTP response dict -> ModelEngine._parse_chat_completion -> LLMResponse
+    -> EngineRegistry.model_call -> RailAction._get_llm_response -> .content -> nemoguard parser
+    -> _parse_response -> RailResult. Mocks at the HTTP boundary so the dict-parsing path is
+    exercised on the way through.
+    """
+
+    @pytest.mark.asyncio
+    async def test_safe_input_full_chain(self, input_action):
+        engine = input_action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(
+            return_value={
+                "id": "chatcmpl-1",
+                "model": "content-safety-model",
+                "choices": [{"message": {"role": "assistant", "content": SAFE_JSON}, "finish_reason": "stop"}],
+            }
+        )
+
+        result = await input_action.run(FLOW_INPUT, MESSAGES)
+
+        assert result.is_safe
+        engine.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unsafe_input_full_chain(self, input_action):
+        engine = input_action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(return_value={"choices": [{"message": {"role": "assistant", "content": UNSAFE_JSON}}]})
+
+        result = await input_action.run(FLOW_INPUT, MESSAGES)
+
+        assert not result.is_safe
+        assert "S1: Violence" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_unsafe_output_full_chain(self, output_action):
+        engine = output_action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(
+            return_value={"choices": [{"message": {"role": "assistant", "content": UNSAFE_OUTPUT_JSON}}]}
+        )
+
+        result = await output_action.run(FLOW_OUTPUT, MESSAGES, bot_response=BOT_RESPONSE)
+
+        assert not result.is_safe
+        assert "S17: Malware" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_reasoning_field_does_not_affect_classification(self, input_action):
+        """Reasoning content is ignored by the content-safety classifier — only `.content` is parsed."""
+        engine = input_action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": SAFE_JSON,
+                            "reasoning_content": "the prompt looks fine to me",
+                        }
+                    }
+                ]
+            }
+        )
+
+        result = await input_action.run(FLOW_INPUT, MESSAGES)
+
+        assert result.is_safe

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -23,6 +23,7 @@ from nemoguardrails.guardrails.api_engine import APIEngine
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
@@ -184,13 +185,14 @@ class TestEngineRegistryGenerateAsync:
 
     @pytest.mark.asyncio
     async def test_generate_from_correct_engine(self, manager):
-        """Calls the named engine's chat_completion() and returns its result."""
+        """Calls the named engine's chat_completion() and returns its LLMResponse."""
         messages = [{"role": "user", "content": "Hi"}]
         engine = manager._get_engine("main", ModelEngine)
-        engine.chat_completion = AsyncMock(return_value="Hello world")
+        expected = LLMResponse(content="Hello world")
+        engine.chat_completion = AsyncMock(return_value=expected)
 
         result = await manager.model_call("main", messages)
-        assert result == "Hello world"
+        assert result is expected
         engine.chat_completion.assert_called_once_with(messages)
 
     @pytest.mark.asyncio
@@ -198,7 +200,7 @@ class TestEngineRegistryGenerateAsync:
         """Extra kwargs (temperature, max_tokens) are forwarded to engine.chat_completion()."""
         messages = [{"role": "user", "content": "Hi"}]
         engine = manager._get_engine("main", ModelEngine)
-        engine.chat_completion = AsyncMock(return_value="ok")
+        engine.chat_completion = AsyncMock(return_value=LLMResponse(content="ok"))
 
         await manager.model_call("main", messages, temperature=0.5, max_tokens=100)
 
@@ -489,17 +491,16 @@ class TestEngineRegistryApiEngineStopErrors:
 
 
 class TestEngineRegistryStreamModelCall:
-    """Test stream_model_call routes to the correct engine and yields chunks."""
+    """Test stream_model_call routes to the correct engine and yields LLMResponseChunk objects."""
 
     @pytest.mark.asyncio
     async def test_streams_chunks_from_correct_engine(self, manager):
-        """Calls the named engine's stream_chat_completion and yields all chunks."""
+        """Calls the named engine's stream_chat_completion and forwards LLMResponseChunk objects."""
         messages = [{"role": "user", "content": "Hi"}]
 
         async def mock_stream_chat_completion(msgs, **kwargs):
-            """Mock stream yielding two chunks."""
-            for chunk in ["Hello", " world"]:
-                yield chunk
+            for text in ["Hello", " world"]:
+                yield LLMResponseChunk(delta_content=text)
 
         engine = manager._get_engine("main", ModelEngine)
         engine.stream_chat_completion = mock_stream_chat_completion
@@ -508,7 +509,31 @@ class TestEngineRegistryStreamModelCall:
         async for chunk in manager.stream_model_call("main", messages):
             chunks.append(chunk)
 
-        assert chunks == ["Hello", " world"]
+        assert all(isinstance(c, LLMResponseChunk) for c in chunks)
+        assert [c.delta_content for c in chunks] == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_streams_reasoning_and_content_chunks(self, manager):
+        """Reasoning deltas flow through alongside content deltas."""
+        messages = [{"role": "user", "content": "Hi"}]
+
+        async def mock_stream_chat_completion(msgs, **kwargs):
+            yield LLMResponseChunk(delta_reasoning="thinking")
+            yield LLMResponseChunk(delta_content="Hello")
+            yield LLMResponseChunk(delta_reasoning=" more")
+
+        engine = manager._get_engine("main", ModelEngine)
+        engine.stream_chat_completion = mock_stream_chat_completion
+
+        chunks = []
+        async for chunk in manager.stream_model_call("main", messages):
+            chunks.append(chunk)
+
+        assert [(c.delta_content, c.delta_reasoning) for c in chunks] == [
+            (None, "thinking"),
+            ("Hello", None),
+            (None, " more"),
+        ]
 
     @pytest.mark.asyncio
     async def test_forwards_kwargs_to_engine(self, manager):
@@ -517,9 +542,8 @@ class TestEngineRegistryStreamModelCall:
         captured_kwargs = {}
 
         async def mock_stream_chat_completion(msgs, **kwargs):
-            """Mock stream that records kwargs."""
             captured_kwargs.update(kwargs)
-            yield "ok"
+            yield LLMResponseChunk(delta_content="ok")
 
         engine = manager._get_engine("main", ModelEngine)
         engine.stream_chat_completion = mock_stream_chat_completion

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -26,6 +26,7 @@ from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
@@ -73,7 +74,7 @@ class TestGenerateAsync:
         llm_response = "Hello from LLM"
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         result = await iorails.generate_async(messages)
@@ -93,7 +94,7 @@ class TestGenerateAsync:
         options = GenerationOptions(llm_params=llm_params)
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         result = await iorails.generate_async(messages, options=options)
@@ -114,7 +115,7 @@ class TestGenerateAsync:
 
         async def mock_generate(model_type, messages):
             call_order.append("generate")
-            return "response"
+            return LLMResponse(content="response")
 
         async def mock_output_safe(messages, response):
             call_order.append("output")
@@ -149,7 +150,7 @@ class TestGenerateAsync:
         llm_response = "Unsafe response from the LLM!"
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
         result = await iorails.generate_async(messages)
@@ -166,7 +167,7 @@ class TestGenerateAsync:
         llm_params = {"temperature": 0.01, "max_completion_tokens": 1000}
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="ok")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         await iorails.generate_async(messages, options={"llm_params": llm_params})
@@ -564,7 +565,7 @@ class TestAutoStart:
         """generate_async() calls start() automatically before running the pipeline."""
         iorails.engine_registry.start = AsyncMock()
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="ok")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         assert not iorails._running
@@ -578,7 +579,7 @@ class TestAutoStart:
         """Two generate_async() calls only trigger start() once."""
         iorails.engine_registry.start = AsyncMock()
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="ok")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
@@ -591,7 +592,7 @@ class TestAutoStart:
         """stream_async() calls start() automatically before streaming."""
 
         async def mock_stream(model_type, messages, **kwargs):
-            yield "hello"
+            yield LLMResponseChunk(delta_content="hello")
 
         iorails_input_only.engine_registry.start = AsyncMock()
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
@@ -611,7 +612,7 @@ class TestAutoStart:
         """Two stream_async() calls only trigger start() once."""
 
         async def mock_stream(model_type, messages, **kwargs):
-            yield "hi"
+            yield LLMResponseChunk(delta_content="hi")
 
         iorails_input_only.engine_registry.start = AsyncMock()
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
@@ -640,7 +641,7 @@ class TestGenerate:
         expected = {"role": "assistant", "content": "Hello from LLM"}
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="Hello from LLM")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello from LLM"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         # Patch IORails so the temp instance inside generate() uses our mocked iorails
@@ -655,7 +656,7 @@ class TestGenerate:
         options = GenerationOptions(llm_params={"temperature": 0.5})
 
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="response")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="response"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -17,7 +17,7 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -25,6 +25,7 @@ import pytest_asyncio
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, STREAM_MAX_CONCURRENCY, IORails
+from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.types import LLMResponseChunk
@@ -440,3 +441,78 @@ class TestStreamAsyncConcurrency:
 
         # Semaphore should be released even after early exit
         assert iorails_input_only._stream_semaphore._value == STREAM_MAX_CONCURRENCY
+
+
+def _build_sse_streaming_mock(deltas):
+    """Build an aiohttp-like response mock that yields SSE lines for the given deltas.
+
+    Each delta is a dict like ``{"content": "Hi"}`` or ``{"reasoning_content": "thinking"}``
+    that becomes a ``data: {"choices":[{"delta": <delta>}]}\\n`` line. Always terminates
+    with ``data: [DONE]``.
+    """
+    lines = []
+    for delta in deltas:
+        payload = json.dumps({"choices": [{"delta": delta}]})
+        lines.append(f"data: {payload}\n".encode())
+    lines.append(b"data: [DONE]\n")
+
+    line_iter = iter(lines)
+
+    async def _readline():
+        return next(line_iter, b"")
+
+    mock_content = MagicMock()
+    mock_content.readline = _readline
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.content = mock_content
+
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    return mock_client
+
+
+class TestStreamAsyncEndToEnd:
+    """Full chain: raw SSE bytes -> ModelEngine.stream_call._parse_chat_completion_chunk
+    -> LLMResponseChunk -> EngineRegistry.stream_model_call -> IORails._generation_task pushes
+    chunk.delta_content -> caller sees text chunks. Mocks at the HTTP boundary so the
+    SSE-parsing path is exercised on the way through.
+    """
+
+    @pytest.mark.asyncio
+    async def test_content_chunks_full_chain(self, iorails_input_only):
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_sse_streaming_mock([{"content": "Hello"}, {"content": " "}, {"content": "world"}])
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_deltas_dropped_from_caller_output(self, iorails_input_only):
+        """Reasoning deltas pass through ModelEngine as LLMResponseChunk.delta_reasoning,
+        but IORails drops them — the caller only sees content text.
+        """
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_sse_streaming_mock(
+            [
+                {"reasoning_content": "let me think"},
+                {"content": "The"},
+                {"reasoning_content": " more thinking"},
+                {"content": " answer"},
+                {"content": " is 42"},
+            ]
+        )
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "The answer is 42"
+        assert "think" not in "".join(chunks)

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -27,6 +27,7 @@ from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, STREAM_MAX_CONCURRENCY, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.types import LLMResponseChunk
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
@@ -60,8 +61,8 @@ _INPUT_ONLY_CONFIG = {
 
 async def _mock_stream(model_type, messages, **kwargs):
     """Async generator simulating streaming chunks from the main LLM."""
-    for chunk in ["Hello", " from", " the", " streaming", " LLM", "!", " Have", " a", " nice", " day"]:
-        yield chunk
+    for text in ["Hello", " from", " the", " streaming", " LLM", "!", " Have", " a", " nice", " day"]:
+        yield LLMResponseChunk(delta_content=text)
 
 
 async def _collect(async_iter):
@@ -77,8 +78,8 @@ async def _failing_stream(model_type, messages, **kwargs):
 
 async def _mid_stream_failure(model_type, messages, **kwargs):
     """Mock stream that yields some chunks then raises."""
-    yield "Hello"
-    yield " world"
+    yield LLMResponseChunk(delta_content="Hello")
+    yield LLMResponseChunk(delta_content=" world")
     raise RuntimeError("connection lost")
 
 
@@ -205,7 +206,7 @@ class TestStreamAsyncNoOutputRails:
         async def capturing_stream(model_type, messages, **kwargs):
             """Mock stream that records kwargs."""
             captured_kwargs.update(kwargs)
-            yield "ok"
+            yield LLMResponseChunk(delta_content="ok")
 
         _wire_mocks(iorails_input_only, stream=capturing_stream)
         options = GenerationOptions(llm_params={"temperature": 0.42})
@@ -223,7 +224,7 @@ class TestStreamAsyncNoOutputRails:
         async def capturing_stream(model_type, messages, **kwargs):
             """Mock stream that records kwargs."""
             captured_kwargs.update(kwargs)
-            yield "ok"
+            yield LLMResponseChunk(delta_content="ok")
 
         _wire_mocks(iorails_input_only, stream=capturing_stream)
         chunks = await _collect(
@@ -424,7 +425,7 @@ class TestStreamAsyncConcurrency:
             """Mock stream that yields many chunks to allow early exit testing."""
             task_started.set()
             for i in range(1000):
-                yield f"chunk{i}"
+                yield LLMResponseChunk(delta_content=f"chunk{i}")
                 await asyncio.sleep(0)  # yield control so cancellation can propagate
 
         _wire_mocks(iorails_input_only, stream=slow_stream)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -34,6 +34,7 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, Rai
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import SystemConstants
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.async_helpers import saturate_stream_semaphore, wait_for_queue_state
 from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
@@ -71,7 +72,7 @@ def _make_tracing_only_config():
 def _stub_safe_pipeline(iorails, llm_response="Hello"):
     """Mock input/output rails as safe and the LLM to return *llm_response*."""
     iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-    iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
+    iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
     iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
 
@@ -232,7 +233,7 @@ class TestEndToEndTracing:
         async def capturing_model_call(model_name, messages, **kwargs):
             captured["llm_req_id"] = get_request_id()
             captured["llm_model"] = model_name
-            return "Generated response"
+            return LLMResponse(content="Generated response")
 
         async def capturing_output_check(messages, response):
             captured["output_req_id"] = get_request_id()
@@ -372,12 +373,14 @@ def _stub_deep_pipeline(iorails, main_llm_response="Hello", input_safe=True):
     for name, engine in iorails.engine_registry._engines.items():
         if isinstance(engine, ModelEngine):
             if name == "main":
-                engine.chat_completion = AsyncMock(return_value=main_llm_response)
+                engine.chat_completion = AsyncMock(return_value=LLMResponse(content=main_llm_response))
             elif name == "content_safety":
                 # Content safety output parser needs Response Safety field
-                engine.chat_completion = AsyncMock(return_value=SAFE_OUTPUT_JSON if input_safe else input_json)
+                engine.chat_completion = AsyncMock(
+                    return_value=LLMResponse(content=SAFE_OUTPUT_JSON if input_safe else input_json)
+                )
             else:
-                engine.chat_completion = AsyncMock(return_value=input_json)
+                engine.chat_completion = AsyncMock(return_value=LLMResponse(content=input_json))
         elif isinstance(engine, APIEngine):
             engine.call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
 
@@ -497,7 +500,7 @@ class TestSpanHierarchy:
             if isinstance(engine, ModelEngine) and name == "content_safety":
                 engine.chat_completion = AsyncMock(side_effect=RuntimeError("LLM down"))
             elif isinstance(engine, ModelEngine):
-                engine.chat_completion = AsyncMock(return_value=SAFE_INPUT_JSON)
+                engine.chat_completion = AsyncMock(return_value=LLMResponse(content=SAFE_INPUT_JSON))
 
         result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE
@@ -707,20 +710,20 @@ def _make_output_streaming_tracing_config(*, stream_first=True):
 
 
 async def _mock_chunks_stream(model_type, messages, **kwargs):
-    """stream_model_call-level mock yielding three string chunks."""
-    for chunk in ["Hello", " ", "world"]:
-        yield chunk
+    """stream_model_call-level mock yielding three LLMResponseChunk objects."""
+    for text in ["Hello", " ", "world"]:
+        yield LLMResponseChunk(delta_content=text)
 
 
 async def _engine_default_stream(messages, **kwargs):
     """ModelEngine.stream_chat_completion-level mock for the main LLM."""
-    for chunk in ["Hello", " from", " the", " stream"]:
-        yield chunk
+    for text in ["Hello", " from", " the", " stream"]:
+        yield LLMResponseChunk(delta_content=text)
 
 
 async def _engine_failing_stream(messages, **kwargs):
     """ModelEngine.stream_chat_completion-level mock that raises mid-stream."""
-    yield "Hello"
+    yield LLMResponseChunk(delta_content="Hello")
     raise RuntimeError("stream broke")
 
 
@@ -743,9 +746,11 @@ def _stub_deep_streaming_pipeline(iorails, main_stream=None, input_safe=True):
             if name == "main":
                 engine.stream_chat_completion = main_stream
             elif name == "content_safety":
-                engine.chat_completion = AsyncMock(return_value=SAFE_OUTPUT_JSON if input_safe else input_json)
+                engine.chat_completion = AsyncMock(
+                    return_value=LLMResponse(content=SAFE_OUTPUT_JSON if input_safe else input_json)
+                )
             else:
-                engine.chat_completion = AsyncMock(return_value=input_json)
+                engine.chat_completion = AsyncMock(return_value=LLMResponse(content=input_json))
         elif isinstance(engine, APIEngine):
             engine.call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
 

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -32,8 +32,11 @@ from nemoguardrails.guardrails.model_engine import (
     _ENGINE_BASE_URLS,
     ModelEngine,
     ModelEngineError,
+    _parse_chat_completion,
+    _parse_chat_completion_chunk,
 )
 from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
 
 
 def _make_model(
@@ -487,7 +490,7 @@ class TestModelEngineStreamCall:
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_stream_call_yields_content_chunks(self):
-        """stream_call() yields content deltas from SSE lines."""
+        """stream_call() yields LLMResponseChunk objects with delta_content set."""
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["Hello", " world", "!"])
@@ -502,7 +505,38 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["Hello", " world", "!"]
+        assert all(isinstance(c, LLMResponseChunk) for c in chunks)
+        assert [c.delta_content for c in chunks] == ["Hello", " world", "!"]
+        assert all(c.delta_reasoning is None for c in chunks)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_yields_reasoning_deltas(self):
+        """stream_call() surfaces delta.reasoning_content as LLMResponseChunk.delta_reasoning."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b'data: {"choices": [{"delta": {"reasoning_content": "let me think"}}]}\n\n',
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+            b'data: {"choices": [{"delta": {"reasoning_content": " more"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert [(c.delta_content, c.delta_reasoning) for c in chunks] == [
+            (None, "let me think"),
+            ("Hello", None),
+            (None, " more"),
+        ]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -621,7 +655,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["Hello"]
+        assert [c.delta_content for c in chunks] == ["Hello"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -647,7 +681,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["ok"]
+        assert [c.delta_content for c in chunks] == ["ok"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -671,7 +705,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["ok"]
+        assert [c.delta_content for c in chunks] == ["ok"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -709,7 +743,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["ok"]
+        assert [c.delta_content for c in chunks] == ["ok"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -732,7 +766,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["Hi"]
+        assert [c.delta_content for c in chunks] == ["Hi"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -769,7 +803,7 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["Hi", "!"]
+        assert [c.delta_content for c in chunks] == ["Hi", "!"]
 
 
 class TestModelEngineConstants:
@@ -794,17 +828,17 @@ class TestModelEngineStreamChatCompletion:
         """stream_chat_completion() yields all chunks from stream_call()."""
         engine = ModelEngine(_make_model())
 
-        async def mock_stream_call(msgs, **kwargs):
-            for chunk in ["Hello", " world"]:
-                yield chunk
+        async def mock_stream_call(messages, **kwargs):
+            for text in ["Hello", " world"]:
+                yield LLMResponseChunk(delta_content=text)
 
-        engine.stream_call = mock_stream_call
+        engine.stream_call = mock_stream_call  # type: ignore[method-assign]
 
         chunks = []
         async for chunk in engine.stream_chat_completion([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
-        assert chunks == ["Hello", " world"]
+        assert [c.delta_content for c in chunks] == ["Hello", " world"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -813,11 +847,11 @@ class TestModelEngineStreamChatCompletion:
         engine = ModelEngine(_make_model())
         captured_kwargs = {}
 
-        async def mock_stream_call(msgs, **kwargs):
+        async def mock_stream_call(messages, **kwargs):
             captured_kwargs.update(kwargs)
-            yield "ok"
+            yield LLMResponseChunk(delta_content="ok")
 
-        engine.stream_call = mock_stream_call
+        engine.stream_call = mock_stream_call  # type: ignore[method-assign]
 
         async for _ in engine.stream_chat_completion(
             [{"role": "user", "content": "Hi"}], temperature=0.7, max_tokens=50
@@ -829,17 +863,77 @@ class TestModelEngineStreamChatCompletion:
 
 
 class TestModelEngineChatCompletion:
-    """Test ModelEngine.chat_completion() extracts content from OpenAI-format response."""
+    """Test ModelEngine.chat_completion() parses OpenAI-format responses into LLMResponse."""
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_returns_content_string(self):
-        """chat_completion() returns the assistant message content from the response."""
+    async def test_returns_llm_response_with_content(self):
+        """chat_completion() returns an LLMResponse carrying the assistant message content."""
         engine = ModelEngine(_make_model())
         engine.call = AsyncMock(return_value={"choices": [{"message": {"role": "assistant", "content": "Hello!"}}]})
 
         result = await engine.chat_completion([{"role": "user", "content": "Hi"}])
-        assert result == "Hello!"
+
+        assert isinstance(result, LLMResponse)
+        assert result.content == "Hello!"
+        assert result.reasoning is None
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_returns_reasoning_when_present(self):
+        """chat_completion() forwards message.reasoning_content to LLMResponse.reasoning."""
+        engine = ModelEngine(_make_model())
+        engine.call = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "The answer is 42.",
+                            "reasoning_content": "Let me think step by step...",
+                        }
+                    }
+                ]
+            }
+        )
+
+        result = await engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+        assert result.content == "The answer is 42."
+        assert result.reasoning == "Let me think step by step..."
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_returns_usage_with_reasoning_tokens(self):
+        """chat_completion() forwards usage incl. reasoning_tokens from completion_tokens_details."""
+        engine = ModelEngine(_make_model())
+        engine.call = AsyncMock(
+            return_value={
+                "id": "chatcmpl-abc",
+                "model": "gpt-5",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 25,
+                    "total_tokens": 35,
+                    "completion_tokens_details": {"reasoning_tokens": 12},
+                    "prompt_tokens_details": {"cached_tokens": 4},
+                },
+            }
+        )
+
+        result = await engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+        assert result.model == "gpt-5"
+        assert result.finish_reason == "stop"
+        assert result.request_id == "chatcmpl-abc"
+        assert result.usage == UsageInfo(
+            input_tokens=10,
+            output_tokens=25,
+            total_tokens=35,
+            reasoning_tokens=12,
+            cached_tokens=4,
+        )
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -902,3 +996,86 @@ class TestModelEngineChatCompletion:
 
         with pytest.raises(ModelEngineError, match="Expected string content"):
             await engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+
+class TestParseChatCompletion:
+    """Direct tests for the _parse_chat_completion helper."""
+
+    def test_minimal_response(self):
+        """Parses content; leaves optional fields as None."""
+        result = _parse_chat_completion({"choices": [{"message": {"content": "hi"}}]})
+        assert isinstance(result, LLMResponse)
+        assert result.content == "hi"
+        assert result.reasoning is None
+        assert result.usage is None
+        assert result.model is None
+        assert result.finish_reason is None
+
+    def test_empty_reasoning_is_normalized_to_none(self):
+        """Empty-string reasoning_content is treated as no reasoning."""
+        result = _parse_chat_completion({"choices": [{"message": {"content": "hi", "reasoning_content": ""}}]})
+        assert result.reasoning is None
+
+    def test_usage_without_details(self):
+        """Usage without completion/prompt details still parses base counts."""
+        result = _parse_chat_completion(
+            {
+                "choices": [{"message": {"content": "hi"}}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+            }
+        )
+        assert result.usage == UsageInfo(input_tokens=5, output_tokens=7, total_tokens=12)
+
+    def test_raises_on_malformed_response(self):
+        """Missing choices/message/content raises ValueError."""
+        with pytest.raises(ValueError, match="Unexpected /v1/chat/completions response shape"):
+            _parse_chat_completion({})
+
+    def test_raises_on_non_string_content(self):
+        """Non-string content raises ValueError."""
+        with pytest.raises(ValueError, match="Expected string content"):
+            _parse_chat_completion({"choices": [{"message": {"content": None}}]})
+
+
+class TestParseChatCompletionChunk:
+    """Direct tests for the _parse_chat_completion_chunk helper."""
+
+    def test_content_only_delta(self):
+        """delta.content populates delta_content."""
+        result = _parse_chat_completion_chunk({"choices": [{"delta": {"content": "hi"}}]})
+        assert isinstance(result, LLMResponseChunk)
+        assert result.delta_content == "hi"
+        assert result.delta_reasoning is None
+
+    def test_reasoning_only_delta(self):
+        """delta.reasoning_content populates delta_reasoning."""
+        result = _parse_chat_completion_chunk({"choices": [{"delta": {"reasoning_content": "thinking"}}]})
+        assert result is not None
+        assert result.delta_content is None
+        assert result.delta_reasoning == "thinking"
+
+    def test_role_only_delta_returns_none(self):
+        """Role-only deltas (typical first event) are skipped."""
+        assert _parse_chat_completion_chunk({"choices": [{"delta": {"role": "assistant"}}]}) is None
+
+    def test_empty_choices_returns_none(self):
+        """Empty-choices events (e.g. include_usage usage chunk) are skipped."""
+        assert _parse_chat_completion_chunk({"choices": []}) is None
+
+    def test_finish_only_delta_returns_none(self):
+        """Finish-only deltas (no content/reasoning) are skipped, matching prior behavior."""
+        assert _parse_chat_completion_chunk({"choices": [{"delta": {}, "finish_reason": "stop"}]}) is None
+
+    def test_passes_through_metadata(self):
+        """model, request id, and finish_reason flow into the chunk when content is present."""
+        result = _parse_chat_completion_chunk(
+            {
+                "id": "chunk-1",
+                "model": "gpt-5",
+                "choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}],
+            }
+        )
+        assert result is not None
+        assert result.model == "gpt-5"
+        assert result.request_id == "chunk-1"
+        assert result.finish_reason == "stop"

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -990,11 +990,39 @@ class TestModelEngineChatCompletion:
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_raises_on_null_content(self):
-        """chat_completion() raises ModelEngineError when content is None (e.g. tool_calls response)."""
+        """chat_completion() raises ModelEngineError for unsupported tool-calls"""
         engine = ModelEngine(_make_model())
         engine.call = AsyncMock(return_value={"choices": [{"message": {"content": None}}]})
 
         with pytest.raises(ModelEngineError, match="Expected string content"):
+            await engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_raises_clearer_error_for_tool_call_only_response(self):
+        """Tool-call-only responses (content=None, tool_calls set) get a scope-specific error."""
+        engine = ModelEngine(_make_model())
+        engine.call = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_abc",
+                                    "type": "function",
+                                    "function": {"name": "calculate", "arguments": '{"expr":"2+2"}'},
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+
+        with pytest.raises(ModelEngineError, match="Tool-call-only responses are not yet supported"):
             await engine.chat_completion([{"role": "user", "content": "Hi"}])
 
 
@@ -1035,6 +1063,28 @@ class TestParseChatCompletion:
         """Non-string content raises ValueError."""
         with pytest.raises(ValueError, match="Expected string content"):
             _parse_chat_completion({"choices": [{"message": {"content": None}}]})
+
+    def test_raises_specific_error_for_tool_call_only_response(self):
+        """When content is None and tool_calls is set, raise a scope-specific error.
+
+        OpenAI returns this shape for tool_choice='required'. Tool-call support is out of
+        scope for this PR series; the error message should make that clear rather than
+        suggesting malformed data.
+        """
+        with pytest.raises(ValueError, match="Tool-call-only responses are not yet supported"):
+            _parse_chat_completion(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f"}}],
+                            }
+                        }
+                    ]
+                }
+            )
 
 
 class TestParseChatCompletionChunk:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1054,6 +1054,13 @@ class TestParseChatCompletionChunk:
         assert result.delta_content is None
         assert result.delta_reasoning == "thinking"
 
+    def test_empty_reasoning_alongside_content_normalized_to_none(self):
+        """Empty-string reasoning_content is normalized to None, matching _parse_chat_completion."""
+        result = _parse_chat_completion_chunk({"choices": [{"delta": {"content": "hi", "reasoning_content": ""}}]})
+        assert result is not None
+        assert result.delta_content == "hi"
+        assert result.delta_reasoning is None
+
     def test_role_only_delta_returns_none(self):
         """Role-only deltas (typical first event) are skipped."""
         assert _parse_chat_completion_chunk({"choices": [{"delta": {"role": "assistant"}}]}) is None

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -540,6 +540,31 @@ class TestModelEngineStreamCall:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
+    async def test_stream_call_yields_combined_content_and_reasoning_in_one_chunk(self):
+        """A single SSE delta with both content and reasoning_content populates both fields."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b'data: {"choices": [{"delta": {"content": "answer", "reasoning_content": "thought"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert chunks[0].delta_content == "answer"
+        assert chunks[0].delta_reasoning == "thought"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
     async def test_stream_call_sends_stream_true(self):
         """stream_call() includes stream=True in the request body."""
         engine = ModelEngine(_make_model())
@@ -1110,6 +1135,19 @@ class TestParseChatCompletionChunk:
         assert result is not None
         assert result.delta_content == "hi"
         assert result.delta_reasoning is None
+
+    def test_combined_content_and_reasoning_in_one_delta(self):
+        """A single delta carrying both content and reasoning_content populates both fields.
+
+        LLMResponseChunk is parallel-optional, not a discriminated union — providers
+        may emit both fields on the same SSE chunk.
+        """
+        result = _parse_chat_completion_chunk(
+            {"choices": [{"delta": {"content": "answer", "reasoning_content": "thought"}}]}
+        )
+        assert result is not None
+        assert result.delta_content == "answer"
+        assert result.delta_reasoning == "thought"
 
     def test_role_only_delta_returns_none(self):
         """Role-only deltas (typical first event) are skipped."""

--- a/tests/guardrails/test_rail_action.py
+++ b/tests/guardrails/test_rail_action.py
@@ -22,6 +22,7 @@ import pytest
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.rail_action import RailAction
+from nemoguardrails.types import LLMResponse
 
 
 class DummyRailAction(RailAction):
@@ -96,11 +97,12 @@ class TestResponseHelpers:
 
     @pytest.mark.asyncio
     async def test_get_llm_response_delegates_to_engine_registry(self, dummy_action):
-        dummy_action.engine_registry.model_call = AsyncMock(return_value="llm output")
+        expected = LLMResponse(content="llm output")
+        dummy_action.engine_registry.model_call = AsyncMock(return_value=expected)
         result = await dummy_action._get_llm_response(
             "content_safety", [{"role": "user", "content": "test"}], temperature=0.01
         )
-        assert result == "llm output"
+        assert result is expected
         dummy_action.engine_registry.model_call.assert_awaited_once_with(
             "content_safety", [{"role": "user", "content": "test"}], temperature=0.01
         )

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -30,6 +30,7 @@ from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import (
     CONTENT_SAFETY_CONFIG,
     NEMOGUARDS_CONFIG,
@@ -176,13 +177,17 @@ class TestIsInputSafe:
 
     @pytest.mark.asyncio
     async def test_safe(self, content_safety_rails_manager):
-        content_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         result = await content_safety_rails_manager.is_input_safe(MESSAGES)
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_unsafe(self, content_safety_rails_manager):
-        content_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_INPUT_JSON)
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
         result = await content_safety_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
         assert "Violence" in result.reason
@@ -206,13 +211,17 @@ class TestIsOutputSafe:
 
     @pytest.mark.asyncio
     async def test_safe(self, content_safety_rails_manager):
-        content_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_OUTPUT_JSON)
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_OUTPUT_JSON)
+        )
         result = await content_safety_rails_manager.is_output_safe(MESSAGES, "response")
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_unsafe(self, content_safety_rails_manager):
-        content_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_OUTPUT_JSON)
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON)
+        )
         result = await content_safety_rails_manager.is_output_safe(MESSAGES, "bad response")
         assert not result.is_safe
         assert "S17: Malware" in result.reason
@@ -238,7 +247,9 @@ class TestSequentialMultiRail:
 
     @pytest.mark.asyncio
     async def test_all_safe(self, nemoguards_rails_manager):
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert result.is_safe
@@ -246,7 +257,9 @@ class TestSequentialMultiRail:
     @pytest.mark.asyncio
     async def test_first_rail_blocks(self, nemoguards_rails_manager):
         """Content safety blocks -> topic safety and jailbreak never called."""
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock()
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
@@ -256,7 +269,9 @@ class TestSequentialMultiRail:
     @pytest.mark.asyncio
     async def test_jailbreak_blocks(self, nemoguards_rails_manager):
         """Content and topic pass, jailbreak blocks."""
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": True, "score": 0.95})
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
@@ -271,13 +286,13 @@ class TestTopicSafetyIsInputSafe:
 
     @pytest.mark.asyncio
     async def test_on_topic(self, topic_safety_rails_manager):
-        topic_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value="on-topic")
+        topic_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="on-topic"))
         result = await topic_safety_rails_manager.is_input_safe(MESSAGES)
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_off_topic(self, topic_safety_rails_manager):
-        topic_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value="off-topic")
+        topic_safety_rails_manager.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="off-topic"))
         result = await topic_safety_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
         assert "off-topic" in result.reason
@@ -297,21 +312,27 @@ class TestJailbreakDetectionIsInputSafe:
 
     @pytest.mark.asyncio
     async def test_safe(self, nemoguards_rails_manager):
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": False, "score": -0.99})
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_jailbreak_detected(self, nemoguards_rails_manager):
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": True, "score": 0.92})
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
 
     @pytest.mark.asyncio
     async def test_api_error(self, nemoguards_rails_manager):
-        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        nemoguards_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         nemoguards_rails_manager.engine_registry.api_call = AsyncMock(side_effect=RuntimeError("connection refused"))
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
@@ -348,7 +369,9 @@ class TestParallelIsInputSafe:
 
     @pytest.mark.asyncio
     async def test_all_safe(self, parallel_input_rails_manager):
-        parallel_input_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        parallel_input_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_INPUT_JSON)
+        )
         parallel_input_rails_manager.engine_registry.api_call = AsyncMock(
             return_value={"jailbreak": False, "score": 0.01}
         )
@@ -357,7 +380,9 @@ class TestParallelIsInputSafe:
 
     @pytest.mark.asyncio
     async def test_one_unsafe(self, parallel_input_rails_manager):
-        parallel_input_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_INPUT_JSON)
+        parallel_input_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
         parallel_input_rails_manager.engine_registry.api_call = AsyncMock(
             return_value={"jailbreak": False, "score": 0.01}
         )
@@ -388,13 +413,17 @@ class TestParallelIsOutputSafe:
 
     @pytest.mark.asyncio
     async def test_all_safe(self, parallel_output_rails_manager):
-        parallel_output_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_OUTPUT_JSON)
+        parallel_output_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_OUTPUT_JSON)
+        )
         result = await parallel_output_rails_manager.is_output_safe(MESSAGES, "response")
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_one_unsafe(self, parallel_output_rails_manager):
-        parallel_output_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_OUTPUT_JSON)
+        parallel_output_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON)
+        )
         result = await parallel_output_rails_manager.is_output_safe(MESSAGES, "bad response")
         assert not result.is_safe
 
@@ -413,24 +442,30 @@ class TestParallelBothDirections:
 
     @pytest.mark.asyncio
     async def test_both_safe(self, parallel_rails_manager):
-        parallel_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_INPUT_JSON)
+        parallel_rails_manager.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=SAFE_INPUT_JSON))
         parallel_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
         input_result = await parallel_rails_manager.is_input_safe(MESSAGES)
         assert input_result.is_safe
 
-        parallel_rails_manager.engine_registry.model_call = AsyncMock(return_value=SAFE_OUTPUT_JSON)
+        parallel_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=SAFE_OUTPUT_JSON)
+        )
         output_result = await parallel_rails_manager.is_output_safe(MESSAGES, "response")
         assert output_result.is_safe
 
     @pytest.mark.asyncio
     async def test_input_unsafe(self, parallel_rails_manager):
-        parallel_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_INPUT_JSON)
+        parallel_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
         parallel_rails_manager.engine_registry.api_call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
         result = await parallel_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
 
     @pytest.mark.asyncio
     async def test_output_unsafe(self, parallel_rails_manager):
-        parallel_rails_manager.engine_registry.model_call = AsyncMock(return_value=UNSAFE_OUTPUT_JSON)
+        parallel_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON)
+        )
         result = await parallel_rails_manager.is_output_safe(MESSAGES, "response")
         assert not result.is_safe

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -37,6 +37,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
 REQUEST_ID_PATTERN = re.compile(rf"^[0-9a-f]{{{REQUEST_ID_HEX_CHARS}}}$")
@@ -111,7 +112,7 @@ class TestSingleRequest:
         captured_ids = []
 
         iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
-        iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", "Hello")
+        iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
@@ -126,7 +127,7 @@ class TestSingleRequest:
         captured_ids = []
 
         iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
-        iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", "Hello")
+        iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
@@ -138,7 +139,7 @@ class TestSingleRequest:
     async def test_request_id_reset_after_completion(self, iorails):
         """After generate_async returns, the ContextVar is reset to default."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="Hello")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
@@ -158,7 +159,7 @@ class TestSingleRequest:
     async def test_request_id_reset_after_output_blocked(self, iorails):
         """ContextVar is reset even when the request is blocked at output."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="bad response")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="bad response"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
@@ -189,7 +190,7 @@ class TestMultipleSequentialRequests:
             return RailResult(is_safe=True)
 
         iorails.rails_manager.is_input_safe = capture_input
-        iorails.engine_registry.model_call = AsyncMock(return_value="Hello")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         for _ in range(5):
@@ -209,7 +210,7 @@ class TestMultipleSequentialRequests:
 
         async def capture_llm(*args, **kwargs):
             request_snapshots.append(("llm", get_request_id()))
-            return "Hello"
+            return LLMResponse(content="Hello")
 
         async def capture_output(*args, **kwargs):
             request_snapshots.append(("output", get_request_id()))
@@ -256,7 +257,7 @@ class TestMultipleConcurrentRequests:
 
         async def capture_llm(*args, **kwargs):
             captured.append(("llm", get_request_id()))
-            return "Hello"
+            return LLMResponse(content="Hello")
 
         async def capture_output(*args, **kwargs):
             captured.append(("output", get_request_id()))
@@ -300,7 +301,7 @@ class TestMultipleConcurrentRequests:
 
             async def capture_llm(*args, **kwargs):
                 captured.append(get_request_id())
-                return "Hello"
+                return LLMResponse(content="Hello")
 
             async def capture_output(*args, **kwargs):
                 captured.append(get_request_id())
@@ -337,7 +338,7 @@ class TestMultipleConcurrentRequests:
     async def test_contextvar_reset_after_concurrent_requests(self, iorails):
         """ContextVar is back to default after all concurrent requests complete."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(return_value="Hello")
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         messages = [{"role": "user", "content": "hi"}]

--- a/tests/guardrails/test_topic_safety_iorails_actions.py
+++ b/tests/guardrails/test_topic_safety_iorails_actions.py
@@ -22,6 +22,7 @@ import pytest
 from nemoguardrails.guardrails.actions.topic_safety_action import TopicSafetyInputAction
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.library.topic_safety.actions import (
     TOPIC_SAFETY_MAX_TOKENS,
     TOPIC_SAFETY_OUTPUT_RESTRICTION,
@@ -29,6 +30,7 @@ from nemoguardrails.library.topic_safety.actions import (
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import TOPIC_SAFETY_CONFIG, TOPIC_SAFETY_INPUT_PROMPT
 
 FLOW = "topic safety check input $model=topic_control"
@@ -107,19 +109,19 @@ class TestTopicSafetyParseResponse:
 class TestTopicSafetyRun:
     @pytest.mark.asyncio
     async def test_on_topic(self, action):
-        action.engine_registry.model_call = AsyncMock(return_value="on-topic")
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="on-topic"))
         result = await action.run(FLOW, MESSAGES)
         assert result.is_safe
 
     @pytest.mark.asyncio
     async def test_off_topic(self, action):
-        action.engine_registry.model_call = AsyncMock(return_value="off-topic")
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="off-topic"))
         result = await action.run(FLOW, MESSAGES)
         assert not result.is_safe
 
     @pytest.mark.asyncio
     async def test_passes_temperature_and_max_tokens(self, action):
-        action.engine_registry.model_call = AsyncMock(return_value="on-topic")
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="on-topic"))
         await action.run(FLOW, MESSAGES)
 
         call_kwargs = action.engine_registry.model_call.call_args
@@ -128,7 +130,7 @@ class TestTopicSafetyRun:
 
     @pytest.mark.asyncio
     async def test_system_prompt_contains_guidelines(self, action):
-        action.engine_registry.model_call = AsyncMock(return_value="on-topic")
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="on-topic"))
         await action.run(FLOW, MESSAGES)
 
         call_args = action.engine_registry.model_call.call_args
@@ -187,9 +189,41 @@ class TestTopicSafetyStopTokens:
         task_manager = LLMTaskManager(config)
         engine_registry = EngineRegistry(config.models, config.rails.config)
         action = TopicSafetyInputAction(engine_registry, task_manager)
-        action.engine_registry.model_call = AsyncMock(return_value="on-topic")
+        action.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="on-topic"))
 
         await action.run(FLOW, MESSAGES)
 
         call_kwargs = action.engine_registry.model_call.call_args.kwargs
         assert call_kwargs["stop"] == ["</s>"]
+
+
+class TestTopicSafetyEndToEnd:
+    """Full chain: raw HTTP response dict -> ModelEngine._parse_chat_completion -> LLMResponse
+    -> EngineRegistry.model_call -> RailAction._get_llm_response -> .content -> _parse_response
+    -> RailResult. Mocks at the HTTP boundary so the dict-parsing path is exercised.
+    """
+
+    @pytest.mark.asyncio
+    async def test_off_topic_full_chain(self, action):
+        engine = action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(
+            return_value={
+                "id": "chatcmpl-1",
+                "model": "topic-control-model",
+                "choices": [{"message": {"role": "assistant", "content": "off-topic"}, "finish_reason": "stop"}],
+            }
+        )
+
+        result = await action.run(FLOW, MESSAGES)
+
+        assert result == RailResult(is_safe=False, reason="Topic safety: off-topic")
+        engine.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_on_topic_full_chain(self, action):
+        engine = action.engine_registry._get_engine(MODEL_TYPE, ModelEngine)
+        engine.call = AsyncMock(return_value={"choices": [{"message": {"role": "assistant", "content": "on-topic"}}]})
+
+        result = await action.run(FLOW, MESSAGES)
+
+        assert result.is_safe


### PR DESCRIPTION
## Description

First in a series of PRs to enable reasoning Guardrails in IORails. Here's a rough outline:

1. **This PR**: Moves to returning a structured `LLMResponse` object for non-streaming and `LLMResponseChunk` object from streaming ModelEngine calls. This is important because we want to include reasoning traces in a separate field of the object and not just return the final content.
2. Connect `reasoning` field to output rails back to the `generate_async()` call stack. This adds reasoning-awareness for non-streaming calls.
3. Connect `reasoning` field back through `stream_async()`. This adds reasoning awareness for streaming calls.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```


### Unit-tests

```
$ poetry run pytest -q
.......................ssss..................................................................................... [  3%]
....s........................................................................................................... [  6%]
................................................................................................................ [  9%]
................................................................................................................ [ 12%]
................................................................................................................ [ 15%]
................................................................................................................ [ 18%]
................................................................................................................ [ 21%]
...................................................................ss....ss....................sssssss.......... [ 24%]
................................................................................................................ [ 27%]
....ss.......s............s..................................................................................... [ 30%]
................................................................................................................ [ 33%]
................................................................s............................................... [ 36%]
...............................................................................................ss............... [ 39%]
............s...............s.......sssss.................................................s..................... [ 43%]
.....................ss........ss...ss............................................s............................. [ 46%]
........................s............s.......................................................................... [ 49%]
................................................................................................................ [ 52%]
................................................................................................................ [ 55%]
.......................sssss......ssssssssssssssssss..........sssss............................................. [ 58%]
.......................................s...........ss...................................sssssssss.ssssssssss.... [ 61%]
...................................s...................................................s....s................... [ 64%]
.....................................ssssssss..............sss...ss...ss.....ssssssssssssss..................... [ 67%]
................................................................................................................ [ 70%]
.................s.............................................................................................. [ 73%]
................s....................ssssssss.........ss........................................................ [ 76%]
...........................................................................sssssss.............................. [ 79%]
...............................s................................................................................ [ 83%]
.........................................................ss..................................................... [ 86%]
................................................................................................................ [ 89%]
................................................................................................................ [ 92%]
....................s........................................................................................... [ 95%]
................................................................................................................ [ 98%]
.........................................................                                                        [100%]
3496 passed, 145 skipped in 121.51s (0:02:01)
```


### Integration test (Chat)

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-27 21:16:42 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-27 21:16:42 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-27 21:16:42 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-27 21:16:42 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-27 21:16:42 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-04-27 21:16:46 INFO: [39a5ca418b635680] generate_async called
2026-04-27 21:16:46 INFO: [39a5ca418b635680] Running input rails
2026-04-27 21:16:46 INFO: [39a5ca418b635680] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-27 21:16:59 INFO: [39a5ca418b635680] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-27 21:16:59 INFO: [39a5ca418b635680] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-27 21:17:00 INFO: [39a5ca418b635680] Calling main LLM
2026-04-27 21:17:00 INFO: [39a5ca418b635680] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-27 21:17:01 INFO: [39a5ca418b635680] Running output rails
2026-04-27 21:17:01 INFO: [39a5ca418b635680] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-27 21:17:01 INFO: [39a5ca418b635680] generate_async completed time=15467.3ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-04-27 21:17:10 INFO: [4b849e9c74132dc4] generate_async called
2026-04-27 21:17:10 INFO: [4b849e9c74132dc4] Running input rails
2026-04-27 21:17:10 INFO: [4b849e9c74132dc4] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-27 21:17:11 INFO: [4b849e9c74132dc4] Input flow content safety check input $model=content_safety blocked
2026-04-27 21:17:11 INFO: [4b849e9c74132dc4] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-27 21:17:11 INFO: [4b849e9c74132dc4] generate_async completed time=735.0ms
I'm sorry, I can't respond to that.
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
