### PR TITLE
fix(kb): include provider parameters in cache key

### DIFF
--- a/nemoguardrails/kb/kb.py
+++ b/nemoguardrails/kb/kb.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
-import json
 from time import time
 from typing import Callable, List, Optional, cast
 

--- a/nemoguardrails/kb/kb.py
+++ b/nemoguardrails/kb/kb.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import json
 from time import time
 from typing import Callable, List, Optional, cast
 
@@ -112,12 +113,13 @@ class KnowledgeBase:
         if not index_items:
             return
 
-        # We compute the hash using default hash algorithm
-        # As part of the hash, we also include the embedding engine and the model
-        # to prevent the cache being used incorrectly when the embedding model changes.
-        hash_prefix = self.config.embedding_search_provider.parameters.get(
-            "embedding_engine", ""
-        ) + self.config.embedding_search_provider.parameters.get("embedding_model", "")
+        # We compute the hash using default hash algorithm. Include all provider
+        # parameters so changes such as Gemini dimensionality invalidate the cache.
+        hash_prefix = json.dumps(
+            self.config.embedding_search_provider.parameters,
+            sort_keys=True,
+            default=str,
+        )
 
         hash_value = compute_hash(hash_prefix + "".join(all_text_items))
         cache_file = os.path.join(CACHE_FOLDER, f"{hash_value}.ann")

--- a/tests/test_kb_cache.py
+++ b/tests/test_kb_cache.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nemoguardrails.kb.kb import KnowledgeBase
+from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, KnowledgeBaseConfig
+
+
+@pytest.mark.asyncio
+async def test_cache_key_includes_embedding_provider_parameters():
+    config = KnowledgeBaseConfig(
+        embedding_search_provider=EmbeddingSearchProvider(
+            name="default",
+            parameters={
+                "embedding_engine": "google",
+                "embedding_model": "models/text-embedding-004",
+                "dimensionality": 768,
+            },
+        )
+    )
+    index = MagicMock()
+    index.add_items = AsyncMock()
+    index.build = AsyncMock()
+    kb = KnowledgeBase(
+        documents=["# Heading\n\nBody"],
+        config=config,
+        get_embedding_search_provider_instance=MagicMock(return_value=index),
+    )
+    kb.init()
+
+    with patch("nemoguardrails.kb.kb.compute_hash", return_value="cache-key") as mock_hash:
+        await kb.build()
+
+    hash_input = mock_hash.call_args.args[0]
+    assert '"dimensionality": 768' in hash_input
+    assert '"embedding_engine": "google"' in hash_input
+    assert '"embedding_model": "models/text-embedding-004"' in hash_input


### PR DESCRIPTION
## Summary
- Include all embedding search provider parameters in the knowledge base cache hash.
- Prevent stale Annoy cache reuse when parameters other than `embedding_engine` / `embedding_model` change, such as Gemini `dimensionality`.
- Keep deterministic cache keys by JSON-serializing provider parameters with sorted keys.

Fixes #1767

## Verification
- `python3 -m compileall nemoguardrails/kb/kb.py`

## PR overlap check
- Searched open PRs for `1767`; no existing open PR covers this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the knowledge base indexing cache key generation mechanism to ensure more consistent behavior when handling different embedding provider configurations, enabling better index reuse and caching efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->