### PR TITLE
docs(configure-rails): align with 0.22 DefaultFramework / LangChain split

### DIFF
--- a/docs/configure-rails/custom-initialization/custom-llm-providers.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-providers.md
@@ -25,7 +25,7 @@ content:
 # Custom LLM Providers
 
 ```{note}
-This guide covers LangChain-based custom providers (`BaseLLM` and `BaseChatModel`). It applies when `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` is set, and was the only extension path before 0.22. For DefaultFramework (the default in 0.22+ for `openai`, `nim`, `nvidia_ai_endpoints`, and `ollama`), implement the `LLMModel` protocol instead.
+This guide covers LangChain-based custom providers (`BaseLLM` and `BaseChatModel`) and applies when `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` is set. It was the only extension path before 0.22. For the built-in client (the 0.22+ default), implement the `LLMModel` Protocol instead — see [Custom LLM Model](custom-llm-model.md).
 ```
 
 NeMo Guardrails supports two types of custom LLM providers:

--- a/docs/configure-rails/custom-initialization/custom-llm-providers.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-providers.md
@@ -2,7 +2,7 @@
 title:
   page: Custom LLM Providers for NeMo Guardrails
   nav: LLM Providers
-description: Register custom text completion (BaseLLM) and chat models (BaseChatModel) for use with NeMo Guardrails.
+description: Register LangChain BaseLLM and BaseChatModel providers under the LangChain framework path (requires NEMOGUARDRAILS_LLM_FRAMEWORK=langchain).
 topics:
 - Configuration
 - Customization
@@ -23,6 +23,10 @@ content:
 ---
 
 # Custom LLM Providers
+
+```{note}
+This guide covers LangChain-based custom providers (`BaseLLM` and `BaseChatModel`). It applies when `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` is set, and was the only extension path before 0.22. For DefaultFramework (the default in 0.22+ for `openai`, `nim`, `nvidia_ai_endpoints`, and `ollama`), implement the `LLMModel` protocol instead.
+```
 
 NeMo Guardrails supports two types of custom LLM providers:
 

--- a/docs/configure-rails/custom-initialization/index.md
+++ b/docs/configure-rails/custom-initialization/index.md
@@ -53,7 +53,7 @@ Define the init() function to initialize resources and register action parameter
 :link: custom-llm-providers
 :link-type: doc
 
-Register custom text completion (BaseLLM) and chat models (BaseChatModel) for use with the NVIDIA NeMo Guardrails library.
+Register custom text completion and chat models. Use the `LLMModel` protocol for DefaultFramework, or LangChain `BaseLLM`/`BaseChatModel` when running with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
 +++
 {bdg-secondary}`How To`
 :::

--- a/docs/configure-rails/custom-initialization/index.md
+++ b/docs/configure-rails/custom-initialization/index.md
@@ -53,7 +53,7 @@ Define the init() function to initialize resources and register action parameter
 :link: custom-llm-providers
 :link-type: doc
 
-Register custom text completion and chat models. Use the `LLMModel` protocol for DefaultFramework, or LangChain `BaseLLM`/`BaseChatModel` when running with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
+Register custom text completion and chat models. Use the `LLMModel` Protocol for the built-in client, or LangChain `BaseLLM`/`BaseChatModel` when running with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
 +++
 {bdg-secondary}`How To`
 :::

--- a/docs/configure-rails/guardrail-catalog/community/llama-guard.md
+++ b/docs/configure-rails/guardrail-catalog/community/llama-guard.md
@@ -8,17 +8,31 @@ In our testing, we observe significantly improved input and output content moder
 
 To configure your bot to use Llama Guard for input/output checking, follow the below steps:
 
-1. Add a model of type `llama_guard` to the models section of the `config.yml` file (the example below uses a vLLM setup):
+1. Add a model of type `llama_guard` to the models section of the `config.yml` file. The example below serves Llama Guard with vLLM and connects to it through NeMo Guardrails' DefaultFramework: vLLM exposes an OpenAI-compatible API, so `engine: openai` plus `parameters.base_url` routes through the built-in HTTP client and no LangChain dependency is required.
 
     ```yaml
     models:
       ...
 
       - type: llama_guard
-        engine: vllm_openai
+        engine: openai
+        model: meta-llama/LlamaGuard-7b
         parameters:
-          openai_api_base: "http://localhost:5123/v1"
-          model_name: "meta-llama/LlamaGuard-7b"
+          base_url: "http://localhost:5123/v1"
+          api_key: EMPTY
+    ```
+
+    ```{note}
+    Set `api_key: EMPTY` (or any non-empty placeholder) when self-hosted vLLM does not enforce auth. If your deployment requires a real token, replace `api_key: EMPTY` with the literal token value, or omit `api_key` and set `api_key_env_var` at the **top level** of the model entry (not inside `parameters:`):
+
+    ```yaml
+    - type: llama_guard
+      engine: openai
+      model: meta-llama/LlamaGuard-7b
+      api_key_env_var: MY_LLAMA_GUARD_API_KEY
+      parameters:
+        base_url: "http://localhost:5123/v1"
+    ```
     ```
 
 2. Include the `llama guard check input` and `llama guard check output` flow names in the rails section of the `config.yml` file:

--- a/docs/configure-rails/guardrail-catalog/community/llama-guard.md
+++ b/docs/configure-rails/guardrail-catalog/community/llama-guard.md
@@ -22,7 +22,7 @@ To configure your bot to use Llama Guard for input/output checking, follow the b
           api_key: EMPTY
     ```
 
-    ```{note}
+    :::{note}
     Set `api_key: EMPTY` (or any non-empty placeholder) when self-hosted vLLM does not enforce auth. If your deployment requires a real token, replace `api_key: EMPTY` with the literal token value, or omit `api_key` and set `api_key_env_var` at the **top level** of the model entry (not inside `parameters:`):
 
     ```yaml
@@ -33,7 +33,7 @@ To configure your bot to use Llama Guard for input/output checking, follow the b
       parameters:
         base_url: "http://localhost:5123/v1"
     ```
-    ```
+    :::
 
 2. Include the `llama guard check input` and `llama guard check output` flow names in the rails section of the `config.yml` file:
 

--- a/docs/configure-rails/guardrail-catalog/community/llama-guard.md
+++ b/docs/configure-rails/guardrail-catalog/community/llama-guard.md
@@ -8,7 +8,7 @@ In our testing, we observe significantly improved input and output content moder
 
 To configure your bot to use Llama Guard for input/output checking, follow the below steps:
 
-1. Add a model of type `llama_guard` to the models section of the `config.yml` file. The example below serves Llama Guard with vLLM and connects to it through NeMo Guardrails' DefaultFramework: vLLM exposes an OpenAI-compatible API, so `engine: openai` plus `parameters.base_url` routes through the built-in HTTP client and no LangChain dependency is required.
+1. Add a model of type `llama_guard` to the models section of the `config.yml` file. The example below serves Llama Guard with vLLM. Because vLLM exposes an OpenAI-compatible API, `engine: openai` plus `parameters.base_url` reaches it through NeMo Guardrails' built-in client with no LangChain dependency. For background, see [Migrating to 0.22](../../../migration/0.22.md).
 
     ```yaml
     models:

--- a/docs/configure-rails/guardrail-catalog/community/patronus-lynx.md
+++ b/docs/configure-rails/guardrail-catalog/community/patronus-lynx.md
@@ -89,17 +89,31 @@ You can also run Patronus Lynx 8B on your personal computer using Ollama!
 
 Here is how to configure your bot to use Patronus Lynx to check for RAG hallucinations in your bot output:
 
-1. Add a model of type `patronus_lynx` in `config.yml` - the example below uses vLLM to run Lynx:
+1. Add a model of type `patronus_lynx` in `config.yml`. The example below serves Lynx with vLLM and connects to it through NeMo Guardrails' DefaultFramework: vLLM exposes an OpenAI-compatible API, so `engine: openai` plus `parameters.base_url` routes through the built-in HTTP client and no LangChain dependency is required.
 
     ```yaml
     models:
       ...
 
       - type: patronus_lynx
-        engine: vllm_openai
+        engine: openai
+        model: PatronusAI/Patronus-Lynx-70B-Instruct  # PatronusAI/Patronus-Lynx-8B-Instruct
         parameters:
-          openai_api_base: "http://localhost:5000/v1"
-          model_name: "PatronusAI/Patronus-Lynx-70B-Instruct" # "PatronusAI/Patronus-Lynx-8B-Instruct"
+          base_url: "http://localhost:5000/v1"
+          api_key: EMPTY
+    ```
+
+    ```{note}
+    Set `api_key: EMPTY` (or any non-empty placeholder) when self-hosted vLLM does not enforce auth. If your deployment requires a real token, replace `api_key: EMPTY` with the literal token value, or omit `api_key` and set `api_key_env_var` at the **top level** of the model entry (not inside `parameters:`):
+
+    ```yaml
+    - type: patronus_lynx
+      engine: openai
+      model: PatronusAI/Patronus-Lynx-70B-Instruct
+      api_key_env_var: MY_PATRONUS_LYNX_API_KEY
+      parameters:
+        base_url: "http://localhost:5000/v1"
+    ```
     ```
 
 2. Add the guardrail `patronus lynx check output hallucination` to your output rails in `config.yml`:

--- a/docs/configure-rails/guardrail-catalog/community/patronus-lynx.md
+++ b/docs/configure-rails/guardrail-catalog/community/patronus-lynx.md
@@ -89,7 +89,7 @@ You can also run Patronus Lynx 8B on your personal computer using Ollama!
 
 Here is how to configure your bot to use Patronus Lynx to check for RAG hallucinations in your bot output:
 
-1. Add a model of type `patronus_lynx` in `config.yml`. The example below serves Lynx with vLLM and connects to it through NeMo Guardrails' DefaultFramework: vLLM exposes an OpenAI-compatible API, so `engine: openai` plus `parameters.base_url` routes through the built-in HTTP client and no LangChain dependency is required.
+1. Add a model of type `patronus_lynx` in `config.yml`. The example below serves Lynx with vLLM. Because vLLM exposes an OpenAI-compatible API, `engine: openai` plus `parameters.base_url` reaches it through NeMo Guardrails' built-in client with no LangChain dependency. For background, see [Migrating to 0.22](../../../migration/0.22.md).
 
     ```yaml
     models:

--- a/docs/configure-rails/guardrail-catalog/content-safety.md
+++ b/docs/configure-rails/guardrail-catalog/content-safety.md
@@ -44,7 +44,7 @@ To use the content safety check, you should:
     ```
 
     ```{note}
-    The vLLM example above uses NeMo Guardrails' DefaultFramework. Because vLLM exposes an OpenAI-compatible API, `engine: openai` plus `parameters.base_url` routes through the built-in OpenAI-compatible HTTP client and no LangChain dependency is required. The legacy `engine: vllm_openai` with `parameters.openai_api_base` is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
+    The vLLM example above uses NeMo Guardrails' built-in OpenAI-compatible client. Because vLLM exposes an OpenAI-compatible API, `engine: openai` plus `parameters.base_url` reaches it directly with no LangChain dependency. The legacy `engine: vllm_openai` with `parameters.openai_api_base` is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. For background, see [Migrating to 0.22](../../migration/0.22.md).
     ```
 
 2. Include the content safety check in the input and output rails section of the `config.yml` file:

--- a/docs/configure-rails/guardrail-catalog/content-safety.md
+++ b/docs/configure-rails/guardrail-catalog/content-safety.md
@@ -27,19 +27,24 @@ To use the content safety check, you should:
 
       - type: "content_safety"
         engine: nim
+        model: llama-3.1-nemoguard-8b-content-safety
         parameters:
           base_url: "http://localhost:8123/v1"
-          model_name: "llama-3.1-nemoguard-8b-content-safety"
 
       - type: llama_guard_2
-        engine: vllm_openai
+        engine: openai
+        model: meta-llama/Meta-Llama-Guard-2-8B
         parameters:
-          openai_api_base: "http://localhost:5005/v1"
-          model_name: "meta-llama/Meta-Llama-Guard-2-8B"
+          base_url: "http://localhost:5005/v1"
+          api_key: EMPTY
     ```
 
     ```{note}
     The `type` is a unique identifier for the model that will be passed to the input and output rails as a parameter.
+    ```
+
+    ```{note}
+    The vLLM example above uses NeMo Guardrails' DefaultFramework. Because vLLM exposes an OpenAI-compatible API, `engine: openai` plus `parameters.base_url` routes through the built-in OpenAI-compatible HTTP client and no LangChain dependency is required. The legacy `engine: vllm_openai` with `parameters.openai_api_base` is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
     ```
 
 2. Include the content safety check in the input and output rails section of the `config.yml` file:

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -110,7 +110,7 @@ models:
 ```
 
 ```{note}
-The `azure` engine is routed through LangChain. Azure OpenAI's deployment-name URL pattern and `api-version` query string are not currently handled by the DefaultFramework's OpenAI-compatible client, so set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-openai` package to use it.
+Azure OpenAI is OpenAI-compatible at the wire level, but the LangChain path is the convenient default because `langchain-openai` handles the deployment-name URL pattern and `api-version` query string for you. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-openai`. Azure is also reachable through the built-in client with manual plumbing; see [Migrating to 0.22](../../migration/0.22.md#azure-openai).
 ```
 
 ### Anthropic
@@ -125,12 +125,12 @@ models:
 ```
 
 ```{note}
-The `anthropic` engine is routed through LangChain. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-anthropic` package to use it.
+Anthropic's API isn't OpenAI-compatible, so this engine is opt-in: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-anthropic`. For background, see [Migrating to 0.22](../../migration/0.22.md#section-3-falling-back-to-langchain).
 ```
 
 ### vLLM (OpenAI-Compatible)
 
-vLLM exposes an OpenAI-compatible API, so the recommended configuration uses NeMo Guardrails' DefaultFramework with the `openai` engine pointed at the vLLM endpoint. No LangChain dependency is required.
+vLLM exposes an OpenAI-compatible API, so the recommended configuration uses `engine: openai` pointed at the vLLM endpoint. The built-in client handles it with no LangChain dependency.
 
 ```yaml
 models:
@@ -142,7 +142,7 @@ models:
       api_key: EMPTY
 ```
 
-The following example shows how to configure Llama Guard as a guardrail model using the same DefaultFramework pattern:
+The following example shows how to configure Llama Guard as a guardrail model using the same pattern:
 
 ```yaml
 models:
@@ -166,7 +166,7 @@ When self-hosted vLLM does not enforce authentication, set `parameters.api_key` 
 ```
 
 ```{note}
-The legacy `engine: vllm_openai` with `parameters.openai_api_base` form is routed through LangChain and is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. For new configurations, prefer the DefaultFramework form above.
+The legacy `engine: vllm_openai` with `parameters.openai_api_base` form is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. For new configurations, prefer the form above.
 ```
 
 ### Other OpenAI-compatible endpoints
@@ -185,7 +185,7 @@ models:
 ```
 
 ```{note}
-The `vertexai` engine is routed through LangChain. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-google-vertexai` package to use it.
+Vertex AI's API isn't OpenAI-compatible, so this engine is opt-in: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-google-vertexai`. For background, see [Migrating to 0.22](../../migration/0.22.md#section-3-falling-back-to-langchain).
 ```
 
 ### Complete Example
@@ -222,7 +222,7 @@ models:
 
 ## Model Parameters
 
-Pass additional parameters to the underlying LLM client. For DefaultFramework engines (`openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, and any other engine you serve via `engine: openai` plus `parameters.base_url`), parameters are forwarded to the OpenAI-compatible HTTP client (for example, `temperature`, `max_tokens`, `base_url`, `api_key`). For LangChain-routed engines, parameters follow the conventions of the underlying LangChain class.
+Pass additional parameters to the underlying LLM client. For engines served by the built-in client (any OpenAI-compatible endpoint), parameters are forwarded to the OpenAI-compatible HTTP request (for example, `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, `default_headers`). For LangChain engines, parameters follow the conventions of the underlying LangChain class.
 
 ```yaml
 models:
@@ -235,4 +235,4 @@ models:
       top_p: 0.9
 ```
 
-Common parameters vary by provider. For DefaultFramework engines, see the OpenAI-compatible client options. For LangChain-routed engines, refer to the corresponding LangChain provider documentation.
+Common parameters vary by provider. For built-in engines, see the OpenAI-compatible client options. For LangChain engines, refer to the corresponding LangChain provider documentation.

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -109,6 +109,10 @@ models:
       azure_endpoint: https://my-resource.openai.azure.com
 ```
 
+```{note}
+The `azure` engine is routed through LangChain. Azure OpenAI's deployment-name URL pattern and `api-version` query string are not currently handled by the DefaultFramework's OpenAI-compatible client, so set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-openai` package to use it.
+```
+
 ### Anthropic
 
 The following example shows how to configure the Anthropic model as the main application LLM:
@@ -120,29 +124,54 @@ models:
     model: claude-3-5-sonnet-20241022
 ```
 
+```{note}
+The `anthropic` engine is routed through LangChain. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-anthropic` package to use it.
+```
+
 ### vLLM (OpenAI-Compatible)
 
-The following example shows how to configure the vLLM model as the main application LLM using the vLLM OpenAI API:
+vLLM exposes an OpenAI-compatible API, so the recommended configuration uses NeMo Guardrails' DefaultFramework with the `openai` engine pointed at the vLLM endpoint. No LangChain dependency is required.
 
 ```yaml
 models:
   - type: main
-    engine: vllm_openai
+    engine: openai
+    model: meta-llama/Llama-3.1-8B-Instruct
     parameters:
-      openai_api_base: http://localhost:5000/v1
-      model_name: meta-llama/Llama-3.1-8B-Instruct
+      base_url: http://localhost:5000/v1
+      api_key: EMPTY
 ```
 
-The following example shows how to configure Llama Guard as a guardrail model using the vLLM OpenAI API:
+The following example shows how to configure Llama Guard as a guardrail model using the same DefaultFramework pattern:
 
 ```yaml
 models:
   - type: llama_guard
-    engine: vllm_openai
+    engine: openai
+    model: meta-llama/LlamaGuard-7b
     parameters:
-      openai_api_base: http://localhost:5000/v1
-      model_name: meta-llama/LlamaGuard-7b
+      base_url: http://localhost:5000/v1
+      api_key: EMPTY
 ```
+
+When self-hosted vLLM does not enforce authentication, set `parameters.api_key` to any non-empty placeholder such as `EMPTY`. If your deployment requires a real token, replace `parameters.api_key` with the literal token, or omit it and set `api_key_env_var` at the **top level** of the model entry (not inside `parameters:`):
+
+```yaml
+- type: main
+  engine: openai
+  model: meta-llama/Llama-3.1-8B-Instruct
+  api_key_env_var: MY_VLLM_API_KEY
+  parameters:
+    base_url: http://localhost:5000/v1
+```
+
+```{note}
+The legacy `engine: vllm_openai` with `parameters.openai_api_base` form is routed through LangChain and is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. For new configurations, prefer the DefaultFramework form above.
+```
+
+### Other OpenAI-compatible endpoints
+
+The same `engine: openai` plus `parameters.base_url` pattern works for any provider whose wire protocol is OpenAI-compatible, including OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek's hosted API at `https://api.deepseek.com/v1`, TGI deployments that expose `/v1/chat/completions`, and `llama.cpp` server with `--api`. Provide `parameters.base_url` and either `parameters.api_key` or a top-level `api_key_env_var`.
 
 ### Google Vertex AI
 
@@ -153,6 +182,10 @@ models:
   - type: main
     engine: vertexai
     model: gemini-1.0-pro
+```
+
+```{note}
+The `vertexai` engine is routed through LangChain. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-google-vertexai` package to use it.
 ```
 
 ### Complete Example
@@ -189,7 +222,7 @@ models:
 
 ## Model Parameters
 
-Pass additional parameters to the underlying LangChain class:
+Pass additional parameters to the underlying LLM client. For DefaultFramework engines (`openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, and any other engine you serve via `engine: openai` plus `parameters.base_url`), parameters are forwarded to the OpenAI-compatible HTTP client (for example, `temperature`, `max_tokens`, `base_url`, `api_key`). For LangChain-routed engines, parameters follow the conventions of the underlying LangChain class.
 
 ```yaml
 models:
@@ -202,4 +235,4 @@ models:
       top_p: 0.9
 ```
 
-Common parameters vary by provider. Refer to the LangChain documentation for provider-specific options.
+Common parameters vary by provider. For DefaultFramework engines, see the OpenAI-compatible client options. For LangChain-routed engines, refer to the corresponding LangChain provider documentation.

--- a/docs/configure-rails/yaml-schema/streaming/global-streaming.md
+++ b/docs/configure-rails/yaml-schema/streaming/global-streaming.md
@@ -150,6 +150,10 @@ pipe = pipeline(
 llm = HuggingFacePipelineCompatible(pipeline=pipe, model_kwargs=params)
 ```
 
+```{note}
+This example uses NeMo Guardrails' LangChain HuggingFace pipeline adapter, which depends on LangChain. It requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and the corresponding LangChain HuggingFace provider package.
+```
+
 ---
 
 ## Related Topics


### PR DESCRIPTION
## Description

Update the configure-rails docs section so each page reflects the 0.22 DefaultFramework / LangChain split: lead vLLM, Llama Guard, and Patronus Lynx examples with engine: openai + parameters.base_url, flag truly LangChain-only paths (Azure, Anthropic, Vertex AI, huggingface_pipeline, huggingface_endpoint default schema), and note the LangChain framework requirement on the HuggingFacePipelineCompatible streaming example and BaseLLM/BaseChatModel custom-providers page.

> [!IMPORTANT]
> Blocked on #1854.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated custom LLM provider guides to clarify DefaultFramework and LangChain configuration approaches
  * Revised integration examples (Llama Guard, Patronus Lynx, Content Safety) with current framework-specific configurations
  * Enhanced model configuration documentation with updated engine routing guidance and parameter handling explanations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->