### PR TITLE
feat(compat): transitional compat layer to migrate from 0.21 to 0.22+

### DIFF
--- a/nemoguardrails/_compat/__init__.py
+++ b/nemoguardrails/_compat/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transitional compatibility shims and migration helpers.
+
+Modules under this package exist to bridge specific upgrade paths and are
+expected to be removed in a later release. Each module documents its own
+sunset version in its docstring.
+"""

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -61,7 +61,7 @@ def _detect_provider_alias(name: str) -> Optional[str]:
     return _canonical_name_for(match.group("canonical"))
 
 
-def _violations_for(model_type: str, model_engine: str, parameters: dict) -> List[Tuple[str, str]]:
+def _violations_for(model_type: str, parameters: dict) -> List[Tuple[str, str]]:
     """Return a list of (model_type, action) tuples for one model."""
     out: List[Tuple[str, str]] = []
     for flag in sorted(_LANGCHAIN_BASE_FLAGS & set(parameters)):
@@ -93,7 +93,7 @@ def check_langchain_kwargs(models: Iterable, active_framework: str) -> None:
         if not params:
             continue
         violations.extend(
-            _violations_for(getattr(model, "type", ""), getattr(model, "engine", ""), params),
+            _violations_for(getattr(model, "type", ""), params),
         )
     if not violations:
         return

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""0.21 -> 0.22 LangChain config migration helper.
+
+Detects LangChain Python-side flags in ``model.parameters`` when the
+default framework is active and raises a clear error at LLMRails
+construction, so a stale 0.21 LangChain config surfaces during init
+rather than as an opaque HTTP 400 deep in a guardrail call.
+
+Remove in 0.23.0. After 0.23 any unrecognized parameter is forwarded
+verbatim to the OpenAI-compatible HTTP client; the wire's HTTP 400 is
+the user's signal to clean up.
+"""
+
+# TODO(0.23): delete this module along with its call site in
+#   nemoguardrails.rails.llm.llmrails.LLMRails._init_llms.
+
+from typing import Dict, Iterable, List, Tuple
+
+# Python-side flags inherited by every LangChain BaseChatModel
+# (ChatOpenAI / ChatNVIDIA / ChatAnthropic / ChatVertexAI / etc.). Sourced
+# from langchain-core BaseChatModel and langchain-openai 1.1.x.
+_LANGCHAIN_BASE_FLAGS = frozenset(
+    {
+        "streaming",
+        "disable_streaming",
+        "verbose",
+        "cache",
+        "callbacks",
+        "tags",
+        "metadata",
+        "name",
+        "model_kwargs",
+    }
+)
+
+# Per-engine Python-side aliases: keys that LangChain's provider package
+# accepts under one name but that the default framework expects under
+# another. Only providers DefaultFramework actually serves over OpenAI-
+# compatible HTTP need entries here.
+_LANGCHAIN_PROVIDER_ALIASES: Dict[str, Dict[str, str]] = {
+    "nim": {"nvidia_api_key": "api_key", "nvidia_base_url": "base_url"},
+    "nvidia_ai_endpoints": {"nvidia_api_key": "api_key", "nvidia_base_url": "base_url"},
+}
+
+
+def _violations_for(model_type: str, model_engine: str, parameters: dict) -> List[Tuple[str, str]]:
+    """Return a list of (model_type, action) tuples for one model."""
+    out: List[Tuple[str, str]] = []
+    aliases = _LANGCHAIN_PROVIDER_ALIASES.get(model_engine, {})
+    for flag in sorted(_LANGCHAIN_BASE_FLAGS & set(parameters)):
+        if flag == "model_kwargs":
+            out.append((model_type, "unpack `model_kwargs` contents directly into `parameters`"))
+        else:
+            out.append((model_type, f"remove `{flag}`"))
+    for old in sorted(aliases.keys() & set(parameters)):
+        out.append((model_type, f"rename `{old}` to `{aliases[old]}`"))
+    return out
+
+
+def check_langchain_kwargs(models: Iterable, active_framework: str) -> None:
+    """Raise ValueError if any model carries LangChain Python-side flags.
+
+    No-op when the active framework is anything other than ``default``;
+    LangChain-flavored kwargs are valid on the LangChain framework.
+    """
+    if active_framework != "default":
+        return
+    violations: List[Tuple[str, str]] = []
+    for model in models:
+        params = getattr(model, "parameters", None) or {}
+        if not params:
+            continue
+        violations.extend(
+            _violations_for(getattr(model, "type", ""), getattr(model, "engine", ""), params),
+        )
+    if not violations:
+        return
+    header = (
+        "Your config has a LangChain-only flag in `parameters` that the default\nframework doesn't forward:"
+        if len(violations) == 1
+        else "Your config has LangChain-only flags in `parameters` that the default\nframework doesn't forward:"
+    )
+    body = "\n".join(f"  models[{model_type}]: {action}" for model_type, action in violations)
+    raise ValueError(
+        f"{header}\n\n"
+        f"{body}\n\n"
+        "To keep 0.21 LangChain behavior instead, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain.\n"
+        "(Migration check; removed in 0.23.0.)"
+    )

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -28,11 +28,9 @@ the user's signal to clean up.
 # TODO(0.23): delete this module along with its call site in
 #   nemoguardrails.rails.llm.llmrails.LLMRails._init_llms.
 
-from typing import Dict, Iterable, List, Tuple
+import re
+from typing import Iterable, List, Optional, Tuple
 
-# Python-side flags inherited by every LangChain BaseChatModel
-# (ChatOpenAI / ChatNVIDIA / ChatAnthropic / ChatVertexAI / etc.). Sourced
-# from langchain-core BaseChatModel and langchain-openai 1.1.x.
 _LANGCHAIN_BASE_FLAGS = frozenset(
     {
         "streaming",
@@ -47,27 +45,37 @@ _LANGCHAIN_BASE_FLAGS = frozenset(
     }
 )
 
-# Per-engine Python-side aliases: keys that LangChain's provider package
-# accepts under one name but that the default framework expects under
-# another. Only providers DefaultFramework actually serves over OpenAI-
-# compatible HTTP need entries here.
-_LANGCHAIN_PROVIDER_ALIASES: Dict[str, Dict[str, str]] = {
-    "nim": {"nvidia_api_key": "api_key", "nvidia_base_url": "base_url"},
-    "nvidia_ai_endpoints": {"nvidia_api_key": "api_key", "nvidia_base_url": "base_url"},
-}
+_PROVIDER_PREFIXED_ALIAS = re.compile(r"^(?P<prefix>[a-zA-Z]\w*?)_(?P<canonical>api_key|base_url|api_base|endpoint)$")
+
+
+def _canonical_name_for(matched_canonical: str) -> str:
+    if matched_canonical == "api_key":
+        return "api_key"
+    return "base_url"
+
+
+def _detect_provider_alias(name: str) -> Optional[str]:
+    match = _PROVIDER_PREFIXED_ALIAS.fullmatch(name)
+    if match is None:
+        return None
+    return _canonical_name_for(match.group("canonical"))
 
 
 def _violations_for(model_type: str, model_engine: str, parameters: dict) -> List[Tuple[str, str]]:
     """Return a list of (model_type, action) tuples for one model."""
     out: List[Tuple[str, str]] = []
-    aliases = _LANGCHAIN_PROVIDER_ALIASES.get(model_engine, {})
     for flag in sorted(_LANGCHAIN_BASE_FLAGS & set(parameters)):
         if flag == "model_kwargs":
             out.append((model_type, "unpack `model_kwargs` contents directly into `parameters`"))
         else:
             out.append((model_type, f"remove `{flag}`"))
-    for old in sorted(aliases.keys() & set(parameters)):
-        out.append((model_type, f"rename `{old}` to `{aliases[old]}`"))
+    for name in sorted(parameters):
+        if name in _LANGCHAIN_BASE_FLAGS:
+            continue
+        canonical = _detect_provider_alias(name)
+        if canonical is None:
+            continue
+        out.append((model_type, f"rename `{name}` to `{canonical}`"))
     return out
 
 
@@ -89,15 +97,14 @@ def check_langchain_kwargs(models: Iterable, active_framework: str) -> None:
         )
     if not violations:
         return
-    header = (
-        "Your config has a LangChain-only flag in `parameters` that the default\nframework doesn't forward:"
-        if len(violations) == 1
-        else "Your config has LangChain-only flags in `parameters` that the default\nframework doesn't forward:"
-    )
     body = "\n".join(f"  models[{model_type}]: {action}" for model_type, action in violations)
     raise ValueError(
-        f"{header}\n\n"
+        "Your config uses 0.21-style LangChain conventions that the default framework\n"
+        "doesn't forward:\n\n"
         f"{body}\n\n"
-        "To keep 0.21 LangChain behavior instead, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain.\n"
+        "Two paths:\n"
+        "  - Adapt to the default framework: apply the renames/removals above.\n"
+        "    Only do this if your endpoint is OpenAI-compatible.\n"
+        "  - Keep 0.21 LangChain behavior: set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain.\n\n"
         "(Migration check; removed in 0.23.0.)"
     )

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -29,7 +29,10 @@ the user's signal to clean up.
 #   nemoguardrails.rails.llm.llmrails.LLMRails._init_llms.
 
 import re
-from typing import Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from nemoguardrails.rails.llm.config import Model
 
 _LANGCHAIN_BASE_FLAGS = frozenset(
     {
@@ -79,7 +82,7 @@ def _violations_for(model_type: str, parameters: dict) -> List[Tuple[str, str]]:
     return out
 
 
-def check_langchain_kwargs(models: Iterable, active_framework: str) -> None:
+def check_langchain_kwargs(models: "Iterable[Model]", active_framework: str) -> None:
     """Raise ValueError if any model carries LangChain Python-side flags.
 
     No-op when the active framework is anything other than ``default``;
@@ -89,12 +92,9 @@ def check_langchain_kwargs(models: Iterable, active_framework: str) -> None:
         return
     violations: List[Tuple[str, str]] = []
     for model in models:
-        params = getattr(model, "parameters", None) or {}
-        if not params:
+        if not model.parameters:
             continue
-        violations.extend(
-            _violations_for(getattr(model, "type", ""), params),
-        )
+        violations.extend(_violations_for(model.type, model.parameters))
     if not violations:
         return
     body = "\n".join(f"  models[{model_type}]: {action}" for model_type, action in violations)

--- a/nemoguardrails/llm/clients/_errors.py
+++ b/nemoguardrails/llm/clients/_errors.py
@@ -157,12 +157,8 @@ def _looks_like_unknown_param_400(error_message: str) -> bool:
     return any(token in msg_lower for token in _UNKNOWN_PARAM_HINT_TOKENS)
 
 
-def _maybe_append_migration_hint(status_code: int, error_message: str) -> str:
-    if status_code not in (400, 422):
-        return error_message
+def _maybe_append_migration_hint(error_message: str) -> str:
     if not _looks_like_unknown_param_400(error_message):
-        return error_message
-    if _MIGRATION_HINT_021 in error_message:
         return error_message
     return f"{error_message}\n\n{_MIGRATION_HINT_021}"
 
@@ -177,7 +173,8 @@ def _classify_bad_request(status_code: int, error_message: str, kwargs: Dict[str
                 f"{error_message} (set include_usage_in_stream=False on the model "
                 "or in config.yml parameters to remove this field from streaming requests)"
             )
-        error_message = _maybe_append_migration_hint(status_code, error_message)
+        else:
+            error_message = _maybe_append_migration_hint(error_message)
         return LLMUnsupportedParamsError(status_code, error_message, **kwargs)
     return LLMBadRequestError(status_code, error_message, **kwargs)
 

--- a/nemoguardrails/llm/clients/_errors.py
+++ b/nemoguardrails/llm/clients/_errors.py
@@ -41,6 +41,13 @@ _CONTEXT_WINDOW_KEYWORDS = [
     "token limit",
 ]
 
+# Bare "is not supported" was deliberately removed: it false-positives on
+# non-param 400s ("model is not supported in your region", "image input is not
+# supported for this model"). Real OpenAI param rejections always carry the
+# "Unsupported parameter:" prefix matched above. A provider emitting bare
+# "X is not supported" without that prefix will classify as LLMBadRequestError
+# instead of LLMUnsupportedParamsError; if observed in the wild, add a tighter
+# phrase here (e.g. "is not a supported parameter").
 _UNSUPPORTED_PARAMS_KEYWORDS = [
     "unsupported parameter",
     "parameter not allowed",
@@ -172,7 +179,6 @@ def _classify_bad_request(status_code: int, error_message: str, kwargs: Dict[str
             )
         error_message = _maybe_append_migration_hint(status_code, error_message)
         return LLMUnsupportedParamsError(status_code, error_message, **kwargs)
-    error_message = _maybe_append_migration_hint(status_code, error_message)
     return LLMBadRequestError(status_code, error_message, **kwargs)
 
 

--- a/nemoguardrails/llm/clients/_errors.py
+++ b/nemoguardrails/llm/clients/_errors.py
@@ -43,18 +43,19 @@ _CONTEXT_WINDOW_KEYWORDS = [
 
 _UNSUPPORTED_PARAMS_KEYWORDS = [
     "unsupported parameter",
-    "is not supported",
     "parameter not allowed",
     "unknown parameter",
     "unrecognized parameter",
+    "unrecognized request argument",
+    "' is unsupported",
+    "extra inputs are not permitted",
 ]
 
 _UNKNOWN_PARAM_HINT_TOKENS = (
-    "unknown parameter",
-    "unrecognized",
-    "extra fields",
-    "additional properties",
-    "is not allowed",
+    "unrecognized request argument",
+    "unsupported parameter",
+    "' is unsupported",
+    "extra inputs are not permitted",
 )
 
 _MIGRATION_HINT_021 = (
@@ -150,7 +151,7 @@ def _looks_like_unknown_param_400(error_message: str) -> bool:
 
 
 def _maybe_append_migration_hint(status_code: int, error_message: str) -> str:
-    if status_code != 400:
+    if status_code not in (400, 422):
         return error_message
     if not _looks_like_unknown_param_400(error_message):
         return error_message

--- a/nemoguardrails/llm/clients/_errors.py
+++ b/nemoguardrails/llm/clients/_errors.py
@@ -49,6 +49,21 @@ _UNSUPPORTED_PARAMS_KEYWORDS = [
     "unrecognized parameter",
 ]
 
+_UNKNOWN_PARAM_HINT_TOKENS = (
+    "unknown parameter",
+    "unrecognized",
+    "extra fields",
+    "additional properties",
+    "is not allowed",
+)
+
+_MIGRATION_HINT_021 = (
+    "(If you upgraded from 0.21: the default framework forwards `parameters` "
+    "verbatim to the OpenAI-compatible endpoint, which rejected the field above. "
+    "LangChain-only flags must be removed for the default framework. To keep "
+    "0.21 LangChain behavior, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain.)"
+)
+
 _SECRET_PATTERN = re.compile(r"(sk-|nvapi-|AIza|bearer\s+)\S+", re.IGNORECASE)
 
 
@@ -129,6 +144,21 @@ def _build_error_fields(parsed_body: Any, raw_body: str, headers: Any, ctx: Erro
     return error_message, kwargs
 
 
+def _looks_like_unknown_param_400(error_message: str) -> bool:
+    msg_lower = error_message.lower()
+    return any(token in msg_lower for token in _UNKNOWN_PARAM_HINT_TOKENS)
+
+
+def _maybe_append_migration_hint(status_code: int, error_message: str) -> str:
+    if status_code != 400:
+        return error_message
+    if not _looks_like_unknown_param_400(error_message):
+        return error_message
+    if _MIGRATION_HINT_021 in error_message:
+        return error_message
+    return f"{error_message}\n\n{_MIGRATION_HINT_021}"
+
+
 def _classify_bad_request(status_code: int, error_message: str, kwargs: Dict[str, Any]) -> LLMClientError:
     msg_lower = error_message.lower()
     if any(kw in msg_lower for kw in _CONTEXT_WINDOW_KEYWORDS):
@@ -139,7 +169,9 @@ def _classify_bad_request(status_code: int, error_message: str, kwargs: Dict[str
                 f"{error_message} (set include_usage_in_stream=False on the model "
                 "or in config.yml parameters to remove this field from streaming requests)"
             )
+        error_message = _maybe_append_migration_hint(status_code, error_message)
         return LLMUnsupportedParamsError(status_code, error_message, **kwargs)
+    error_message = _maybe_append_migration_hint(status_code, error_message)
     return LLMBadRequestError(status_code, error_message, **kwargs)
 
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -428,6 +428,11 @@ class LLMRails:
         Raises:
             ModelInitializationError: If any model initialization fails
         """
+        from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
+        from nemoguardrails.llm.frameworks import get_default_framework
+
+        check_langchain_kwargs(self.config.models, get_default_framework())
+
         # If the user supplied an already-constructed LLM via the constructor we
         # treat it as the *main* model, but **still** iterate through the
         # configuration to load any additional models (e.g. `content_safety`).

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -431,7 +431,10 @@ class LLMRails:
         from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
         from nemoguardrails.llm.frameworks import get_default_framework
 
-        check_langchain_kwargs(self.config.models, get_default_framework())
+        models_to_check = (
+            [model for model in self.config.models if model.type != "main"] if self.llm else self.config.models
+        )
+        check_langchain_kwargs(models_to_check, get_default_framework())
 
         # If the user supplied an already-constructed LLM via the constructor we
         # treat it as the *main* model, but **still** iterate through the

--- a/tests/_compat/__init__.py
+++ b/tests/_compat/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/_compat/test_langchain_kwargs.py
+++ b/tests/_compat/test_langchain_kwargs.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemoguardrails._compat.langchain_kwargs import check_langchain_kwargs
+
+
+def _model(model_type="main", engine="openai", parameters=None):
+    return SimpleNamespace(type=model_type, engine=engine, parameters=parameters or {})
+
+
+class TestNoOpOnNonDefaultFramework:
+    def test_langchain_framework_skips_check(self):
+        # On the langchain framework, these flags are valid; we must not raise.
+        models = [_model(parameters={"streaming": True, "verbose": True, "model_kwargs": {"x": 1}})]
+        check_langchain_kwargs(models, active_framework="langchain")
+
+    def test_other_framework_skips_check(self):
+        models = [_model(parameters={"streaming": True})]
+        check_langchain_kwargs(models, active_framework="some_custom_framework")
+
+
+class TestBaseFlagsRaise:
+    def test_streaming_raises_on_default(self):
+        models = [_model(parameters={"streaming": True})]
+        with pytest.raises(ValueError, match=r"streaming"):
+            check_langchain_kwargs(models, active_framework="default")
+
+    def test_each_base_flag_raises(self):
+        for flag in ("streaming", "disable_streaming", "verbose", "cache", "callbacks", "tags", "metadata", "name"):
+            with pytest.raises(ValueError, match=rf"{flag}"):
+                check_langchain_kwargs([_model(parameters={flag: True})], active_framework="default")
+
+    def test_model_kwargs_uses_unpack_action(self):
+        with pytest.raises(ValueError, match=r"unpack `model_kwargs`"):
+            check_langchain_kwargs([_model(parameters={"model_kwargs": {"top_k": 50}})], active_framework="default")
+
+
+class TestProviderAliases:
+    def test_nim_alias_raises(self):
+        with pytest.raises(ValueError, match=r"nvidia_api_key.*to.*api_key"):
+            check_langchain_kwargs(
+                [_model(engine="nim", parameters={"nvidia_api_key": "nvapi-..."})],
+                active_framework="default",
+            )
+
+    def test_nvidia_ai_endpoints_alias_raises(self):
+        with pytest.raises(ValueError, match=r"nvidia_base_url"):
+            check_langchain_kwargs(
+                [_model(engine="nvidia_ai_endpoints", parameters={"nvidia_base_url": "https://..."})],
+                active_framework="default",
+            )
+
+    def test_alias_only_for_matching_engine(self):
+        # nvidia_api_key is not a known LangChain alias for openai engine; the
+        # validator should not flag it (the wire will reject it as unknown).
+        check_langchain_kwargs(
+            [_model(engine="openai", parameters={"nvidia_api_key": "nvapi-..."})],
+            active_framework="default",
+        )
+
+
+class TestValidParameters:
+    def test_legitimate_wire_fields_pass(self):
+        params = {
+            "temperature": 0.5,
+            "max_tokens": 100,
+            "top_p": 0.9,
+            "presence_penalty": 0.1,
+            "tools": [{"type": "function"}],
+        }
+        check_langchain_kwargs([_model(parameters=params)], active_framework="default")
+
+    def test_client_config_fields_pass(self):
+        params = {
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "timeout": 30,
+            "max_retries": 3,
+        }
+        check_langchain_kwargs([_model(parameters=params)], active_framework="default")
+
+    def test_provider_extensions_pass(self):
+        # NIM nvext, vLLM min_p/top_k/guided_*, Ollama keep_alive — all forwarded verbatim.
+        params = {
+            "nvext": {"foo": "bar"},
+            "min_p": 0.05,
+            "top_k": 40,
+            "guided_json": {"type": "object"},
+            "keep_alive": "10m",
+        }
+        check_langchain_kwargs([_model(engine="nim", parameters=params)], active_framework="default")
+
+
+class TestEmptyConfig:
+    def test_no_models(self):
+        check_langchain_kwargs([], active_framework="default")
+
+    def test_model_without_parameters(self):
+        check_langchain_kwargs([_model(parameters=None)], active_framework="default")
+
+    def test_model_with_empty_parameters(self):
+        check_langchain_kwargs([_model(parameters={})], active_framework="default")
+
+
+class TestMultipleViolations:
+    def test_aggregates_across_models(self):
+        models = [
+            _model(model_type="main", parameters={"streaming": True}),
+            _model(model_type="self_check_input", parameters={"verbose": True}),
+        ]
+        with pytest.raises(ValueError) as excinfo:
+            check_langchain_kwargs(models, active_framework="default")
+        assert "main" in str(excinfo.value)
+        assert "self_check_input" in str(excinfo.value)
+
+    def test_message_includes_sunset_note(self):
+        with pytest.raises(ValueError, match=r"removed in 0\.23\.0"):
+            check_langchain_kwargs([_model(parameters={"streaming": True})], active_framework="default")

--- a/tests/_compat/test_langchain_kwargs.py
+++ b/tests/_compat/test_langchain_kwargs.py
@@ -26,7 +26,6 @@ def _model(model_type="main", engine="openai", parameters=None):
 
 class TestNoOpOnNonDefaultFramework:
     def test_langchain_framework_skips_check(self):
-        # On the langchain framework, these flags are valid; we must not raise.
         models = [_model(parameters={"streaming": True, "verbose": True, "model_kwargs": {"x": 1}})]
         check_langchain_kwargs(models, active_framework="langchain")
 
@@ -51,26 +50,67 @@ class TestBaseFlagsRaise:
             check_langchain_kwargs([_model(parameters={"model_kwargs": {"top_k": 50}})], active_framework="default")
 
 
-class TestProviderAliases:
-    def test_nim_alias_raises(self):
+class TestProviderAliasPatternDetection:
+    def test_nim_alias_still_detected_via_pattern(self):
         with pytest.raises(ValueError, match=r"nvidia_api_key.*to.*api_key"):
             check_langchain_kwargs(
                 [_model(engine="nim", parameters={"nvidia_api_key": "nvapi-..."})],
                 active_framework="default",
             )
 
-    def test_nvidia_ai_endpoints_alias_raises(self):
-        with pytest.raises(ValueError, match=r"nvidia_base_url"):
+    def test_nvidia_ai_endpoints_alias_still_detected_via_pattern(self):
+        with pytest.raises(ValueError, match=r"nvidia_base_url.*to.*base_url"):
             check_langchain_kwargs(
                 [_model(engine="nvidia_ai_endpoints", parameters={"nvidia_base_url": "https://..."})],
                 active_framework="default",
             )
 
-    def test_alias_only_for_matching_engine(self):
-        # nvidia_api_key is not a known LangChain alias for openai engine; the
-        # validator should not flag it (the wire will reject it as unknown).
+    def test_openai_api_key_detected(self):
+        with pytest.raises(ValueError, match=r"openai_api_key.*to.*api_key"):
+            check_langchain_kwargs(
+                [_model(engine="openai", parameters={"openai_api_key": "sk-..."})],
+                active_framework="default",
+            )
+
+    def test_cohere_api_key_detected(self):
+        with pytest.raises(ValueError, match=r"cohere_api_key.*to.*api_key"):
+            check_langchain_kwargs(
+                [_model(engine="cohere", parameters={"cohere_api_key": "co-..."})],
+                active_framework="default",
+            )
+
+    def test_azure_endpoint_detected_and_collapsed_to_base_url(self):
+        with pytest.raises(ValueError, match=r"azure_endpoint.*to.*base_url"):
+            check_langchain_kwargs(
+                [_model(engine="azure", parameters={"azure_endpoint": "https://..."})],
+                active_framework="default",
+            )
+
+    def test_xyz_base_url_detected(self):
+        with pytest.raises(ValueError, match=r"xyz_base_url.*to.*base_url"):
+            check_langchain_kwargs(
+                [_model(engine="xyz", parameters={"xyz_base_url": "https://..."})],
+                active_framework="default",
+            )
+
+    def test_huggingfacehub_api_base_collapsed_to_base_url(self):
+        with pytest.raises(ValueError, match=r"huggingfacehub_api_base.*to.*base_url"):
+            check_langchain_kwargs(
+                [_model(engine="huggingface", parameters={"huggingfacehub_api_base": "https://..."})],
+                active_framework="default",
+            )
+
+
+class TestCanonicalNamesNotFalseFlagged:
+    def test_api_key_does_not_trigger(self):
         check_langchain_kwargs(
-            [_model(engine="openai", parameters={"nvidia_api_key": "nvapi-..."})],
+            [_model(parameters={"api_key": "sk-test"})],
+            active_framework="default",
+        )
+
+    def test_base_url_does_not_trigger(self):
+        check_langchain_kwargs(
+            [_model(parameters={"base_url": "https://api.openai.com/v1"})],
             active_framework="default",
         )
 
@@ -96,13 +136,13 @@ class TestValidParameters:
         check_langchain_kwargs([_model(parameters=params)], active_framework="default")
 
     def test_provider_extensions_pass(self):
-        # NIM nvext, vLLM min_p/top_k/guided_*, Ollama keep_alive — all forwarded verbatim.
         params = {
             "nvext": {"foo": "bar"},
             "min_p": 0.05,
             "top_k": 40,
             "guided_json": {"type": "object"},
             "keep_alive": "10m",
+            "temperature": 0.7,
         }
         check_langchain_kwargs([_model(engine="nim", parameters=params)], active_framework="default")
 
@@ -132,3 +172,19 @@ class TestMultipleViolations:
     def test_message_includes_sunset_note(self):
         with pytest.raises(ValueError, match=r"removed in 0\.23\.0"):
             check_langchain_kwargs([_model(parameters={"streaming": True})], active_framework="default")
+
+
+class TestErrorMessageBothPaths:
+    def test_message_contains_both_remediation_paths_and_sunset(self):
+        with pytest.raises(ValueError) as excinfo:
+            check_langchain_kwargs(
+                [_model(engine="nim", parameters={"streaming": True, "nvidia_api_key": "nvapi-..."})],
+                active_framework="default",
+            )
+        message = str(excinfo.value)
+        assert "Adapt to the default framework" in message
+        assert "Keep 0.21 LangChain behavior" in message
+        assert "NEMOGUARDRAILS_LLM_FRAMEWORK=langchain" in message
+        assert "removed in 0.23.0" in message
+        assert "remove `streaming`" in message
+        assert "rename `nvidia_api_key` to `api_key`" in message

--- a/tests/llm/clients/test_openai_compatible.py
+++ b/tests/llm/clients/test_openai_compatible.py
@@ -164,7 +164,16 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_400_unsupported_params(self):
         client = make_client()
-        mock_httpx_post(client, [(400, {"error": {"message": "temperature is not supported"}}, {})])
+        mock_httpx_post(
+            client,
+            [
+                (
+                    400,
+                    {"error": {"message": "Unsupported parameter: 'temperature' is not supported with this model"}},
+                    {},
+                )
+            ],
+        )
         with pytest.raises(LLMUnsupportedParamsError):
             await client.chat_completion("gpt-4o", [])
 

--- a/tests/llm/clients/test_openai_compatible_400_enrichment.py
+++ b/tests/llm/clients/test_openai_compatible_400_enrichment.py
@@ -45,7 +45,7 @@ class TestMigrationHintAppendedOnUnknownParam400:
                 )
             ],
         )
-        with pytest.raises(LLMBadRequestError) as exc_info:
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
             await client.chat_completion("gpt-4o", [])
         assert _HINT_FRAGMENT in exc_info.value.error_message
 
@@ -162,6 +162,20 @@ class TestMigrationHintNotAppendedOnFalsePositiveBroadPhrases:
         )
         with pytest.raises(LLMBadRequestError) as exc_info:
             await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+
+class TestStreamOptionsRejection:
+    @pytest.mark.asyncio
+    async def test_stream_options_rejection_uses_specific_guidance_only(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Unrecognized request argument supplied: stream_options"}}, {})],
+        )
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert "include_usage_in_stream=False" in exc_info.value.error_message
         assert _HINT_FRAGMENT not in exc_info.value.error_message
 
 

--- a/tests/llm/clients/test_openai_compatible_400_enrichment.py
+++ b/tests/llm/clients/test_openai_compatible_400_enrichment.py
@@ -28,62 +28,141 @@ _FRAMEWORK_ENV = "NEMOGUARDRAILS_LLM_FRAMEWORK=langchain"
 
 class TestMigrationHintAppendedOnUnknownParam400:
     @pytest.mark.asyncio
-    async def test_unknown_parameter_message_triggers_hint(self):
+    async def test_openai_canonical_phrasing_triggers_hint(self):
         client = make_client()
         mock_httpx_post(
             client,
-            [(400, {"error": {"message": "Unknown parameter: 'streaming'"}}, {})],
+            [
+                (
+                    400,
+                    {
+                        "error": {
+                            "message": "Unrecognized request argument supplied: streaming",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    {},
+                )
+            ],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_nim_canonical_phrasing_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [
+                (
+                    400,
+                    {
+                        "error": {
+                            "message": "Validation: Unsupported parameter(s): `streaming`",
+                            "type": "Bad Request",
+                            "code": 400,
+                        }
+                    },
+                    {},
+                )
+            ],
         )
         with pytest.raises(LLMUnsupportedParamsError) as exc_info:
             await client.chat_completion("gpt-4o", [])
-        message = exc_info.value.error_message
-        assert "Unknown parameter: 'streaming'" in message
-        assert _HINT_FRAGMENT in message
-        assert _FRAMEWORK_ENV in message
+        assert _HINT_FRAGMENT in exc_info.value.error_message
 
     @pytest.mark.asyncio
-    async def test_unrecognized_token_triggers_hint(self):
+    async def test_groq_canonical_phrasing_triggers_hint(self):
         client = make_client()
         mock_httpx_post(
             client,
-            [(400, {"error": {"message": "Field 'verbose' is unrecognized"}}, {})],
+            [
+                (
+                    400,
+                    {
+                        "error": {
+                            "message": "property 'streaming' is unsupported",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    {},
+                )
+            ],
         )
-        with pytest.raises(LLMBadRequestError) as exc_info:
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
             await client.chat_completion("gpt-4o", [])
         assert _HINT_FRAGMENT in exc_info.value.error_message
 
     @pytest.mark.asyncio
-    async def test_extra_fields_triggers_hint(self):
+    async def test_fireworks_canonical_phrasing_triggers_hint(self):
         client = make_client()
         mock_httpx_post(
             client,
-            [(400, {"error": {"message": "Request contains extra fields: callbacks"}}, {})],
+            [
+                (
+                    400,
+                    {
+                        "error": {
+                            "object": "error",
+                            "type": "invalid_request_error",
+                            "code": "invalid_request_error",
+                            "message": "Extra inputs are not permitted, field: 'streaming', value: True",
+                        }
+                    },
+                    {},
+                )
+            ],
         )
-        with pytest.raises(LLMBadRequestError) as exc_info:
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
             await client.chat_completion("gpt-4o", [])
         assert _HINT_FRAGMENT in exc_info.value.error_message
 
     @pytest.mark.asyncio
-    async def test_additional_properties_triggers_hint(self):
+    async def test_422_with_unsupported_parameter_triggers_hint(self):
         client = make_client()
         mock_httpx_post(
             client,
-            [(400, {"error": {"message": "Additional properties are not allowed (cache, tags)"}}, {})],
+            [(422, {"error": {"message": "Validation: Unsupported parameter(s): `verbose`"}}, {})],
         )
-        with pytest.raises(LLMBadRequestError) as exc_info:
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
             await client.chat_completion("gpt-4o", [])
         assert _HINT_FRAGMENT in exc_info.value.error_message
 
+
+class TestMigrationHintNotAppendedOnFalsePositiveBroadPhrases:
     @pytest.mark.asyncio
-    async def test_is_not_allowed_triggers_hint(self):
+    async def test_content_type_not_allowed_no_hint(self):
         client = make_client()
         mock_httpx_post(
             client,
-            [(400, {"error": {"message": "field 'metadata' is not allowed here"}}, {})],
+            [(400, {"error": {"message": "Content type is not allowed"}}, {})],
         )
         with pytest.raises(LLMBadRequestError) as exc_info:
             await client.chat_completion("gpt-4o", [])
-        assert _HINT_FRAGMENT in exc_info.value.error_message
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_action_not_allowed_for_plan_no_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "This action is not allowed for your plan"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_auth_scheme_no_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Unrecognized authentication scheme"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
 
 
 class TestMigrationHintNotAppendedOnUnrelated400:
@@ -151,7 +230,7 @@ class TestPreservesOriginalProviderError:
     @pytest.mark.asyncio
     async def test_appended_hint_does_not_replace_original(self):
         client = make_client()
-        original_message = "Unknown parameter: 'nvidia_api_key'"
+        original_message = "Unrecognized request argument supplied: nvidia_api_key"
         mock_httpx_post(
             client,
             [(400, {"error": {"message": original_message}}, {})],

--- a/tests/llm/clients/test_openai_compatible_400_enrichment.py
+++ b/tests/llm/clients/test_openai_compatible_400_enrichment.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.exceptions import (
+    LLMAuthenticationError,
+    LLMBadRequestError,
+    LLMUnsupportedParamsError,
+)
+from tests.llm.clients._helpers import make_client, mock_httpx_post, ok_response
+
+_HINT_FRAGMENT = "If you upgraded from 0.21"
+_FRAMEWORK_ENV = "NEMOGUARDRAILS_LLM_FRAMEWORK=langchain"
+
+
+class TestMigrationHintAppendedOnUnknownParam400:
+    @pytest.mark.asyncio
+    async def test_unknown_parameter_message_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Unknown parameter: 'streaming'"}}, {})],
+        )
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        message = exc_info.value.error_message
+        assert "Unknown parameter: 'streaming'" in message
+        assert _HINT_FRAGMENT in message
+        assert _FRAMEWORK_ENV in message
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_token_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Field 'verbose' is unrecognized"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Request contains extra fields: callbacks"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_additional_properties_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Additional properties are not allowed (cache, tags)"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_is_not_allowed_triggers_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "field 'metadata' is not allowed here"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT in exc_info.value.error_message
+
+
+class TestMigrationHintNotAppendedOnUnrelated400:
+    @pytest.mark.asyncio
+    async def test_generic_400_no_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Invalid value for temperature"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_context_window_400_no_hint(self):
+        from nemoguardrails.exceptions import LLMContextWindowError
+
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "maximum context length exceeded"}}, {})],
+        )
+        with pytest.raises(LLMContextWindowError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_shaped_400_no_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": "Quota exceeded for this organization"}}, {})],
+        )
+        with pytest.raises(LLMBadRequestError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+    @pytest.mark.asyncio
+    async def test_auth_shaped_401_no_hint(self):
+        client = make_client()
+        mock_httpx_post(
+            client,
+            [(401, {"error": {"message": "Invalid API key"}}, {})],
+        )
+        with pytest.raises(LLMAuthenticationError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        assert _HINT_FRAGMENT not in exc_info.value.error_message
+
+
+class TestNoEnrichmentOn200:
+    @pytest.mark.asyncio
+    async def test_200_response_unchanged(self):
+        from nemoguardrails.llm.clients.base import HTTPResponse
+
+        client = make_client()
+        mock_httpx_post(client, [(200, ok_response(), {})])
+        result = await client.chat_completion("gpt-4o", [])
+        assert isinstance(result, HTTPResponse)
+        assert result.status_code == 200
+        assert result.body["choices"][0]["message"]["content"] == "Hello"
+
+
+class TestPreservesOriginalProviderError:
+    @pytest.mark.asyncio
+    async def test_appended_hint_does_not_replace_original(self):
+        client = make_client()
+        original_message = "Unknown parameter: 'nvidia_api_key'"
+        mock_httpx_post(
+            client,
+            [(400, {"error": {"message": original_message}}, {})],
+        )
+        with pytest.raises(LLMUnsupportedParamsError) as exc_info:
+            await client.chat_completion("gpt-4o", [])
+        message = exc_info.value.error_message
+        assert original_message in message
+        assert _HINT_FRAGMENT in message
+        assert message.index(original_message) < message.index(_HINT_FRAGMENT)

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -755,6 +755,47 @@ async def test_llm_constructor_with_empty_models_config():
     assert any(event.get("intent") == "express greeting" for event in new_events)
 
 
+@pytest.fixture
+def llm_config_with_main_streaming_param():
+    """Fixture providing a config whose main model carries a LangChain-only `streaming` flag."""
+    return RailsConfig.parse_object(
+        {
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "openai",
+                    "model": "gpt-4",
+                    "parameters": {"streaming": True},
+                },
+            ],
+            "user_messages": {"express greeting": ["Hello!"]},
+            "flows": [
+                {
+                    "elements": [
+                        {"user": "express greeting"},
+                        {"bot": "express greeting"},
+                    ]
+                },
+            ],
+            "bot_messages": {"express greeting": ["Hello!"]},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_compat_check_skips_main_when_constructor_llm_provided(llm_config_with_main_streaming_param):
+    """When self.llm is injected, the compat validator must skip the ignored `main` config entry."""
+    injected_llm = FakeLLMModel(responses=["express greeting"])
+    LLMRails(config=llm_config_with_main_streaming_param, llm=injected_llm)
+
+
+@pytest.mark.asyncio
+async def test_compat_check_runs_against_main_when_no_constructor_llm(llm_config_with_main_streaming_param):
+    """When no constructor LLM is provided, the validator runs against `main` and raises."""
+    with pytest.raises(ValueError, match=r"streaming"):
+        LLMRails(config=llm_config_with_main_streaming_param)
+
+
 @pytest.mark.asyncio
 @patch(
     "nemoguardrails.rails.llm.llmrails.init_llm_model",


### PR DESCRIPTION
## Description [ Generated by Copilot]


Two-layer safeguard for users carrying 0.21 LangChain-style configs into the
0.22 default framework:

1. **Boot-time shape detector** (`nemoguardrails/_compat/langchain_kwargs.py`).
   Replaces the previous hand-maintained per-provider alias map with a generic
   pattern matcher. Detects two shapes in `model.parameters` when the active
   framework is `default`:
   - LangChain `BaseChatModel` Python flags: `streaming`, `disable_streaming`,
     `verbose`, `cache`, `callbacks`, `tags`, `metadata`, `name`, `model_kwargs`.
    - Provider-prefixed credential/URL aliases via regex `^(?P<prefix>[a-zA-Z]\w*?)_(?P<canonical>api_key|base_url|api_base|endpoint)$`, emitting a remediation rename to canonical `api_key` / `base_url`. Raises a `ValueError` at `LLMRails` construction with two paths surfaced: either adapt the config to OpenAI-compatible shape, or set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` to keep 0.21 behavior. Sunset in 0.23.0.
2. **Wire-level HTTP 400/422 enrichment** (`nemoguardrails/llm/clients/_errors.py`).
   When `OpenAICompatibleClient` receives a 400 or 422 whose body matches one
   of `_UNKNOWN_PARAM_HINT_TOKENS`, append a single hedged migration hint to
   the original provider error. Original message is preserved verbatim before
   the hint. Hint is hedged with "If you upgraded from 0.21..." so users on
   unrelated rejections can ignore it. Same sunset.

## Why two layers

The boot detector catches the recognizable 0.21 *shape* of a config. The wire enrichment handles the long tail: legitimate provider extensions (NIM `nvext`, vLLM `min_p`/`top_k`/`guided_*`, Ollama `keep_alive`) pass through untouched; if the wire rejects something, the user gets the actual provider error message *plus* migration context with the field name preserved. No enumeration treadmill.

## Token list provenance

Methodology used to arrive at the final token list: a probe script hits each provider's `/chat/completions` with deliberately-malformed payloads (LangChain `BaseChatModel` flags as request fields, plus snake_case credential aliases and a gibberish field), captures the actual error body, and classifies each result.


The probe script is not part of this PR. The results below are the empirical input that determined the shipping token list.

### Empirical results (per provider, all 9 LangChain-shape payloads sent)

**OpenAI**  every malformed payload returned identical canonical phrasing:

```
{"error": {"message": "Unrecognized request argument supplied: <field>",
           "type": "invalid_request_error", "param": null, "code": null}}
```

Status 400. 9/9 cases identical.

**NIM** (NVIDIA Integrate API):

```
{"error": {"message": "Validation: Unsupported parameter(s): `<field>`",
           "type": "Bad Request", "code": 400}}
```

Status 400. 9/9 cases identical.

**Groq:**

```
{"error": {"message": "property '<field>' is unsupported",
           "type": "invalid_request_error"}}
```

Status 400. 9/9 cases identical.

**Fireworks** (`accounts/fireworks/models/llama-v3p3-70b-instruct`):

```
{"error": {"object": "error", "type": "invalid_request_error",
           "code": "invalid_request_error",
           "message": "Extra inputs are not permitted, field: '<field>', value: <value>"}}
```

Status 400. 9/9 cases identical. The phrase is pydantic v2's literal default validation error; any FastAPI/pydantic-v2-backed proxy is likely to share it.




**OpenRouter:** all 9 payloads returned status 200 with the unknown field silently dropped and the request forwarded to the upstream model. No validation rejection emitted. Permissive-proxy behavior. Boot-time shape detector covers LangChain-specific cases regardless.

**Together AI:** same permissive-proxy behavior: payloads that completed returned status 200; remainder rate-limited (Together's 1 QPS account limit; the probe fires sequentially without throttling). No validation phrase to match.

**Ollama** (self-hosted, `localhost:11434/v1`, latest version, CPU-only): all 9 payloads returned status 200 with the unknown field silently dropped and the completion produced normally. Same permissive-proxy pattern as OpenRouter and Together AI. **The boot-time shape detector is the only safety net for Ollama users with stale LangChain configs** since the wire emits no signal.

### Final token list

```python
_UNKNOWN_PARAM_HINT_TOKENS = (
    "unrecognized request argument",       # OpenAI
    "unsupported parameter",               # NIM
    "' is unsupported",                    # Groq (apostrophe-space anchored)
    "extra inputs are not permitted",      # Fireworks (pydantic v2)
)
```

Same set added to `_UNSUPPORTED_PARAMS_KEYWORDS` so all four classify consistently as `LLMUnsupportedParamsError` (matches the existing handling for `unsupported parameter`/`unknown parameter`).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration validation now occurs during initialization to identify incompatibilities earlier, preventing unexpected runtime failures.
  * Error messages now include specific guidance when configuration parameters are invalid or unsupported.

* **Tests**
  * Added comprehensive test coverage for the new validation and error messaging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->