### PR TITLE
refactor(llm/clients): return HTTPResponse(body, headers, status_code) from _apost

### DIFF
--- a/nemoguardrails/llm/clients/base.py
+++ b/nemoguardrails/llm/clients/base.py
@@ -18,7 +18,8 @@ import json
 import logging
 import random
 import warnings
-from typing import Any, AsyncGenerator, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator, Dict, Mapping, Optional
 from urllib.parse import urlparse
 
 import httpx
@@ -42,6 +43,13 @@ from nemoguardrails.llm.clients.constants import (
 )
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HTTPResponse:
+    body: Dict[str, Any]
+    headers: Mapping[str, str] = field(default_factory=dict)
+    status_code: int = 200
 
 
 class BaseClient:
@@ -147,7 +155,7 @@ class BaseClient:
         log.info("Retrying (delay=%.1fs, attempted=%d)", delay, retries_attempted)
         await asyncio.sleep(delay)
 
-    async def _apost(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _apost(self, path: str, payload: Dict[str, Any]) -> HTTPResponse:
         retries_remaining = self._max_retries
         retries_attempted = 0
         ctx = self._error_context()
@@ -192,10 +200,9 @@ class BaseClient:
                     response_data=None,
                     **ctx.as_kwargs(),
                 ) from err
-            data["_response_headers"] = dict(response.headers)
-            return data
+            return HTTPResponse(body=data, headers=dict(response.headers), status_code=response.status_code)
 
-    async def _apost_stream(self, path: str, payload: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+    async def _apost_stream(self, path: str, payload: Dict[str, Any]) -> AsyncGenerator[HTTPResponse, None]:
         retries_remaining = self._max_retries
         retries_attempted = 0
         ctx = self._error_context()
@@ -222,6 +229,7 @@ class BaseClient:
                         raise_for_status(response.status_code, response.text, response.headers, ctx)
 
                     response_headers = dict(response.headers)
+                    response_status = response.status_code
                     decoder = SSEDecoder()
                     async for line in response.aiter_lines():
                         sse = decoder.decode(line)
@@ -237,10 +245,9 @@ class BaseClient:
                                 response_data=None,
                                 **ctx.as_kwargs(),
                             ) from err
-                        parsed["_response_headers"] = response_headers
                         self._check_sse_error(parsed, response.headers, ctx)
                         first_yielded = True
-                        yield parsed
+                        yield HTTPResponse(body=parsed, headers=response_headers, status_code=response_status)
 
                     sse = decoder.decode("")
                     if sse is not None and not sse.data.startswith("[DONE]"):
@@ -252,9 +259,8 @@ class BaseClient:
                                 response_data=None,
                                 **ctx.as_kwargs(),
                             ) from err
-                        parsed["_response_headers"] = response_headers
                         self._check_sse_error(parsed, response.headers, ctx)
-                        yield parsed
+                        yield HTTPResponse(body=parsed, headers=response_headers, status_code=response_status)
                     return
             except httpx.TimeoutException as err:
                 if first_yielded or retries_remaining <= 0:

--- a/nemoguardrails/llm/clients/openai_chat_model.py
+++ b/nemoguardrails/llm/clients/openai_chat_model.py
@@ -17,6 +17,7 @@ import json
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from nemoguardrails.exceptions import LLMClientError, LLMResponseValidationError
+from nemoguardrails.llm.clients.base import HTTPResponse
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
 from nemoguardrails.types import (
     ChatMessage,
@@ -40,7 +41,7 @@ _FINISH_REASON_MAP: Dict[str, FinishReason] = {
     "content_filter": "content_filter",
 }
 
-_STANDARD_RESPONSE_KEYS = frozenset({"model", "choices", "usage", "id", "object", "created", "_response_headers"})
+_STANDARD_RESPONSE_KEYS = frozenset({"model", "choices", "usage", "id", "object", "created"})
 
 
 def _is_openai_reasoning_model(model_name: str) -> bool:
@@ -122,10 +123,10 @@ class OpenAIChatModel:
         messages = self._to_messages(prompt)
         params = self._prepare_params(stop, kwargs)
         try:
-            data = await self._client.chat_completion(self._model, messages, **params)
+            response = await self._client.chat_completion(self._model, messages, **params)
         except LLMClientError as exc:
             raise self._enrich(exc)
-        return self._parse_response(data)
+        return self._parse_response(response)
 
     async def stream_async(
         self,
@@ -141,8 +142,9 @@ class OpenAIChatModel:
 
         gen = self._client.stream_chat_completion(self._model, messages, **params)
         try:
-            async for chunk_data in gen:
-                choices = chunk_data.get("choices", [])
+            async for chunk_response in gen:
+                chunk_body = chunk_response.body
+                choices = chunk_body.get("choices", [])
                 if choices:
                     delta = choices[0].get("delta", {})
                     raw_tool_calls = delta.get("tool_calls")
@@ -160,7 +162,7 @@ class OpenAIChatModel:
                             if arg_fragment:
                                 tool_call_acc[idx]["arguments_buffer"] += arg_fragment
 
-                chunk = self._parse_chunk(chunk_data)
+                chunk = self._parse_chunk(chunk_response)
                 if chunk is None:
                     continue
 
@@ -222,7 +224,8 @@ class OpenAIChatModel:
             raise LLMResponseValidationError("Missing or invalid 'message' in choices[0]", response_data=data, **ctx)
         return message
 
-    def _parse_response(self, data: Dict[str, Any]) -> LLMResponse:
+    def _parse_response(self, response: HTTPResponse) -> LLMResponse:
+        data = response.body
         message = self._validate_response(data)
         choice = data["choices"][0]
 
@@ -252,9 +255,8 @@ class OpenAIChatModel:
 
         provider_metadata = {k: v for k, v in data.items() if k not in _STANDARD_RESPONSE_KEYS and v is not None}
 
-        response_headers = data.get("_response_headers")
-        if response_headers:
-            provider_metadata["response_headers"] = response_headers
+        if response.headers:
+            provider_metadata["response_headers"] = dict(response.headers)
 
         return LLMResponse(
             content=content,
@@ -267,11 +269,11 @@ class OpenAIChatModel:
             provider_metadata=provider_metadata or None,
         )
 
-    def _parse_chunk(self, data: Dict[str, Any]) -> Optional[LLMResponseChunk]:
+    def _parse_chunk(self, response: HTTPResponse) -> Optional[LLMResponseChunk]:
+        data = response.body
         provider_metadata = {k: v for k, v in data.items() if k not in _STANDARD_RESPONSE_KEYS and v is not None}
-        response_headers = data.get("_response_headers")
-        if response_headers:
-            provider_metadata["response_headers"] = response_headers
+        if response.headers:
+            provider_metadata["response_headers"] = dict(response.headers)
 
         choices = data.get("choices", [])
         if not choices:

--- a/nemoguardrails/llm/clients/openai_compatible.py
+++ b/nemoguardrails/llm/clients/openai_compatible.py
@@ -15,7 +15,7 @@
 
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
-from nemoguardrails.llm.clients.base import BaseClient
+from nemoguardrails.llm.clients.base import BaseClient, HTTPResponse
 
 
 class OpenAICompatibleClient(BaseClient):
@@ -55,7 +55,7 @@ class OpenAICompatibleClient(BaseClient):
         *,
         stop: Optional[List[str]] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> HTTPResponse:
         payload = self._build_payload(model, messages, stop=stop, **kwargs)
         return await self._apost(self._ROUTE, payload)
 
@@ -66,7 +66,7 @@ class OpenAICompatibleClient(BaseClient):
         *,
         stop: Optional[List[str]] = None,
         **kwargs: Any,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[HTTPResponse, None]:
         payload = self._build_payload(model, messages, stop=stop, stream=True, **kwargs)
         gen = self._apost_stream(self._ROUTE, payload)
         try:

--- a/tests/llm/clients/test_openai_chat_model.py
+++ b/tests/llm/clients/test_openai_chat_model.py
@@ -23,6 +23,7 @@ from nemoguardrails.exceptions import (
     LLMRateLimitError,
     LLMResponseValidationError,
 )
+from nemoguardrails.llm.clients.base import HTTPResponse
 from nemoguardrails.llm.clients.openai_chat_model import OpenAIChatModel, _is_openai_reasoning_model
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
 from nemoguardrails.types import ChatMessage, LLMResponse, Role, ToolCall, ToolCallFunction
@@ -50,6 +51,7 @@ def _response(
     reasoning_content=None,
     usage=None,
     extra_fields=None,
+    headers=None,
 ):
     message = {"content": content, "role": "assistant"}
     if tool_calls:
@@ -65,24 +67,30 @@ def _response(
         resp["usage"] = usage
     if extra_fields:
         resp.update(extra_fields)
-    return resp
+    return HTTPResponse(body=resp, headers=headers or {}, status_code=200)
 
 
-def _stream_chunks(deltas, model="gpt-4o", usage=None):
+def _stream_chunks(deltas, model="gpt-4o", usage=None, headers=None):
     chunks = []
+    hdrs = headers or {}
     for i, delta in enumerate(deltas):
         finish_reason = None
         if i == len(deltas) - 1:
             finish_reason = "stop"
-        chunks.append(
-            {
-                "id": "chatcmpl-123",
-                "model": model,
-                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
-            }
-        )
+        body = {
+            "id": "chatcmpl-123",
+            "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+        chunks.append(HTTPResponse(body=body, headers=hdrs, status_code=200))
     if usage:
-        chunks.append({"id": "chatcmpl-123", "model": model, "choices": [], "usage": usage})
+        chunks.append(
+            HTTPResponse(
+                body={"id": "chatcmpl-123", "model": model, "choices": [], "usage": usage},
+                headers=hdrs,
+                status_code=200,
+            )
+        )
     return chunks
 
 
@@ -200,9 +208,7 @@ class TestGenerate:
     @pytest.mark.asyncio
     async def test_response_headers_in_metadata(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(
-            return_value=_response(extra_fields={"_response_headers": {"x-request-id": "req-abc"}})
-        )
+        mc.chat_completion = AsyncMock(return_value=_response(headers={"x-request-id": "req-abc"}))
         m = _model(mc)
 
         result = await m.generate_async("Hi")
@@ -290,7 +296,7 @@ class TestStream:
                 },
                 {"id": "c", "model": "gpt-4o", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
             ]:
-                yield c
+                yield HTTPResponse(body=c)
 
         mc.stream_chat_completion = mock_stream
         m = _model(mc)
@@ -355,7 +361,7 @@ class TestStream:
                 },
                 {"id": "c", "model": "gpt-4o", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
             ]:
-                yield c
+                yield HTTPResponse(body=c)
 
         mc.stream_chat_completion = mock_stream
         m = _model(mc)
@@ -408,7 +414,7 @@ class TestStream:
                 },
                 {"id": "c", "model": "gpt-4o", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
             ]:
-                yield c
+                yield HTTPResponse(body=c)
 
         mc.stream_chat_completion = mock_stream
         m = _model(mc)
@@ -623,7 +629,7 @@ class TestValidation:
     @pytest.mark.asyncio
     async def test_no_choices(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(return_value={"id": "c", "model": "gpt-4o"})
+        mc.chat_completion = AsyncMock(return_value=HTTPResponse(body={"id": "c", "model": "gpt-4o"}))
         m = _model(mc)
 
         with pytest.raises(LLMResponseValidationError, match="choices"):
@@ -632,7 +638,7 @@ class TestValidation:
     @pytest.mark.asyncio
     async def test_empty_choices(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(return_value={"id": "c", "model": "gpt-4o", "choices": []})
+        mc.chat_completion = AsyncMock(return_value=HTTPResponse(body={"id": "c", "model": "gpt-4o", "choices": []}))
         m = _model(mc)
 
         with pytest.raises(LLMResponseValidationError, match="choices"):
@@ -641,7 +647,9 @@ class TestValidation:
     @pytest.mark.asyncio
     async def test_no_message(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(return_value={"id": "c", "model": "gpt-4o", "choices": [{"index": 0}]})
+        mc.chat_completion = AsyncMock(
+            return_value=HTTPResponse(body={"id": "c", "model": "gpt-4o", "choices": [{"index": 0}]})
+        )
         m = _model(mc)
 
         with pytest.raises(LLMResponseValidationError, match="message"):
@@ -683,7 +691,7 @@ class TestErrorEnrichment:
     @pytest.mark.asyncio
     async def test_validation_error_enriched_with_context(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(return_value={"id": "x", "model": "gpt-4o"})
+        mc.chat_completion = AsyncMock(return_value=HTTPResponse(body={"id": "x", "model": "gpt-4o"}))
         m = _model(mc, model="gpt-4o")
 
         with pytest.raises(LLMResponseValidationError) as exc_info:
@@ -743,7 +751,7 @@ class TestErrorEnrichment:
     @pytest.mark.asyncio
     async def test_validation_error_status_code_is_zero(self):
         mc = _mock_client()
-        mc.chat_completion = AsyncMock(return_value={"id": "x", "model": "gpt-4o"})
+        mc.chat_completion = AsyncMock(return_value=HTTPResponse(body={"id": "x", "model": "gpt-4o"}))
         m = _model(mc, model="gpt-4o")
 
         with pytest.raises(LLMResponseValidationError) as exc_info:

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -59,13 +59,15 @@ class TestProviderUrl:
 
 class TestChatCompletion:
     @pytest.mark.asyncio
-    async def test_returns_raw_dict(self):
+    async def test_returns_http_response(self):
+        from nemoguardrails.llm.clients.base import HTTPResponse
+
         client = make_client()
         mock_httpx_post(client, [(200, ok_response(), {})])
         result = await client.chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}])
-        assert isinstance(result, dict)
-        assert result["choices"][0]["message"]["content"] == "Hello"
-        assert "_response_headers" in result
+        assert isinstance(result, HTTPResponse)
+        assert result.body["choices"][0]["message"]["content"] == "Hello"
+        assert result.headers is not None
 
     @pytest.mark.asyncio
     async def test_builds_correct_payload(self):
@@ -843,7 +845,7 @@ class TestDoneSentinel:
         )
         chunks = await consume(client)
         assert len(chunks) == 1
-        assert chunks[0]["choices"][0]["delta"]["content"] == "hi"
+        assert chunks[0].body["choices"][0]["delta"]["content"] == "hi"
 
     @pytest.mark.asyncio
     async def test_done_discards_subsequent_data(self):
@@ -859,7 +861,7 @@ class TestDoneSentinel:
         )
         chunks = await consume(client)
         assert len(chunks) == 1
-        assert chunks[0]["choices"][0]["delta"]["content"] == "first"
+        assert chunks[0].body["choices"][0]["delta"]["content"] == "first"
 
     @pytest.mark.asyncio
     async def test_done_with_trailing_whitespace(self):
@@ -1115,8 +1117,8 @@ class TestConcurrency:
         )
 
         for prompt, result in zip(prompts, results):
-            assert result["id"] == f"chatcmpl-{prompt}"
-            assert result["choices"][0]["message"]["content"] == f"reply-{prompt}"
+            assert result.body["id"] == f"chatcmpl-{prompt}"
+            assert result.body["choices"][0]["message"]["content"] == f"reply-{prompt}"
 
     @pytest.mark.asyncio
     async def test_concurrent_streams_independent(self):
@@ -1154,8 +1156,8 @@ class TestConcurrency:
 
         for prompt, chunks in zip(prompts, results):
             assert len(chunks) == 1
-            assert chunks[0]["id"] == f"c-{prompt}"
-            assert chunks[0]["choices"][0]["delta"]["content"] == f"{prompt}-chunk"
+            assert chunks[0].body["id"] == f"c-{prompt}"
+            assert chunks[0].body["choices"][0]["delta"]["content"] == f"{prompt}-chunk"
 
     @pytest.mark.asyncio
     async def test_429_on_one_call_does_not_block_peers(self):
@@ -1199,8 +1201,8 @@ class TestConcurrency:
         )
 
         for prompt, result in zip(prompts, results):
-            assert result["id"] == f"c-{prompt}"
-            assert result["choices"][0]["message"]["content"] == f"ok-{prompt}"
+            assert result.body["id"] == f"c-{prompt}"
+            assert result.body["choices"][0]["message"]["content"] == f"ok-{prompt}"
 
         assert seen_calls["slow"] == 2
         for p in prompts[1:]:

--- a/tests/llm/clients/test_openai_compatible_live.py
+++ b/tests/llm/clients/test_openai_compatible_live.py
@@ -83,8 +83,12 @@ def _load_fixture(name):
 def _to_http_response(data):
     from nemoguardrails.llm.clients.base import HTTPResponse
 
-    headers = data.pop("_response_headers", {}) if isinstance(data, dict) else {}
-    return HTTPResponse(body=data, headers=headers, status_code=200)
+    if isinstance(data, dict):
+        headers = data.get("_response_headers", {})
+        body = {key: value for key, value in data.items() if key != "_response_headers"}
+    else:
+        headers, body = {}, data
+    return HTTPResponse(body=body, headers=headers, status_code=200)
 
 
 def _load_response_fixture(name):

--- a/tests/llm/clients/test_openai_compatible_live.py
+++ b/tests/llm/clients/test_openai_compatible_live.py
@@ -1128,18 +1128,19 @@ class TestOpenAIProviderContract:
             base_url="https://api.openai.com/v1",
             api_key=os.environ.get("OPENAI_API_KEY"),
         ) as client:
-            data = await client.chat_completion(
+            response = await client.chat_completion(
                 "gpt-4o-mini",
                 [{"role": "user", "content": "Say hello in one word"}],
             )
-        assert "id" in data
-        assert "model" in data
-        choices = data.get("choices")
+        body = response.body
+        assert "id" in body
+        assert "model" in body
+        choices = body.get("choices")
         assert isinstance(choices, list) and len(choices) > 0
         message = choices[0].get("message")
         assert isinstance(message, dict) and "content" in message
         assert "finish_reason" in choices[0]
-        usage = data.get("usage")
+        usage = body.get("usage")
         assert isinstance(usage, dict)
         assert "prompt_tokens" in usage and "completion_tokens" in usage
 
@@ -1184,8 +1185,8 @@ class TestOpenAIProviderContract:
             ):
                 chunks.append(chunk)
         assert len(chunks) > 0
-        assert any(c.get("choices") for c in chunks)
-        assert any(c.get("usage") for c in chunks)
+        assert any(chunk.body.get("choices") for chunk in chunks)
+        assert any(chunk.body.get("usage") for chunk in chunks)
 
     @pytest.mark.asyncio
     async def test_401_body_does_not_echo_bad_key(self):

--- a/tests/llm/clients/test_openai_compatible_live.py
+++ b/tests/llm/clients/test_openai_compatible_live.py
@@ -80,12 +80,27 @@ def _load_fixture(name):
         return json.load(f)
 
 
+def _to_http_response(data):
+    from nemoguardrails.llm.clients.base import HTTPResponse
+
+    headers = data.pop("_response_headers", {}) if isinstance(data, dict) else {}
+    return HTTPResponse(body=data, headers=headers, status_code=200)
+
+
+def _load_response_fixture(name):
+    return _to_http_response(_load_fixture(name))
+
+
+def _load_stream_fixture(name):
+    return [_to_http_response(c) for c in _load_fixture(name)]
+
+
 def _fixture_exists(name):
     return (FIXTURES_DIR / name).exists()
 
 
 def _replay_stream(model, fixture_name):
-    chunks_data = _load_fixture(fixture_name)
+    chunks_data = _load_stream_fixture(fixture_name)
 
     async def replay(*args, **kwargs):
         for chunk_data in chunks_data:
@@ -114,7 +129,7 @@ class TestRecordedOpenAI:
     """
 
     def test_parse_text_response(self):
-        data = _load_fixture("openai_generate_text.json")
+        data = _load_response_fixture("openai_generate_text.json")
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
         result = client._parse_response(data)
 
@@ -133,7 +148,7 @@ class TestRecordedOpenAI:
         assert "system_fingerprint" in result.provider_metadata
 
     def test_parse_tool_call_response(self):
-        data = _load_fixture("openai_generate_tool_call.json")
+        data = _load_response_fixture("openai_generate_tool_call.json")
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
         result = client._parse_response(data)
 
@@ -148,7 +163,7 @@ class TestRecordedOpenAI:
         assert result.usage.cached_tokens is not None
 
     def test_parse_stream_text_chunks(self):
-        chunks_data = _load_fixture("openai_stream_text.json")
+        chunks_data = _load_stream_fixture("openai_stream_text.json")
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
 
         content_parts = []
@@ -184,7 +199,7 @@ class TestRecordedOpenAI:
         assert usage_chunk[0].usage.total_tokens > 0
 
     def test_stream_text_request_id_consistent(self):
-        chunks_data = _load_fixture("openai_stream_text.json")
+        chunks_data = _load_stream_fixture("openai_stream_text.json")
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
 
         request_ids = set()
@@ -213,7 +228,7 @@ class TestRecordedNIM:
         reason="NIM fixtures not recorded",
     )
     def test_parse_text_response(self):
-        data = _load_fixture("nim_generate_text.json")
+        data = _load_response_fixture("nim_generate_text.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
         result = client._parse_response(data)
 
@@ -229,7 +244,7 @@ class TestRecordedNIM:
         reason="NIM fixtures not recorded",
     )
     def test_parse_tool_call_response(self):
-        data = _load_fixture("nim_generate_tool_call.json")
+        data = _load_response_fixture("nim_generate_tool_call.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
         result = client._parse_response(data)
 
@@ -244,7 +259,7 @@ class TestRecordedNIM:
         reason="NIM fixtures not recorded",
     )
     def test_parse_reasoning_response(self):
-        data = _load_fixture("nim_generate_reasoning.json")
+        data = _load_response_fixture("nim_generate_reasoning.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
         result = client._parse_response(data)
 
@@ -277,7 +292,7 @@ class TestRecordedNIM:
 
     @pytest.mark.skipif(not _fixture_exists("nim_stream_text.json"), reason="NIM fixtures not recorded")
     def test_parse_stream_text_chunks(self):
-        chunks_data = _load_fixture("nim_stream_text.json")
+        chunks_data = _load_stream_fixture("nim_stream_text.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
 
         content_parts = []
@@ -290,7 +305,7 @@ class TestRecordedNIM:
 
     @pytest.mark.skipif(not _fixture_exists("nim_generate_tool_call.json"), reason="NIM fixtures not recorded")
     def test_nim_null_fields_dont_crash(self):
-        data = _load_fixture("nim_generate_tool_call.json")
+        data = _load_response_fixture("nim_generate_tool_call.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
         result = client._parse_response(data)
 
@@ -300,7 +315,7 @@ class TestRecordedNIM:
 
     @pytest.mark.skipif(not _fixture_exists("nim_generate_tool_call.json"), reason="NIM fixtures not recorded")
     def test_reasoning_alongside_tool_calls(self):
-        data = _load_fixture("nim_generate_tool_call.json")
+        data = _load_response_fixture("nim_generate_tool_call.json")
         client = _make_model(model="nvidia/nemotron-3-nano-30b-a3b", base_url="https://integrate.api.nvidia.com/v1")
         result = client._parse_response(data)
 
@@ -319,7 +334,7 @@ class TestRecordedEdgeCases:
 
     def test_empty_tool_call_arguments(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
-        data = {
+        body = {
             "id": "chatcmpl-test",
             "model": "gpt-4o-mini",
             "choices": [
@@ -340,14 +355,14 @@ class TestRecordedEdgeCases:
                 }
             ],
         }
-        result = client._parse_response(data)
+        result = client._parse_response(_to_http_response(body))
 
         assert result.tool_calls[0].function.name == "get_status"
         assert result.tool_calls[0].function.arguments == {}
 
     def test_content_alongside_tool_calls(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
-        data = {
+        body = {
             "id": "chatcmpl-test",
             "model": "gpt-4o-mini",
             "choices": [
@@ -368,7 +383,7 @@ class TestRecordedEdgeCases:
                 }
             ],
         }
-        result = client._parse_response(data)
+        result = client._parse_response(_to_http_response(body))
 
         assert result.content == "Let me check that for you."
         assert result.tool_calls is not None
@@ -383,17 +398,17 @@ class TestFixtureSanity:
     """
 
     def test_openai_generate_tool_call_fixture_is_parallel(self):
-        data = _load_fixture("openai_generate_tool_call.json")
-        tool_calls = data["choices"][0]["message"].get("tool_calls") or []
+        data = _load_response_fixture("openai_generate_tool_call.json")
+        tool_calls = data.body["choices"][0]["message"].get("tool_calls") or []
         assert len(tool_calls) >= 2, (
             "fixture should contain >=2 parallel tool calls; re-record with a multi-tool prompt"
         )
 
     def test_openai_stream_tool_calls_fixture_is_parallel(self):
-        chunks = _load_fixture("openai_stream_tool_calls.json")
+        chunks = _load_stream_fixture("openai_stream_tool_calls.json")
         indexes = set()
         for chunk in chunks:
-            choices = chunk.get("choices") or []
+            choices = chunk.body.get("choices") or []
             if not choices:
                 continue
             for tc in choices[0].get("delta", {}).get("tool_calls") or []:
@@ -434,7 +449,7 @@ class TestRecordedFinishLength:
     )
     def test_finish_reason_length_parsed(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
-        data = _load_fixture("openai_generate_finish_length.json")
+        data = _load_response_fixture("openai_generate_finish_length.json")
         result = client._parse_response(data)
         assert result.finish_reason == "length"
 
@@ -446,7 +461,7 @@ class TestRecordedRefusal:
     )
     def test_refusal_produces_response(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
-        data = _load_fixture("openai_generate_refusal.json")
+        data = _load_response_fixture("openai_generate_refusal.json")
         result = client._parse_response(data)
         assert result.finish_reason in ("stop", "content_filter", "other")
 
@@ -458,7 +473,7 @@ class TestRecordedMultimodal:
     )
     def test_multimodal_generate_parses(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
-        data = _load_fixture("openai_generate_multimodal.json")
+        data = _load_response_fixture("openai_generate_multimodal.json")
         result = client._parse_response(data)
         assert result.content
         assert result.finish_reason == "stop"
@@ -482,7 +497,7 @@ class TestRecordedMultiTurn:
     def test_first_turn_has_tool_call(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
         data = _load_fixture("openai_multiturn_tool_roundtrip.json")
-        first = client._parse_response(data["first_response"])
+        first = client._parse_response(_to_http_response(data["first_response"]))
         assert first.tool_calls is not None
         assert len(first.tool_calls) >= 1
         assert first.finish_reason == "tool_calls"
@@ -494,7 +509,7 @@ class TestRecordedMultiTurn:
     def test_second_turn_has_text_content(self):
         client = _make_model(model="gpt-4o-mini", base_url="https://api.openai.com/v1")
         data = _load_fixture("openai_multiturn_tool_roundtrip.json")
-        second = client._parse_response(data["second_response"])
+        second = client._parse_response(_to_http_response(data["second_response"]))
         assert second.content
         assert second.finish_reason == "stop"
 


### PR DESCRIPTION
## Description

_apost / _apost_stream now return / yield HTTPResponse instead of injecting a sentinel _response_headers key into the parsed JSON body. Removes collision risk and types the client return surface explicitly.

resolves https://github.com/NVIDIA-NeMo/Guardrails/pull/1797#discussion_r3140548145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured HTTP response handling to use a standardized response wrapper instead of embedded metadata in response bodies, improving consistency across client implementations and making header/status information more accessible alongside response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->