### PR TITLE
fix(llm): drop temperature/stop and rename max_tokens for OpenAI reasoning models

### DIFF
--- a/nemoguardrails/llm/clients/openai_chat_model.py
+++ b/nemoguardrails/llm/clients/openai_chat_model.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union
 from nemoguardrails.exceptions import LLMClientError, LLMResponseValidationError
 from nemoguardrails.llm.clients.base import HTTPResponse
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
-from nemoguardrails.llm.openai_reasoning import is_openai_reasoning_model
+from nemoguardrails.llm.openai_reasoning import apply_openai_reasoning_overrides, is_openai_reasoning_model
 from nemoguardrails.types import (
     ChatMessage,
     FinishReason,
@@ -84,8 +84,7 @@ class OpenAIChatModel:
         if stop is not None:
             merged["stop"] = stop
         if is_openai_reasoning_model(self._model):
-            merged.pop("temperature", None)
-            merged.pop("stop", None)
+            merged = apply_openai_reasoning_overrides(merged)
         return merged
 
     def _to_messages(self, prompt: Union[str, List[ChatMessage]]) -> List[Dict[str, Any]]:

--- a/nemoguardrails/llm/openai_reasoning.py
+++ b/nemoguardrails/llm/openai_reasoning.py
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 
+from typing import Any, Dict
+
+_REASONING_DROP_PARAMS = frozenset({"temperature", "stop"})
+
+
 def is_openai_reasoning_model(model_name: str) -> bool:
     """True for OpenAI reasoning models (o1/o3/o4 series, gpt-5+).
 
@@ -30,3 +35,34 @@ def is_openai_reasoning_model(model_name: str) -> bool:
     if name.startswith(("gpt-5.", "gpt-6")):
         return True
     return False
+
+
+def apply_openai_reasoning_overrides(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop unsupported params and remap max_tokens for OpenAI reasoning models.
+
+    OpenAI reasoning models (o-series, gpt-5+) require ``max_completion_tokens``
+    instead of ``max_tokens`` and reject ``temperature`` / ``stop`` on most
+    members of the family. This helper applies the rename and the drop list
+    in one place so the DefaultFramework OpenAI client and the LangChain
+    adapter cannot drift on what they strip.
+
+    The drop list is deliberately limited to the params OpenAI's API itself
+    is documented to reject (verified by the live probe in
+    tests/integrations/langchain/test_openai_param_filter.py); other
+    sometimes-rejected params (top_p, presence_penalty, etc.) are accepted
+    by some reasoning models in the family and are left to the caller.
+
+    Returns a new dict; does not mutate the input.
+
+    Drops: ``temperature``, ``stop``.
+
+    Renames: ``max_tokens`` -> ``max_completion_tokens`` (only if
+    ``max_tokens`` is present and ``max_completion_tokens`` is not, so an
+    explicit ``max_completion_tokens`` always wins).
+    """
+    out = {key: value for key, value in params.items() if key not in _REASONING_DROP_PARAMS}
+    if "max_tokens" in out and "max_completion_tokens" not in out:
+        out["max_completion_tokens"] = out.pop("max_tokens")
+    else:
+        out.pop("max_tokens", None)
+    return out

--- a/nemoguardrails/llm/openai_reasoning.py
+++ b/nemoguardrails/llm/openai_reasoning.py
@@ -57,11 +57,13 @@ def apply_openai_reasoning_overrides(params: Dict[str, Any]) -> Dict[str, Any]:
     Drops: ``temperature``, ``stop``.
 
     Renames: ``max_tokens`` -> ``max_completion_tokens`` (only if
-    ``max_tokens`` is present and ``max_completion_tokens`` is not, so an
-    explicit ``max_completion_tokens`` always wins).
+    ``max_tokens`` carries a non-None value and ``max_completion_tokens``
+    is not already present, so an explicit ``max_completion_tokens``
+    always wins and an unset ``max_tokens`` is not promoted to a null
+    wire field).
     """
     out = {key: value for key, value in params.items() if key not in _REASONING_DROP_PARAMS}
-    if "max_tokens" in out and "max_completion_tokens" not in out:
+    if out.get("max_tokens") is not None and "max_completion_tokens" not in out:
         out["max_completion_tokens"] = out.pop("max_tokens")
     else:
         out.pop("max_tokens", None)

--- a/tests/llm/clients/test_openai_chat_model.py
+++ b/tests/llm/clients/test_openai_chat_model.py
@@ -438,7 +438,9 @@ class TestParams:
 
         call = mc.chat_completion.call_args
         assert "temperature" not in call.kwargs
-        assert call.kwargs["max_tokens"] == 100
+        # max_tokens is renamed to max_completion_tokens on reasoning models.
+        assert "max_tokens" not in call.kwargs
+        assert call.kwargs["max_completion_tokens"] == 100
 
     @pytest.mark.asyncio
     async def test_non_reasoning_keeps_temperature(self):
@@ -501,6 +503,55 @@ class TestParams:
         await m.generate_async("Hi", temperature=0.9)
 
         assert mc.chat_completion.call_args.kwargs["temperature"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_reasoning_model_renames_max_tokens(self):
+        mc = _mock_client()
+        mc.chat_completion = AsyncMock(return_value=_response())
+        m = _model(mc, model="gpt-5-mini")
+
+        await m.generate_async("Hi", max_tokens=1024)
+
+        call = mc.chat_completion.call_args
+        assert "max_tokens" not in call.kwargs
+        assert call.kwargs["max_completion_tokens"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_non_reasoning_keeps_max_tokens(self):
+        mc = _mock_client()
+        mc.chat_completion = AsyncMock(return_value=_response())
+        m = _model(mc, model="gpt-4o")
+
+        await m.generate_async("Hi", max_tokens=1024)
+
+        call = mc.chat_completion.call_args
+        assert call.kwargs["max_tokens"] == 1024
+        assert "max_completion_tokens" not in call.kwargs
+
+    @pytest.mark.asyncio
+    async def test_reasoning_model_keeps_explicit_max_completion_tokens(self):
+        mc = _mock_client()
+        mc.chat_completion = AsyncMock(return_value=_response())
+        m = _model(mc, model="o3-mini")
+
+        await m.generate_async("Hi", max_tokens=1024, max_completion_tokens=512)
+
+        call = mc.chat_completion.call_args
+        # Explicit max_completion_tokens wins; max_tokens dropped.
+        assert call.kwargs["max_completion_tokens"] == 512
+        assert "max_tokens" not in call.kwargs
+
+    @pytest.mark.asyncio
+    async def test_reasoning_model_renames_default_max_tokens(self):
+        mc = _mock_client()
+        mc.chat_completion = AsyncMock(return_value=_response())
+        m = _model(mc, model="o3-mini", max_tokens=256)
+
+        await m.generate_async("Hi")
+
+        call = mc.chat_completion.call_args
+        assert "max_tokens" not in call.kwargs
+        assert call.kwargs["max_completion_tokens"] == 256
 
 
 class TestIsReasoningModel:

--- a/tests/llm/test_openai_reasoning.py
+++ b/tests/llm/test_openai_reasoning.py
@@ -64,6 +64,12 @@ class TestMaxTokensRename:
         result = apply_openai_reasoning_overrides({"model": "gpt-5-mini"})
         assert result == {"model": "gpt-5-mini"}
 
+    def test_max_tokens_none_does_not_promote(self):
+        # `None` is the Python idiom for "value not set"; renaming it would
+        # send a useless null to the wire. Drop it instead.
+        result = apply_openai_reasoning_overrides({"max_tokens": None})
+        assert result == {}
+
 
 class TestPurity:
     def test_does_not_mutate_input(self):

--- a/tests/llm/test_openai_reasoning.py
+++ b/tests/llm/test_openai_reasoning.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.llm.openai_reasoning import apply_openai_reasoning_overrides
+
+
+class TestDrops:
+    def test_drops_temperature(self):
+        result = apply_openai_reasoning_overrides({"temperature": 0.5, "model": "x"})
+        assert "temperature" not in result
+        assert result["model"] == "x"
+
+    def test_drops_stop(self):
+        result = apply_openai_reasoning_overrides({"stop": ["END"], "model": "x"})
+        assert "stop" not in result
+        assert result["model"] == "x"
+
+    def test_drops_both(self):
+        result = apply_openai_reasoning_overrides({"temperature": 0.5, "stop": ["END"]})
+        assert result == {}
+
+    def test_keeps_unrelated_params(self):
+        # top_p, presence_penalty, etc. are sometimes accepted by reasoning
+        # models in the family; this helper does not drop them.
+        params = {
+            "top_p": 0.9,
+            "presence_penalty": 0.1,
+            "frequency_penalty": 0.1,
+            "logprobs": True,
+            "logit_bias": {"50256": -100},
+            "n": 1,
+        }
+        result = apply_openai_reasoning_overrides(params)
+        assert result == params
+
+
+class TestMaxTokensRename:
+    def test_renames_max_tokens_to_max_completion_tokens(self):
+        result = apply_openai_reasoning_overrides({"max_tokens": 100})
+        assert result == {"max_completion_tokens": 100}
+
+    def test_explicit_max_completion_tokens_wins(self):
+        # Caller already used the canonical name; we must not stomp on it.
+        result = apply_openai_reasoning_overrides({"max_tokens": 100, "max_completion_tokens": 50})
+        assert result == {"max_completion_tokens": 50}
+
+    def test_max_completion_tokens_alone_passes_through(self):
+        result = apply_openai_reasoning_overrides({"max_completion_tokens": 100})
+        assert result == {"max_completion_tokens": 100}
+
+    def test_no_max_tokens_at_all(self):
+        result = apply_openai_reasoning_overrides({"model": "gpt-5-mini"})
+        assert result == {"model": "gpt-5-mini"}
+
+
+class TestPurity:
+    def test_does_not_mutate_input(self):
+        params = {"temperature": 0.5, "max_tokens": 100, "model": "x"}
+        snapshot = dict(params)
+        apply_openai_reasoning_overrides(params)
+        assert params == snapshot
+
+    def test_returns_new_dict(self):
+        params = {"model": "x"}
+        result = apply_openai_reasoning_overrides(params)
+        assert result is not params
+
+
+class TestCombined:
+    def test_drop_and_rename_together(self):
+        # Realistic action-code shape: temperature + max_tokens.
+        result = apply_openai_reasoning_overrides({"temperature": 0.001, "max_tokens": 1024})
+        assert result == {"max_completion_tokens": 1024}


### PR DESCRIPTION

Add `apply_openai_reasoning_overrides()` in nemoguardrails/llm/openai_reasoning.py that drops the params OpenAI reasoning models reject and renames max_tokens to max_completion_tokens. OpenAIChatModel._prepare_params calls the helper for any model is_openai_reasoning_model() flags as reasoning.

The drop list is limited to the params the live probe in `tests/integrations/langchain/test_openai_param_filter.py` confirms are rejected by gpt-5 / gpt-5.x / o-series models AND that nemoguardrails sends from internal action code: temperature and stop. Other params that some reasoning models reject (top_p, presence_penalty, etc.) are accepted by others (gpt-5.1 / 5.2 / 5.4 non-chat variants) and are left alone. logprobs and top_logprobs return account-level 403s that also fire on non-reasoning chat models, so they are not reasoning-specific signals.

The rename is what actually unblocks reasoning-model configs in the DefaultFramework path: passing max_tokens to a reasoning model previously hit HTTP 400 ("Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."). An explicit max_completion_tokens always wins over a renamed max_tokens.

The LangChain adapter is intentionally not touched here. langchain-openai 1.1.10 already does the max_tokens -> max_completion_tokens rename and the temperature drop on its own (verified by capturing the wire body); applying our override on top would be redundant or risk double-rename.

**Stack:**
1. #1836 
2. drop / remap params OpenAI rejects on reasoning models (this PR)
3. #1838
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter handling for OpenAI reasoning models to ensure proper compatibility and configuration across integrations.

* **Tests**
  * Added comprehensive test coverage for OpenAI reasoning model parameter handling and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->