### PR TITLE
feat(iorails): Support non-streaming reasoning-model responses

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -287,13 +287,14 @@ class IORails:
             llm_kwargs = options.llm_params
 
         response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        # Log raw content before reasoning extraction and think-token removal
+        log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
 
         # Reasoning extraction prefers LLMResponse `reasoning` field if the provider
         # supports it, falling back to extracting <think>...</think> tags otherwise.
         # The fallback mutates response.content to remove reasoning content.
         reasoning_content = response.reasoning or _extract_and_remove_think_tags(response)
         response_text = response.content
-        log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
 
         # Step 3: Check output rails
         log.info("[%s] Running output rails", req_id)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -28,6 +28,7 @@ from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import nullcontext, suppress
 from typing import Optional, Union
 
+from nemoguardrails.actions.llm.utils import _extract_and_remove_think_tags
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
@@ -285,8 +286,13 @@ class IORails:
         if isinstance(options, GenerationOptions) and options.llm_params:
             llm_kwargs = options.llm_params
 
-        # Extract content string from structured LLMResponse.
-        response_text = (await self.engine_registry.model_call("main", messages, **llm_kwargs)).content
+        response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+
+        # Reasoning extraction prefers LLMResponse `reasoning` field if the provider
+        # supports it, falling back to extracting <think>...</think> tags otherwise.
+        # The fallback mutates response.content to remove reasoning content.
+        reasoning_content = response.reasoning or _extract_and_remove_think_tags(response)
+        response_text = response.content
         log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
 
         # Step 3: Check output rails
@@ -297,6 +303,11 @@ class IORails:
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.OUTPUT)
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+        # TODO: Support returning GenerationResponse `reasoning_content` to match LLMRails
+        # For now, embed the reasoning on the content with think-tags
+        if reasoning_content:
+            response_text = f"<think>{reasoning_content}</think>\n" + response_text
 
         return {"role": "assistant", "content": response_text}
 

--- a/tests/guardrails/async_helpers.py
+++ b/tests/guardrails/async_helpers.py
@@ -22,9 +22,36 @@ tests that need to observe state transitions mid-flight.
 """
 
 import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+from unittest.mock import patch
 
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+
+
+@asynccontextmanager
+async def started_iorails(config_dict: dict) -> AsyncIterator[IORails]:
+    """Build, start, yield, then stop an IORails instance for tests.
+
+    Centralises the ``async with iorails`` lifecycle pattern duplicated across
+    ``test_iorails_streaming.py``, ``test_iorails_telemetry.py``, and
+    ``test_iorails_reasoning.py``.  Each fixture becomes a one-liner::
+
+        @pytest_asyncio.fixture
+        async def iorails():
+            async with started_iorails(NEMOGUARDS_CONFIG) as iorails:
+                yield iorails
+
+    The ``NVIDIA_API_KEY`` env patch covers config loading; the ``async with``
+    on the IORails instance starts the worker queue and stops it on teardown
+    so no asyncio tasks leak past the test's event loop.
+    """
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        iorails = IORails(RailsConfig.from_content(config=config_dict))
+    async with iorails:
+        yield iorails
 
 
 async def wait_for_queue_state(

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reasoning-model support for IORails (non-streaming).
+
+Mirrors LLMRails behavior (``actions/llm/utils.py:_store_reasoning_traces``
+and ``rails/llm/llmrails.py:1173-1175``):
+- Prefer the provider-native ``LLMResponse.reasoning`` field.
+- Fall back to inline ``<think>...</think>`` tags in content (the helper
+  strips the tags from ``response.content`` in place so output rails never
+  see reasoning).
+- Surface reasoning to the caller via a ``<think>{reasoning}</think>\\n``
+  prefix on the returned content (LLMRails legacy delivery shape).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def rails_config():
+    return RailsConfig.from_content(config=NEMOGUARDS_CONFIG)
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails(rails_config):
+    return IORails(rails_config)
+
+
+def _stub_safe_rails(iorails: IORails) -> None:
+    """Default-safe input + output rails so each test focuses on the LLM call."""
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+class TestReasoningContent:
+    """Reasoning extraction + delivery on the non-streaming path."""
+
+    @pytest.mark.asyncio
+    async def test_native_reasoning_field_prefixes_content(self, iorails):
+        """``response.reasoning`` is wrapped in <think> tags and prefixed to content."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Hello", reasoning="thinking step")
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
+        # Output rails see the original content unchanged when reasoning came from
+        # the native field (no <think> tags to strip).
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello")
+
+    @pytest.mark.asyncio
+    async def test_inline_think_tags_extracted_and_stripped(self, iorails):
+        """<think>...</think> in content is extracted, stripped before output rails, and re-prefixed on return."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="<think>thinking step</think>Hello")
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
+        # Output rails MUST receive content with <think> tags stripped — this is
+        # the central guarantee that reasoning bypasses output rails.
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello")
+
+    @pytest.mark.asyncio
+    async def test_native_reasoning_wins_over_inline_tags(self, iorails):
+        """When both are present, ``response.reasoning`` is used and inline tags are NOT stripped.
+
+        Mirrors the LLMRails ``_store_reasoning_traces`` order (utils.py:339-342):
+        the inline-tag fallback is only consulted if the native field is empty.
+        Inline tags remain in content verbatim — output rails see them unstripped.
+        """
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(
+                content="<think>tag reasoning</think>Hello",
+                reasoning="native reasoning",
+            )
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {
+            "role": "assistant",
+            "content": "<think>native reasoning</think>\n<think>tag reasoning</think>Hello",
+        }
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "<think>tag reasoning</think>Hello")
+
+    @pytest.mark.asyncio
+    async def test_malformed_think_tag_opener_only(self, iorails):
+        """Opening tag without closing → no extraction, content preserved verbatim."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="<think>incomplete reasoning"))
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "<think>incomplete reasoning"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "<think>incomplete reasoning")
+
+    @pytest.mark.asyncio
+    async def test_malformed_think_tag_closer_only(self, iorails):
+        """Closing tag without opening → no extraction, content preserved verbatim."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="orphan</think> reply"))
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "orphan</think> reply"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "orphan</think> reply")
+
+    @pytest.mark.asyncio
+    async def test_output_rail_block_with_native_reasoning(self, iorails):
+        """When output rails block, reasoning is dropped — refusal carries no <think> prefix."""
+        messages = [{"role": "user", "content": "hi"}]
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="bad answer", reasoning="reasoning step")
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_output_rail_block_with_inline_tags(self, iorails):
+        """Block path strips inline <think> tags from output-rail input even though the rail blocks."""
+        messages = [{"role": "user", "content": "hi"}]
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="<think>thinking</think>bad answer")
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        # Output rails see only the stripped content — they're judging the model
+        # output, not the reasoning trace.
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "bad answer")
+
+    @pytest.mark.asyncio
+    async def test_empty_string_reasoning_falls_through_to_inline_extraction(self, iorails):
+        """``response.reasoning = ''`` is falsy → fallback to inline-tag extraction runs."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="<think>fallback reasoning</think>Hi", reasoning="")
+        )
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "<think>fallback reasoning</think>\nHi"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hi")
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_returns_unchanged_content(self, iorails):
+        """Baseline: no ``response.reasoning`` and no inline tags → content unmodified, no prefix."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="plain answer"))
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "plain answer"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "plain answer")

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -25,27 +25,23 @@ and ``rails/llm/llmrails.py:1173-1175``):
   prefix on the returned content (LLMRails legacy delivery shape).
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
+import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
-from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.types import LLMResponse
+from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
-@pytest.fixture
-@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
-def rails_config():
-    return RailsConfig.from_content(config=NEMOGUARDS_CONFIG)
-
-
-@pytest.fixture
-@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
-def iorails(rails_config):
-    return IORails(rails_config)
+@pytest_asyncio.fixture
+async def iorails():
+    """Started IORails instance with worker-queue teardown after each test."""
+    async with started_iorails(NEMOGUARDS_CONFIG) as iorails:
+        yield iorails
 
 
 def _stub_safe_rails(iorails: IORails) -> None:


### PR DESCRIPTION
## Description

1. #1827 : Moves to returning a structured LLMResponse object for non-streaming and LLMResponseChunk object from streaming ModelEngine calls. This is important because we want to include reasoning traces in a separate field of the object and not just return the final content. (Merged)
2. #1842 **[This PR]** : Connect reasoning field to output rails back to the generate_async() call stack. This adds reasoning-awareness for non-streaming calls.
3. Connect reasoning field back through stream_async(). This adds reasoning awareness for streaming calls.
4. Telemetry and observability

## Related Issue(s)

#1827: Added LLMResponse(Chunk) from ModelEngine to provide reasoning content separately from messages for providers that support it.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s...................... [  3%]
........................................................................................................................................... [  6%]
........................................................................................................................................... [ 10%]
........................................................................................................................................... [ 13%]
........................................................................................................................................... [ 17%]
........................................................................................................................................... [ 20%]
...........................................................................s......ss...................sssssss............................. [ 23%]
..................................................................................................s.......s................................ [ 27%]
........................................................................................................................................... [ 30%]
...........................................................................................................s............................... [ 34%]
........................................................................................................................................... [ 37%]
.............................................................................................................ssssssss......ssssss..ss.s.... [ 40%]
.........ssssssss.......................................................................................................................... [ 44%]
..............................................................ss...........................s...............s.......sssss................... [ 47%]
..............................s..........................................ss........ss...ss............................................s.... [ 51%]
.................................................s............s............................................................................ [ 54%]
........................................................................................................................................... [ 58%]
..........................................................................................................sssss......ssssssssssssssssss.... [ 61%]
......sssss....................................................................................s...........ss.............................. [ 64%]
.....sssssssss.ssssssssss.......................................s...................................................s....s................. [ 68%]
.......................................ssssssss..............sss...ss...ss.....sssssssssssss............................................... [ 71%]
.......................................................................................................s................................... [ 75%]
...........................................................................s....................ssssssss.........ss........................ [ 78%]
...........................................................................................................sssssss......................... [ 81%]
....................................s...................................................................................................... [ 85%]
........................................................................................................................................... [ 88%]
........................................................................................................................................... [ 92%]
........................................................s.................................................................................. [ 95%]
........................................................................................................................................... [ 99%]
.......................................                                                                                                     [100%]
3906 passed, 164 skipped in 139.38s (0:02:19)
```

### Integration test with chat
```
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-30 10:46:02 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-30 10:46:02 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-30 10:46:02 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-30 10:46:02 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-30 10:46:02 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-04-30 10:46:14 INFO: [e7f0a7c18831e1df] generate_async called
2026-04-30 10:46:14 INFO: [e7f0a7c18831e1df] Running input rails
2026-04-30 10:46:14 INFO: [e7f0a7c18831e1df] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 10:46:15 INFO: [e7f0a7c18831e1df] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-30 10:46:16 INFO: [e7f0a7c18831e1df] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-30 10:46:16 INFO: [e7f0a7c18831e1df] Calling main LLM
2026-04-30 10:46:16 INFO: [e7f0a7c18831e1df] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-30 10:46:23 INFO: [e7f0a7c18831e1df] Running output rails
2026-04-30 10:46:23 INFO: [e7f0a7c18831e1df] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 10:46:23 INFO: [e7f0a7c18831e1df] generate_async completed time=9339.1ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I blow up a car?
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] generate_async called
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] Running input rails
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] Input flow content safety check input $model=content_safety blocked
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] Input blocked: Safety categories: Guns and Illegal Weapons, Criminal Planning/Confessions
2026-04-30 10:46:29 INFO: [b31347c3eebe10cc] generate_async completed time=772.4ms
I'm sorry, I can't respond to that.
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LLM response handling to capture complete structured outputs from language models.
  * Improved preservation of reasoning content from both native reasoning fields and inline formatting.
  * Reasoning information is now seamlessly integrated into final responses for better transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->