### PR TITLE
fix(ci): override annoy's -march=native to actually enforce baseline x86-64

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -76,7 +76,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.runner-arch.outputs.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.runner-arch.outputs.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-annoy-baseline
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'
@@ -86,11 +86,11 @@ jobs:
         run: poetry check --lock
 
       - name: Set baseline x86-64 compiler flags
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && steps.runner-arch.outputs.arch == 'x86_64'
         run: |
           echo "CFLAGS=-march=x86-64" >> $GITHUB_ENV
           echo "CXXFLAGS=-march=x86-64" >> $GITHUB_ENV
-          echo "ANNOY_COMPILER_ARGS=-D_CRT_SECURE_NO_WARNINGS,-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14" >> $GITHUB_ENV
+          echo "ANNOY_COMPILER_ARGS=-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           echo "CFLAGS=-march=x86-64" >> $GITHUB_ENV
           echo "CXXFLAGS=-march=x86-64" >> $GITHUB_ENV
+          echo "ANNOY_COMPILER_ARGS=-D_CRT_SECURE_NO_WARNINGS,-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ env:
   PYTHON_VERSION: "3.11"
   CFLAGS: "-march=x86-64"
   CXXFLAGS: "-march=x86-64"
-  ANNOY_COMPILER_ARGS: "-D_CRT_SECURE_NO_WARNINGS,-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14"
+  ANNOY_COMPILER_ARGS: "-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14"
 
 jobs:
   lint:
@@ -48,7 +48,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.runner-arch.outputs.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.runner-arch.outputs.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-annoy-baseline
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ env:
   PYTHON_VERSION: "3.11"
   CFLAGS: "-march=x86-64"
   CXXFLAGS: "-march=x86-64"
+  ANNOY_COMPILER_ARGS: "-D_CRT_SECURE_NO_WARNINGS,-fpermissive,-march=x86-64,-O3,-ffast-math,-fno-associative-math,-DANNOYLIB_MULTITHREADED_BUILD,-std=c++14"
 
 jobs:
   lint:


### PR DESCRIPTION
## Description
CI tests still intermittently crash with `Fatal Python error: Illegal instruction` (SIGILL, exit code 132) inside `annoy.add_item()` despite #1785 setting `CFLAGS=-march=x86-64` to constrain native extensions to baseline x86-64 instructions.

Example failing job:
https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/25104491162/job/73562088447

## Root Cause

#1785 was a no-op for `annoy` specifically. Annoy's `setup.py` hardcodes `-march=native` in `extra_compile_args`:

```
    extra_compile_args += ['-march=native']
```

setuptools appends `extra_compile_args` AFTER the user's `CFLAGS`/`CXXFLAGS` on the compiler command line. When GCC sees multiple `-march` flags, the last one wins, so annoy's `-march=native` overrides our `-march=x86-64`. The compiled `annoylib.so` ends up with whatever SIMD instructions the build runner's CPU supports (AVX-512 on some, AVX2 on others), and crashes when the cached venv is restored onto a runner with a smaller instruction set.

Annoy's setup.py provides one escape hatch: the `ANNOY_COMPILER_ARGS` env var which REPLACES the entire `extra_compile_args` list when set. This is the only way to remove `-march=native` without patching annoy.

## Fix

Set `ANNOY_COMPILER_ARGS` alongside `CFLAGS`/`CXXFLAGS` on Linux runners,
mirroring annoy's defaults but with `-march=x86-64` instead of `-march=native`:
```
    ANNOY_COMPILER_ARGS=-D_CRT_SECURE_NO_WARNINGS,-fpermissive,-march=x86-64,
                       -O3,-ffast-math,-fno-associative-math,
                       -DANNOYLIB_MULTITHREADED_BUILD
```

Existing caches built with the broken `annoylib.so` need to be cleared
manually (`gh cache list | awk '{print $1}' | xargs gh cache delete`) so
the next run rebuilds with the new flags.

## Related

- #1785 (insufficient for annoy)

## Test Plan

- [ ] Clear all GitHub Actions caches before merging
- [ ] Confirm CI passes on all platforms (Ubuntu, macOS, Windows)
- [ ] Monitor for SIGILL recurrence over subsequent runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to standardize compiler configuration across build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->