### PR TITLE
fix(llm/frameworks): point users to LangChain when DefaultFramework has no base_url

### DIFF
--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -44,7 +44,9 @@ def _resolve_base_url(provider_name: str) -> str:
         return url
     raise ValueError(
         f"No default base_url for provider '{provider_name}'. "
-        "Set it explicitly in model parameters: parameters.base_url"
+        "If your endpoint is OpenAI-compatible, set parameters.base_url. "
+        "Otherwise, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain and install "
+        "the matching langchain-<provider> package (see migration guide)."
     )
 
 

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -472,6 +472,25 @@ class TestDefaultFramework:
             await fw.reset()
 
     @pytest.mark.asyncio
+    async def test_unknown_provider_error_lists_both_fix_paths(self):
+        """Error message must name both the OpenAI-compatible fix and the
+        LangChain fix so users don't have to search the docs to know what the
+        runtime is asking of them."""
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError) as excinfo:
+                fw.create_model("claude-3-5-sonnet-latest", "anthropic", {})
+            message = str(excinfo.value)
+            assert "anthropic" in message
+            assert "parameters.base_url" in message
+            assert "NEMOGUARDRAILS_LLM_FRAMEWORK=langchain" in message
+            assert "langchain-<provider>" in message
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
     async def test_custom_base_url(self):
         from nemoguardrails.llm.frameworks.default import DefaultFramework
 


### PR DESCRIPTION
## Description

When a 0.21 config with a bare LangChain-only engine (anthropic, cohere, vertexai, deepseek, ...) lands on DefaultFramework with no env var set, `_resolve_base_url` raises with a hint that only points to `parameters.base_url`. That fix path is wrong for engines whose API is not OpenAI-compatible.

Update the error to name both fix paths:

- parameters.base_url for OpenAI-compatible endpoints,
- NEMOGUARDRAILS_LLM_FRAMEWORK=langchain plus the matching langchain-<provider> package for everything else.

Aligns the runtime hint with the migration guide so users hitting the error don't have to search the docs to know what the runtime is asking of them.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when encountering unsupported LLM providers, now including detailed guidance on configuring OpenAI-compatible endpoints and alternative framework setup options.

* **Tests**
  * Added test case to validate error message content, configuration paths, and provider information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->