### PR TITLE
refactor(llm/default_framework): split reset() into aclose() + clear_providers()

### DIFF
--- a/nemoguardrails/llm/default_framework.py
+++ b/nemoguardrails/llm/default_framework.py
@@ -126,12 +126,18 @@ class DefaultFramework:
     def get_provider_names(self) -> List[str]:
         return sorted({*_DEFAULT_BASE_URLS, *self._providers})
 
-    async def reset(self) -> None:
-        """Close all pooled HTTP clients and clear registered providers.
+    async def aclose(self) -> None:
+        """Close all pooled HTTP clients and drop them from the pool.
 
-        Destructive: clears both the client pool and any providers registered
-        via ``register_provider``. Callers expecting custom providers to
-        survive must re-register them after ``reset``.
+        Connection-pool teardown only. Registered providers are kept.
+        Mirrors ``httpx.AsyncClient.aclose()`` semantics: an async resource
+        cleanup hook that releases sockets and TLS sessions back to the OS.
+
+        Re-creating models after ``aclose`` works as expected: the next call
+        to ``create_model`` for a given config rebuilds the client.
+
+        If any ``client.close()`` fails, all remaining closes are still
+        attempted; the first error is re-raised after the pool is cleared.
         """
         errors = []
         for client in list(self._clients.values()):
@@ -141,6 +147,26 @@ class DefaultFramework:
                 errors.append(exc)
                 log.warning("Error closing pooled client: %s", exc)
         self._clients.clear()
-        self._providers.clear()
         if errors:
             raise errors[0]
+
+    def clear_providers(self) -> None:
+        """Drop all providers registered via ``register_provider``.
+
+        Registry teardown only. Pooled HTTP clients are not affected; if
+        the registered provider classes constructed clients via the
+        framework, those clients survive in the pool until ``aclose()``.
+        """
+        self._providers.clear()
+
+    async def reset(self) -> None:
+        """Test-only convenience: tear down both pools and providers.
+
+        Equivalent to ``await fw.aclose(); fw.clear_providers()``. In
+        production code, prefer the granular methods so connection refresh
+        doesn't accidentally drop registered providers.
+        """
+        try:
+            await self.aclose()
+        finally:
+            self.clear_providers()

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -376,6 +376,91 @@ class TestDefaultFramework:
         await injected.aclose()
 
     @pytest.mark.asyncio
+    async def test_aclose_closes_pools_only_keeps_providers(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        m1 = fw.create_model("gpt-4o", "openai", {"api_key": "sk-a"})
+        client = m1._client._client
+        fw.register_provider("custom", lambda **kw: object())
+
+        await fw.aclose()
+
+        assert client.is_closed
+        assert fw._clients == {}
+        assert "custom" in fw._providers
+
+    @pytest.mark.asyncio
+    async def test_aclose_can_be_called_repeatedly(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        fw.create_model("gpt-4o", "openai", {"api_key": "sk-a"})
+        await fw.aclose()
+        await fw.aclose()
+
+    @pytest.mark.asyncio
+    async def test_aclose_then_create_model_rebuilds_pool(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            m1 = fw.create_model("gpt-4o", "openai", {"api_key": "sk"})
+            first_client = m1._client._client
+            await fw.aclose()
+
+            m2 = fw.create_model("gpt-4o", "openai", {"api_key": "sk"})
+            assert m2._client._client is not first_client
+            assert not m2._client._client.is_closed
+        finally:
+            await fw.aclose()
+
+    def test_clear_providers_drops_registry_only(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        fw.register_provider("custom_a", lambda **kw: object())
+        fw.register_provider("custom_b", lambda **kw: object())
+        assert "custom_a" in fw._providers
+        assert "custom_b" in fw._providers
+
+        fw.clear_providers()
+
+        assert fw._providers == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_providers_does_not_touch_pool(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            m1 = fw.create_model("gpt-4o", "openai", {"api_key": "sk"})
+            client = m1._client._client
+            fw.register_provider("custom", lambda **kw: object())
+
+            fw.clear_providers()
+
+            assert not client.is_closed
+            assert fw._clients != {}
+        finally:
+            await fw.aclose()
+
+    @pytest.mark.asyncio
+    async def test_reset_calls_both_aclose_and_clear_providers(self):
+        from nemoguardrails.llm.default_framework import DefaultFramework
+
+        fw = DefaultFramework()
+        m1 = fw.create_model("gpt-4o", "openai", {"api_key": "sk"})
+        client = m1._client._client
+        fw.register_provider("custom", lambda **kw: object())
+
+        await fw.reset()
+
+        assert client.is_closed
+        assert fw._clients == {}
+        assert fw._providers == {}
+
+    @pytest.mark.asyncio
     async def test_unknown_provider_raises(self):
         from nemoguardrails.llm.default_framework import DefaultFramework
 


### PR DESCRIPTION
## Description

aclose() closes pooled clients; clear_providers() drops the register_provider() registry; reset() stays as a convenience that calls both. Lets callers refresh connections without dropping registered providers.

addresses resolves https://github.com/NVIDIA-NeMo/Guardrails/pull/1797#discussion_r3150960821 in #1797 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized framework lifecycle management to separately handle connection cleanup and provider registry operations, improving reliability of resource teardown and repeated operations.

* **Tests**
  * Added comprehensive test coverage for lifecycle management behaviors, including cleanup operations and provider management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->