### PR TITLE
feat: Allow for multiple self-check rails

### DIFF
--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -14,27 +14,35 @@
 # limitations under the License.
 
 import logging
-from typing import Optional
+from typing import Dict, List, Optional
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
-from nemoguardrails.actions.llm.utils import llm_call, warn_if_truncated
-from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.library.self_check.utils import (
+    SELF_CHECK_INPUT_DEFAULT_TASK,
+    SELF_CHECK_INPUT_FLOW,
+    SELF_CHECK_INPUT_TASK_PARAM,
+    resolve_self_check_task,
+    run_self_check_task,
+)
 from nemoguardrails.llm.taskmanager import LLMTaskManager
-from nemoguardrails.llm.types import Task
-from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import new_event_dict
 
 log = logging.getLogger(__name__)
 
+DEFAULT_TASK = SELF_CHECK_INPUT_DEFAULT_TASK
+
 
 @action(is_system_action=True)
 async def self_check_input(
+    llms: Dict[str, LLMModel],
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    events: Optional[List[dict]] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
+    task: Optional[str] = None,
     **kwargs,
 ):
     """Checks the input from the user.
@@ -46,47 +54,37 @@ async def self_check_input(
         True if the input should be allowed, False otherwise.
     """
 
-    _MAX_TOKENS = 1024
+    context = context or {}
     user_input = context.get("user_message")
-    task = Task.SELF_CHECK_INPUT
+
+    task = resolve_self_check_task(
+        task,
+        context,
+        events,
+        triggered_rail_key="triggered_input_rail",
+        start_rail_event_type="StartInputRail",
+        flow_id=SELF_CHECK_INPUT_FLOW,
+        task_param=SELF_CHECK_INPUT_TASK_PARAM,
+        default_task=DEFAULT_TASK,
+    )
 
     if user_input:
-        prompt = llm_task_manager.render_task_prompt(
+        is_safe, response = await run_self_check_task(
             task=task,
-            context={
+            prompt_context={
                 "user_input": user_input,
             },
+            llms=llms,
+            default_task=DEFAULT_TASK,
+            main_llm=llm,
+            llm_task_manager=llm_task_manager,
+            lowest_temperature=config.lowest_temperature,
         )
-        stop = llm_task_manager.get_stop_tokens(task=task)
-        max_tokens = llm_task_manager.get_max_tokens(task=task)
-        max_tokens = max_tokens or _MAX_TOKENS
 
-        # Initialize the LLMCallInfo object
-        llm_call_info_var.set(LLMCallInfo(task=task.value))
-
-        llm_response = await llm_call(
-            llm,
-            prompt,
-            stop=stop,
-            llm_params={
-                "temperature": config.lowest_temperature,
-                "max_tokens": max_tokens,
-            },
-        )
-        warn_if_truncated(llm_response, task.value)
-        response = llm_response.content
-
-        log.info(f"Input self-checking result is: `{response}`.")
-
-        # for sake of backward compatibility
-        # if the output_parser is not registered we will use the default one
-        if llm_task_manager.has_output_parser(task):
-            result = llm_task_manager.parse_task_output(task, output=response)
-
+        if task == DEFAULT_TASK:
+            log.info(f"Input self-checking result is: `{response}`.")
         else:
-            result = llm_task_manager.parse_task_output(task, output=response, forced_output_parser="is_content_safe")
-
-        is_safe = result[0]
+            log.info(f"Input self-checking result for task={task} is: `{response}`.")
 
         if not is_safe:
             return ActionResult(

--- a/nemoguardrails/library/self_check/input_check/flows.co
+++ b/nemoguardrails/library/self_check/input_check/flows.co
@@ -1,6 +1,5 @@
-
-flow self check input
-  $allowed = await SelfCheckInputAction
+flow self check input $task="self_check_input"
+  $allowed = await SelfCheckInputAction(task=$task)
 
   if not $allowed
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -14,26 +14,34 @@
 # limitations under the License.
 
 import logging
-from typing import Optional
+from typing import Dict, List, Optional
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
-from nemoguardrails.actions.llm.utils import llm_call, warn_if_truncated
-from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.library.self_check.utils import (
+    SELF_CHECK_OUTPUT_DEFAULT_TASK,
+    SELF_CHECK_OUTPUT_FLOW,
+    SELF_CHECK_OUTPUT_TASK_PARAM,
+    resolve_self_check_task,
+    run_self_check_task,
+)
 from nemoguardrails.llm.taskmanager import LLMTaskManager
-from nemoguardrails.llm.types import Task
-from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
+DEFAULT_TASK = SELF_CHECK_OUTPUT_DEFAULT_TASK
+
 
 @action(is_system_action=True, output_mapping=lambda value: not value)
 async def self_check_output(
+    llms: Dict[str, LLMModel],
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    events: Optional[List[dict]] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
+    task: Optional[str] = None,
     **kwargs,
 ):
     """Checks if the output from the bot.
@@ -48,50 +56,40 @@ async def self_check_output(
         True if the output should be allowed, False otherwise.
     """
 
-    _MAX_TOKENS = 1024
+    context = context or {}
     bot_response = context.get("bot_message")
     user_input = context.get("user_message")
     bot_thinking = context.get("bot_thinking")
 
-    task = Task.SELF_CHECK_OUTPUT
+    task = resolve_self_check_task(
+        task,
+        context,
+        events,
+        triggered_rail_key="triggered_output_rail",
+        start_rail_event_type="StartOutputRail",
+        flow_id=SELF_CHECK_OUTPUT_FLOW,
+        task_param=SELF_CHECK_OUTPUT_TASK_PARAM,
+        default_task=DEFAULT_TASK,
+    )
 
     if bot_response:
-        prompt = llm_task_manager.render_task_prompt(
+        is_safe, response = await run_self_check_task(
             task=task,
-            context={
+            prompt_context={
                 "user_input": user_input,
                 "bot_response": bot_response,
                 "bot_thinking": bot_thinking,
             },
+            llms=llms,
+            default_task=DEFAULT_TASK,
+            main_llm=llm,
+            llm_task_manager=llm_task_manager,
+            lowest_temperature=config.lowest_temperature,
         )
-        stop = llm_task_manager.get_stop_tokens(task=task)
-        max_tokens = llm_task_manager.get_max_tokens(task=task)
-        max_tokens = max_tokens or _MAX_TOKENS
 
-        # Initialize the LLMCallInfo object
-        llm_call_info_var.set(LLMCallInfo(task=task.value))
-
-        llm_response = await llm_call(
-            llm,
-            prompt,
-            stop=stop,
-            llm_params={
-                "temperature": config.lowest_temperature,
-                "max_tokens": max_tokens,
-            },
-        )
-        warn_if_truncated(llm_response, task.value)
-        response = llm_response.content
-
-        log.info(f"Output self-checking result is: `{response}`.")
-
-        # for sake of backward compatibility
-        # if the output_parser is not registered we will use the default one
-        if llm_task_manager.has_output_parser(task):
-            result = llm_task_manager.parse_task_output(task, output=response)
+        if task == DEFAULT_TASK:
+            log.info(f"Output self-checking result is: `{response}`.")
         else:
-            result = llm_task_manager.parse_task_output(task, output=response, forced_output_parser="is_content_safe")
-
-        is_safe = result[0]
+            log.info(f"Output self-checking result for task={task} is: `{response}`.")
 
         return is_safe

--- a/nemoguardrails/library/self_check/output_check/flows.co
+++ b/nemoguardrails/library/self_check/output_check/flows.co
@@ -1,10 +1,9 @@
-
-flow self check output
-  $allowed = await SelfCheckOutputAction
+flow self check output $task="self_check_output"
+  $allowed = await SelfCheckOutputAction(task=$task)
 
   if not $allowed
     if $system.config.enable_rails_exceptions
       send OutputRailException(message="Output not allowed. The output was blocked by the 'self check output' flow.")
     else
       bot refuse to respond
-      abort
+    abort

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from nemoguardrails.actions.llm.utils import llm_call, warn_if_truncated
+from nemoguardrails.colang.v1_0.runtime.flows import _get_flow_params, _normalize_flow_id
+from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
+
+log = logging.getLogger(__name__)
+
+SELF_CHECK_INPUT_FLOW = "self check input"
+SELF_CHECK_OUTPUT_FLOW = "self check output"
+SELF_CHECK_INPUT_TASK_PARAM = "task"
+SELF_CHECK_OUTPUT_TASK_PARAM = "task"
+SELF_CHECK_INPUT_DEFAULT_TASK = "self_check_input"
+SELF_CHECK_OUTPUT_DEFAULT_TASK = "self_check_output"
+
+
+def get_self_check_task_from_rail(flow: Any, flow_id: str, task_param: str, default_task: str) -> Optional[str]:
+    if not isinstance(flow, str) or _normalize_flow_id(flow) != flow_id:
+        return None
+
+    return _get_flow_params(flow).get(task_param) or default_task
+
+
+def resolve_self_check_task(
+    task: Optional[str],
+    context: Optional[dict],
+    events: Optional[List[dict]],
+    triggered_rail_key: str,
+    start_rail_event_type: str,
+    flow_id: str,
+    task_param: str,
+    default_task: str,
+) -> str:
+    if task and not task.startswith("$"):
+        return task
+
+    context = context or {}
+    context_task = get_self_check_task_from_rail(
+        context.get(triggered_rail_key),
+        flow_id=flow_id,
+        task_param=task_param,
+        default_task=default_task,
+    )
+    if context_task:
+        return context_task
+
+    for event in reversed(events or []):
+        if event.get("type") == "start_flow" and event.get("flow_id") == flow_id:
+            event_params = event.get("params") or {}
+            return event_params.get(task_param) or default_task
+
+        if event.get("type") == start_rail_event_type:
+            event_task = get_self_check_task_from_rail(
+                event.get("flow_id"),
+                flow_id=flow_id,
+                task_param=task_param,
+                default_task=default_task,
+            )
+            if event_task:
+                return event_task
+
+    return default_task
+
+
+def get_self_check_llm(
+    llms: Dict[str, LLMModel],
+    task: str,
+    default_task: str,
+    main_llm: Optional[LLMModel],
+) -> LLMModel:
+    if task in llms:
+        return llms[task]
+
+    if default_task in llms:
+        log.debug("No model found with type=%s, falling back to default %s model", task, default_task)
+        return llms[default_task]
+
+    if main_llm is not None:
+        log.debug("No model found with type=%s or type=%s, falling back to main model", task, default_task)
+        return main_llm
+
+    raise ValueError(
+        f"No matching model for task={task} found. "
+        f"Please configure a model with type={task}, type={default_task}, or type=main"
+    )
+
+
+def parse_self_check_output(llm_task_manager: Any, task: str, response: str):
+    if llm_task_manager.has_output_parser(task):
+        return llm_task_manager.parse_task_output(task, output=response)
+
+    return llm_task_manager.parse_task_output(task, output=response, forced_output_parser="is_content_safe")
+
+
+async def run_self_check_task(
+    task: str,
+    prompt_context: Dict[str, Any],
+    llms: Dict[str, LLMModel],
+    default_task: str,
+    main_llm: Optional[LLMModel],
+    llm_task_manager: Any,
+    lowest_temperature: float,
+    max_tokens: int = 1024,
+) -> tuple[bool, str]:
+    llm = get_self_check_llm(llms, task, default_task=default_task, main_llm=main_llm)
+
+    prompt = llm_task_manager.render_task_prompt(
+        task=task,
+        context=prompt_context,
+    )
+    stop = llm_task_manager.get_stop_tokens(task=task)
+    task_max_tokens = llm_task_manager.get_max_tokens(task=task) or max_tokens
+
+    llm_call_info_var.set(LLMCallInfo(task=task))
+
+    llm_response = await llm_call(
+        llm,
+        prompt,
+        stop=stop,
+        llm_params={
+            "temperature": lowest_temperature,
+            "max_tokens": task_max_tokens,
+        },
+    )
+    warn_if_truncated(llm_response, task)
+    response = llm_response.content
+
+    result = parse_self_check_output(llm_task_manager, task, response)
+    return bool(result[0]), response

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -36,7 +36,7 @@ from pydantic import (
 
 from nemoguardrails import utils
 from nemoguardrails.colang import parse_colang_file, parse_flow_elements
-from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id
+from nemoguardrails.colang.v1_0.runtime.flows import _get_flow_params, _normalize_flow_id
 from nemoguardrails.colang.v2_x.lang.utils import format_colang_parsing_error_message
 from nemoguardrails.colang.v2_x.runtime.errors import ColangParsingError
 from nemoguardrails.exceptions import (
@@ -1906,10 +1906,9 @@ class RailsConfig(BaseModel):
         provided_task_prompts = [prompt.task if hasattr(prompt, "task") else prompt.get("task") for prompt in prompts]
 
         # Input moderation prompt verification
-        if "self check input" in enabled_input_rails and "self_check_input" not in provided_task_prompts:
-            raise InvalidRailsConfigurationError(
-                "Missing a `self_check_input` prompt template, which is required for the `self check input` rail."
-            )
+        _validate_self_check_prompts(
+            enabled_input_rails, provided_task_prompts, "self check input", "self_check_input", "task"
+        )
         if "llama guard check input" in enabled_input_rails and "llama_guard_check_input" not in provided_task_prompts:
             raise InvalidRailsConfigurationError(
                 "Missing a `llama_guard_check_input` prompt template, which is required for the `llama guard check input` rail."
@@ -1922,10 +1921,9 @@ class RailsConfig(BaseModel):
         _validate_rail_prompts(enabled_input_rails, provided_task_prompts, "topic safety check input")
 
         # Output moderation prompt verification
-        if "self check output" in enabled_output_rails and "self_check_output" not in provided_task_prompts:
-            raise InvalidRailsConfigurationError(
-                "Missing a `self_check_output` prompt template, which is required for the `self check output` rail."
-            )
+        _validate_self_check_prompts(
+            enabled_output_rails, provided_task_prompts, "self check output", "self_check_output", "task"
+        )
         if (
             "llama guard check output" in enabled_output_rails
             and "llama_guard_check_output" not in provided_task_prompts
@@ -2309,6 +2307,25 @@ def _get_flow_model(flow_text) -> Optional[str]:
     if MODEL_PREFIX not in flow_text:
         return None
     return flow_text.split(MODEL_PREFIX)[-1].strip()
+
+
+def _validate_self_check_prompts(
+    rails: list[str],
+    prompts: list[Any],
+    flow_name: str,
+    default_task: str,
+    task_param: str,
+) -> None:
+    for rail in rails:
+        normalized = _normalize_flow_id(rail)
+        if normalized != flow_name:
+            continue
+        custom_task = _get_flow_params(rail).get(task_param)
+        expected = custom_task if custom_task else default_task
+        if expected not in prompts:
+            raise InvalidRailsConfigurationError(
+                f"Missing a `{expected}` prompt template, which is required for the `{rail}` rail."
+            )
 
 
 def _validate_rail_prompts(rails: list[str], prompts: list[Any], validation_rail: str) -> None:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -53,7 +53,7 @@ from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
 from nemoguardrails.base_guardrails import BaseGuardrails
 from nemoguardrails.colang import parse_colang_file
-from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id, compute_context
+from nemoguardrails.colang.v1_0.runtime.flows import _get_flow_params, _normalize_flow_id, compute_context
 from nemoguardrails.colang.v1_0.runtime.runtime import Runtime, RuntimeV1_0
 from nemoguardrails.colang.v2_x.runtime.flows import Action, State
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
@@ -1859,10 +1859,11 @@ class LLMRails(BaseGuardrails):
             bot_response_chunk: str,
             prompt: Optional[str] = None,
             messages: Optional[List[dict]] = None,
-            action_params: Dict[str, Any] = {},
+            action_params: Optional[Dict[str, Any]] = None,
         ):
             context_message = _get_last_context_message(messages)
             user_message = prompt or _get_latest_user_message(messages)
+            flow_params = _get_flow_params(flow_id)
 
             context = {
                 "user_message": user_message,
@@ -1871,18 +1872,20 @@ class LLMRails(BaseGuardrails):
 
             if context_message:
                 context.update(context_message["content"])
+            context["triggered_output_rail"] = flow_id
 
             model_name = flow_id.split("$")[-1].split("=")[-1].strip('"')
 
-            # Resolve $bot_message / $user_message into a new dict. action_params
-            # is the shared flow config (reused across chunks and requests) and
-            # must not be mutated in place.
-            resolved_params = dict(action_params or {})
-            for key, value in resolved_params.items():
-                if value == "$bot_message":
-                    resolved_params[key] = bot_response_chunk
-                elif value == "$user_message":
-                    resolved_params[key] = user_message
+            context_params = {
+                "bot_message": bot_response_chunk,
+                "user_message": user_message,
+                **flow_params,
+            }
+            resolved_action_params = {}
+            for key, value in (action_params or {}).items():
+                if isinstance(value, str) and value.startswith("$"):
+                    value = context_params.get(value[1:], value)
+                resolved_action_params[key] = value
 
             return {
                 # TODO:: are there other context variables that need to be passed?
@@ -1894,7 +1897,7 @@ class LLMRails(BaseGuardrails):
                 "model_name": model_name,
                 "llms": self.runtime.registered_action_params.get("llms", {}),
                 "llm": self.runtime.registered_action_params.get(f"{action_name}_llm", self.llm),
-                **resolved_params,
+                **resolved_action_params,
             }
 
         buffer_strategy = get_buffer_strategy(output_rails_streaming_config)

--- a/tests/integrations/langchain/test_streaming.py
+++ b/tests/integrations/langchain/test_streaming.py
@@ -448,8 +448,6 @@ async def test_streaming_output_rails_preserve_custom_task():
     assert custom_llm.inference_count > 0
     assert default_llm.inference_count == 0
 
-    await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
-
 
 @pytest.mark.asyncio
 async def test_streaming_output_rails_blocked(output_rails_streaming_config):

--- a/tests/integrations/langchain/test_streaming.py
+++ b/tests/integrations/langchain/test_streaming.py
@@ -23,6 +23,7 @@ from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.testing.fake_model import FakeLLMModel
 from tests.utils import TestChat
 
 
@@ -377,6 +378,75 @@ async def test_sequential_streaming_output_rails_allowed(
 
     error_chunks = [chunk for chunk in chunks if chunk.startswith('{"error":')]
     assert len(error_chunks) == 0
+
+    await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_rails_preserve_custom_task():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    "flows": ["self check output $task=check_data_leakage"],
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                        "context_size": 2,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "prompts": [
+                {
+                    "task": "check_data_leakage",
+                    "content": """
+                    Bot response: {{ bot_response }}
+                    Answer No.
+                    """,
+                },
+                {
+                    "task": "self_check_output",
+                    "content": """
+                    Bot response: {{ bot_response }}
+                    Answer Yes.
+                    """,
+                },
+            ],
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+
+        define flow
+          user express greeting
+          bot tell joke
+        """,
+    )
+    custom_llm = FakeLLMModel(responses=["No", "No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
+            '  "This response should stream safely."',
+        ],
+        streaming=True,
+    )
+    chat.app.runtime.registered_action_params["llms"]["check_data_leakage"] = custom_llm
+    chat.app.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+
+    chunks = []
+    async for chunk in chat.app.stream_async(
+        messages=[{"role": "user", "content": "Hi!"}],
+    ):
+        chunks.append(chunk)
+
+    assert "".join(chunks) == "This response should stream safely."
+    assert custom_llm.inference_count > 0
+    assert default_llm.inference_count == 0
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -1,0 +1,922 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for running multiple self-check input/output rails with different tasks."""
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.library.self_check.utils import (
+    SELF_CHECK_INPUT_DEFAULT_TASK,
+    SELF_CHECK_INPUT_FLOW,
+    SELF_CHECK_INPUT_TASK_PARAM,
+    get_self_check_llm,
+    get_self_check_task_from_rail,
+    resolve_self_check_task,
+    run_self_check_task,
+)
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.testing.fake_model import FakeLLMModel
+from tests.utils import TestChat
+
+multi_input_config = RailsConfig.from_content(
+    """
+    define user express greeting
+        "hello"
+        "hi"
+
+    define bot express greeting
+        "Hey!"
+
+    define flow greeting
+        user express greeting
+        bot express greeting
+""",
+    yaml_content="""
+    models: []
+    rails:
+        input:
+            flows:
+                - self check input $task=check_harmful
+                - self check input $task=check_off_topic
+    prompts:
+        - task: check_harmful
+          content: |
+            Is this message harmful?
+            User message: "{{ user_input }}"
+            Answer (Yes or No):
+        - task: check_off_topic
+          content: |
+            Is this message off-topic?
+            User message: "{{ user_input }}"
+            Answer (Yes or No):
+
+    enable_rails_exceptions: True
+    """,
+)
+
+
+def test_multiple_input_rails_both_pass():
+    """Both input checks return No (allowed) — message should pass through."""
+    chat = TestChat(
+        multi_input_config,
+        llm_completions=[
+            "No",
+            "No",
+            "  express greeting",
+            '  "Hey!"',
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+
+
+def test_multiple_input_rails_first_blocks():
+    """First input check blocks — should not reach second check."""
+    chat = TestChat(
+        multi_input_config,
+        llm_completions=[
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "bad message"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+
+
+def test_multiple_input_rails_second_blocks():
+    """First input check passes, second blocks."""
+    chat = TestChat(
+        multi_input_config,
+        llm_completions=[
+            "No",
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "off topic message"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+
+
+multi_output_config = RailsConfig.from_content(
+    """
+    define user ask question
+        "tell me something"
+
+    define flow
+        user ask question
+        bot respond
+""",
+    yaml_content="""
+    models: []
+    rails:
+        output:
+            flows:
+                - self check output $task=check_inappropriate
+                - self check output $task=check_data_leakage
+    prompts:
+        - task: check_inappropriate
+          content: |
+            Is this response inappropriate?
+            Bot response: "{{ bot_response }}"
+            Answer (Yes or No):
+        - task: check_data_leakage
+          content: |
+            Does this response leak sensitive data?
+            Bot response: "{{ bot_response }}"
+            Answer (Yes or No):
+
+    enable_rails_exceptions: True
+    """,
+)
+
+
+def test_multiple_output_rails_both_pass():
+    """Both output checks return No (allowed) — LLM-generated response should pass through."""
+    chat = TestChat(
+        multi_output_config,
+        llm_completions=[
+            "  ask question",
+            "  Here is the answer.",
+            "No",
+            "No",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "assistant"
+    assert new_message["content"] == "Here is the answer."
+
+
+def test_multiple_output_rails_first_blocks():
+    """First output check blocks — should not reach second check."""
+    chat = TestChat(
+        multi_output_config,
+        llm_completions=[
+            "  ask question",
+            '  "Some bad output"',
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+
+
+def test_multiple_output_rails_second_blocks():
+    """First output check passes, second blocks."""
+    chat = TestChat(
+        multi_output_config,
+        llm_completions=[
+            "  ask question",
+            '  "Response with leaked data"',
+            "No",
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+
+
+default_task_config = RailsConfig.from_content(
+    """
+    define user ask question
+        "tell me something"
+
+    define flow
+        user ask question
+        bot respond
+""",
+    yaml_content="""
+    models: []
+    rails:
+        input:
+            flows:
+                - self check input
+        output:
+            flows:
+                - self check output
+    prompts:
+        - task: self_check_input
+          content: ...
+        - task: self_check_output
+          content: ...
+
+    enable_rails_exceptions: True
+    """,
+)
+
+
+def test_default_task_input_still_works():
+    """Self check input without $task should use default self_check_input task."""
+    chat = TestChat(
+        default_task_config,
+        llm_completions=[
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "bad input"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+
+
+def test_mixed_input_rails_run_custom_and_default_tasks():
+    config = RailsConfig.from_content(
+        """
+        define user express greeting
+            "hello"
+            "hi"
+
+        define bot express greeting
+            "Hey!"
+
+        define flow greeting
+            user express greeting
+            bot express greeting
+    """,
+        yaml_content="""
+        models: []
+        rails:
+            input:
+                flows:
+                    - self check input $task=check_harmful
+                    - self check input
+        prompts:
+            - task: check_harmful
+              content: |
+                Is this message harmful?
+                User message: "{{ user_input }}"
+                Answer (Yes or No):
+            - task: self_check_input
+              content: |
+                Is this message safe?
+                User message: "{{ user_input }}"
+                Answer (Yes or No):
+
+        enable_rails_exceptions: True
+        """,
+    )
+    custom_llm = FakeLLMModel(responses=["No", "No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hey!"',
+        ],
+    )
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert custom_llm.inference_count == 1
+    assert default_llm.inference_count == 1
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+
+
+def test_default_task_output_still_works():
+    """Self check output without $task should use default self_check_output task."""
+    chat = TestChat(
+        default_task_config,
+        llm_completions=[
+            "No",
+            "  ask question",
+            '  "Something that should be blocked"',
+            "Yes",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+
+
+def test_mixed_output_rails_run_custom_and_default_tasks():
+    config = RailsConfig.from_content(
+        """
+        define user ask question
+            "tell me something"
+
+        define flow
+            user ask question
+            bot respond
+    """,
+        yaml_content="""
+        models: []
+        rails:
+            output:
+                flows:
+                    - self check output $task=check_inappropriate
+                    - self check output
+        prompts:
+            - task: check_inappropriate
+              content: |
+                Is this response inappropriate?
+                Bot response: "{{ bot_response }}"
+                Answer (Yes or No):
+            - task: self_check_output
+              content: |
+                Is this response safe?
+                Bot response: "{{ bot_response }}"
+                Answer (Yes or No):
+
+        enable_rails_exceptions: True
+        """,
+    )
+    custom_llm = FakeLLMModel(responses=["No", "No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  ask question",
+            '  "Response that the default rail blocks"',
+        ],
+    )
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert custom_llm.inference_count == 1
+    assert default_llm.inference_count == 1
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+
+
+per_task_input_config = RailsConfig.from_content(
+    """
+    define user express greeting
+        "hello"
+        "hi"
+
+    define bot express greeting
+        "Hey!"
+
+    define flow greeting
+        user express greeting
+        bot express greeting
+""",
+    yaml_content="""
+    models: []
+    rails:
+        input:
+            flows:
+                - self check input $task=check_harmful
+                - self check input $task=check_off_topic
+    prompts:
+        - task: check_harmful
+          content: |
+            Is this message harmful?
+            User message: "{{ user_input }}"
+            Answer (Yes or No):
+        - task: check_off_topic
+          content: |
+            Is this message off-topic?
+            User message: "{{ user_input }}"
+            Answer (Yes or No):
+
+    enable_rails_exceptions: True
+    """,
+)
+
+
+def test_per_task_llm_input_uses_task_specific_model():
+    """Each input check task should use its own LLM when configured in the llms dict."""
+    harmful_llm = FakeLLMModel(responses=["No"])
+    off_topic_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_input_config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hey!"',
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = harmful_llm
+    rails.runtime.registered_action_params["llms"]["check_off_topic"] = off_topic_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+    assert harmful_llm.inference_count == 1
+    assert off_topic_llm.inference_count == 1
+
+
+def test_per_task_llm_input_first_blocks_skips_second():
+    """When the first per-task LLM blocks, the second task-specific LLM should not be called."""
+    harmful_llm = FakeLLMModel(responses=["Yes"])
+    off_topic_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_input_config,
+        llm_completions=[],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = harmful_llm
+    rails.runtime.registered_action_params["llms"]["check_off_topic"] = off_topic_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "bad message"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+    assert harmful_llm.inference_count == 1
+    assert off_topic_llm.inference_count == 0
+
+
+per_task_output_config = RailsConfig.from_content(
+    """
+    define user ask question
+        "tell me something"
+
+    define flow
+        user ask question
+        bot respond
+""",
+    yaml_content="""
+    models: []
+    rails:
+        output:
+            flows:
+                - self check output $task=check_inappropriate
+                - self check output $task=check_data_leakage
+    prompts:
+        - task: check_inappropriate
+          content: |
+            Is this response inappropriate?
+            Bot response: "{{ bot_response }}"
+            Answer (Yes or No):
+        - task: check_data_leakage
+          content: |
+            Does this response leak sensitive data?
+            Bot response: "{{ bot_response }}"
+            Answer (Yes or No):
+
+    enable_rails_exceptions: True
+    """,
+)
+
+
+def test_per_task_llm_output_uses_task_specific_model():
+    """Each output check task should use its own LLM when configured in the llms dict."""
+    inappropriate_llm = FakeLLMModel(responses=["No"])
+    data_leakage_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_output_config,
+        llm_completions=[
+            "  ask question",
+            "  Here is the answer.",
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = inappropriate_llm
+    rails.runtime.registered_action_params["llms"]["check_data_leakage"] = data_leakage_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "assistant"
+    assert new_message["content"] == "Here is the answer."
+    assert inappropriate_llm.inference_count == 1
+    assert data_leakage_llm.inference_count == 1
+
+
+def test_per_task_llm_output_first_blocks_skips_second():
+    """When the first per-task output LLM blocks, the second should not be called."""
+    inappropriate_llm = FakeLLMModel(responses=["Yes"])
+    data_leakage_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_output_config,
+        llm_completions=[
+            "  ask question",
+            '  "Some bad output"',
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = inappropriate_llm
+    rails.runtime.registered_action_params["llms"]["check_data_leakage"] = data_leakage_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+    assert inappropriate_llm.inference_count == 1
+    assert data_leakage_llm.inference_count == 0
+
+
+def test_parallel_input_rail_uses_custom_task():
+    config = RailsConfig.from_content(
+        """
+        define user express greeting
+            "hello"
+            "hi"
+
+        define bot express greeting
+            "Hey!"
+
+        define flow greeting
+            user express greeting
+            bot express greeting
+    """,
+        yaml_content="""
+        models: []
+        rails:
+            input:
+                parallel: true
+                flows:
+                    - self check input $task=check_harmful
+        prompts:
+            - task: check_harmful
+              content: |
+                Is this message harmful?
+                User message: "{{ user_input }}"
+                Answer (Yes or No):
+            - task: self_check_input
+              content: |
+                Is this message safe?
+                User message: "{{ user_input }}"
+                Answer (Yes or No):
+
+        enable_rails_exceptions: True
+        """,
+    )
+    custom_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hey!"',
+        ],
+    )
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+    assert custom_llm.inference_count == 1
+    assert default_llm.inference_count == 0
+
+
+def test_parallel_output_rail_uses_custom_task():
+    config = RailsConfig.from_content(
+        """
+        define user ask question
+            "tell me something"
+
+        define flow
+            user ask question
+            bot respond
+    """,
+        yaml_content="""
+        models: []
+        rails:
+            output:
+                parallel: true
+                flows:
+                    - self check output $task=check_inappropriate
+        prompts:
+            - task: check_inappropriate
+              content: |
+                Is this response inappropriate?
+                Bot response: "{{ bot_response }}"
+                Answer (Yes or No):
+            - task: self_check_output
+              content: |
+                Is this response safe?
+                Bot response: "{{ bot_response }}"
+                Answer (Yes or No):
+
+        enable_rails_exceptions: True
+        """,
+    )
+    custom_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  ask question",
+            "  Here is the answer.",
+        ],
+    )
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "assistant"
+    assert new_message["content"] == "Here is the answer."
+    assert custom_llm.inference_count == 1
+    assert default_llm.inference_count == 0
+
+
+def test_per_task_llm_falls_back_to_main_when_not_configured():
+    """When no task-specific LLM is in the llms dict, it should fall back to the main LLM."""
+    chat = TestChat(
+        per_task_input_config,
+        llm_completions=[
+            "No",
+            "No",
+            "  express greeting",
+        ],
+    )
+
+    rails = chat.app
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+    assert chat.llm.inference_count == 3
+
+
+def test_input_fallback_to_default_task_model():
+    """When a custom task has no model, fall back to the self_check_input model."""
+    default_llm = FakeLLMModel(responses=["No", "No"])
+
+    chat = TestChat(
+        per_task_input_config,
+        llm_completions=[
+            "  express greeting",
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+    assert default_llm.inference_count == 2
+    assert chat.llm.inference_count == 1
+
+
+def test_output_fallback_to_default_task_model():
+    """When a custom task has no model, fall back to the self_check_output model."""
+    default_llm = FakeLLMModel(responses=["No", "No"])
+
+    chat = TestChat(
+        per_task_output_config,
+        llm_completions=[
+            "  ask question",
+            "  Here is the answer.",
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "assistant"
+    assert new_message["content"] == "Here is the answer."
+    assert default_llm.inference_count == 2
+    assert chat.llm.inference_count == 2
+
+
+def test_input_fallback_chain_prefers_task_over_default():
+    """Task-specific model takes priority over default self_check_input model."""
+    task_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_input_config,
+        llm_completions=[
+            "  express greeting",
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = task_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
+
+    assert new_message["role"] == "assistant"
+    assert task_llm.inference_count == 1
+    assert default_llm.inference_count == 1
+    assert chat.llm.inference_count == 1
+
+
+def test_output_fallback_chain_prefers_task_over_default():
+    """Task-specific model takes priority over default self_check_output model."""
+    task_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["No"])
+
+    chat = TestChat(
+        per_task_output_config,
+        llm_completions=[
+            "  ask question",
+            "  Here is the answer.",
+        ],
+    )
+
+    rails = chat.app
+    rails.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = task_llm
+
+    new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
+
+    assert new_message["role"] == "assistant"
+    assert task_llm.inference_count == 1
+    assert default_llm.inference_count == 1
+    assert chat.llm.inference_count == 2
+
+
+def _resolve_input_task(task=None, context=None, events=None):
+    return resolve_self_check_task(
+        task,
+        context,
+        events,
+        triggered_rail_key="triggered_input_rail",
+        start_rail_event_type="StartInputRail",
+        flow_id=SELF_CHECK_INPUT_FLOW,
+        task_param=SELF_CHECK_INPUT_TASK_PARAM,
+        default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_self_check_task_uses_concrete_task_without_runtime_context():
+    task_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+
+    is_safe, response = await run_self_check_task(
+        task="check_harmful",
+        prompt_context={"user_input": "hello"},
+        llms={
+            "check_harmful": task_llm,
+            "self_check_input": default_llm,
+        },
+        default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+        main_llm=None,
+        llm_task_manager=LLMTaskManager(per_task_input_config),
+        lowest_temperature=per_task_input_config.lowest_temperature,
+    )
+
+    assert is_safe
+    assert response == "No"
+    assert task_llm.inference_count == 1
+    assert default_llm.inference_count == 0
+
+
+def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
+    assert (
+        get_self_check_task_from_rail(
+            "self check input $task=check_harmful",
+            flow_id=SELF_CHECK_INPUT_FLOW,
+            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+        )
+        == "check_harmful"
+    )
+
+    assert (
+        get_self_check_task_from_rail(
+            "self check input",
+            flow_id=SELF_CHECK_INPUT_FLOW,
+            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+        )
+        == SELF_CHECK_INPUT_DEFAULT_TASK
+    )
+
+    assert (
+        get_self_check_task_from_rail(
+            "self check output $task=check_inappropriate",
+            flow_id=SELF_CHECK_INPUT_FLOW,
+            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+        )
+        is None
+    )
+
+
+def test_resolve_self_check_task_prefers_explicit_task():
+    task = _resolve_input_task(
+        task="check_harmful",
+        context={"triggered_input_rail": "self check input $task=check_off_topic"},
+    )
+
+    assert task == "check_harmful"
+
+
+def test_resolve_self_check_task_uses_triggered_rail_context():
+    task = _resolve_input_task(
+        task="$task",
+        context={"triggered_input_rail": "self check input $task=check_harmful"},
+    )
+
+    assert task == "check_harmful"
+
+
+def test_resolve_self_check_task_uses_latest_start_rail_event():
+    task = _resolve_input_task(
+        task="$task",
+        events=[
+            {"type": "StartInputRail", "flow_id": "self check input $task=check_off_topic"},
+            {"type": "SomeOtherEvent", "flow_id": "self check input $task=ignored"},
+            {"type": "StartInputRail", "flow_id": "self check input $task=check_harmful"},
+        ],
+    )
+
+    assert task == "check_harmful"
+
+
+def test_resolve_self_check_task_uses_start_flow_params():
+    task = _resolve_input_task(
+        events=[
+            {"type": "start_flow", "flow_id": SELF_CHECK_INPUT_FLOW, "params": {"task": "check_harmful"}},
+        ],
+    )
+
+    assert task == "check_harmful"
+
+
+def test_resolve_self_check_task_defaults_unresolved_placeholders():
+    assert _resolve_input_task(context={"triggered_input_rail": "self check input"}) == SELF_CHECK_INPUT_DEFAULT_TASK
+    assert _resolve_input_task(task="$task") == SELF_CHECK_INPUT_DEFAULT_TASK
+    assert _resolve_input_task() == SELF_CHECK_INPUT_DEFAULT_TASK
+
+
+def test_input_no_model_raises_error():
+    """When no model is available at any fallback level, get_self_check_llm raises ValueError."""
+    with pytest.raises(ValueError, match="No matching model"):
+        get_self_check_llm({}, "check_harmful", "self_check_input", main_llm=None)
+
+
+def test_get_llm_fallback_chain():
+    """get_self_check_llm resolves models in order: task -> default_task -> main -> ValueError."""
+    task_llm = FakeLLMModel(responses=[])
+    default_llm = FakeLLMModel(responses=[])
+    main_llm = FakeLLMModel(responses=[])
+
+    all_llms = {
+        "check_harmful": task_llm,
+        "self_check_input": default_llm,
+    }
+
+    # Level 1: exact task match
+    assert get_self_check_llm(all_llms, "check_harmful", "self_check_input", main_llm=main_llm) is task_llm
+
+    # Level 2: fall back to default task
+    assert get_self_check_llm(all_llms, "check_off_topic", "self_check_input", main_llm=main_llm) is default_llm
+
+    # Level 3: fall back to default_llm (the llm action param)
+    assert get_self_check_llm({}, "check_harmful", "self_check_input", main_llm=main_llm) is main_llm
+
+    # Level 4: no model raises ValueError
+    with pytest.raises(ValueError, match="No matching model"):
+        get_self_check_llm({}, "check_harmful", "self_check_input", main_llm=None)
+
+    with pytest.raises(ValueError, match="No matching model"):
+        get_self_check_llm({}, "check_inappropriate", "self_check_output", main_llm=None)

--- a/tests/test_rails_config.py
+++ b/tests/test_rails_config.py
@@ -98,6 +98,70 @@ def test_check_prompt_exist_for_self_check_rails():
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
 
+def test_check_prompt_exist_for_custom_self_check_task():
+    """Test that custom $task= values on self-check rails are validated."""
+
+    # Custom input task with matching prompt passes
+    values = {
+        "rails": {
+            "input": {"flows": ["self check input $task=check_harmful"]},
+            "output": {"flows": []},
+        },
+        "prompts": [{"task": "check_harmful", "content": "..."}],
+    }
+    result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
+    assert result == values
+
+    # Custom input task without matching prompt fails
+    values = {
+        "rails": {
+            "input": {"flows": ["self check input $task=check_harmful"]},
+            "output": {"flows": []},
+        },
+        "prompts": [],
+    }
+    with pytest.raises(ValueError, match="Missing a `check_harmful` prompt template"):
+        RailsConfig.check_prompt_exist_for_self_check_rails(values)
+
+    # Multiple custom tasks, one missing, fails
+    values = {
+        "rails": {
+            "input": {
+                "flows": [
+                    "self check input $task=check_harmful",
+                    "self check input $task=check_off_topic",
+                ]
+            },
+            "output": {"flows": []},
+        },
+        "prompts": [{"task": "check_harmful", "content": "..."}],
+    }
+    with pytest.raises(ValueError, match="Missing a `check_off_topic` prompt template"):
+        RailsConfig.check_prompt_exist_for_self_check_rails(values)
+
+    # Custom output task without matching prompt fails
+    values = {
+        "rails": {
+            "input": {"flows": []},
+            "output": {"flows": ["self check output $task=check_inappropriate"]},
+        },
+        "prompts": [],
+    }
+    with pytest.raises(ValueError, match="Missing a `check_inappropriate` prompt template"):
+        RailsConfig.check_prompt_exist_for_self_check_rails(values)
+
+    # Custom output task with matching prompt passes
+    values = {
+        "rails": {
+            "input": {"flows": []},
+            "output": {"flows": ["self check output $task=check_inappropriate"]},
+        },
+        "prompts": [{"task": "check_inappropriate", "content": "..."}],
+    }
+    result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
+    assert result == values
+
+
 def test_fill_in_default_values_for_v2_x():
     """Test that default values are correctly filled in for v2.x."""
 


### PR DESCRIPTION
## Description
Adds an optional `$input_task` and `$output_task` variable to the self_check rails, that allows for specification of multiple sequential self-check prompts in a configuration, e.g.:

```yaml
   prompts:
      - task: check_harmful_content
        content: |
          Your task is to check if the user message contains harmful,
          abusive, or inappropriate content.

          User message: "{{ user_input }}"

          Should this message be blocked (Yes or No)?
          Answer:

      - task: check_off_topic
        content: |
          Your task is to check if the user message is off-topic.
          This bot only handles questions about billing and account management.
          General conversation and greetings are allowed.

          User message: "{{ user_input }}"

          Is this message off-topic and should be blocked (Yes or No)?
          Answer:
```

```yaml
    rails:
      input:
        flows:
          - self check input $input_task=check_harmful_content
          - self check input $input_task=check_off_topic
```     

This PR also:
1) Provides support for per-task model configuration, identical to the `content_safety` rail
2) Standardizes the input and output self-check actions into the same function, to allow for easier future expansion.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Addresses https://github.com/NVIDIA-NeMo/Guardrails/issues/1873

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-check input and output rails now support custom task names and default task fallbacks.
  * Multiple self-check checks can be configured together, with task-specific model selection and fallback handling.
  * Streaming output rails now preserve custom task behavior during responses.

* **Bug Fixes**
  * Improved rail exception handling when input or output checks block a response.
  * Better task resolution across flow settings and runtime context, reducing unexpected model selection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->