### PR TITLE
fix(iorails): Route to LLMRails if Guardrails inits with provided LLM

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -64,7 +64,7 @@ class Guardrails:
             configure_logging(logging.INFO)
 
         # Whether to use IORailsEngine for inference requests
-        use_iorails_engine = use_iorails and self._has_only_iorails_flows()
+        use_iorails_engine = use_iorails and not llm and self._has_only_iorails_flows()
         self._rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
 
         # Track whether startup() has been called (supports lazy initialization)

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -64,7 +64,7 @@ class Guardrails:
             configure_logging(logging.INFO)
 
         # Whether to use IORailsEngine for inference requests
-        use_iorails_engine = use_iorails and not llm and self._has_only_iorails_flows()
+        use_iorails_engine = use_iorails and llm is None and self._has_only_iorails_flows()
         self._rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
 
         # Track whether startup() has been called (supports lazy initialization)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -266,6 +266,35 @@ class TestGuardrailsInit:
         assert guardrails.verbose is True
         assert guardrails.rails_engine == mock_llmrails_instance
 
+    @patch.object(IORails, "__init__", return_value=None)
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_init_with_llm_forces_llmrails(
+        self, mock_llmrails_class, mock_iorails_init, _content_safety_rails_config, mock_llm
+    ):
+        """Passing `llm` forces LLMRails even with use_iorails=True and an IORails-compatible config."""
+        mock_llmrails_class.return_value = MagicMock()
+        Guardrails(config=_content_safety_rails_config, llm=mock_llm, use_iorails=True)
+        mock_llmrails_class.assert_called_once_with(_content_safety_rails_config, mock_llm, False)
+        mock_iorails_init.assert_not_called()
+
+    @patch.object(IORails, "__init__", return_value=None)
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_init_with_llm_use_iorails_false_uses_llmrails(
+        self, mock_llmrails_class, mock_iorails_init, _content_safety_rails_config, mock_llm
+    ):
+        """Passing `llm` with use_iorails=False routes to LLMRails even on an IORails-compatible config."""
+        mock_llmrails_class.return_value = MagicMock()
+        Guardrails(config=_content_safety_rails_config, llm=mock_llm, use_iorails=False)
+        mock_llmrails_class.assert_called_once_with(_content_safety_rails_config, mock_llm, False)
+        mock_iorails_init.assert_not_called()
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_init_without_llm_uses_iorails(self, mock_iorails_init, _content_safety_rails_config):
+        """Omitting `llm` (the default) selects IORails on an IORails-compatible config."""
+        guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+        mock_iorails_init.assert_called_once_with(_content_safety_rails_config)
+
 
 class TestConvertToMessages:
     """Tests for the _convert_to_messages static method."""


### PR DESCRIPTION
## Description

Users passing an initialized `llm` to the Guardrails constructor would end up instantiating IORails which doesn't support pre-initialized references to LLMs being passed in, only RailsConfig objects. This PR ensures if a user ever passes in an `llm` they'll get LLMRails rather than IORails which **does** support pre-initialized LLMs.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s...................... [  3%]
........................................................................................................................................... [  6%]
........................................................................................................................................... [ 10%]
........................................................................................................................................... [ 13%]
........................................................................................................................................... [ 17%]
........................................................................................................................................... [ 20%]
.....................................................................s......ss...................sssssss................................... [ 23%]
............................................................................................s.......s...................................... [ 27%]
........................................................................................................................................... [ 30%]
.....................................................................................................s..................................... [ 34%]
........................................................................................................................................... [ 37%]
.......................................................................................................ssssssss......ssssss..ss.s.......... [ 41%]
...ssssssss................................................................................................................................ [ 44%]
........................................................ss...........................s...............s.......sssss......................... [ 47%]
........................s..........................................ss........ss...ss............................................s.......... [ 51%]
...........................................s............s.................................................................................. [ 54%]
........................................................................................................................................... [ 58%]
....................................................................................................sssss......ssssssssssssssssss.......... [ 61%]
sssss....................................................................................s...........ss...................................s [ 64%]
ssssssss.ssssssssss.......................................s...................................................s....s....................... [ 68%]
.................................ssssssss..............sss...ss...ss.....sssssssssssss..................................................... [ 71%]
.................................................................................................s......................................... [ 75%]
.....................................................................s....................ssssssss.........ss.............................. [ 78%]
.....................................................................................................sssssss............................... [ 82%]
..............................s............................................................................................................ [ 85%]
........................................................................................................................................... [ 88%]
........................................................................................................................................... [ 92%]
..................................................s........................................................................................ [ 95%]
........................................................................................................................................... [ 99%]
.................................                                                                                                           [100%]
3900 passed, 164 skipped in 135.86s (0:02:15)
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed engine selection logic to ensure the correct engine is initialized when an LLM instance is provided.

* **Tests**
  * Added test cases validating engine initialization behavior across different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->