### PR TITLE
refactor(llm): share OpenAI reasoning-model classifier across adapters

### DIFF
--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -18,6 +18,7 @@ import logging
 import uuid
 from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Union
 
+from nemoguardrails.llm.openai_reasoning import is_openai_reasoning_model
 from nemoguardrails.types import (
     ChatMessage,
     FinishReason,
@@ -110,17 +111,6 @@ def _infer_provider_from_module(llm: Any) -> Optional[str]:
     return None
 
 
-def _is_openai_reasoning_model(model_name: str) -> bool:
-    name = model_name.lower()
-    if name in ("o1", "o3", "o4") or name.startswith(("o1-", "o3-", "o4-")):
-        return True
-    if name == "gpt-5" or name.startswith("gpt-5-"):
-        return "chat" not in name
-    if name.startswith(("gpt-5.", "gpt-6")):
-        return True
-    return False
-
-
 _BASE_URL_ATTRIBUTES = [
     "base_url",
     "endpoint_url",
@@ -164,7 +154,7 @@ class LangChainLLMAdapter:
         params = dict(kwargs)
         if stop is not None:
             params["stop"] = stop
-        if _is_openai_reasoning_model(self.model_name):
+        if is_openai_reasoning_model(self.model_name):
             params.pop("temperature", None)
             params.pop("stop", None)
         return params

--- a/nemoguardrails/llm/clients/openai_chat_model.py
+++ b/nemoguardrails/llm/clients/openai_chat_model.py
@@ -19,6 +19,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union
 from nemoguardrails.exceptions import LLMClientError, LLMResponseValidationError
 from nemoguardrails.llm.clients.base import HTTPResponse
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
+from nemoguardrails.llm.openai_reasoning import is_openai_reasoning_model
 from nemoguardrails.types import (
     ChatMessage,
     FinishReason,
@@ -42,17 +43,6 @@ _FINISH_REASON_MAP: Dict[str, FinishReason] = {
 }
 
 _STANDARD_RESPONSE_KEYS = frozenset({"model", "choices", "usage", "id", "object", "created"})
-
-
-def _is_openai_reasoning_model(model_name: str) -> bool:
-    name = model_name.lower()
-    if name in ("o1", "o3", "o4") or name.startswith(("o1-", "o3-", "o4-")):
-        return True
-    if name == "gpt-5" or name.startswith("gpt-5-"):
-        return "chat" not in name
-    if name.startswith(("gpt-5.", "gpt-6")):
-        return True
-    return False
 
 
 class OpenAIChatModel:
@@ -93,7 +83,7 @@ class OpenAIChatModel:
         merged = {**self._default_kwargs, **kwargs}
         if stop is not None:
             merged["stop"] = stop
-        if _is_openai_reasoning_model(self._model):
+        if is_openai_reasoning_model(self._model):
             merged.pop("temperature", None)
             merged.pop("stop", None)
         return merged

--- a/nemoguardrails/llm/openai_reasoning.py
+++ b/nemoguardrails/llm/openai_reasoning.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def is_openai_reasoning_model(model_name: str) -> bool:
+    """True for OpenAI reasoning models (o1/o3/o4 series, gpt-5+).
+
+    Used to decide whether to strip parameters that OpenAI rejects on these
+    models (temperature, stop, etc.) and how to remap others
+    (max_tokens -> max_completion_tokens). Shared by the DefaultFramework
+    OpenAI client and the LangChain adapter so the two paths cannot drift.
+    """
+    name = model_name.lower()
+    if name in ("o1", "o3", "o4") or name.startswith(("o1-", "o3-", "o4-")):
+        return True
+    if name == "gpt-5" or name.startswith("gpt-5-"):
+        return "chat" not in name
+    if name.startswith(("gpt-5.", "gpt-6")):
+        return True
+    return False

--- a/tests/integrations/langchain/test_openai_param_filter.py
+++ b/tests/integrations/langchain/test_openai_param_filter.py
@@ -18,7 +18,7 @@
 Two layers of coverage:
 
 - test_classifier_matches_baseline: fast, no-network. Reads the committed
-  baseline JSON of probe results and asserts _is_openai_reasoning_model has zero
+  baseline JSON of probe results and asserts is_openai_reasoning_model has zero
   false negatives against it. Runs in normal CI. Catches accidental
   classifier regressions.
 
@@ -45,7 +45,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from nemoguardrails.integrations.langchain.llm_adapter import _is_openai_reasoning_model
+from nemoguardrails.llm.openai_reasoning import is_openai_reasoning_model
 
 BASELINE_PATH = Path(__file__).parent / "data" / "openai_reasoning_probe_baseline.json"
 
@@ -105,7 +105,7 @@ def _evaluate(probe_results: list[dict]) -> tuple[list[dict], list[str]]:
     false_negatives = []
     false_positives = []
     for result in probe_results:
-        predicted = _is_openai_reasoning_model(result["model"])
+        predicted = is_openai_reasoning_model(result["model"])
         rejects = result["stop"] == "rejected" or result["temperature"] == "rejected"
         if rejects and not predicted:
             false_negatives.append(result)
@@ -121,7 +121,7 @@ def test_classifier_matches_baseline():
     assert not false_negatives, (
         "Classifier says these models do NOT reject stop/temperature, "
         "but the committed probe baseline shows they DO. Update "
-        f"_is_openai_reasoning_model or regenerate baseline: {false_negatives}"
+        f"is_openai_reasoning_model or regenerate baseline: {false_negatives}"
     )
     unexpected = set(false_positives) - KNOWN_FALSE_POSITIVES
     assert not unexpected, (
@@ -219,7 +219,7 @@ async def test_probe_openai_live():
     assert results, "probe returned no models"
     false_negatives, _ = _evaluate(results)
     assert not false_negatives, (
-        f"Live OpenAI probe found models the classifier misses. Update _is_openai_reasoning_model: {false_negatives}"
+        f"Live OpenAI probe found models the classifier misses. Update is_openai_reasoning_model: {false_negatives}"
     )
 
 

--- a/tests/llm/clients/test_openai_chat_model.py
+++ b/tests/llm/clients/test_openai_chat_model.py
@@ -24,8 +24,9 @@ from nemoguardrails.exceptions import (
     LLMResponseValidationError,
 )
 from nemoguardrails.llm.clients.base import HTTPResponse
-from nemoguardrails.llm.clients.openai_chat_model import OpenAIChatModel, _is_openai_reasoning_model
+from nemoguardrails.llm.clients.openai_chat_model import OpenAIChatModel
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
+from nemoguardrails.llm.openai_reasoning import is_openai_reasoning_model
 from nemoguardrails.types import ChatMessage, LLMResponse, Role, ToolCall, ToolCallFunction
 from tests.llm.clients._helpers import make_client, mock_httpx_post, stream_client
 
@@ -529,7 +530,7 @@ class TestIsReasoningModel:
         ],
     )
     def test_reasoning_models(self, model_name):
-        assert _is_openai_reasoning_model(model_name) is True
+        assert is_openai_reasoning_model(model_name) is True
 
     @pytest.mark.parametrize(
         "model_name",
@@ -554,7 +555,7 @@ class TestIsReasoningModel:
         ],
     )
     def test_non_reasoning_models(self, model_name):
-        assert _is_openai_reasoning_model(model_name) is False
+        assert is_openai_reasoning_model(model_name) is False
 
 
 class TestMessageSerialization:


### PR DESCRIPTION

## Description

Move `is_openai_reasoning_model` into nemoguardrails/llm/openai_reasoning.py so the `DefaultFramework` OpenAI client and the LangChain adapter can use a single source of truth. the only behavior change is the rename from `_is_openai_reasoning_model` (private) to `is_openai_reasoning_model` (public) since callers now reach across package boundaries.

Stack:
1. share OpenAI reasoning-model classifier (this PR)
2. #1837 
3. #1838 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal OpenAI reasoning model detection logic across modules for improved code organization. No changes to user-facing behavior—reasoning models continue to have temperature and stop parameters appropriately managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->