### PR TITLE
feat(llm): add inter-chunk read timeout for streaming

### DIFF
--- a/nemoguardrails/llm/clients/base.py
+++ b/nemoguardrails/llm/clients/base.py
@@ -34,6 +34,7 @@ from nemoguardrails.llm.clients._sse import SSEDecoder
 from nemoguardrails.llm.clients.constants import (
     DEFAULT_CONNECTION_LIMITS,
     DEFAULT_MAX_RETRIES,
+    DEFAULT_STREAM_TIMEOUT,
     DEFAULT_TIMEOUT,
     INITIAL_RETRY_DELAY,
     MAX_RETRY_AFTER,
@@ -209,6 +210,7 @@ class BaseClient:
                     json=payload,
                     headers=self._build_headers(),
                     params=self._custom_query or None,
+                    timeout=DEFAULT_STREAM_TIMEOUT,
                 ) as response:
                     if self._should_retry(response.status_code, response.headers) and retries_remaining > 0:
                         await response.aread()

--- a/nemoguardrails/llm/clients/base.py
+++ b/nemoguardrails/llm/clients/base.py
@@ -92,6 +92,9 @@ class BaseClient:
             timeout=httpx.Timeout(_timeout, connect=_connect_timeout),
             limits=DEFAULT_CONNECTION_LIMITS,
         )
+        self._stream_timeout: Optional[httpx.Timeout] = (
+            DEFAULT_STREAM_TIMEOUT if (timeout is None and connect_timeout is None and http_client is None) else None
+        )
 
     @property
     def provider_name(self) -> Optional[str]:
@@ -201,6 +204,10 @@ class BaseClient:
         retries_attempted = 0
         ctx = self._error_context()
 
+        stream_kwargs: Dict[str, Any] = {}
+        if self._stream_timeout is not None:
+            stream_kwargs["timeout"] = self._stream_timeout
+
         while True:
             first_yielded = False
             try:
@@ -210,7 +217,7 @@ class BaseClient:
                     json=payload,
                     headers=self._build_headers(),
                     params=self._custom_query or None,
-                    timeout=DEFAULT_STREAM_TIMEOUT,
+                    **stream_kwargs,
                 ) as response:
                     if self._should_retry(response.status_code, response.headers) and retries_remaining > 0:
                         await response.aread()

--- a/nemoguardrails/llm/clients/constants.py
+++ b/nemoguardrails/llm/clients/constants.py
@@ -16,6 +16,7 @@
 import httpx
 
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=600.0, connect=5.0)
+DEFAULT_STREAM_TIMEOUT = httpx.Timeout(timeout=600.0, connect=5.0, read=120.0)
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=100)
 

--- a/nemoguardrails/llm/clients/constants.py
+++ b/nemoguardrails/llm/clients/constants.py
@@ -16,7 +16,7 @@
 import httpx
 
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=600.0, connect=5.0)
-DEFAULT_STREAM_TIMEOUT = httpx.Timeout(timeout=600.0, connect=5.0, read=120.0)
+DEFAULT_STREAM_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=600.0, pool=600.0)
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=100)
 

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -32,7 +32,13 @@ from nemoguardrails.exceptions import (
     LLMUnsupportedParamsError,
 )
 from nemoguardrails.llm.clients.base import BaseClient
-from nemoguardrails.llm.clients.constants import INITIAL_RETRY_DELAY, MAX_RETRY_AFTER, MAX_RETRY_DELAY
+from nemoguardrails.llm.clients.constants import (
+    DEFAULT_STREAM_TIMEOUT,
+    DEFAULT_TIMEOUT,
+    INITIAL_RETRY_DELAY,
+    MAX_RETRY_AFTER,
+    MAX_RETRY_DELAY,
+)
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
 from tests.llm.clients._helpers import (
     consume,
@@ -638,6 +644,117 @@ class TestNetworkExceptionRetry:
                 pass
         assert call_count == 2
         assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
+
+
+class TestStreamTimeout:
+    def test_stream_timeout_constant_tightens_read(self):
+        assert DEFAULT_STREAM_TIMEOUT.read == 120.0
+        assert DEFAULT_STREAM_TIMEOUT.connect == DEFAULT_TIMEOUT.connect
+
+    @pytest.mark.asyncio
+    async def test_stream_call_receives_stream_timeout(self):
+        client = make_client()
+        captured = {}
+
+        @asynccontextmanager
+        async def capturing_stream(*args, **kwargs):
+            captured.update(kwargs)
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}'
+                    yield ""
+                    yield "data: [DONE]"
+                    yield ""
+
+            yield FakeResponse()
+
+        client._client = type("MockClient", (), {"stream": capturing_stream})()
+        async for _ in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+            pass
+
+        assert captured["timeout"] is DEFAULT_STREAM_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_before_first_chunk_retries(self):
+        call_count = 0
+
+        @asynccontextmanager
+        async def first_call_times_out(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ReadTimeout("no bytes from server")
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}'
+                    yield ""
+                    yield "data: [DONE]"
+                    yield ""
+
+            yield FakeResponse()
+
+        with mock.patch(
+            "nemoguardrails.llm.clients.base.BaseClient._calculate_retry_delay",
+            staticmethod(low_retry_delay),
+        ):
+            client = make_client(max_retries=2)
+            client._client = type("MockClient", (), {"stream": first_call_times_out})()
+            chunks = []
+            async for chunk in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+                chunks.append(chunk)
+            assert call_count == 2
+            assert len(chunks) == 1
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_after_first_chunk_does_not_retry(self):
+        call_count = 0
+
+        @asynccontextmanager
+        async def stalls_after_first_chunk(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"}}]}'
+                    yield ""
+                    raise httpx.ReadTimeout("server stalled mid-stream")
+
+            yield FakeResponse()
+
+        with mock.patch(
+            "nemoguardrails.llm.clients.base.BaseClient._calculate_retry_delay",
+            staticmethod(low_retry_delay),
+        ):
+            client = make_client(max_retries=2)
+            client._client = type("MockClient", (), {"stream": stalls_after_first_chunk})()
+            chunks = []
+            with pytest.raises(LLMTimeoutError) as exc_info:
+                async for chunk in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+                    chunks.append(chunk)
+            assert call_count == 1
+            assert len(chunks) == 1
+            assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
 
 
 class TestCalculateRetryDelay:

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -647,9 +647,11 @@ class TestNetworkExceptionRetry:
 
 
 class TestStreamTimeout:
-    def test_stream_timeout_constant_tightens_read(self):
-        assert DEFAULT_STREAM_TIMEOUT.read == 120.0
+    def test_stream_timeout_constant_axes(self):
         assert DEFAULT_STREAM_TIMEOUT.connect == DEFAULT_TIMEOUT.connect
+        assert DEFAULT_STREAM_TIMEOUT.read == 120.0
+        assert DEFAULT_STREAM_TIMEOUT.write == 600.0
+        assert DEFAULT_STREAM_TIMEOUT.pool == 600.0
 
     @pytest.mark.asyncio
     async def test_stream_call_receives_stream_timeout(self):
@@ -680,6 +682,70 @@ class TestStreamTimeout:
             pass
 
         assert captured["timeout"] is DEFAULT_STREAM_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_stream_respects_user_configured_timeout(self):
+        client = make_client(timeout=30.0)
+        captured = {}
+
+        @asynccontextmanager
+        async def capturing_stream(*args, **kwargs):
+            captured.update(kwargs)
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}'
+                    yield ""
+                    yield "data: [DONE]"
+                    yield ""
+
+            yield FakeResponse()
+
+        client._client = type("MockClient", (), {"stream": capturing_stream})()
+        async for _ in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+            pass
+
+        assert "timeout" not in captured
+
+    @pytest.mark.asyncio
+    async def test_stream_respects_user_provided_http_client(self):
+        captured = {}
+
+        @asynccontextmanager
+        async def capturing_stream(*args, **kwargs):
+            captured.update(kwargs)
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}'
+                    yield ""
+                    yield "data: [DONE]"
+                    yield ""
+
+            yield FakeResponse()
+
+        user_http_client = httpx.AsyncClient()
+        client = make_client(http_client=user_http_client)
+        client._client = type("MockClient", (), {"stream": capturing_stream})()
+        try:
+            async for _ in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+                pass
+        finally:
+            await user_http_client.aclose()
+
+        assert "timeout" not in captured
 
     @pytest.mark.asyncio
     async def test_read_timeout_before_first_chunk_retries(self):


### PR DESCRIPTION
## Description

Streaming uses DEFAULT_STREAM_TIMEOUT (read=120s) instead of inheriting DEFAULT_TIMEOUT (read=600s). Stalled streams now detected in 2 min instead of 10. First-chunk timeouts retry; mid-stream stalls don't.

addresses https://github.com/NVIDIA-NeMo/Guardrails/pull/1797#discussion_r3140331094 in #1797 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timeout configuration for streaming operations with optimized read timeout settings, improving reliability and error handling during extended streaming sessions and network interruptions.

* **Tests**
  * Added comprehensive tests validating stream timeout behavior, retry logic, and proper error propagation in streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->