### PR TITLE
fix(build): remove chat-ui references from wheel build script

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -5,18 +5,14 @@ set -e
 
 # Define variables for paths
 PACKAGE_DIR="nemoguardrails"
-CHAT_UI_SRC="chat-ui"
 EXAMPLES_SRC="examples"
-CHAT_UI_DST="$PACKAGE_DIR/chat-ui"
 EXAMPLES_DST="$PACKAGE_DIR/examples"
 
 # Copy the directories into the package directory
-cp -r "$CHAT_UI_SRC" "$CHAT_UI_DST"
 cp -r "$EXAMPLES_SRC" "$EXAMPLES_DST"
 
 # Build the wheel using Poetry
 poetry build
 
 # Remove the copied directories after building
-rm -rf "$CHAT_UI_DST"
 rm -rf "$EXAMPLES_DST"


### PR DESCRIPTION
## Description

The chat-ui directory was removed in #1734 (Chatbot UI replaced by Chainlit), but .github/scripts/build.sh still tried to copy it into the package before running poetry build, causing the publish workflow to fail with "cannot stat 'chat-ui'".

Drop the CHAT_UI_SRC/DST variables and the corresponding cp/rm lines so the wheel build only copies the still-existing examples directory.

Resolves the failure at
https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/25082804479

### Test Plan

failed at
https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/25082804479
passed at:
https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/25104043497




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build packaging workflow by removing unnecessary steps from the build script, resulting in a cleaner and more efficient build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->