### PR TITLE
test(llm): expand reasoning-model param probe + regenerate baseline

### DIFF
--- a/tests/integrations/langchain/data/openai_reasoning_probe_baseline.json
+++ b/tests/integrations/langchain/data/openai_reasoning_probe_baseline.json
@@ -1,356 +1,426 @@
 {
-  "captured_at": "2026-04-27",
+  "captured_at": "2026-04-29",
   "openai_chat_completions_url": "https://api.openai.com/v1/chat/completions",
   "results": [
     {
       "model": "gpt-3.5-turbo",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-3.5-turbo-0125",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-3.5-turbo-1106",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-3.5-turbo-16k",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-3.5-turbo-instruct",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-3.5-turbo-instruct-0914",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-4",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4-0613",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4-turbo",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4-turbo-2024-04-09",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1-2025-04-14",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1-mini",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1-mini-2025-04-14",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1-nano",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4.1-nano-2025-04-14",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o-2024-05-13",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o-2024-08-06",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o-2024-11-20",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o-mini",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-4o-mini-2024-07-18",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-5",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-2025-08-07",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-chat-latest",
       "stop": "accepted",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "accepted"
     },
     {
       "model": "gpt-5-codex",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "gpt-5-mini",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-mini-2025-08-07",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-nano",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-nano-2025-08-07",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5-pro",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "gpt-5-pro-2025-10-06",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "gpt-5.1",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.1-2025-11-13",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.1-chat-latest",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.1-codex",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.1-codex-max",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.1-codex-mini",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "gpt-5.2",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.2-2025-12-11",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.2-chat-latest",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.2-codex",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.2-pro",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.2-pro-2025-12-11",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.3-chat-latest",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.3-codex",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.4",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-2026-03-05",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-mini",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-mini-2026-03-17",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-nano",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-nano-2026-03-17",
       "stop": "rejected",
-      "temperature": "accepted"
+      "temperature": "accepted",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.4-pro",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.4-pro-2026-03-05",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.5",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.5-2026-04-23",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "gpt-5.5-pro",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "gpt-5.5-pro-2026-04-23",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "o1",
       "stop": "accepted",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o1-2024-12-17",
       "stop": "accepted",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o1-pro",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "o1-pro-2025-03-19",
       "stop": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
-      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
+      "temperature": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions.",
+      "max_tokens": "other: invalid_request_error: This model is only supported in v1/responses and not in v1/chat/completions."
     },
     {
       "model": "o3",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o3-2025-04-16",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o3-mini",
       "stop": "accepted",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o3-mini-2025-01-31",
       "stop": "accepted",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o3-pro",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "o3-pro-2025-06-10",
       "stop": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
-      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
+      "temperature": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?",
+      "max_tokens": "other: invalid_request_error: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?"
     },
     {
       "model": "o4-mini",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     },
     {
       "model": "o4-mini-2025-04-16",
       "stop": "rejected",
-      "temperature": "rejected"
+      "temperature": "rejected",
+      "max_tokens": "rejected"
     }
   ]
 }

--- a/tests/integrations/langchain/test_openai_param_filter.py
+++ b/tests/integrations/langchain/test_openai_param_filter.py
@@ -206,21 +206,22 @@ def _classify(resp: httpx.Response, param: str) -> str:
     message = err.get("message", "") or ""
     if err.get("param") == param or f"'{param}'" in message:
         return "rejected"
-    # 403 / param=None case: rejection mentions the param by bare name with no
-    # quotes, e.g. "You are not allowed to request logprobs from this model".
+    # Bare-keyword case: rejection mentions the param without single quotes
+    # and ``err.param`` is None, e.g. 403 "You are not allowed to request
+    # logprobs from this model" or 400 "specify max_completion_tokens rather
+    # than max_tokens". We require both the keyword and a rejection-shaped
+    # phrase so requirement-shaped messages ("max_tokens parameter is
+    # required") fall through to accepted-by-inference instead.
     msg_lower = message.lower()
-    if re.search(rf"\b{re.escape(param)}\b", msg_lower) and (
-        "not allowed" in msg_lower or "not supported" in msg_lower
-    ):
-        return "rejected"
-    # Guard: the accepted-by-inference fallback below treats any mention of
-    # max_tokens as a generation-limit error, which only makes sense for
-    # probes that send max_completion_tokens=1 in the body. For the
-    # max_tokens probe itself, a message naming max_tokens that did not
-    # match the earlier rejection patterns is safer to flag as rejected
-    # than to silently accept (e.g. "Please specify max_completion_tokens
-    # rather than max_tokens").
-    if param == "max_tokens" and re.search(r"\bmax_tokens\b", msg_lower):
+    rejection_indicators = (
+        "not allowed",
+        "not supported",
+        "rather than",
+        "instead",
+        "unsupported",
+        "deprecated",
+    )
+    if re.search(rf"\b{re.escape(param)}\b", msg_lower) and any(p in msg_lower for p in rejection_indicators):
         return "rejected"
     # OpenAI validates params before generation, so a max_completion_tokens /
     # max_tokens / output-limit error on a 1-token probe means the param was

--- a/tests/integrations/langchain/test_openai_param_filter.py
+++ b/tests/integrations/langchain/test_openai_param_filter.py
@@ -27,6 +27,12 @@ Two layers of coverage:
   classifier still matches current OpenAI API behavior. Run this quarterly
   or after bumping langchain-openai.
 
+Each candidate model is probed concurrently against every parameter listed
+in PROBES. A model is treated as a reasoning model (in the classifier
+sense) if the API rejects any of those params. The baseline records the
+per-param verdict ("accepted" / "rejected" / "other: ...") so future
+diffs surface OpenAI behavior changes per param.
+
 Regenerate the baseline file (after confirming classifier changes):
 
     UPDATE_BASELINE=1 OPENAI_API_KEY=sk-... \\
@@ -38,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -95,18 +102,35 @@ KNOWN_FALSE_POSITIVES = frozenset(
 )
 
 
+PROBES: dict[str, dict] = {
+    "stop": {"stop": ["User:"]},
+    "temperature": {"temperature": 0.5},
+    # max_tokens probe: do not also send max_completion_tokens (the default
+    # body field) so a "use max_completion_tokens instead" rejection on
+    # reasoning models is unambiguous.
+    "max_tokens": {"max_tokens": 1},
+}
+
+
 def _load_baseline() -> list[dict]:
     payload = json.loads(BASELINE_PATH.read_text())
     return payload["results"]
 
 
 def _evaluate(probe_results: list[dict]) -> tuple[list[dict], list[str]]:
-    """Return (false_negatives, ignored_false_positives)."""
+    """Return (false_negatives, ignored_false_positives).
+
+    A model is considered to behave as a reasoning model (in the
+    classifier's sense) if it rejects any probed param. PROBES is
+    deliberately limited to params nemoguardrails actually sends from
+    internal action code (temperature, stop, max_tokens); other OpenAI
+    params are out of scope here.
+    """
     false_negatives = []
     false_positives = []
     for result in probe_results:
         predicted = is_openai_reasoning_model(result["model"])
-        rejects = result["stop"] == "rejected" or result["temperature"] == "rejected"
+        rejects = any(result.get(param) == "rejected" for param in PROBES)
         if rejects and not predicted:
             false_negatives.append(result)
         elif predicted and not rejects:
@@ -117,15 +141,21 @@ def _evaluate(probe_results: list[dict]) -> tuple[list[dict], list[str]]:
 def test_classifier_matches_baseline():
     results = _load_baseline()
     assert results, "baseline is empty, regenerate via UPDATE_BASELINE=1"
+    missing_fields = [result["model"] for result in results if any(param not in result for param in PROBES)]
+    assert not missing_fields, (
+        "Baseline is missing per-param probe results; regenerate via "
+        f"UPDATE_BASELINE=1. Missing entries for: {sorted(set(missing_fields))[:5]}..."
+    )
     false_negatives, false_positives = _evaluate(results)
+    probed_list = ", ".join(sorted(PROBES))
     assert not false_negatives, (
-        "Classifier says these models do NOT reject stop/temperature, "
+        f"Classifier says these models do NOT reject any of {{{probed_list}}}, "
         "but the committed probe baseline shows they DO. Update "
         f"is_openai_reasoning_model or regenerate baseline: {false_negatives}"
     )
     unexpected = set(false_positives) - KNOWN_FALSE_POSITIVES
     assert not unexpected, (
-        "Classifier strips stop/temperature for models that actually accept them: "
+        f"Classifier strips reasoning-only params for models that accept all of {{{probed_list}}}: "
         f"{sorted(unexpected)}. If intentional, add them to KNOWN_FALSE_POSITIVES."
     )
 
@@ -148,12 +178,16 @@ async def _fetch_models(client: httpx.AsyncClient, api_key: str) -> list[str]:
 
 
 async def _post(client: httpx.AsyncClient, api_key: str, model: str, extra: dict) -> httpx.Response:
-    body = {
+    body: dict = {
         "model": model,
         "messages": [{"role": "user", "content": "hi"}],
-        "max_completion_tokens": 1,
-        **extra,
     }
+    # Only set the default token field when the probe itself is not testing
+    # max_tokens; otherwise the body would carry both fields and OpenAI's
+    # response signal becomes ambiguous.
+    if "max_tokens" not in extra:
+        body["max_completion_tokens"] = 1
+    body.update(extra)
     return await client.post(
         CHAT_COMPLETIONS_URL,
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -169,13 +203,20 @@ def _classify(resp: httpx.Response, param: str) -> str:
         err = resp.json().get("error", {})
     except Exception:
         return f"http_{resp.status_code}"
-    message = err.get("message", "")
+    message = err.get("message", "") or ""
     if err.get("param") == param or f"'{param}'" in message:
         return "rejected"
-    # OpenAI validates params before generation, so a max_tokens/output-limit
-    # error on a 1-token probe means the param was accepted and generation
-    # started. Treat as accepted-by-inference.
-    if "max_tokens" in message or "output limit" in message:
+    # 403 / param=None case: rejection mentions the param by bare name with no
+    # quotes, e.g. "You are not allowed to request logprobs from this model".
+    msg_lower = message.lower()
+    if re.search(rf"\b{re.escape(param)}\b", msg_lower) and (
+        "not allowed" in msg_lower or "not supported" in msg_lower
+    ):
+        return "rejected"
+    # OpenAI validates params before generation, so a max_completion_tokens /
+    # max_tokens / output-limit error on a 1-token probe means the param was
+    # accepted and generation started. Treat as accepted-by-inference.
+    if "max_completion_tokens" in message or "max_tokens" in message or "output limit" in message:
         return "accepted"
     # Preserve the API's error type + message so baseline diffs surface why a
     # model is neither accepted nor rejected (eg "only supported in v1/responses").
@@ -184,18 +225,14 @@ def _classify(resp: httpx.Response, param: str) -> str:
 
 
 async def _probe_model(client: httpx.AsyncClient, api_key: str, model: str) -> dict:
-    # Two independent probes per model run concurrently; models are still
-    # iterated sequentially by the caller to avoid hitting OpenAI rate limits
-    # with ~130 concurrent requests on a large account.
-    stop_resp, temp_resp = await asyncio.gather(
-        _post(client, api_key, model, {"stop": ["User:"]}),
-        _post(client, api_key, model, {"temperature": 0.5}),
-    )
-    return {
-        "model": model,
-        "stop": _classify(stop_resp, "stop"),
-        "temperature": _classify(temp_resp, "temperature"),
-    }
+    # Independent probes per param run concurrently; models are still
+    # iterated sequentially by the caller to avoid hitting OpenAI rate limits.
+    names = list(PROBES.keys())
+    responses = await asyncio.gather(*(_post(client, api_key, model, PROBES[name]) for name in names))
+    result: dict = {"model": model}
+    for name, resp in zip(names, responses):
+        result[name] = _classify(resp, name)
+    return result
 
 
 async def _probe_all(client: httpx.AsyncClient, api_key: str) -> list[dict]:

--- a/tests/integrations/langchain/test_openai_param_filter.py
+++ b/tests/integrations/langchain/test_openai_param_filter.py
@@ -213,6 +213,15 @@ def _classify(resp: httpx.Response, param: str) -> str:
         "not allowed" in msg_lower or "not supported" in msg_lower
     ):
         return "rejected"
+    # Guard: the accepted-by-inference fallback below treats any mention of
+    # max_tokens as a generation-limit error, which only makes sense for
+    # probes that send max_completion_tokens=1 in the body. For the
+    # max_tokens probe itself, a message naming max_tokens that did not
+    # match the earlier rejection patterns is safer to flag as rejected
+    # than to silently accept (e.g. "Please specify max_completion_tokens
+    # rather than max_tokens").
+    if param == "max_tokens" and re.search(r"\bmax_tokens\b", msg_lower):
+        return "rejected"
     # OpenAI validates params before generation, so a max_completion_tokens /
     # max_tokens / output-limit error on a 1-token probe means the param was
     # accepted and generation started. Treat as accepted-by-inference.


### PR DESCRIPTION
## Description

Probe stop, temperature, and max_tokens against every chat-candidate OpenAI model returned by /v1/models, not just stop and temperature. These are the params nemoguardrails actually passes from internal action code (self_check_*, content_safety, topic_safety) and from prompt-task configs, so the probe scope matches what we actually filter.

The baseline now records per-param accepted/rejected/other verdicts and is regenerated against the current OpenAI surface (70 chat candidates). The classifier check requires every PROBE field to be present in the baseline, forcing any future probe-set change through a regeneration.

Findings from the regen worth noting:
- max_tokens is universally rejected by OpenAI reasoning models (gpt-5, gpt-5.x, o-series); they require max_completion_tokens. This validates the rename in #1837  .
- temperature is rejected by gpt-5 / gpt-5-chat-latest / gpt-5.1-chat / gpt-5.5 / o-series, but accepted by gpt-5.1 / 5.2 / 5.4 (non-chat variants). The classifier still strips it defensively.
- stop is rejected by most reasoning models, accepted by o1 / o3-mini.

The probe deliberately omits top_p, presence_penalty, frequency_penalty, logprobs, top_logprobs, and logit_bias. nemoguardrails never sends those from internal code, and the logprobs rejection in particular turned out to be account-level (also fires on gpt-5-chat-latest, a non-reasoning model) rather than reasoning-specific.

**Stack:**
1. #1836 
2. #1837 
3. expand the live param-filter probe (this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OpenAI parameter validation testing to probe a broader set of chat-completions parameters.
  * Improved error classification logic for better detection and handling of parameter rejection messages.
  * Updated test data to reflect expanded parameter coverage and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->