### PR TITLE
feat(llm/frameworks): validate framework on registration

### DIFF
--- a/nemoguardrails/llm/frameworks/registry.py
+++ b/nemoguardrails/llm/frameworks/registry.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import inspect
 import logging
 import os
 from typing import Dict
@@ -44,11 +45,15 @@ def register_framework(name: str, framework: LLMFramework) -> None:
     if name in _frameworks:
         raise ValueError(f"Framework '{name}' is already registered.")
     if not isinstance(framework, LLMFramework):
-        raise TypeError(
-            f"Framework '{name}' does not implement LLMFramework. "
-            "Required methods: create_model, register_provider, get_provider_names, reset."
+        required = sorted(
+            getattr(
+                LLMFramework,
+                "__protocol_attrs__",
+                {"create_model", "register_provider", "get_provider_names", "reset"},
+            )
         )
-    if not asyncio.iscoroutinefunction(getattr(framework, "reset", None)):
+        raise TypeError(f"Framework '{name}' does not implement LLMFramework. Required methods: {', '.join(required)}.")
+    if not inspect.iscoroutinefunction(getattr(framework, "reset", None)):
         raise TypeError(f"Framework '{name}'.reset must be an async coroutine function.")
     _frameworks[name] = framework
 

--- a/nemoguardrails/llm/frameworks/registry.py
+++ b/nemoguardrails/llm/frameworks/registry.py
@@ -53,7 +53,7 @@ def register_framework(name: str, framework: LLMFramework) -> None:
             )
         )
         raise TypeError(f"Framework '{name}' does not implement LLMFramework. Required methods: {', '.join(required)}.")
-    if not inspect.iscoroutinefunction(getattr(framework, "reset", None)):
+    if not inspect.iscoroutinefunction(framework.reset):
         raise TypeError(f"Framework '{name}'.reset must be an async coroutine function.")
     _frameworks[name] = framework
 
@@ -63,11 +63,11 @@ def get_framework(name: str) -> LLMFramework:
         if name == "langchain":
             from nemoguardrails.integrations.langchain.llm_adapter import LangChainFramework
 
-            _frameworks["langchain"] = LangChainFramework()
+            register_framework("langchain", LangChainFramework())
         elif name == "default":
             from nemoguardrails.llm.frameworks.default import DefaultFramework
 
-            _frameworks["default"] = DefaultFramework()
+            register_framework("default", DefaultFramework())
         else:
             available = list(_frameworks.keys())
             raise KeyError(f"Unknown framework '{name}'. Available frameworks: {available}")

--- a/nemoguardrails/llm/frameworks/registry.py
+++ b/nemoguardrails/llm/frameworks/registry.py
@@ -27,8 +27,29 @@ _default_framework: str = os.environ.get("NEMOGUARDRAILS_LLM_FRAMEWORK", "defaul
 
 
 def register_framework(name: str, framework: LLMFramework) -> None:
+    """Register an `LLMFramework` instance under `name`.
+
+    Validates two invariants before storing the instance:
+
+    1. The object structurally matches the `LLMFramework` Protocol
+       (`create_model`, `register_provider`, `get_provider_names`, `reset`).
+    2. Its `reset` attribute is an `async` coroutine function. The registry
+       awaits it directly during shutdown / test teardown.
+
+    Raises:
+        ValueError: a framework is already registered under `name`.
+        TypeError: `framework` does not implement the `LLMFramework`
+            Protocol, or its `reset` is not an async coroutine function.
+    """
     if name in _frameworks:
         raise ValueError(f"Framework '{name}' is already registered.")
+    if not isinstance(framework, LLMFramework):
+        raise TypeError(
+            f"Framework '{name}' does not implement LLMFramework. "
+            "Required methods: create_model, register_provider, get_provider_names, reset."
+        )
+    if not asyncio.iscoroutinefunction(getattr(framework, "reset", None)):
+        raise TypeError(f"Framework '{name}'.reset must be an async coroutine function.")
     _frameworks[name] = framework
 
 

--- a/tests/llm/frameworks/test_registry.py
+++ b/tests/llm/frameworks/test_registry.py
@@ -48,6 +48,12 @@ class FakeFramework:
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
 
+    def register_provider(self, name, provider_cls):
+        return None
+
+    def get_provider_names(self):
+        return []
+
     async def reset(self):
         return
 
@@ -104,6 +110,12 @@ class _ResetSpyFramework:
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
 
+    def register_provider(self, name, provider_cls):
+        return None
+
+    def get_provider_names(self):
+        return []
+
     async def reset(self):
         self.reset_count += 1
 
@@ -131,8 +143,17 @@ class TestAresetFrameworks:
 
 
 class _FrameworkWithoutReset:
+    """Used to validate that `_areset_frameworks` is defensive about a
+    missing `reset` even though `register_framework` would now reject it."""
+
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
+
+    def register_provider(self, name, provider_cls):
+        return None
+
+    def get_provider_names(self):
+        return []
 
 
 class _RaisingFramework:
@@ -141,6 +162,12 @@ class _RaisingFramework:
 
     def create_model(self, model_name, provider_name, model_kwargs=None):
         return MagicMock(spec=LLMModel)
+
+    def register_provider(self, name, provider_cls):
+        return None
+
+    def get_provider_names(self):
+        return []
 
     async def reset(self):
         raise self._exc
@@ -164,17 +191,70 @@ class TestResetFrameworksErrorIsolation:
 
 
 class TestResetFrameworksMissingResetMethod:
+    """`register_framework` now rejects frameworks without an async `reset`,
+    but `_areset_frameworks` keeps a defensive guard for any framework that
+    arrives in the registry through other paths (test injection, future
+    refactors). These tests bypass `register_framework` to exercise that
+    safety net directly."""
+
     def test_framework_without_reset_does_not_crash(self):
-        register_framework("no_reset", _FrameworkWithoutReset())
+        from nemoguardrails.llm.frameworks import registry as _r
+
+        _r._frameworks["no_reset"] = _FrameworkWithoutReset()
         _reset_frameworks()
         with pytest.raises(KeyError):
             get_framework("no_reset")
 
     def test_framework_without_reset_resets_default(self, monkeypatch):
+        from nemoguardrails.llm.frameworks import registry as _r
+
         monkeypatch.setenv("NEMOGUARDRAILS_LLM_FRAMEWORK", "default")
-        register_framework("no_reset_2", _FrameworkWithoutReset())
+        _r._frameworks["no_reset_2"] = _FrameworkWithoutReset()
         _reset_frameworks()
         assert get_default_framework() == "default"
+
+
+class TestRegisterFrameworkValidation:
+    """`register_framework` rejects two authoring mistakes at registration
+    time: a sync `reset`, and an object that does not match the
+    `LLMFramework` protocol."""
+
+    def test_sync_reset_raises_typeerror(self):
+        class BadFramework:
+            def create_model(self, model_name, provider_name, model_kwargs=None):
+                return MagicMock(spec=LLMModel)
+
+            def register_provider(self, name, provider_cls):
+                return None
+
+            def get_provider_names(self):
+                return []
+
+            def reset(self):  # missing async
+                return
+
+        with pytest.raises(TypeError, match="must be an async coroutine function"):
+            register_framework("bad_sync_reset", BadFramework())
+
+    def test_missing_protocol_methods_raises_typeerror(self):
+        class NotAFramework:
+            pass
+
+        with pytest.raises(TypeError, match="does not implement LLMFramework"):
+            register_framework("not_a_framework", NotAFramework())
+
+    def test_partial_protocol_raises_typeerror(self):
+        class Partial:
+            def create_model(self, model_name, provider_name, model_kwargs=None):
+                return MagicMock(spec=LLMModel)
+
+            async def reset(self):
+                return
+
+            # missing register_provider, get_provider_names
+
+        with pytest.raises(TypeError, match="does not implement LLMFramework"):
+            register_framework("partial", Partial())
 
 
 class FakeChatProvider:


### PR DESCRIPTION
## Summary

`register_framework()` now validates two invariants before storing the instance:
1. The object structurally matches the `LLMFramework` Protocol (`@runtime_checkable` `isinstance` check covers `create_model`, `register_provider`, `get_provider_names`, `reset`).
2. Its `reset` attribute is an `async` coroutine function (the registry awaits it directly).

Both raise `TypeError` with a clear message at registration time, before the framework is ever exercised.

## Why

The docs in `docs/configure-rails/custom-initialization/custom-llm-framework.md` (PR #1857) describe these guarantees in a "Failure Modes" section. Without this change those claims are false: `register_framework("bad", BadFramework())` silently accepts a sync-`reset` framework today and the user only sees a confusing failure deep inside the runtime.

## Test plan

- [x] `pytest tests/llm/frameworks/test_registry.py` — 19 passed (existing tests + 3 new failure-mode tests for sync reset, missing protocol methods, partial protocol)
- [x] Anti-example reproduction confirmed to raise the documented `TypeError`:
  - `BadFramework` (sync `reset`) -> `TypeError: Framework 'bad'.reset must be an async coroutine function.`
  - `NotAFramework` (no methods) -> `TypeError: Framework 'nope' does not implement LLMFramework. Required methods: create_model, register_provider, get_provider_names, reset.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced framework registration validation to immediately detect and report configuration issues, including duplicate registrations and frameworks that don't meet protocol requirements. Invalid configurations now fail fast with clear error messages instead of causing cryptic failures during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->