### PR TITLE
fix(iorails): strip trailing /v1 from base_url to avoid doubled path

### DIFF
--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -233,7 +233,13 @@ class ModelEngine(BaseEngine):
     def _prepare_request(self, messages: LLMMessages, **kwargs: Any) -> _RequestParams:
         """Build the client, URL, headers, and body common to every request."""
         client = cast(RetryClient, self._client)
-        url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_ENDPOINT
+        # Strip an optional trailing "/v1" from base_url so users can follow the
+        # OpenAI / LLMRails convention of including "/v1" in base_url without
+        # producing a doubled "/v1/v1/chat/completions" path.
+        base = self.base_url.rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+        url = base + _CHAT_COMPLETIONS_ENDPOINT
 
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self.api_key:

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -182,19 +182,28 @@ class ModelEngine(BaseEngine):
         )
 
     def _resolve_base_url(self) -> str:
-        """Resolve the base URL from model parameters or engine type."""
+        """Resolve the base URL from model parameters or engine type.
+
+        Strips an optional trailing "/v1" so users can follow the OpenAI / LLMRails
+        convention of including "/v1" in base_url without producing a doubled
+        "/v1/v1/chat/completions" path when _CHAT_COMPLETIONS_ENDPOINT is appended.
+        """
         params = self.model_config.parameters or {}
+        engine = self.model_config.engine
 
         if params.get("base_url"):
-            return params["base_url"]
+            base_url = params["base_url"]
+        elif engine in _ENGINE_BASE_URLS:
+            base_url = _ENGINE_BASE_URLS[engine]
+        else:
+            raise ValueError(
+                f"No base_url in parameters and cannot infer from engine '{engine}' for model '{self.model_name}'"
+            )
 
-        engine = self.model_config.engine
-        if engine in _ENGINE_BASE_URLS:
-            return _ENGINE_BASE_URLS[engine]
-
-        raise ValueError(
-            f"No base_url in parameters and cannot infer from engine '{engine}' for model '{self.model_name}'"
-        )
+        base_url = base_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+        return base_url
 
     def _get_environment_variable(self, variable_name: str) -> str | None:
         """Return the value stored in environment variable `variable_name`."""
@@ -233,13 +242,7 @@ class ModelEngine(BaseEngine):
     def _prepare_request(self, messages: LLMMessages, **kwargs: Any) -> _RequestParams:
         """Build the client, URL, headers, and body common to every request."""
         client = cast(RetryClient, self._client)
-        # Strip an optional trailing "/v1" from base_url so users can follow the
-        # OpenAI / LLMRails convention of including "/v1" in base_url without
-        # producing a doubled "/v1/v1/chat/completions" path.
-        base = self.base_url.rstrip("/")
-        if base.endswith("/v1"):
-            base = base[:-3]
-        url = base + _CHAT_COMPLETIONS_ENDPOINT
+        url = self.base_url + _CHAT_COMPLETIONS_ENDPOINT
 
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self.api_key:

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -16,18 +16,19 @@
 """Unit tests for iorails module."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
 
+from nemoguardrails.guardrails.guardrails import Guardrails
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.types import LLMResponse, LLMResponseChunk
-from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
 
 @pytest.fixture
@@ -681,3 +682,141 @@ class TestRefusalMessage:
         """REFUSAL_MESSAGE is a non-empty string."""
         assert isinstance(REFUSAL_MESSAGE, str)
         assert len(REFUSAL_MESSAGE) > 0
+
+
+class TestIORailsConfigToCallURL:
+    """End-to-end: from a RailsConfig with a user-supplied base_url to the URL the engine POSTs.
+
+    Covers regression for issue #1861 / PR #1862: a base_url with or without a trailing
+    "/v1" must produce a single /v1/chat/completions in the final HTTP request.
+    """
+
+    @pytest.mark.parametrize(
+        "base_url_input",
+        [
+            "https://custom.example.com",
+            "https://custom.example.com/v1",
+        ],
+    )
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_main_model_url_not_doubled(self, base_url_input):
+        """A user base_url with or without /v1 yields a single /v1 in the POST URL through the full IORails pipeline."""
+        config = RailsConfig.from_content(
+            config={
+                "models": [
+                    {
+                        "type": "main",
+                        "engine": "nim",
+                        "model": "meta/llama-3.3-70b-instruct",
+                        "parameters": {"base_url": base_url_input},
+                    },
+                ],
+            }
+        )
+        iorails = IORails(config)
+
+        # No rails are configured, so RailsManager short-circuits both checks to
+        # is_safe=True and the only outbound HTTP call is the main-model call.
+        # Pre-seed the main engine's HTTP client + _running=True so BaseEngine.start()
+        # short-circuits via its "if running: return" guard — no real aiohttp session
+        # is ever created.
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+
+        main_engine = iorails.engine_registry._engines["main"]
+        main_engine._client = mock_client
+        main_engine._running = True
+
+        try:
+            await iorails.generate_async([{"role": "user", "content": "Hi"}])
+        finally:
+            await iorails.stop()
+
+        url = mock_client.post.call_args[0][0]
+        assert url == "https://custom.example.com/v1/chat/completions"
+        assert "/v1/v1/" not in url
+
+
+def _make_mock_http_client(content: str):
+    """Build an AsyncMock RetryClient whose .post() returns a chat-completions response with the given content."""
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": content}}]})
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    mock_client.closed = False
+    return mock_client
+
+
+class TestGuardrailsConfigToCallURLs:
+    """End-to-end through the top-level Guardrails class: every model's POST URL
+    must have a single /v1, including rail-engine models.
+
+    Uses CONTENT_SAFETY_CONFIG (input + output content-safety rails + main model),
+    overrides both models with /v1-suffixed base_urls, and verifies that
+    guardrails.generate_async() composes correct URLs for every outbound HTTP call.
+    """
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_main_and_content_safety_urls_not_doubled(self):
+        """Both main and content_safety models POST to single-/v1 URLs through guardrails.generate_async()."""
+        # SAFE_OUTPUT_JSON works for both input and output content-safety parsers:
+        # the input parser keys on "User Safety", the output parser on "Response Safety".
+        safe_output_json = '{"User Safety": "safe", "Response Safety": "safe"}'
+
+        config_dict = {
+            **CONTENT_SAFETY_CONFIG,
+            "models": [
+                {**CONTENT_SAFETY_CONFIG["models"][0], "parameters": {"base_url": "https://main.example.com/v1"}},
+                {**CONTENT_SAFETY_CONFIG["models"][1], "parameters": {"base_url": "https://safety.example.com/v1"}},
+            ],
+        }
+        config = RailsConfig.from_content(config=config_dict)
+        guardrails = Guardrails(config=config)
+
+        # Sanity: CONTENT_SAFETY_CONFIG flows are IORails-eligible, so routing goes to IORails.
+        assert isinstance(guardrails.rails_engine, IORails)
+        iorails = guardrails.rails_engine
+
+        main_engine = iorails.engine_registry._get_engine("main", ModelEngine)
+        safety_engine = iorails.engine_registry._get_engine("content_safety", ModelEngine)
+
+        # Construction-time normalization: both engines' base_url have /v1 stripped.
+        assert main_engine.base_url == "https://main.example.com"
+        assert safety_engine.base_url == "https://safety.example.com"
+
+        # Pre-seed each engine with a mock HTTP client + _running=True so
+        # BaseEngine.start() short-circuits and no real aiohttp session is created.
+        main_client = _make_mock_http_client("Hello from main")
+        safety_client = _make_mock_http_client(safe_output_json)
+        main_engine._client = main_client
+        main_engine._running = True
+        safety_engine._client = safety_client
+        safety_engine._running = True
+
+        try:
+            await guardrails.generate_async(messages=[{"role": "user", "content": "Hi"}])
+        finally:
+            await iorails.stop()
+
+        # Main model POSTs once to a single-/v1 URL.
+        main_url = main_client.post.call_args[0][0]
+        assert main_url == "https://main.example.com/v1/chat/completions"
+        assert "/v1/v1/" not in main_url
+
+        # Content-safety model POSTs once for the input rail and once for the output rail.
+        # Every call must hit a single-/v1 URL.
+        assert safety_client.post.call_count == 2
+        for call_args in safety_client.post.call_args_list:
+            url = call_args[0][0]
+            assert url == "https://safety.example.com/v1/chat/completions"
+            assert "/v1/v1/" not in url

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -103,6 +103,29 @@ class TestModelEngineBaseUrl:
         with pytest.raises(ValueError, match="cannot infer from engine"):
             ModelEngine(_make_model(engine="unknown"))
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_base_url_with_trailing_v1_does_not_double_v1(self):
+        """A user-supplied base_url ending in /v1 must not produce /v1/v1/chat/completions."""
+        engine = ModelEngine(_make_model(engine="nim", parameters={"base_url": "https://custom.example.com/v1"}))
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        url = mock_client.post.call_args[0][0]
+        assert url == "https://custom.example.com/v1/chat/completions"
+        assert "/v1/v1/" not in url
+
 
 class TestModelEngineApiKey:
     """Test API key resolution from environment variables."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -126,6 +126,105 @@ class TestModelEngineBaseUrl:
         assert url == "https://custom.example.com/v1/chat/completions"
         assert "/v1/v1/" not in url
 
+    @pytest.mark.parametrize(
+        "base_url_input,expected",
+        [
+            ("https://host.example.com", "https://host.example.com"),
+            ("https://host.example.com/", "https://host.example.com"),
+            ("https://host.example.com/v1", "https://host.example.com"),
+            ("https://host.example.com/v1/", "https://host.example.com"),
+            ("https://api-v1.example.com", "https://api-v1.example.com"),
+            ("https://api-v1.example.com/v1", "https://api-v1.example.com"),
+            ("https://host.example.com/api/v1", "https://host.example.com/api"),
+        ],
+    )
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_resolve_base_url_normalization_https(self, base_url_input, expected):
+        """_resolve_base_url strips trailing slash + trailing /v1 path segment only.
+
+        Hostnames containing 'v1' (e.g. api-v1.example.com) must not be mangled.
+        """
+        engine = ModelEngine(_make_model(engine="nim", parameters={"base_url": base_url_input}))
+        assert engine.base_url == expected
+
+    @pytest.mark.parametrize(
+        "base_url_input,expected",
+        [
+            ("http://localhost:8000", "http://localhost:8000"),
+            ("http://localhost:8000/v1", "http://localhost:8000"),
+            ("http://localhost:11434/v1/", "http://localhost:11434"),
+            ("http://127.0.0.1:8000/v1", "http://127.0.0.1:8000"),
+        ],
+    )
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_resolve_base_url_normalization_http(self, base_url_input, expected):
+        """Same normalization for plain-http base_urls (common for local models: vLLM, Ollama)."""
+        engine = ModelEngine(_make_model(engine="nim", parameters={"base_url": base_url_input}))
+        assert engine.base_url == expected
+
+    @pytest.mark.parametrize(
+        "base_url_input,expected_url",
+        [
+            ("https://host.example.com", "https://host.example.com/v1/chat/completions"),
+            ("https://host.example.com/", "https://host.example.com/v1/chat/completions"),
+            ("https://host.example.com/v1/", "https://host.example.com/v1/chat/completions"),
+            ("https://api-v1.example.com", "https://api-v1.example.com/v1/chat/completions"),
+        ],
+    )
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_url_for_accepted_base_url_shapes_https(self, base_url_input, expected_url):
+        """End-to-end: call() POSTs to a canonical /v1/chat/completions URL across accepted https base_url shapes."""
+        engine = ModelEngine(_make_model(engine="nim", parameters={"base_url": base_url_input}))
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        url = mock_client.post.call_args[0][0]
+        assert url == expected_url
+        assert "/v1/v1/" not in url
+
+    @pytest.mark.parametrize(
+        "base_url_input,expected_url",
+        [
+            ("http://localhost:8000", "http://localhost:8000/v1/chat/completions"),
+            ("http://localhost:8000/v1", "http://localhost:8000/v1/chat/completions"),
+            ("http://127.0.0.1:11434/v1/", "http://127.0.0.1:11434/v1/chat/completions"),
+        ],
+    )
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_url_for_accepted_base_url_shapes_http(self, base_url_input, expected_url):
+        """End-to-end: same URL composition for plain-http local-model base_urls."""
+        engine = ModelEngine(_make_model(engine="nim", parameters={"base_url": base_url_input}))
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        url = mock_client.post.call_args[0][0]
+        assert url == expected_url
+        assert "/v1/v1/" not in url
+
 
 class TestModelEngineApiKey:
     """Test API key resolution from environment variables."""


### PR DESCRIPTION
## Description

`ModelEngine._prepare_request()` appends `/v1/chat/completions` to `self.base_url`, so a user-supplied `base_url` that already ends in `/v1` (the OpenAI / LLMRails / vLLM convention) produced `/v1/v1/chat/completions` and a 404 from the upstream server. The same config worked under LLMRails because the LangChain OpenAI client only appends `/chat/completions`.

This strips an optional trailing `/v1` from `base_url` before composing the URL, so both `https://host/v1` and `https://host` produce the correct `https://host/v1/chat/completions`.

## Related Issue(s)

- Fixes #1861

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where API endpoint paths could duplicate the `/v1` segment when users included it in their base URL configuration, ensuring the final request URL consistently targets `/v1/chat/completions`.

* **Tests**
  * Added unit and end-to-end tests verifying base URL normalization across various inputs (trailing slashes, `/v1` present/absent) to prevent double `/v1` segments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1862)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->