### PR TITLE
docs(guardrails): document max_tokens fallback and reasoning model guidance

### DIFF
--- a/docs/configure-rails/guardrail-catalog/content-safety.md
+++ b/docs/configure-rails/guardrail-catalog/content-safety.md
@@ -114,7 +114,7 @@ The above is an example prompt that you can use with the *content safety check i
 
 The `content safety check input` and `content safety check output` rails executes the [`content_safety_check_input`](../../../nemoguardrails/library/content_safety/actions.py) and [`content_safety_check_output`](../../../nemoguardrails/library/content_safety/actions.py) actions respectively.
 
-### Reasoning Models as Content Safety Guards
+## Reasoning Models as Content Safety Guards
 
 Reasoning guard models such as [Nemotron Content Safety Reasoning](../../getting-started/tutorials/nemotron-content-safety-reasoning-deployment.md), and OpenAI `gpt-oss-safeguard` spend output tokens on internal reasoning before emitting the safety verdict. If the configured `max_tokens` is too small, the budget can be exhausted by the reasoning phase and the model returns empty content with `finish_reason="length"`. The content safety actions log a warning in that case and continue with empty output, which the parser typically treats as unsafe.
 

--- a/docs/configure-rails/guardrail-catalog/content-safety.md
+++ b/docs/configure-rails/guardrail-catalog/content-safety.md
@@ -114,6 +114,23 @@ The above is an example prompt that you can use with the *content safety check i
 
 The `content safety check input` and `content safety check output` rails executes the [`content_safety_check_input`](../../../nemoguardrails/library/content_safety/actions.py) and [`content_safety_check_output`](../../../nemoguardrails/library/content_safety/actions.py) actions respectively.
 
+### Reasoning Models as Content Safety Guards
+
+Reasoning guard models such as [Nemotron Content Safety Reasoning](../../getting-started/tutorials/nemotron-content-safety-reasoning-deployment.md), and OpenAI `gpt-oss-safeguard` spend output tokens on internal reasoning before emitting the safety verdict. If the configured `max_tokens` is too small, the budget can be exhausted by the reasoning phase and the model returns empty content with `finish_reason="length"`. The content safety actions log a warning in that case and continue with empty output, which the parser typically treats as unsafe.
+
+To use a reasoning guard, set `max_tokens` on the corresponding prompt task in `prompts.yml` to a value that fits both the reasoning trace and the verdict:
+
+```yaml
+prompts:
+  - task: content_safety_check_input $model=content_safety_reasoning
+    content: |
+      ...
+    output_parser: nemotron_reasoning_parse_prompt_safety
+    max_tokens: 2048
+```
+
+If `max_tokens` is not set on the prompt task, the action falls back to a default of `1024` tokens. Adjust this value for the model's expected reasoning trace length.
+
 ## Multilingual Refusal Messages
 
 <!-- TODO: should we mention nvidia/llama-3.1-nemotron-safety-guard-8b-v3  -->

--- a/docs/configure-rails/guardrail-catalog/fact-checking.md
+++ b/docs/configure-rails/guardrail-catalog/fact-checking.md
@@ -59,6 +59,10 @@ The above is an example prompt that you can use with the *self check facts rail*
 
 The self-check fact-checking rail executes the [`self_check_facts` action](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/nemoguardrails/library/self_check/output_check/actions.py), which returns a score between `0.0` (response is not accurate) and `1.0` (response is accurate). The reason a number is returned, instead of a boolean, is to keep a consistent API with other methods that return a score, e.g., the AlignScore method below.
 
+```{note}
+If the LLM hits its `max_tokens` budget before producing a verdict (`finish_reason="length"` with empty content), the action fail-closes and returns `0.0` so the response is blocked. This typically happens with reasoning models that consume output tokens on internal reasoning. Set `max_tokens` on the `self_check_facts` prompt task to fit both the reasoning trace and the yes/no verdict; if unset, the action falls back to `1024` tokens. See [Reasoning Models as Self-Check LLMs](self-check.md#reasoning-models-as-self-check-llms).
+```
+
 ```text
 define subflow self check facts
   if $check_facts == True

--- a/docs/configure-rails/guardrail-catalog/self-check.md
+++ b/docs/configure-rails/guardrail-catalog/self-check.md
@@ -19,6 +19,22 @@ This category of rails relies on prompting the LLM to perform various tasks like
 You should only use the example self-check prompts as a starting point. For production use cases, you should perform additional evaluations and customizations.
 ```
 
+### Reasoning Models as Self-Check LLMs
+
+The `self_check_input`, `self_check_output`, and `self_check_facts` tasks all log a warning if the LLM hits `max_tokens` before producing visible output (`finish_reason="length"` with empty content). With the default parser, `self_check_input` and `self_check_output` treat empty output as unsafe and block. `self_check_facts` explicitly fail-closes by returning a score of `0.0`, because its scoring logic would otherwise accept empty output.
+
+If you use a reasoning model (OpenAI o-series, `gpt-5` and similar) for self-check, set an explicit `max_tokens` on the prompt task in `prompts.yml` large enough to cover both the reasoning trace and the final yes/no verdict:
+
+```yaml
+prompts:
+  - task: self_check_input
+    content: |-
+      ...
+    max_tokens: 2048
+```
+
+If `max_tokens` is not set, the action falls back to a default of `1024` tokens. Adjust this value for the model's expected reasoning trace length.
+
 ## Self Check Input
 
 The goal of the input self-checking rail is to determine if the input from the user should be allowed for further processing. This rail will prompt the LLM using a custom prompt. Common reasons for rejecting the input from the user include jailbreak attempts, harmful or abusive content, or other inappropriate instructions.

--- a/docs/configure-rails/guardrail-catalog/self-check.md
+++ b/docs/configure-rails/guardrail-catalog/self-check.md
@@ -19,7 +19,7 @@ This category of rails relies on prompting the LLM to perform various tasks like
 You should only use the example self-check prompts as a starting point. For production use cases, you should perform additional evaluations and customizations.
 ```
 
-### Reasoning Models as Self-Check LLMs
+## Reasoning Models as Self-Check LLMs
 
 The `self_check_input`, `self_check_output`, and `self_check_facts` tasks all log a warning if the LLM hits `max_tokens` before producing visible output (`finish_reason="length"` with empty content). With the default parser, `self_check_input` and `self_check_output` treat empty output as unsafe and block. `self_check_facts` explicitly fail-closes by returning a score of `0.0`, because its scoring logic would otherwise accept empty output.
 

--- a/docs/configure-rails/yaml-schema/prompt-configuration.md
+++ b/docs/configure-rails/yaml-schema/prompt-configuration.md
@@ -165,7 +165,7 @@ The `mode` in the prompt definition must match the `prompting_mode` in the top-l
 | `max_length` | `int` | `16000` | Maximum prompt length in characters. |
 | `mode` | `str` | `"standard"` | Prompting mode this prompt applies to. |
 | `stop` | `list[str]` | — | Stop tokens for models that support them. |
-| `max_tokens` | `int` | — | Maximum number of tokens for the completion. |
+| `max_tokens` | `int` | — | Maximum number of tokens for the completion. The self-check (`self_check_input`, `self_check_output`, `self_check_facts`) and content safety (`content_safety_check_input`, `content_safety_check_output`) actions fall back to `1024` if unset. Reasoning models that spend output tokens on internal reasoning need this set explicitly to fit both the reasoning trace and the verdict. |
 
 ## Template Variables
 


### PR DESCRIPTION
## Description

Add guidance for self-check and content-safety actions covering:
- new 1024 fallback when max_tokens is unset on the prompt task
- when to raise max_tokens for reasoning guard models that consume output tokens on internal reasoning before emitting a verdict
- self_check_facts fail-close behavior (returns 0.0) on truncation

Also extend the prompt-configuration reference to note the per-action fallback and the reasoning-model implication.


Documents #1816



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring reasoning models with content safety checks and fact-checking features, including `max_tokens` defaults and recommended configuration practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->