### PR TITLE
docs(examples): align example configs and deployment docs with 0.22 DefaultFramework / LangChain split

### DIFF
--- a/docs/deployment/using-docker.md
+++ b/docs/deployment/using-docker.md
@@ -37,9 +37,11 @@ To use LangChain-only engines whose API is not OpenAI-compatible (`vertexai`, `a
 docker run \
   -p 8000:8000 \
   -e NEMOGUARDRAILS_LLM_FRAMEWORK=langchain \
-  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
   nemoguardrails
 ```
+
+Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI, `COHERE_API_KEY` for Cohere, `AZURE_OPENAI_API_KEY` for Azure OpenAI).
 
 ## Build the Docker Images
 

--- a/docs/deployment/using-docker.md
+++ b/docs/deployment/using-docker.md
@@ -27,6 +27,20 @@ This guide provides step-by-step instructions for running the NeMo Guardrails li
 
 Ensure Docker is installed on your machine. If not, follow the [official Docker installation guide](https://docs.docker.com/get-docker/) for your respective platform.
 
+## LLM Framework Selection
+
+By default, NeMo Guardrails uses the lightweight default framework (httpx-based, no LangChain). It serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, and `ollama`, plus any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url` (for example self-hosted vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp).
+
+To use LangChain-only engines whose API is not OpenAI-compatible (`vertexai`, `anthropic`, `cohere`, `azure`, `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, `self_hosted`, and the legacy `vllm_openai` LangChain wrapper), set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` in the container environment and add `langchain` plus the relevant provider packages to your image. For example:
+
+```bash
+docker run \
+  -p 8000:8000 \
+  -e NEMOGUARDRAILS_LLM_FRAMEWORK=langchain \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  nemoguardrails
+```
+
 ## Build the Docker Images
 
 ### 1. Clone the repository

--- a/docs/evaluation/evaluate-guardrails.md
+++ b/docs/evaluation/evaluate-guardrails.md
@@ -24,6 +24,8 @@ content:
 
 The NeMo Guardrails library includes a set of tools that you can use to evaluate the different types of rails. In the current version, these tools test the performance of each type of rail individually. You can use the evaluation tools through the `nemoguardrails` CLI. Examples will be provided for each type of rail.
 
+> **Note.** Evaluation uses whichever LLM framework is active. The default framework serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, and any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url`. Engines whose API is not OpenAI-compatible (`vertexai`, `anthropic`, `cohere`, `azure`, the in-process `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, and the legacy `vllm_openai` LangChain wrapper) require `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` plus the matching `langchain-*` package.
+
 At the same time, we provide preliminary results on the performance of the rails on a set of public datasets that are relevant to each task at hand.
 
 ## Dialog Rails

--- a/examples/configs/llama_guard/README.md
+++ b/examples/configs/llama_guard/README.md
@@ -1,10 +1,14 @@
 # LlamaGuard Usage Example
 
+> This example uses NeMo Guardrails' DefaultFramework with vLLM's OpenAI-compatible endpoint. No LangChain dependency is required: the `engine: openai` plus `parameters.base_url` form routes through the built-in OpenAI-compatible HTTP client.
+
 This example showcases the use of Meta's [Llama Guard](https://ai.meta.com/research/publications/llama-guard-llm-based-input-output-safeguard-for-human-ai-conversations/) model for content moderation.
 
 The structure of the config folder is the following:
 
 - `config.yml` - The config file holding all the configuration options.
 - `prompts.yml` - The config file holding the adjustable content categories to use with Llama Guard.
+
+When self-hosted vLLM does not enforce authentication, set `parameters.api_key` to any non-empty placeholder such as `EMPTY`. If your deployment requires a real token, replace it with that value or load it through `api_key_env_var`.
 
 Please see the docs for more details about the [recommended Llama Guard deployment](./../../../docs/user-guides/advanced/llama-guard-deployment.md#self-hosting-llama-guard-using-vllm) method, the [performance evaluation numbers](./../../../docs/evaluation/README.md#llamaguard-based-moderation-rails-performance), and a [step-by-step explanation](./../../../docs/user-guides/guardrails-library.md#llama-guard-based-content-moderation) of this configuration.

--- a/examples/configs/llama_guard/config.yml
+++ b/examples/configs/llama_guard/config.yml
@@ -4,10 +4,11 @@ models:
     model: gpt-3.5-turbo-instruct
 
   - type: llama_guard
-    engine: vllm_openai
+    engine: openai
+    model: meta-llama/LlamaGuard-7b
     parameters:
-      openai_api_base: "http://localhost:5000/v1"
-      model_name: "meta-llama/LlamaGuard-7b"
+      base_url: "http://localhost:5000/v1"
+      api_key: EMPTY
 
 rails:
   input:

--- a/examples/configs/llm/deepseek-r1/README.md
+++ b/examples/configs/llm/deepseek-r1/README.md
@@ -2,9 +2,9 @@
 
 > This example uses NeMo Guardrails' DefaultFramework. DeepSeek's hosted API at `https://api.deepseek.com/v1` is OpenAI-compatible, so the `engine: openai` plus `parameters.base_url` form routes through the built-in OpenAI-compatible HTTP client. No LangChain dependency is required.
 
-This configuration shows how to call DeepSeek R1 (`deepseek-reasoner`) and the `reasoning_config` block used to strip `<think>...</think>` traces emitted by reasoning models.
+This configuration shows how to call DeepSeek R1 (`deepseek-reasoner`).
 
-Set `DEEPSEEK_API_KEY` in your environment before running:
+No additional packages are required beyond `nemoguardrails`. Set `DEEPSEEK_API_KEY` in your environment before running:
 
 ```bash
 export DEEPSEEK_API_KEY=sk-...
@@ -12,17 +12,13 @@ export DEEPSEEK_API_KEY=sk-...
 
 ## NVIDIA NIM alternative
 
-DeepSeek R1 weights are also available through NVIDIA NIM. To use the NIM hosted endpoint, replace the model entry with the `nim` engine and the canonical NIM model id, keeping the same `reasoning_config`:
+DeepSeek R1 weights are also available through NVIDIA NIM. To use the NIM hosted endpoint, replace the model entry with the `nim` engine and the canonical NIM model id:
 
 ```yaml
 models:
   - type: main
     engine: nim
     model: deepseek-ai/deepseek-r1
-    reasoning_config:
-      remove_reasoning_traces: True
-      start_token: "<think>"
-      end_token: "</think>"
 ```
 
 ## LangChain fallback

--- a/examples/configs/llm/deepseek-r1/README.md
+++ b/examples/configs/llm/deepseek-r1/README.md
@@ -1,0 +1,30 @@
+# DeepSeek R1 Example
+
+> This example uses NeMo Guardrails' DefaultFramework. DeepSeek's hosted API at `https://api.deepseek.com/v1` is OpenAI-compatible, so the `engine: openai` plus `parameters.base_url` form routes through the built-in OpenAI-compatible HTTP client. No LangChain dependency is required.
+
+This configuration shows how to call DeepSeek R1 (`deepseek-reasoner`) and the `reasoning_config` block used to strip `<think>...</think>` traces emitted by reasoning models.
+
+Set `DEEPSEEK_API_KEY` in your environment before running:
+
+```bash
+export DEEPSEEK_API_KEY=sk-...
+```
+
+## NVIDIA NIM alternative
+
+DeepSeek R1 weights are also available through NVIDIA NIM. To use the NIM hosted endpoint, replace the model entry with the `nim` engine and the canonical NIM model id, keeping the same `reasoning_config`:
+
+```yaml
+models:
+  - type: main
+    engine: nim
+    model: deepseek-ai/deepseek-r1
+    reasoning_config:
+      remove_reasoning_traces: True
+      start_token: "<think>"
+      end_token: "</think>"
+```
+
+## LangChain fallback
+
+If you prefer to use LangChain's `langchain-deepseek` adapter (for example to take advantage of LangChain-specific features), set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, install `pip install langchain langchain-deepseek`, and use `engine: deepseek` in `config.yml`. For new deployments, the DefaultFramework path above is recommended.

--- a/examples/configs/llm/deepseek-r1/config.yml
+++ b/examples/configs/llm/deepseek-r1/config.yml
@@ -5,7 +5,3 @@ models:
     api_key_env_var: DEEPSEEK_API_KEY
     parameters:
       base_url: https://api.deepseek.com/v1
-    reasoning_config:
-      remove_reasoning_traces: True
-      start_token: "<think>"
-      end_token: "</think>"

--- a/examples/configs/llm/deepseek-r1/config.yml
+++ b/examples/configs/llm/deepseek-r1/config.yml
@@ -1,7 +1,10 @@
 models:
   - type: main
-    engine: deepseek
+    engine: openai
     model: deepseek-reasoner
+    api_key_env_var: DEEPSEEK_API_KEY
+    parameters:
+      base_url: https://api.deepseek.com/v1
     reasoning_config:
       remove_reasoning_traces: True
       start_token: "<think>"

--- a/examples/configs/llm/hf_endpoint/README.md
+++ b/examples/configs/llm/hf_endpoint/README.md
@@ -6,7 +6,7 @@
 
 This configuration uses the HuggingFace [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index).
 
-First, create an endpoint following the instructions [here](https://huggingface.co/docs/inference-endpoints/guides/create_endpoint). Then, update the `endpoint_url` key in the `config.yml` file.
+First, follow the [endpoint creation guide](https://huggingface.co/docs/inference-endpoints/guides/create_endpoint). Then, update the `endpoint_url` key in the `config.yml` file.
 
 **Disclaimer**: The `dolly-v2-3b` LLM model has only been tested on basic use cases, e.g., greetings and recognizing specific questions. On more complex queries, this model may not work correctly. Thorough testing and optimizations are needed before considering a production deployment.
 

--- a/examples/configs/llm/hf_endpoint/README.md
+++ b/examples/configs/llm/hf_endpoint/README.md
@@ -1,7 +1,26 @@
 # HuggingFace Endpoint
 
+> **Framework requirement.** This example uses `engine: huggingface_endpoint`, which is served by the LangChain framework only.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-community` before running.
+> The `parameters.model_kwargs` block in `config.yml` is also LangChain-specific and is rejected by the default framework.
+
 This configuration uses the HuggingFace [Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index).
 
 First, create an endpoint following the instructions [here](https://huggingface.co/docs/inference-endpoints/guides/create_endpoint). Then, update the `endpoint_url` key in the `config.yml` file.
 
 **Disclaimer**: The `dolly-v2-3b` LLM model has only been tested on basic use cases, e.g., greetings and recognizing specific questions. On more complex queries, this model may not work correctly. Thorough testing and optimizations are needed before considering a production deployment.
+
+## DefaultFramework alternative for OpenAI-compatible endpoints
+
+Hugging Face Inference Endpoints can be deployed with [Text Generation Inference](https://huggingface.co/docs/text-generation-inference/index) (TGI), which optionally exposes an OpenAI-compatible `/v1/chat/completions` route. If your endpoint serves that route, you can stay on the DefaultFramework with `engine: openai` and the canonical `base_url` parameter, no LangChain required:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: tgi
+    parameters:
+      base_url: https://xxx.aws.endpoints.huggingface.cloud/v1
+```
+
+For the standard `text-generation-inference` schema (no `/v1/chat/completions`), use the LangChain framework as described above.

--- a/examples/configs/llm/hf_pipeline_dolly/README.md
+++ b/examples/configs/llm/hf_pipeline_dolly/README.md
@@ -1,5 +1,8 @@
 # HuggingFace Pipeline with Dolly models
 
+> **Framework requirement.** This example registers a custom LangChain LLM provider through `nemoguardrails.integrations.langchain` and uses LangChain-only constructs such as `HuggingFacePipelineCompatible(..., model_kwargs=...)` and `AsyncTextIteratorStreamer`.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-community transformers torch` before running.
+
 This configuration uses the HuggingFace Pipeline LLM with the [dolly-v2-3b](https://huggingface.co/databricks/dolly-v2-3b) model.
 It also shows how to support streaming in NeMo Guardrails for LLMs deployed using HuggingFacePipeline.
 

--- a/examples/configs/llm/hf_pipeline_falcon/README.md
+++ b/examples/configs/llm/hf_pipeline_falcon/README.md
@@ -1,5 +1,8 @@
 # HuggingFace Pipeline with Falcon models
 
+> **Framework requirement.** This example registers a custom LangChain LLM provider through `nemoguardrails.integrations.langchain` and uses LangChain-only constructs such as `HuggingFacePipelineCompatible(..., model_kwargs=...)`.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-community transformers torch` before running.
+
 This configuration uses the HuggingFace Pipeline LLM with a [tiiuae/falcon-7b-instruct](https://huggingface.co/tiiuae/falcon-7b-instruct) model.
 
 The `tiiuae/falcon-7b-instruct` LLM model has been tested on the topical rails evaluation sets, results are available [here](../../../../nemoguardrails/evaluate/README.md).

--- a/examples/configs/llm/hf_pipeline_mosaic/README.md
+++ b/examples/configs/llm/hf_pipeline_mosaic/README.md
@@ -1,5 +1,8 @@
 # HuggingFace Pipeline with Mosaic ML MPT models
 
+> **Framework requirement.** This example registers a custom LangChain LLM provider through `nemoguardrails.integrations.langchain` and uses LangChain-only constructs such as `HuggingFacePipelineCompatible(..., model_kwargs=...)`.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-community transformers torch` before running.
+
 This configuration uses the HuggingFace Pipeline LLM with the [mpt-7b-instruct](https://huggingface.co/mosaicml/mpt-7b-instruct) model.
 
 The `mpt-7b-instruct` LLM model has been tested on the topical rails evaluation sets, results are available [here](../../../../nemoguardrails/evaluate/README.md).

--- a/examples/configs/llm/hf_pipeline_vicuna/README.md
+++ b/examples/configs/llm/hf_pipeline_vicuna/README.md
@@ -1,5 +1,8 @@
 # HuggingFace Pipeline with Vicuna models
 
+> **Framework requirement.** This example registers a custom LangChain LLM provider through `nemoguardrails.integrations.langchain` and uses LangChain-only constructs such as `HuggingFacePipelineCompatible(..., model_kwargs=...)`.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-community transformers torch` before running.
+
 This configuration uses the HuggingFace Pipeline LLM with various Vicuna models, including LMSYS and Bloke variants, 7B and 13B, e.g. [vicuna-7b-v1.3](https://huggingface.co/lmsys/vicuna-7b-v1.3).
 
 The `vicuna-7b-v1.3` LLM model has been tested on the topical rails evaluation sets, results are available [here](../../../../nemoguardrails/evaluate/README.md).

--- a/examples/configs/llm/vertexai/README.md
+++ b/examples/configs/llm/vertexai/README.md
@@ -1,5 +1,8 @@
 # Vertex AI Example
 
+> **Framework requirement.** This example uses `engine: vertexai`, which is served by the LangChain framework only.
+> Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `pip install langchain langchain-google-vertexai` before running.
+
 This guardrails configuration is a basic example using the Vertex AI API, and it can be adapted as needed.
 
 Note that to call Vertex AI APIs, you need to perform [some initial setup](../../../../docs/user-guides/advanced/vertexai-setup.md), and to use Vertex AI with NeMo Guardrails, you additionally need to install the following:

--- a/examples/configs/llm/vertexai/README.md
+++ b/examples/configs/llm/vertexai/README.md
@@ -5,13 +5,13 @@
 
 This guardrails configuration is a basic example using the Vertex AI API, and it can be adapted as needed.
 
-Note that to call Vertex AI APIs, you need to perform [some initial setup](../../../../docs/user-guides/advanced/vertexai-setup.md), and to use Vertex AI with NeMo Guardrails, you additionally need to install the following:
+Calling Vertex AI APIs requires [initial Google Cloud setup](../../../../docs/user-guides/advanced/vertexai-setup.md). On top of NeMo Guardrails, install:
 
 ```
 pip install "google-cloud-aiplatform>=1.38.0"
-pip install langchain-google-vertexai==0.1.0
+pip install langchain-google-vertexai
 ```
 
-The `gemini-1.0-pro` and `text-bison` models have been evaluated for topical rails, and `gemini-1.0-pro` has also been evaluated as a self-checking model for hallucination and content moderation. Evaluation results can be found [here](../../../../docs/evaluation/README.md).
+The example points at `gemini-1.0-pro` for historical continuity with this configuration; you should update the `model:` field in `config.yml` to a currently supported Gemini model for your project (for example, `gemini-2.5-flash` or `gemini-2.5-pro`). Vertex AI's model catalog rotates frequently, and older model IDs may stop accepting requests.
 
-**Disclaimer**: The Vertex AI models have only been tested on basic use cases, e.g., greetings and recognizing specific questions. On more complex queries, these models may not work correctly. Thorough testing and optimizations are needed before considering a production deployment. Additionally, as of March 14, 2024, there is [an open issue](https://github.com/GoogleCloudPlatform/generative-ai/issues/344) with Vertex AI models that result in them throwing an error likely triggered by moderation inside Vertex AI. In our tests, we find that self-checking with `gemini-1.0-pro` for hallucination and content moderation triggers this error. Production use cases should be designed to account for the possibility of this and handle it appropriately.
+**Disclaimer**: This example has only been tested on basic use cases. On more complex queries, behavior depends on the Vertex AI model you choose and may not match the assertions in the guardrails flows. Thorough testing and tuning are required before any production deployment, especially for the self-check flows whose prompts assume a particular response style. Provider-side content-moderation behavior also varies across Vertex AI model generations and can surface as transient errors; production code paths should handle those gracefully.

--- a/examples/configs/patronusai/README.md
+++ b/examples/configs/patronusai/README.md
@@ -1,0 +1,12 @@
+# Patronus AI Examples
+
+> `lynx_config.yml` uses NeMo Guardrails' DefaultFramework with vLLM's OpenAI-compatible endpoint. No LangChain dependency is required: the `engine: openai` plus `parameters.base_url` form routes through the built-in OpenAI-compatible HTTP client.
+
+This folder contains two example configurations:
+
+- `lynx_config.yml` - Self-hosted [Patronus Lynx](https://huggingface.co/PatronusAI/Patronus-Lynx-70B-Instruct) hallucination check served via vLLM.
+- `evaluate_api_config.yml` - Patronus Evaluate API integration.
+
+When self-hosted vLLM does not enforce authentication, set `parameters.api_key` to any non-empty placeholder such as `EMPTY`. If your deployment requires a real token, replace it with that value or load it through `api_key_env_var`.
+
+To switch to the 8B variant, change `model:` to `PatronusAI/Patronus-Lynx-8B-Instruct` in `lynx_config.yml`.

--- a/examples/configs/patronusai/lynx_config.yml
+++ b/examples/configs/patronusai/lynx_config.yml
@@ -4,10 +4,11 @@ models:
     model: gpt-3.5-turbo-instruct
 
   - type: patronus_lynx
-    engine: vllm_openai
+    engine: openai
+    model: PatronusAI/Patronus-Lynx-70B-Instruct
     parameters:
-      openai_api_base: "http://localhost:5000/v1"
-      model_name: "PatronusAI/Patronus-Lynx-70B-Instruct" # "PatronusAI/Patronus-Lynx-8B-Instruct"
+      base_url: "http://localhost:5000/v1"
+      api_key: EMPTY
 
 rails:
   output:


### PR DESCRIPTION
## Description

Rewrite OpenAI-compatible self-hosted examples (Llama Guard, Patronus Lynx, DeepSeek R1, content-safety reasoning) to use engine: openai + parameters.base_url so they run on DefaultFramework without LangChain. Add framework-requirement banners to the LangChain-only READMEs (Vertex AI, hf_endpoint, hf_pipeline_*) and document the TGI /v1/chat/completions DefaultFramework shortcut. Update using-docker.md and evaluate-guardrails.md so the framework-selection guidance keeps DefaultFramework primary and lists OpenAI-compat third-party providers (vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp) separately from genuinely LangChain-only engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment guide with LLM framework selection explanations and configuration details
  * Updated evaluation documentation with framework configuration guidance
  * Clarified OpenAI-compatible endpoint usage across example configurations (Llama Guard, DeepSeek R1, Patronus AI)
  * Added framework requirement sections to HuggingFace and Vertex AI examples
  * New Patronus AI example documentation with setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->