### PR TITLE
docs: mark LangChain integration as opt-in in 0.22 entry-point docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can use programmable guardrails in different types of use cases:
 1. **Question Answering** over a set of documents (a.k.a. Retrieval Augmented Generation): Enforce fact-checking and output moderation.
 2. **Domain-specific Assistants** (a.k.a. chatbots): Ensure the assistant stays on topic and follows the designed conversational flows.
 3. **LLM Endpoints**: Add guardrails to your custom LLM for safer customer interaction.
-4. **Advanced: LangChain Chains** (optional): If you use LangChain for any use case, you can add a guardrails layer around your chains. This integration is opt-in and requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
+4. **LangChain Chains** (optional): If you use LangChain for any use case, you can add a guardrails layer around your chains. To enable this integration, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`.
 
 ### Usage
 
@@ -284,7 +284,7 @@ To start a guardrails server, you can also use a Docker container. The NeMo Guar
 
 ## Integration with LangChain (Optional)
 
-LangChain integration is opt-in. Enable it by setting `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` or by calling `set_default_framework("langchain")`, and install the LangChain packages your configuration requires. Once enabled, you can wrap a guardrails configuration around a LangChain chain (or any `Runnable`), and you can call a LangChain chain from within a guardrails configuration. For more details, check out the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/langchain/langchain-integration.html)
+LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Then install the LangChain packages your configuration requires. After you enable the integration, you can wrap a guardrails configuration around a LangChain chain (or any `Runnable`), and you can call a LangChain chain from within a guardrails configuration. For more information, refer to the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/langchain/langchain-integration.html).
 
 ## Evaluation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can use programmable guardrails in different types of use cases:
 1. **Question Answering** over a set of documents (a.k.a. Retrieval Augmented Generation): Enforce fact-checking and output moderation.
 2. **Domain-specific Assistants** (a.k.a. chatbots): Ensure the assistant stays on topic and follows the designed conversational flows.
 3. **LLM Endpoints**: Add guardrails to your custom LLM for safer customer interaction.
-4. **LangChain Chains**: If you use LangChain for any use case, you can add a guardrails layer around your chains.
+4. **Advanced: LangChain Chains** (optional): If you use LangChain for any use case, you can add a guardrails layer around your chains. This integration is opt-in and requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`.
 
 ### Usage
 
@@ -282,9 +282,9 @@ Sample output:
 
 To start a guardrails server, you can also use a Docker container. The NeMo Guardrails library provides a [Dockerfile](./Dockerfile) that you can use to build a `nemoguardrails` image. For further information, see the [using Docker](https://docs.nvidia.com/nemo/guardrails/user-guides/advanced/using-docker.html) section.
 
-## Integration with LangChain
+## Integration with LangChain (Optional)
 
-The NeMo Guardrails library integrates seamlessly with LangChain. You can easily wrap a guardrails configuration around a LangChain chain (or any `Runnable`). You can also call a LangChain chain from within a guardrails configuration. For more details, check out the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/langchain/langchain-integration.html)
+LangChain integration is opt-in. Enable it by setting `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` or by calling `set_default_framework("langchain")`, and install the LangChain packages your configuration requires. Once enabled, you can wrap a guardrails configuration around a LangChain chain (or any `Runnable`), and you can call a LangChain chain from within a guardrails configuration. For more details, check out the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/langchain/langchain-integration.html)
 
 ## Evaluation
 

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -107,7 +107,7 @@ Agentic security provides specialized guardrails for LLM-based agents that use t
 This includes:
 
 - **Tool call validation**: Execute rails that validate tool inputs and outputs before and after invocation.
-- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety.
+- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety (requires LangChain framework).
 - **Secure tool integration**: Review guidelines for safely connecting LLMs to external resources (refer to [Security Guidelines](../resources/security/guidelines.md)).
 - **Action monitoring**: Monitor detailed logging and tracing of agent actions.
 
@@ -128,7 +128,7 @@ If you have a script or tool that runs a custom guardrail, you can use it in NeM
 
 1. **Python actions**: Create custom actions in Python for complex logic and external integrations. For more information, refer to the [](../configure-rails/actions/index.md).
 
-2. **LangChain tool integration**: Register LangChain tools as custom actions. For more information, refer to the [](../integration/tools-integration.md).
+2. **LangChain tool integration** (optional, if using LangChain framework): Register LangChain tools as custom actions. For more information, refer to the [](../integration/tools-integration.md).
 
 3. **Third-party API integration**: Integrate external moderation and validation services. For a complete list of supported third-party guardrail services, refer to [Third-Party APIs](../configure-rails/guardrail-catalog/third-party.md) in the Guardrail Catalog.
 :::

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -107,7 +107,7 @@ Agentic security provides specialized guardrails for LLM-based agents that use t
 This includes:
 
 - **Tool call validation**: Execute rails that validate tool inputs and outputs before and after invocation.
-- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety (requires LangChain framework).
+- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety. To use this, you need to install the LangChain framework.
 - **Secure tool integration**: Review guidelines for safely connecting LLMs to external resources (refer to [Security Guidelines](../resources/security/guidelines.md)).
 - **Action monitoring**: Monitor detailed logging and tracing of agent actions.
 
@@ -128,7 +128,7 @@ If you have a script or tool that runs a custom guardrail, you can use it in NeM
 
 1. **Python actions**: Create custom actions in Python for complex logic and external integrations. For more information, refer to the [](../configure-rails/actions/index.md).
 
-2. **LangChain tool integration** (optional, if using LangChain framework): Register LangChain tools as custom actions. For more information, refer to the [](../integration/tools-integration.md).
+2. **LangChain tool integration**: Register LangChain tools as custom actions. Requires the LangChain framework. For more information, refer to the [](../integration/tools-integration.md).
 
 3. **Third-party API integration**: Integrate external moderation and validation services. For a complete list of supported third-party guardrail services, refer to [Third-Party APIs](../configure-rails/guardrail-catalog/third-party.md) in the Guardrail Catalog.
 :::

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -107,7 +107,7 @@ Agentic security provides specialized guardrails for LLM-based agents that use t
 This includes:
 
 - **Tool call validation**: Execute rails that validate tool inputs and outputs before and after invocation.
-- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety. To use this, you need to install the LangChain framework.
+- **Agent workflow protection**: Integrate with [LangGraph](../integration/langchain/langgraph-integration.md) for multi-agent safety. Requires the LangChain opt-in (`NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`) and the matching `langchain-*` packages.
 - **Secure tool integration**: Review guidelines for safely connecting LLMs to external resources (refer to [Security Guidelines](../resources/security/guidelines.md)).
 - **Action monitoring**: Monitor detailed logging and tracing of agent actions.
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -52,7 +52,7 @@ For a complete record of changes in a release, refer to the
 - Added the `GuardrailsMiddleware` class, a new middleware that integrates with
   LangChain's Agent Middleware protocol, applying input and output rail checks before and after
   every model call in the agent loop. It includes the `InputRailsMiddleware` and `OutputRailsMiddleware`
-  convenience subclasses.
+  convenience subclasses (requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`).
   For more information, refer to [](../integration/langchain/agent-middleware.md).
 
 - Added three new community rails:

--- a/docs/getting-started/integrate-into-application.md
+++ b/docs/getting-started/integrate-into-application.md
@@ -36,7 +36,11 @@ The NeMo Guardrails library provides the following tools to integrate guardrails
    response = rails.generate(messages=[...])
    ```
 
-- Use the NeMo Guardrails LangChain integration capabilities to wrap guardrails around LangChain chains or use chains within guardrails. As of 0.22, this path requires opting into the LangChain framework: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain` plus `langchain-community` (or the matching `langchain-<provider>` package) before importing.
+- Use the NeMo Guardrails LangChain integration to wrap guardrails around LangChain chains or use chains within guardrails.
+
+   ```{note}
+   Starting in 0.22, the LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Install `langchain` and `langchain-community` (or the matching `langchain-<provider>` package) before importing.
+   ```
 
    ```python
    from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails

--- a/docs/getting-started/integrate-into-application.md
+++ b/docs/getting-started/integrate-into-application.md
@@ -39,7 +39,7 @@ The NeMo Guardrails library provides the following tools to integrate guardrails
 - Use the NeMo Guardrails LangChain integration to wrap guardrails around LangChain chains or use chains within guardrails.
 
    ```{note}
-   Starting in 0.22, the LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Install `langchain` and `langchain-community` (or the matching `langchain-<provider>` package) before importing.
+   Starting in 0.22, the LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Install `langchain` and `langchain-community` (or the matching `langchain-<provider>` package) before importing. For background, see [Migrating to 0.22](../migration/0.22.md).
    ```
 
    ```python

--- a/docs/getting-started/integrate-into-application.md
+++ b/docs/getting-started/integrate-into-application.md
@@ -2,7 +2,7 @@
 title:
   page: Integrate Guardrails into Your Application
   nav: Integrate Guardrails
-description: Add guardrails to existing applications using the Python SDK, LangChain, or HTTP API.
+description: Add guardrails to existing applications using the Python SDK, the HTTP API, or the optional LangChain integration.
 topics:
 - Get Started
 - AI Safety
@@ -36,7 +36,7 @@ The NeMo Guardrails library provides the following tools to integrate guardrails
    response = rails.generate(messages=[...])
    ```
 
-- Use the NeMo Guardrails LangChain integration capabilities to wrap guardrails around LangChain chains or use chains within guardrails.
+- Use the NeMo Guardrails LangChain integration capabilities to wrap guardrails around LangChain chains or use chains within guardrails. As of 0.22, this path requires opting into the LangChain framework: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain` plus `langchain-community` (or the matching `langchain-<provider>` package) before importing.
 
    ```python
    from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails


### PR DESCRIPTION
## Description

Reflect 0.22 LangChain optionality in entry-point pages (README, about/overview.md, getting-started/integrate-into-application.md, release-notes.md): mark LangChain integration, LangGraph, and LangChain tool integration as opt-in.

> [!IMPORTANT]
> Blocked on #1854


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and integration guides to clarify that LangChain integration is optional and requires explicit enablement via environment variable or configuration method.
  * Improved documentation clarity on agent workflow protection and LangChain tool integration requirements across multiple documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->