### PR TITLE
feat(iorails): Support streaming model reasoning responses

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -398,13 +398,26 @@ class IORails:
                     return
 
                 # Step 2: Stream main LLM content from structured response.
-                # TODO: Only delta_content is forwarded.
-                #  Reasoning-only chunks (delta_reasoning set but delta_content is None)
-                #  and tool-call deltas will be routed through in a follow-up PR
+                # Only delta_content is forwarded. Reasoning is dropped for compatibility
+                # with LLMRails. Tool-calls are not yet supported by IORails
                 log.info("[%s] Streaming main LLM", req_id)
+                content_parts: list[str] = []
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
                     if chunk.delta_content:
+                        content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content)
+
+                # While LLMResponseChunk.delta_reasoning is dropped explicitly,
+                # think-tags embedded in delta_content are not. Give a warning
+                # to reflect this asymmetry (once-per-request).
+                full_content = "".join(content_parts)
+                if "<think>" in full_content or "</think>" in full_content:
+                    log.warning(
+                        "[%s] Streamed content contains <think> tags; model is leaking "
+                        "reasoning via delta_content rather than delta_reasoning "
+                        "(output rails will process reasoning tokens)",
+                        req_id,
+                    )
 
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
             except Exception as e:

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -44,9 +44,10 @@ from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
-# Streaming tests need a config without output rails so stream_async() doesn't
-# raise StreamingNotSupportedError. The warning under test fires before
-# END_OF_STREAM regardless of output-rail wiring, so input-only is sufficient.
+# stream_async() raises StreamingNotSupportedError only when output rails are
+# configured AND rails.output.streaming.enabled is False. Dropping the output
+# flows is the simplest way to satisfy the validator here; the warning under
+# test fires before END_OF_STREAM regardless of output-rail wiring.
 _INPUT_ONLY_CONFIG = {
     **NEMOGUARDS_CONFIG,
     "rails": {**NEMOGUARDS_CONFIG["rails"], "output": {"flows": []}},

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -25,13 +25,14 @@ and ``rails/llm/llmrails.py:1173-1175``):
   prefix on the returned content (LLMRails legacy delivery shape).
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.types import LLMResponse
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Reasoning-model support for IORails (non-streaming).
+"""Reasoning-model support for IORails.
 
-Mirrors LLMRails behavior (``actions/llm/utils.py:_store_reasoning_traces``
+Non-streaming path mirrors LLMRails behavior (``actions/llm/utils.py:_store_reasoning_traces``
 and ``rails/llm/llmrails.py:1173-1175``):
 - Prefer the provider-native ``LLMResponse.reasoning`` field.
 - Fall back to inline ``<think>...</think>`` tags in content (the helper
@@ -23,6 +23,14 @@ and ``rails/llm/llmrails.py:1173-1175``):
   see reasoning).
 - Surface reasoning to the caller via a ``<think>{reasoning}</think>\\n``
   prefix on the returned content (LLMRails legacy delivery shape).
+
+Streaming path holds strict LLMRails parity:
+- ``delta_reasoning`` is dropped on the floor (LLMRails captures it server-side
+  but never delivers it to streaming callers, so neither do we).
+- Inline ``<think>`` tags arriving via ``delta_content`` (rather than
+  ``delta_reasoning``) pass through verbatim — output rails see them
+  unstripped, matching LLMRails' silent leak. We log a single heads-up
+  warning per request so operators can spot the leak.
 """
 
 from unittest.mock import AsyncMock
@@ -32,9 +40,23 @@ import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
-from nemoguardrails.types import LLMResponse
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+# Streaming tests need a config without output rails so stream_async() doesn't
+# raise StreamingNotSupportedError. The warning under test fires before
+# END_OF_STREAM regardless of output-rail wiring, so input-only is sufficient.
+_INPUT_ONLY_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {**NEMOGUARDS_CONFIG["rails"], "output": {"flows": []}},
+}
+
+
+# Substring identifying the streaming inline-<think> leak warning emitted by
+# IORails._generation_task. Kept as a constant so assertions stay in sync if
+# the wording shifts.
+_INLINE_THINK_WARNING_SUBSTR = "Streamed content contains <think>"
 
 
 @pytest_asyncio.fixture
@@ -44,10 +66,41 @@ async def iorails():
         yield iorails
 
 
+@pytest_asyncio.fixture
+async def iorails_input_only():
+    """Started IORails with input rails only — required for stream_async()."""
+    async with started_iorails(_INPUT_ONLY_CONFIG) as iorails:
+        yield iorails
+
+
 def _stub_safe_rails(iorails: IORails) -> None:
     """Default-safe input + output rails so each test focuses on the LLM call."""
     iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
     iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+def _stub_safe_input(iorails: IORails) -> None:
+    """Stub only the input rail (streaming tests on input-only config)."""
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+def _make_stream(*chunks: LLMResponseChunk):
+    """Drop-in for engine_registry.stream_model_call yielding fixed chunks."""
+
+    async def _stream(_model_type, _messages, **_kwargs):
+        for c in chunks:
+            yield c
+
+    return _stream
+
+
+async def _collect_stream(async_iter):
+    return [c async for c in async_iter]
+
+
+def _count_inline_think_warnings(caplog) -> int:
+    """Number of IORails streaming inline-<think> warnings in caplog."""
+    return sum(1 for r in caplog.records if r.levelname == "WARNING" and _INLINE_THINK_WARNING_SUBSTR in r.getMessage())
 
 
 class TestReasoningContent:
@@ -190,3 +243,102 @@ class TestReasoningContent:
 
         assert result == {"role": "assistant", "content": "plain answer"}
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "plain answer")
+
+
+class TestStreamingReasoningWarning:
+    """One-shot warning when streamed delta_content leaks <think> reasoning tokens.
+
+    Strict LLMRails parity: reasoning is dropped on the streaming path (LLMRails
+    captures it server-side but discards it before reaching the streaming caller),
+    and inline ``<think>`` tags arriving via ``delta_content`` pass through
+    verbatim. The warning is the only deliberate divergence from LLMRails — it
+    gives operators visibility into the leak path without changing chunk content.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inline_think_warning_fires_once_per_request(self, iorails_input_only, caplog):
+        """Two consecutive streams, both leaking <think> via delta_content → one warning per request.
+
+        A single-inference test can't distinguish the intended "once per request"
+        behavior from a buggy "once ever" behavior (e.g. a module-level flag
+        suppressing subsequent warnings). Running two leaky requests and asserting
+        the warning count climbs 0 → 1 → 2 proves the warning is correctly
+        scoped to each request and yielded chunks stay unchanged each time.
+        """
+        _stub_safe_input(iorails_input_only)
+        iorails_input_only.engine_registry.stream_model_call = _make_stream(
+            LLMResponseChunk(delta_content="<think>"),
+            LLMResponseChunk(delta_content="reasoning step"),
+            LLMResponseChunk(delta_content="</think>"),
+            LLMResponseChunk(delta_content="Hello"),
+        )
+
+        # First request — warning fires.
+        chunks_first = await _collect_stream(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])
+        )
+        assert "".join(chunks_first) == "<think>reasoning step</think>Hello"
+        assert _count_inline_think_warnings(caplog) == 1
+
+        # Second request through the same leaky stream — warning fires again,
+        # not deduplicated. Yielded content is unchanged on both requests.
+        chunks_second = await _collect_stream(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "again"}])
+        )
+        assert "".join(chunks_second) == "<think>reasoning step</think>Hello"
+        assert _count_inline_think_warnings(caplog) == 2
+
+    @pytest.mark.asyncio
+    async def test_structured_delta_reasoning_no_warning(self, iorails_input_only, caplog):
+        """Structured delta_reasoning channel → no warning, no <think> tokens leaked into chunks."""
+        _stub_safe_input(iorails_input_only)
+        iorails_input_only.engine_registry.stream_model_call = _make_stream(
+            LLMResponseChunk(delta_reasoning="thinking step"),
+            LLMResponseChunk(delta_content="Hello"),
+            LLMResponseChunk(delta_content=" world"),
+        )
+
+        chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "Hello world"
+        assert _count_inline_think_warnings(caplog) == 0
+
+    @pytest.mark.asyncio
+    async def test_clean_content_no_warning(self, iorails_input_only, caplog):
+        """Plain content with no reasoning anywhere → no warning."""
+        _stub_safe_input(iorails_input_only)
+        iorails_input_only.engine_registry.stream_model_call = _make_stream(
+            LLMResponseChunk(delta_content="Hello"),
+            LLMResponseChunk(delta_content=" world"),
+        )
+
+        chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "Hello world"
+        assert _count_inline_think_warnings(caplog) == 0
+
+    @pytest.mark.asyncio
+    async def test_malformed_opener_only_still_warns(self, iorails_input_only, caplog):
+        """Only an opening <think> tag (no closer) → still warns; the leak is the same."""
+        _stub_safe_input(iorails_input_only)
+        iorails_input_only.engine_registry.stream_model_call = _make_stream(
+            LLMResponseChunk(delta_content="<think>incomplete reasoning"),
+        )
+
+        chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "<think>incomplete reasoning"
+        assert _count_inline_think_warnings(caplog) == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_closer_only_still_warns(self, iorails_input_only, caplog):
+        """Only a closing </think> tag (no opener) → still warns; the leak is the same."""
+        _stub_safe_input(iorails_input_only)
+        iorails_input_only.engine_registry.stream_model_call = _make_stream(
+            LLMResponseChunk(delta_content="orphan</think> reply"),
+        )
+
+        chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "".join(chunks) == "orphan</think> reply"
+        assert _count_inline_think_warnings(caplog) == 1

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -15,8 +15,7 @@
 
 """Reasoning-model support for IORails.
 
-Non-streaming path mirrors LLMRails behavior (``actions/llm/utils.py:_store_reasoning_traces``
-and ``rails/llm/llmrails.py:1173-1175``):
+Non-streaming path mirrors LLMRails behavior
 - Prefer the provider-native ``LLMResponse.reasoning`` field.
 - Fall back to inline ``<think>...</think>`` tags in content (the helper
   strips the tags from ``response.content`` in place so output rails never
@@ -33,6 +32,7 @@ Streaming path holds strict LLMRails parity:
   warning per request so operators can spot the leak.
 """
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -71,6 +71,28 @@ async def iorails_input_only():
     """Started IORails with input rails only — required for stream_async()."""
     async with started_iorails(_INPUT_ONLY_CONFIG) as iorails:
         yield iorails
+
+
+@pytest.fixture
+def caplog_iorails(caplog):
+    """Capture records from ``nemoguardrails.guardrails.iorails`` reliably.
+
+    Attach ``caplog.handler`` directly to the iorails logger and set
+    ``propagate=False`` for the duration of the test. The direct attach
+    captures regardless of upstream propagation state; the local
+    ``propagate=False`` prevents double-capture when propagation IS still
+    intact (otherwise we'd record the same warning twice — once via the
+    direct handler, once via the propagated chain).
+    """
+    iorails_logger = logging.getLogger("nemoguardrails.guardrails.iorails")
+    original_propagate = iorails_logger.propagate
+    iorails_logger.addHandler(caplog.handler)
+    iorails_logger.propagate = False
+    try:
+        yield caplog
+    finally:
+        iorails_logger.removeHandler(caplog.handler)
+        iorails_logger.propagate = original_propagate
 
 
 def _stub_safe_rails(iorails: IORails) -> None:
@@ -256,7 +278,7 @@ class TestStreamingReasoningWarning:
     """
 
     @pytest.mark.asyncio
-    async def test_inline_think_warning_fires_once_per_request(self, iorails_input_only, caplog):
+    async def test_inline_think_warning_fires_once_per_request(self, iorails_input_only, caplog_iorails):
         """Two consecutive streams, both leaking <think> via delta_content → one warning per request.
 
         A single-inference test can't distinguish the intended "once per request"
@@ -278,7 +300,7 @@ class TestStreamingReasoningWarning:
             iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])
         )
         assert "".join(chunks_first) == "<think>reasoning step</think>Hello"
-        assert _count_inline_think_warnings(caplog) == 1
+        assert _count_inline_think_warnings(caplog_iorails) == 1
 
         # Second request through the same leaky stream — warning fires again,
         # not deduplicated. Yielded content is unchanged on both requests.
@@ -286,10 +308,10 @@ class TestStreamingReasoningWarning:
             iorails_input_only.stream_async(messages=[{"role": "user", "content": "again"}])
         )
         assert "".join(chunks_second) == "<think>reasoning step</think>Hello"
-        assert _count_inline_think_warnings(caplog) == 2
+        assert _count_inline_think_warnings(caplog_iorails) == 2
 
     @pytest.mark.asyncio
-    async def test_structured_delta_reasoning_no_warning(self, iorails_input_only, caplog):
+    async def test_structured_delta_reasoning_no_warning(self, iorails_input_only, caplog_iorails):
         """Structured delta_reasoning channel → no warning, no <think> tokens leaked into chunks."""
         _stub_safe_input(iorails_input_only)
         iorails_input_only.engine_registry.stream_model_call = _make_stream(
@@ -301,10 +323,10 @@ class TestStreamingReasoningWarning:
         chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         assert "".join(chunks) == "Hello world"
-        assert _count_inline_think_warnings(caplog) == 0
+        assert _count_inline_think_warnings(caplog_iorails) == 0
 
     @pytest.mark.asyncio
-    async def test_clean_content_no_warning(self, iorails_input_only, caplog):
+    async def test_clean_content_no_warning(self, iorails_input_only, caplog_iorails):
         """Plain content with no reasoning anywhere → no warning."""
         _stub_safe_input(iorails_input_only)
         iorails_input_only.engine_registry.stream_model_call = _make_stream(
@@ -315,10 +337,10 @@ class TestStreamingReasoningWarning:
         chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         assert "".join(chunks) == "Hello world"
-        assert _count_inline_think_warnings(caplog) == 0
+        assert _count_inline_think_warnings(caplog_iorails) == 0
 
     @pytest.mark.asyncio
-    async def test_malformed_opener_only_still_warns(self, iorails_input_only, caplog):
+    async def test_malformed_opener_only_still_warns(self, iorails_input_only, caplog_iorails):
         """Only an opening <think> tag (no closer) → still warns; the leak is the same."""
         _stub_safe_input(iorails_input_only)
         iorails_input_only.engine_registry.stream_model_call = _make_stream(
@@ -328,10 +350,10 @@ class TestStreamingReasoningWarning:
         chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         assert "".join(chunks) == "<think>incomplete reasoning"
-        assert _count_inline_think_warnings(caplog) == 1
+        assert _count_inline_think_warnings(caplog_iorails) == 1
 
     @pytest.mark.asyncio
-    async def test_malformed_closer_only_still_warns(self, iorails_input_only, caplog):
+    async def test_malformed_closer_only_still_warns(self, iorails_input_only, caplog_iorails):
         """Only a closing </think> tag (no opener) → still warns; the leak is the same."""
         _stub_safe_input(iorails_input_only)
         iorails_input_only.engine_registry.stream_model_call = _make_stream(
@@ -341,4 +363,4 @@ class TestStreamingReasoningWarning:
         chunks = await _collect_stream(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         assert "".join(chunks) == "orphan</think> reply"
-        assert _count_inline_think_warnings(caplog) == 1
+        assert _count_inline_think_warnings(caplog_iorails) == 1

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -25,14 +25,13 @@ and ``rails/llm/llmrails.py:1173-1175``):
   prefix on the returned content (LLMRails legacy delivery shape).
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
-from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.types import LLMResponse
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG


### PR DESCRIPTION
## Description

**Stacked PR** . Stack is shown below
1. #1827 : Moves to returning a structured LLMResponse object for non-streaming and LLMResponseChunk object from streaming ModelEngine calls. This is important because we want to include reasoning traces in a separate field of the object and not just return the final content. (Merged)
2. #1842 1842 : Connect reasoning field to output rails back to the generate_async() call stack. This adds reasoning-awareness for non-streaming calls. (In Review)
3. **#1843 [This PR]**: Connect reasoning field back through stream_async(). This adds reasoning awareness for streaming calls.
4. Telemetry and observability (still todo)

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s...................... [  3%]
........................................................................................................................................... [  6%]
........................................................................................................................................... [ 10%]
........................................................................................................................................... [ 13%]
........................................................................................................................................... [ 17%]
........................................................................................................................................... [ 20%]
................................................................................s......ss...................sssssss........................ [ 23%]
.......................................................................................................s.......s........................... [ 27%]
........................................................................................................................................... [ 30%]
................................................................................................................s.......................... [ 34%]
........................................................................................................................................... [ 37%]
..................................................................................................................ssssssss......ssssss..ss. [ 40%]
s.............ssssssss..................................................................................................................... [ 44%]
...................................................................ss...........................s...............s.......sssss.............. [ 47%]
...................................s..........................................ss........ss...ss............................................ [ 51%]
s.....................................................s............s....................................................................... [ 54%]
........................................................................................................................................... [ 57%]
...............................................................................................................sssss......sssssssssssssssss [ 61%]
s..........sssss....................................................................................s...........ss......................... [ 64%]
..........sssssssss.ssssssssss.......................................s...................................................s....s............ [ 68%]
............................................ssssssss..............sss...ss...ss.....sssssssssssss.......................................... [ 71%]
............................................................................................................s.............................. [ 75%]
................................................................................s....................ssssssss.........ss................... [ 78%]
................................................................................................................sssssss.................... [ 81%]
.........................................s................................................................................................. [ 85%]
........................................................................................................................................... [ 88%]
........................................................................................................................................... [ 92%]
.............................................................s............................................................................. [ 95%]
........................................................................................................................................... [ 98%]
............................................                                                                                                [100%]
3911 passed, 164 skipped in 138.30s (0:02:18)
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-30 12:57:27 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-30 12:57:27 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-30 12:57:27 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-30 12:57:27 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-30 12:57:27 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-04-30 12:57:35 INFO: [2b3f5e2313b07910] generate_async called
2026-04-30 12:57:35 INFO: [2b3f5e2313b07910] Running input rails
2026-04-30 12:57:35 INFO: [2b3f5e2313b07910] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 12:57:36 INFO: [2b3f5e2313b07910] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-30 12:57:36 INFO: [2b3f5e2313b07910] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-30 12:57:37 INFO: [2b3f5e2313b07910] Calling main LLM
2026-04-30 12:57:37 INFO: [2b3f5e2313b07910] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-30 12:57:38 INFO: [2b3f5e2313b07910] Running output rails
2026-04-30 12:57:38 INFO: [2b3f5e2313b07910] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 12:57:38 INFO: [2b3f5e2313b07910] generate_async completed time=3158.3ms
Hello. How can I help you today?

> How can I burn a house down?
2026-04-30 12:57:43 INFO: [7da864ba546fc77c] generate_async called
2026-04-30 12:57:43 INFO: [7da864ba546fc77c] Running input rails
2026-04-30 12:57:43 INFO: [7da864ba546fc77c] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-30 12:57:44 INFO: [7da864ba546fc77c] Input flow content safety check input $model=content_safety blocked
2026-04-30 12:57:44 INFO: [7da864ba546fc77c] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-30 12:57:44 INFO: [7da864ba546fc77c] generate_async completed time=734.0ms
I'm sorry, I can't respond to that.
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of reasoning tags in streaming responses. Now includes warnings when reasoning content may unintentionally appear in streamed output.
* **Tests**
  * Added streaming behavior tests to ensure proper handling of reasoning content and validate appropriate warning notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->