### PR TITLE
feat(cli): add server workers option

### DIFF
--- a/docs/reference/cli/index.mdx
+++ b/docs/reference/cli/index.mdx
@@ -92,6 +92,7 @@ nemoguardrails server --config examples/configs --port 8000
 | `--verbose` | Enable verbose mode with detailed logs including prompts. |
 | `--disable-chat-ui` | Disable the Chat UI served at the root path. |
 | `--auto-reload` | Enable auto reload when configuration files change. |
+| `--workers` | Number of Uvicorn worker processes. Default: `1`. |
 | `--prefix` | A prefix to add to all server paths. Must start with `/`. |
 
 ---

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -145,6 +145,11 @@ def server(
         help="Weather the ChatUI should be disabled",
     ),
     auto_reload: bool = typer.Option(default=False, help="Enable auto reload option."),
+    workers: int = typer.Option(
+        default=1,
+        min=1,
+        help="The number of Uvicorn worker processes to run.",
+    ),
     prefix: str = typer.Option(
         default="",
         help="A prefix that should be added to all server paths. Should start with '/'.",
@@ -209,7 +214,7 @@ def server(
     if default_config_id:
         api.set_default_config_id(default_config_id)  # Call function
 
-    uvicorn.run(server_app, port=port, log_level="info", host="0.0.0.0")
+    uvicorn.run(server_app, port=port, log_level="info", host="0.0.0.0", workers=workers)
 
 
 @app.command()

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -183,26 +183,29 @@ def server(
     if config:
         # We make sure there is no trailing separator, as that might break things in
         # single config mode.
-        setattr(
-            api.app,
-            "rails_config_path",
-            os.path.expanduser(config[0].rstrip(os.path.sep)),
-        )
+        rails_config_path = os.path.expanduser(config[0].rstrip(os.path.sep))
     else:
         # If we don't have a config, we try to see if there is a local config folder
         local_path = os.getcwd()
         local_configs_path = os.path.join(local_path, "config")
 
         if os.path.exists(local_configs_path):
-            setattr(api.app, "rails_config_path", local_configs_path)
+            rails_config_path = local_configs_path
+        else:
+            rails_config_path = api.app.rails_config_path
+
+    os.environ["NEMO_GUARDRAILS_CONFIG_PATH"] = rails_config_path
+    api.app.rails_config_path = rails_config_path
 
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
 
     if disable_chat_ui:
+        os.environ["NEMO_GUARDRAILS_DISABLE_CHAT_UI"] = "true"
         setattr(api.app, "disable_chat_ui", True)
 
     if auto_reload:
+        os.environ["NEMO_GUARDRAILS_AUTO_RELOAD"] = "true"
         setattr(api.app, "auto_reload", True)
 
     if prefix:
@@ -212,9 +215,26 @@ def server(
         server_app = api.app
 
     if default_config_id:
+        os.environ["NEMO_GUARDRAILS_DEFAULT_CONFIG_ID"] = default_config_id
         api.set_default_config_id(default_config_id)  # Call function
 
-    uvicorn.run(server_app, port=port, log_level="info", host="0.0.0.0", workers=workers)
+    if workers > 1:
+        if prefix:
+            typer.secho(
+                "The --prefix option is not supported with --workers > 1.",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(1)
+        uvicorn.run(
+            "nemoguardrails.server.api:create_app",
+            factory=True,
+            port=port,
+            log_level="info",
+            host="0.0.0.0",
+            workers=workers,
+        )
+    else:
+        uvicorn.run(server_app, port=port, log_level="info", host="0.0.0.0")
 
 
 @app.command()

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -194,10 +194,12 @@ def server(
         else:
             rails_config_path = api.app.rails_config_path
 
+    rails_config_path = os.fspath(rails_config_path)
     os.environ["NEMO_GUARDRAILS_CONFIG_PATH"] = rails_config_path
     api.app.rails_config_path = rails_config_path
 
     if verbose:
+        os.environ["NEMO_GUARDRAILS_VERBOSE"] = "true"
         logging.getLogger().setLevel(logging.INFO)
 
     if disable_chat_ui:

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -227,6 +227,12 @@ def server(
                 fg=typer.colors.RED,
             )
             raise typer.Exit(1)
+        if auto_reload:
+            typer.secho(
+                "The --auto-reload option is not supported with --workers > 1.",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(1)
         uvicorn.run(
             "nemoguardrails.server.api:create_app",
             factory=True,

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -58,6 +58,9 @@ except ImportError:
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
+if os.getenv("NEMO_GUARDRAILS_VERBOSE", "false").lower() == "true":
+    logging.getLogger().setLevel(logging.INFO)
+
 
 class GuardrailsApp(FastAPI):
     """Custom FastAPI subclass with additional attributes for Guardrails server."""

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -209,10 +209,10 @@ if ENABLE_CORS:
 app.default_config_id = None
 
 # By default, we use the rails in the examples folder
-app.rails_config_path = utils.get_examples_data_path("bots")
+app.rails_config_path = os.getenv("NEMO_GUARDRAILS_CONFIG_PATH", utils.get_examples_data_path("bots"))
 
 # auto reload flag
-app.auto_reload = False
+app.auto_reload = os.getenv("NEMO_GUARDRAILS_AUTO_RELOAD", "false").lower() == "true"
 
 # stop signal for observer
 app.stop_signal = False
@@ -220,6 +220,14 @@ app.stop_signal = False
 # Whether the server is pointed to a directory containing a single config.
 app.single_config_mode = False
 app.single_config_id = None
+
+if default_config_id := os.getenv("NEMO_GUARDRAILS_DEFAULT_CONFIG_ID"):
+    app.default_config_id = default_config_id
+
+
+def create_app() -> GuardrailsApp:
+    """Return the configured FastAPI app for Uvicorn worker imports."""
+    return app
 
 
 @app.get(

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 import os
+import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -214,26 +215,24 @@ class TestServerCommand:
         assert os.environ["NEMO_GUARDRAILS_VERBOSE"] == "true"
 
     def test_server_api_reads_worker_env_on_import(self):
-        from nemoguardrails.server import api
+        env = {
+            **os.environ,
+            "NEMO_GUARDRAILS_CONFIG_PATH": "/worker/config",
+            "NEMO_GUARDRAILS_DISABLE_CHAT_UI": "true",
+            "NEMO_GUARDRAILS_AUTO_RELOAD": "true",
+            "NEMO_GUARDRAILS_DEFAULT_CONFIG_ID": "worker_config",
+        }
+        script = """
+from nemoguardrails.server import api
 
-        with patch.dict(
-            os.environ,
-            {
-                "NEMO_GUARDRAILS_CONFIG_PATH": "/worker/config",
-                "NEMO_GUARDRAILS_DISABLE_CHAT_UI": "true",
-                "NEMO_GUARDRAILS_AUTO_RELOAD": "true",
-                "NEMO_GUARDRAILS_DEFAULT_CONFIG_ID": "worker_config",
-            },
-            clear=True,
-        ):
-            api = importlib.reload(api)
+assert api.app.rails_config_path == "/worker/config"
+assert api.app.disable_chat_ui is True
+assert api.app.auto_reload is True
+assert api.app.default_config_id == "worker_config"
+"""
 
-        assert api.app.rails_config_path == "/worker/config"
-        assert api.app.disable_chat_ui is True
-        assert api.app.auto_reload is True
-        assert api.app.default_config_id == "worker_config"
-
-        importlib.reload(api)
+        result = subprocess.run([sys.executable, "-c", script], env=env)
+        assert result.returncode == 0
 
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -209,7 +209,11 @@ class TestServerCommand:
     @patch.dict(os.environ, {}, clear=True)
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")
-    def test_server_with_verbose_sets_worker_env(self, mock_app, mock_uvicorn):
+    @patch("os.path.exists")
+    @patch("os.getcwd")
+    def test_server_with_verbose_sets_worker_env(self, mock_getcwd, mock_exists, mock_app, mock_uvicorn):
+        mock_getcwd.return_value = "/current/dir"
+        mock_exists.return_value = True
         result = runner.invoke(app, ["server", "--verbose"])
         assert result.exit_code == 0
         assert os.environ["NEMO_GUARDRAILS_VERBOSE"] == "true"

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 from unittest.mock import MagicMock, patch
 
@@ -211,6 +212,28 @@ class TestServerCommand:
         result = runner.invoke(app, ["server", "--verbose"])
         assert result.exit_code == 0
         assert os.environ["NEMO_GUARDRAILS_VERBOSE"] == "true"
+
+    def test_server_api_reads_worker_env_on_import(self):
+        from nemoguardrails.server import api
+
+        with patch.dict(
+            os.environ,
+            {
+                "NEMO_GUARDRAILS_CONFIG_PATH": "/worker/config",
+                "NEMO_GUARDRAILS_DISABLE_CHAT_UI": "true",
+                "NEMO_GUARDRAILS_AUTO_RELOAD": "true",
+                "NEMO_GUARDRAILS_DEFAULT_CONFIG_ID": "worker_config",
+            },
+            clear=True,
+        ):
+            api = importlib.reload(api)
+
+        assert api.app.rails_config_path == "/worker/config"
+        assert api.app.disable_chat_ui is True
+        assert api.app.auto_reload is True
+        assert api.app.default_config_id == "worker_config"
+
+        importlib.reload(api)
 
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -287,6 +287,48 @@ class TestServerCommand:
             telemetry._deployment_type_override = None
             telemetry._lock = telemetry.threading.Lock()
 
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    @patch("os.path.exists")
+    @patch("os.getcwd")
+    def test_server_with_workers_uses_app_factory(
+        self, mock_getcwd, mock_exists, mock_app, mock_uvicorn
+    ):
+        mock_getcwd.return_value = "/current/dir"
+        mock_exists.return_value = True
+
+        result = runner.invoke(app, ["server", "--workers=2"])
+
+        assert result.exit_code == 0
+        assert os.environ["NEMO_GUARDRAILS_CONFIG_PATH"] == os.path.join("/current/dir", "config")
+        mock_uvicorn.assert_called_once_with(
+            "nemoguardrails.server.api:create_app",
+            factory=True,
+            port=8000,
+            log_level="info",
+            host="0.0.0.0",
+            workers=2,
+        )
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_rejects_prefix_with_workers(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server", "--workers=2", "--prefix=/api/v1"])
+
+        assert result.exit_code == 1
+        assert "The --prefix option is not supported with --workers > 1." in result.output
+        mock_uvicorn.assert_not_called()
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_rejects_auto_reload_with_workers(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server", "--workers=2", "--auto-reload"])
+
+        assert result.exit_code == 1
+        assert "The --auto-reload option is not supported with --workers > 1." in result.output
+        mock_uvicorn.assert_not_called()
+
 
 class TestConvertCommand:
     def test_convert_missing_path(self):

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -204,6 +204,14 @@ class TestServerCommand:
         assert result.exit_code == 0
         assert mock_app.auto_reload is True
 
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_with_verbose_sets_worker_env(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server", "--verbose"])
+        assert result.exit_code == 0
+        assert os.environ["NEMO_GUARDRAILS_VERBOSE"] == "true"
+
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")
     @patch("nemoguardrails.server.api.set_default_config_id")

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -292,9 +292,7 @@ class TestServerCommand:
     @patch("nemoguardrails.server.api.app")
     @patch("os.path.exists")
     @patch("os.getcwd")
-    def test_server_with_workers_uses_app_factory(
-        self, mock_getcwd, mock_exists, mock_app, mock_uvicorn
-    ):
+    def test_server_with_workers_uses_app_factory(self, mock_getcwd, mock_exists, mock_app, mock_uvicorn):
         mock_getcwd.return_value = "/current/dir"
         mock_exists.return_value = True
 
@@ -311,18 +309,30 @@ class TestServerCommand:
             workers=2,
         )
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")
-    def test_server_rejects_prefix_with_workers(self, mock_app, mock_uvicorn):
+    @patch("os.path.exists")
+    @patch("os.getcwd")
+    def test_server_rejects_prefix_with_workers(self, mock_getcwd, mock_exists, mock_app, mock_uvicorn):
+        mock_getcwd.return_value = "/current/dir"
+        mock_exists.return_value = True
+
         result = runner.invoke(app, ["server", "--workers=2", "--prefix=/api/v1"])
 
         assert result.exit_code == 1
         assert "The --prefix option is not supported with --workers > 1." in result.output
         mock_uvicorn.assert_not_called()
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")
-    def test_server_rejects_auto_reload_with_workers(self, mock_app, mock_uvicorn):
+    @patch("os.path.exists")
+    @patch("os.getcwd")
+    def test_server_rejects_auto_reload_with_workers(self, mock_getcwd, mock_exists, mock_app, mock_uvicorn):
+        mock_getcwd.return_value = "/current/dir"
+        mock_exists.return_value = True
+
         result = runner.invoke(app, ["server", "--workers=2", "--auto-reload"])
 
         assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- Add a `--workers` option to `nemoguardrails server`.
- Pass the configured worker count through to `uvicorn.run`.
- Document the new CLI option in the server command reference.

Fixes #1746

## Verification
- `python3 -m compileall nemoguardrails/cli/__init__.py`

## PR overlap check
- Searched open PRs for `1746`; no existing open PR covers this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--workers` CLI option to the server command for specifying the number of Uvicorn worker processes to run (default: 1, minimum: 1), enabling multi-process serving configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->