### PR TITLE
fix(llm/clients): retry on stale event loop binding

### DIFF
--- a/nemoguardrails/llm/clients/base.py
+++ b/nemoguardrails/llm/clients/base.py
@@ -45,6 +45,33 @@ from nemoguardrails.llm.clients.constants import (
 log = logging.getLogger(__name__)
 
 
+_STALE_LOOP_MARKERS = (
+    "event loop is closed",
+    "different loop",
+    "different event loop",
+)
+
+
+def _is_stale_loop_error(err: BaseException) -> bool:
+    """Return True if ``err`` is a RuntimeError caused by a stale loop binding.
+
+    CPython raises one of several messages when an httpx transport (or any
+    asyncio primitive it owns) is reused on a loop other than the one it
+    was created on:
+      * 'Event loop is closed' (BaseEventLoop._check_closed) when the
+        original loop has been closed.
+      * '<asyncio.X object> is bound to a different event loop' (Lock /
+        Event / Semaphore / Queue) when the original loop is still alive.
+      * 'got Future attached to a different loop' / 'Task got Future ...'
+        when a Future created in another loop is awaited.
+
+    All three are transient: httpx invalidates the stale primitive on retry
+    and rebuilds it in the running loop.
+    """
+    text = str(err).lower()
+    return any(marker in text for marker in _STALE_LOOP_MARKERS)
+
+
 @dataclass(frozen=True)
 class HTTPResponse:
     body: Dict[str, Any]
@@ -182,6 +209,16 @@ class BaseClient:
                     retries_attempted += 1
                     continue
                 raise LLMConnectionError(0, f"Connection error: {err}", **ctx.as_kwargs()) from err
+            except RuntimeError as err:
+                if not _is_stale_loop_error(err):
+                    raise
+                if retries_remaining > 0:
+                    log.warning("Retrying after stale event loop binding: %s", err)
+                    await self._sleep_for_retry(retries_attempted)
+                    retries_remaining -= 1
+                    retries_attempted += 1
+                    continue
+                raise LLMConnectionError(0, f"Stale event loop: {err}", **ctx.as_kwargs()) from err
 
             if self._should_retry(response.status_code, response.headers) and retries_remaining > 0:
                 await self._sleep_for_retry(retries_attempted, response.headers)
@@ -272,6 +309,16 @@ class BaseClient:
             except httpx.NetworkError as err:
                 if first_yielded or retries_remaining <= 0:
                     raise LLMConnectionError(0, f"Connection error: {err}", **ctx.as_kwargs()) from err
+                await self._sleep_for_retry(retries_attempted)
+                retries_remaining -= 1
+                retries_attempted += 1
+                continue
+            except RuntimeError as err:
+                if not _is_stale_loop_error(err):
+                    raise
+                if first_yielded or retries_remaining <= 0:
+                    raise LLMConnectionError(0, f"Stale event loop: {err}", **ctx.as_kwargs()) from err
+                log.warning("Retrying stream after stale event loop binding: %s", err)
                 await self._sleep_for_retry(retries_attempted)
                 retries_remaining -= 1
                 retries_attempted += 1

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -912,6 +912,28 @@ class TestNetworkExceptionRetry:
 
         assert post_calls == loops * 2
 
+    def test_recovers_with_real_httpx_against_refused_endpoint_across_asyncio_run(self):
+        """Real httpx.AsyncClient making real network attempts across asyncio.run().
+
+        httpx reliably fails on the second asyncio.run() with RuntimeError:
+        Event loop is closed. With our retry in place, the same client should surface
+        a NETWORK error on the second call (proving recovery happened and we reached the
+        connection-attempt phase), not a "Stale event loop" error (which
+        would mean retries exhausted on consecutive RuntimeErrors and
+        recovery never happened).
+        """
+        client = OpenAICompatibleClient(base_url="http://127.0.0.1:1", api_key="sk-test", max_retries=2)
+
+        with pytest.raises(LLMConnectionError) as exc1:
+            asyncio.run(client.chat_completion("gpt-4o", [{"role": "user", "content": "hi"}]))
+        assert "Stale event loop" not in str(exc1.value)
+        assert "Connection error" in str(exc1.value)
+
+        with pytest.raises(LLMConnectionError) as exc2:
+            asyncio.run(client.chat_completion("gpt-4o", [{"role": "user", "content": "hi"}]))
+        assert "Stale event loop" not in str(exc2.value)
+        assert "Connection error" in str(exc2.value)
+
 
 class TestCalculateRetryDelay:
     @pytest.mark.parametrize(

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -641,6 +641,277 @@ class TestNetworkExceptionRetry:
         assert call_count == 2
         assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
 
+    @pytest.mark.asyncio
+    async def test_runtime_error_retries_then_succeeds(self):
+        """RuntimeError (e.g. 'Event loop is closed') is treated as transient.
+
+        When a cached httpx.AsyncClient is reused on a new event loop, the first
+        send raises RuntimeError because the underlying transport is bound to
+        the dead loop. httpx's connection pool invalidates the stale connection
+        and the retry opens a fresh one in the running loop. The retry path
+        only works if RuntimeError is caught by the loop in _apost.
+        """
+        client = make_client()
+        call_count = 0
+
+        async def flaky_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise RuntimeError("Event loop is closed")
+            return httpx.Response(
+                200,
+                json=ok_response(),
+                request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            )
+
+        client._client = type("MockClient", (), {"post": flaky_post})()
+        await client.chat_completion("gpt-4o", [])
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_exhausts_retries_raises_connection(self):
+        client = make_client(max_retries=1)
+        call_count = 0
+
+        async def always_runtime_error(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Event loop is closed")
+
+        client._client = type("MockClient", (), {"post": always_runtime_error})()
+        with pytest.raises(LLMConnectionError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert call_count == 2
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_stream_runtime_error_before_first_chunk_retries(self):
+        call_count = 0
+
+        @asynccontextmanager
+        async def flaky_stream(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise RuntimeError("Event loop is closed")
+
+            class FakeResponse:
+                status_code = 200
+                headers = {}
+
+                async def aread(self):
+                    pass
+
+                async def aiter_lines(self):
+                    yield 'data: {"id":"c","choices":[{"index":0,"delta":{"content":"hi"}}]}'
+                    yield ""
+                    yield "data: [DONE]"
+                    yield ""
+
+            yield FakeResponse()
+
+        client = make_client()
+        client._client = type("MockClient", (), {"stream": flaky_stream})()
+        chunks = []
+        async for chunk in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+        assert call_count == 2
+        assert len(chunks) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_runtime_error_before_first_chunk_exhausts_retries_wrapped(self):
+        call_count = 0
+
+        @asynccontextmanager
+        async def always_runtime_error(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Event loop is closed")
+            yield  # pragma: no cover — make this an async generator
+
+        client = make_client(max_retries=1)
+        client._client = type("MockClient", (), {"stream": always_runtime_error})()
+        with pytest.raises(LLMConnectionError) as exc_info:
+            async for _ in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+                pass
+        assert call_count == 2
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_runtime_error_propagates_without_retry(self):
+        """Only stale-event-loop RuntimeErrors are treated as transient.
+
+        A RuntimeError with any other message must propagate untouched so
+        programmer bugs are not silently retried and re-wrapped as a
+        connection error.
+        """
+        client = make_client()
+        call_count = 0
+
+        async def raise_unrelated(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("dictionary changed size during iteration")
+
+        client._client = type("MockClient", (), {"post": raise_unrelated})()
+        with pytest.raises(RuntimeError, match="dictionary changed"):
+            await client.chat_completion("gpt-4o", [])
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_with_max_retries_zero_raises_immediately(self):
+        """With retries disabled, a stale-event-loop error surfaces clearly.
+
+        The error is wrapped in LLMConnectionError so callers see a typed
+        exception with the original RuntimeError as __cause__.
+        """
+        client = make_client(max_retries=0)
+        call_count = 0
+
+        async def stale_loop(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Event loop is closed")
+
+        client._client = type("MockClient", (), {"post": stale_loop})()
+        with pytest.raises(LLMConnectionError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert call_count == 1
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert "event loop" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_stream_unrelated_runtime_error_propagates_without_retry(self):
+        call_count = 0
+
+        @asynccontextmanager
+        async def raise_unrelated(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("dictionary changed size during iteration")
+            yield  # pragma: no cover
+
+        client = make_client()
+        client._client = type("MockClient", (), {"stream": raise_unrelated})()
+        with pytest.raises(RuntimeError, match="dictionary changed"):
+            async for _ in client.stream_chat_completion("gpt-4o", [{"role": "user", "content": "Hi"}]):
+                pass
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Event loop is closed",
+            "got Future attached to a different loop",
+            "Task got Future <Future pending> attached to a different loop",
+            "<asyncio.locks.Event object at 0x10731c8a0 [unset]> is bound to a different event loop",
+        ],
+    )
+    async def test_stale_loop_messages_all_retry(self, message):
+        """All known stale-loop RuntimeError variants are retried.
+
+        These are flavors of the same defect (a transport bound to one
+        loop being reused on another). Verified empirically:
+          * 'Event loop is closed' fires after asyncio.run closes its loop.
+          * 'is bound to a different event loop' fires when an asyncio
+            primitive (Lock/Event/Semaphore/Queue) is reused across loops.
+          * 'got Future attached to a different loop' fires when a Future
+            created in another loop is awaited.
+        The retry path must absorb all of them.
+        """
+        client = make_client()
+        call_count = 0
+
+        async def flaky_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise RuntimeError(message)
+            return httpx.Response(
+                200,
+                json=ok_response(),
+                request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            )
+
+        client._client = type("MockClient", (), {"post": flaky_post})()
+        await client.chat_completion("gpt-4o", [])
+        assert call_count == 2
+
+    @pytest.mark.parametrize("runs", [2, 5, 10])
+    def test_recovers_when_same_client_used_across_asyncio_run_calls(self, runs):
+        """Same client reused across N asyncio.run() boundaries.
+
+        Each fresh loop sees one stale-transport RuntimeError on its first
+        request and recovers via the retry path. Without the fix, the second
+        asyncio.run raises 'Event loop is closed'.
+        """
+        client = make_client()
+        first_call_per_loop = {"is_first": True}
+        post_calls = 0
+
+        async def post_simulating_loop_binding(*args, **kwargs):
+            nonlocal post_calls
+            post_calls += 1
+            if first_call_per_loop["is_first"]:
+                first_call_per_loop["is_first"] = False
+                raise RuntimeError("Event loop is closed")
+            return httpx.Response(
+                200,
+                json=ok_response(),
+                request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            )
+
+        client._client = type("MockClient", (), {"post": post_simulating_loop_binding})()
+
+        for _ in range(runs):
+            first_call_per_loop["is_first"] = True
+            result = asyncio.run(client.chat_completion("gpt-4o", [{"role": "user", "content": "hi"}]))
+            assert result.body["choices"][0]["message"]["content"] == "Hello"
+
+        assert post_calls == runs * 2
+
+    @pytest.mark.parametrize("loops", [2, 5, 10])
+    def test_recovers_when_same_client_used_across_function_scope_loops(self, loops):
+        """Same client called from N freshly-created event loops.
+
+        Mirrors the pytest-asyncio function-scope pattern (session-scoped
+        client, function-scoped loops). Each new loop's first request sees
+        a stale-transport RuntimeError and recovers via the retry. Verified
+        across a range of loop counts to catch any per-loop accumulation.
+        """
+        client = make_client()
+        first_call_per_loop = {"is_first": True}
+        post_calls = 0
+
+        async def post_simulating_loop_binding(*args, **kwargs):
+            nonlocal post_calls
+            post_calls += 1
+            if first_call_per_loop["is_first"]:
+                first_call_per_loop["is_first"] = False
+                raise RuntimeError("Event loop is closed")
+            return httpx.Response(
+                200,
+                json=ok_response(),
+                request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            )
+
+        client._client = type("MockClient", (), {"post": post_simulating_loop_binding})()
+
+        for _ in range(loops):
+            first_call_per_loop["is_first"] = True
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                result = loop.run_until_complete(client.chat_completion("gpt-4o", [{"role": "user", "content": "hi"}]))
+                assert result.body["choices"][0]["message"]["content"] == "Hello"
+            finally:
+                loop.close()
+                asyncio.set_event_loop(None)
+
+        assert post_calls == loops * 2
+
 
 class TestCalculateRetryDelay:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

`httpx.AsyncClient` binds its connection pool to the first event loop on first I/O. Any client reused on a new loop (pytest-asyncio function-scope, repeated `asyncio.run` on the same `LLMRails`) crashes with `RuntimeError: Event loop is closed`.

The bug is not unique to NeMo Guardrails. The exact same defect exists in:
- raw `httpx.AsyncClient`
- `openai.AsyncOpenAI` with `max_retries=0`
- `langchain` `ChatOpenAI` with `max_retries=0`

It is masked in production by the openai SDK's default `max_retries=2` plus its broad `except Exception:` retry. Our `BaseClient` had `max_retries=2` too but only caught `httpx.TimeoutException` and `httpx.NetworkError`, so the `RuntimeError` propagated unmasked.

The fix mirrors the openai SDK's behavior: catch the stale-loop `RuntimeError` (gated on the message text) inside the existing retry loop. Six lines of code per request method, plus a `log.warning` on the recovery branch.


## Reproduce the underlying defect


### 1. Raw httpx — the root cause

```python
# repro_httpx.py
import asyncio, httpx

client = httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0))

async def fetch(label):
    try:
        r = await client.get(
            "https://api.openai.com/v1/models",
            headers={"Authorization": "Bearer fake"},
        )
        print(f"{label}: status={r.status_code}")
    except Exception as exc:
        print(f"{label}: FAIL {type(exc).__name__}: {exc}")

asyncio.run(fetch("call 1"))
asyncio.run(fetch("call 2"))
```

```
call 1: status=401
call 2: FAIL RuntimeError: Event loop is closed
```

### 2. openai SDK with retries=0

```python
# repro_openai.py
import asyncio
from openai import AsyncOpenAI

client = AsyncOpenAI(max_retries=0)

async def call(label):
    try:
        r = await client.chat.completions.create(
            model="gpt-4o-mini",
            messages=[{"role": "user", "content": "hi"}],
            max_completion_tokens=3,
        )
        print(f"{label}: OK -> {r.choices[0].message.content!r}")
    except Exception as exc:
        print(f"{label}: FAIL -> {type(exc).__name__}: {exc}")
        if exc.__cause__:
            print(f"  caused by: {type(exc.__cause__).__name__}: {exc.__cause__}")

asyncio.run(call("call 1"))
asyncio.run(call("call 2"))
```

```
call 1: OK -> 'Hello!'
call 2: FAIL -> APIConnectionError: Connection error.
  caused by: RuntimeError: Event loop is closed
```

### 3. LangChain ChatOpenAI with retries=0

```python
# repro_langchain.py
import asyncio
from langchain_openai import ChatOpenAI
from langchain_core.messages import HumanMessage

llm = ChatOpenAI(model="gpt-4o-mini", max_retries=0)

async def call(label):
    try:
        r = await llm.ainvoke([HumanMessage(content="say ok")])
        print(f"{label}: OK -> {r.content!r}")
    except Exception as exc:
        print(f"{label}: FAIL -> {type(exc).__name__}: {exc}")
        if exc.__cause__:
            print(f"  caused by: {type(exc.__cause__).__name__}: {exc.__cause__}")

asyncio.run(call("call 1"))
asyncio.run(call("call 2"))
```

```
call 1: OK -> 'Ok'
call 2: FAIL -> APIConnectionError: Connection error.
  caused by: RuntimeError: Event loop is closed
```

The same `RuntimeError: Event loop is closed` is the underlying cause in all three cases. The wrapping is cosmetic.



## Why the bug is invisible at default settings

Same scripts as above, but at the library defaults:

```python
client = AsyncOpenAI()                       # default max_retries=2
llm = ChatOpenAI(model="gpt-4o-mini")        # default max_retries=2
```

Both produce:

```
call 1: OK
call 2: OK
```

The openai SDK's `_request` method catches **`Exception`** (not just httpx errors) inside its retry loop:

```python
# openai/_base_client.py (around line 1623)
try:
    response = await self._client.send(request, ...)
except httpx.TimeoutException as err:
    if remaining_retries > 0:
        await self._sleep_for_retry(...); continue
    raise APITimeoutError(...) from err
except Exception as err:                # this catches RuntimeError too
    if remaining_retries > 0:
        await self._sleep_for_retry(...); continue
    raise APIConnectionError(...) from err
```

When the first attempt raises `RuntimeError: Event loop is closed`, the broad catch retries. httpx's connection pool detects the stale connection on retry and opens a fresh one in the running loop. The user sees a successful call.

LangChain `ChatOpenAI` delegates to `AsyncOpenAI`, inheriting the same retry behavior.

NeMo Guardrails' `DefaultFramework` previously caught only the two httpx-specific exceptions, so `RuntimeError` propagated past the retry loop and surfaced as a hard failure.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient stale event loop errors with automatic retry logic and exponential backoff.
  * Enhanced error reporting for event loop-related connection failures.

* **Tests**
  * Added comprehensive test coverage for retry behavior on event loop errors across streaming and non-streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->