### PR TITLE
test(telemetry): add smoke driver and fixtures 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,14 @@ coverage.xml
 # Logs
 *.log
 
+# Local telemetry smoke verification outputs
+/kibana*.json
+/smoke-*/
+/telemetry-smoke-*/
+/telemetry-smoke-manifest*.json
+/usage_stats.json
+/usage_stats.json.1
+
 # OS generated files
 .DS_Store
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/scripts/kibana_verify_export.py
+++ b/scripts/kibana_verify_export.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify a Kibana JSON export against a smoke-run manifest.
+
+Offline verifier for environments where the operator has Kibana
+Discover access but cannot issue an API key. Workflow:
+
+  1. Run ``scripts/telemetry_smoke.py``. Note the manifest path it
+     prints.
+  2. Open Kibana Discover at the staging telemetry data view
+     (``<staging-telemetry-data-view>``). Filter on the
+     manifest's ``session_prefix_root``:
+
+         client.sessionId : smoke-<run_id>-*
+
+  3. Share -> get the JSON of the visible documents. Save the file
+     locally (e.g. ``kibana.json``).
+  4. Run this script:
+
+         poetry run python scripts/kibana_verify_export.py \\
+             --manifest <run_dir>/manifest.json \\
+             --export kibana.json
+
+The script ignores any documents in the export whose ``eventName``
+is not ``guardrails_usage_event`` (Kibana exports tend to include
+sibling event types if the filter is broad).
+
+Per-scenario logic:
+
+  - Positive scenarios: assert the number of documents with a
+    matching session_prefix is >= ``expected_event_count``.
+  - Negative scenarios (``opt_out_*``, expected count 0): assert
+    exactly zero documents under the prefix.
+  - Scenarios whose local smoke verdict was FAIL: report FAIL. Receiver
+    verification cannot make a broken smoke scenario successful.
+
+Exit codes:
+  0  every scenario verified
+  1  one or more scenarios failed
+  2  configuration error (missing files, malformed manifest)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+EVENT_NAME = "guardrails_usage_event"
+
+
+def _load_json(path: Path, what: str) -> Any:
+    if not path.exists():
+        sys.stderr.write(f"{what} not found: {path}\n")
+        sys.exit(2)
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"{what} is not valid JSON ({path}): {exc}\n")
+        sys.exit(2)
+
+
+def _extract_session_id(doc: dict[str, Any]) -> str:
+    """Pull the guardrails sessionId from a Kibana export document.
+
+    Kibana export shape: ``doc["fields"]["client.sessionId"]`` is a
+    list because Kibana wraps every field value in a list. This is the
+    staging field exposed for smoke-run filtering.
+    """
+    fields = doc.get("fields", {})
+    values = fields.get("client.sessionId", [])
+    if not values:
+        return ""
+    return str(values[0])
+
+
+def _is_guardrails_event(doc: dict[str, Any]) -> bool:
+    fields = doc.get("fields", {})
+    event_names = fields.get("eventName", [])
+    return bool(event_names) and event_names[0] == EVENT_NAME
+
+
+def _bucket_docs_by_prefix(docs: list[dict[str, Any]], prefixes: list[str]) -> dict[str, list[dict[str, Any]]]:
+    """Group every guardrails doc into the scenario prefix it matches.
+
+    A doc is assigned to the longest matching prefix (so if two prefixes
+    overlap the more specific wins). Docs that match no prefix are
+    silently dropped: those are not part of this smoke run.
+    """
+    sorted_prefixes = sorted(prefixes, key=len, reverse=True)
+    buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for doc in docs:
+        if not _is_guardrails_event(doc):
+            continue
+        session_id = _extract_session_id(doc)
+        if not session_id:
+            continue
+        for prefix in sorted_prefixes:
+            if session_id.startswith(prefix):
+                buckets[prefix].append(doc)
+                break
+    return buckets
+
+
+def _verify(manifest: dict[str, Any], docs: list[dict[str, Any]]) -> tuple[int, int]:
+    scenarios = manifest.get("results", [])
+    if not scenarios:
+        sys.stderr.write("manifest has no results to verify\n")
+        sys.exit(2)
+
+    prefixes = [scenario["session_prefix"] for scenario in scenarios]
+    buckets = _bucket_docs_by_prefix(docs, prefixes)
+
+    pass_count = 0
+    fail_count = 0
+
+    for scenario in scenarios:
+        name = scenario["name"]
+        prefix = scenario["session_prefix"]
+        expected = scenario["expected_event_count"]
+
+        if scenario.get("verdict") == "FAIL":
+            print(f"[{name}] FAIL  (smoke verdict was FAIL)")
+            fail_count += 1
+            continue
+
+        actual = len(buckets.get(prefix, []))
+        if expected == 0:
+            ok = actual == 0
+            comparator = "=="
+        else:
+            ok = actual >= expected
+            comparator = ">="
+
+        verdict = "PASS" if ok else "FAIL"
+        print(f"[{name}] {verdict}  (kibana={actual}, expected{comparator}{expected})")
+        if ok:
+            pass_count += 1
+        else:
+            fail_count += 1
+
+    return pass_count, fail_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, help="Path to manifest.json from a smoke run.")
+    parser.add_argument(
+        "--export",
+        required=True,
+        help="Path to the JSON file downloaded from Kibana Discover (array of documents).",
+    )
+    args = parser.parse_args()
+
+    manifest = _load_json(Path(args.manifest), "manifest")
+    docs = _load_json(Path(args.export), "Kibana export")
+
+    if not isinstance(docs, list):
+        sys.stderr.write(f"Kibana export must be a JSON array of documents; got {type(docs).__name__}\n")
+        sys.exit(2)
+
+    guardrails_docs = sum(1 for doc in docs if _is_guardrails_event(doc))
+    print(
+        f"manifest: {args.manifest}\n"
+        f"export:   {args.export} ({len(docs)} docs total, {guardrails_docs} guardrails_usage_event)\n"
+    )
+
+    pass_count, fail_count = _verify(manifest, docs)
+    print()
+    print(f"=== summary: {pass_count} PASS, {fail_count} FAIL ===")
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kibana_verify_export.py
+++ b/scripts/kibana_verify_export.py
@@ -116,8 +116,7 @@ def _scenario_session_ids(scenario: dict[str, Any]) -> list[str]:
 def _verify(manifest: dict[str, Any], docs: list[dict[str, Any]]) -> tuple[int, int]:
     scenarios = manifest.get("results", [])
     if not scenarios:
-        sys.stderr.write("manifest has no results to verify\n")
-        sys.exit(2)
+        raise ValueError("manifest has no results to verify")
 
     all_session_ids = sorted({session_id for scenario in scenarios for session_id in _scenario_session_ids(scenario)})
     buckets = _bucket_docs_by_session_id(docs, all_session_ids)
@@ -176,7 +175,12 @@ def main() -> int:
         f"export:   {args.export} ({len(docs)} docs total, {guardrails_docs} guardrails_usage_event)\n"
     )
 
-    pass_count, fail_count = _verify(manifest, docs)
+    try:
+        pass_count, fail_count = _verify(manifest, docs)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
     print()
     print(f"=== summary: {pass_count} PASS, {fail_count} FAIL ===")
     return 0 if fail_count == 0 else 1

--- a/scripts/kibana_verify_export.py
+++ b/scripts/kibana_verify_export.py
@@ -21,10 +21,11 @@ Discover access but cannot issue an API key. Workflow:
   1. Run ``scripts/telemetry_smoke.py``. Note the manifest path it
      prints.
   2. Open Kibana Discover at the staging telemetry data view
-     (``<staging-telemetry-data-view>``). Filter on the
-     manifest's ``session_prefix_root``:
+     (``<staging-telemetry-data-view>``). Filter on the exact
+     ``kibana_filter`` printed by the smoke driver and saved in the
+     manifest, for example:
 
-         client.sessionId : smoke-<run_id>-*
+         client.sessionId : ("id1" or "id2" or "id3")
 
   3. Share -> get the JSON of the visible documents. Save the file
      locally (e.g. ``kibana.json``).
@@ -41,9 +42,9 @@ sibling event types if the filter is broad).
 Per-scenario logic:
 
   - Positive scenarios: assert the number of documents with a
-    matching session_prefix is >= ``expected_event_count``.
+    matching exact startup session ID is >= ``expected_event_count``.
   - Negative scenarios (``opt_out_*``, expected count 0): assert
-    exactly zero documents under the prefix.
+    exactly zero documents for their recorded session IDs.
   - Scenarios whose local smoke verdict was FAIL: report FAIL. Receiver
     verification cannot make a broken smoke scenario successful.
 
@@ -58,7 +59,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -96,26 +96,21 @@ def _is_guardrails_event(doc: dict[str, Any]) -> bool:
     return bool(event_names) and event_names[0] == EVENT_NAME
 
 
-def _bucket_docs_by_prefix(docs: list[dict[str, Any]], prefixes: list[str]) -> dict[str, list[dict[str, Any]]]:
-    """Group every guardrails doc into the scenario prefix it matches.
-
-    A doc is assigned to the longest matching prefix (so if two prefixes
-    overlap the more specific wins). Docs that match no prefix are
-    silently dropped: those are not part of this smoke run.
-    """
-    sorted_prefixes = sorted(prefixes, key=len, reverse=True)
-    buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+def _bucket_docs_by_session_id(docs: list[dict[str, Any]], session_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    """Group guardrails docs by exact client.sessionId."""
+    session_id_set = set(session_ids)
+    buckets: dict[str, list[dict[str, Any]]] = {session_id: [] for session_id in session_id_set}
     for doc in docs:
         if not _is_guardrails_event(doc):
             continue
         session_id = _extract_session_id(doc)
-        if not session_id:
-            continue
-        for prefix in sorted_prefixes:
-            if session_id.startswith(prefix):
-                buckets[prefix].append(doc)
-                break
+        if session_id in session_id_set:
+            buckets[session_id].append(doc)
     return buckets
+
+
+def _scenario_session_ids(scenario: dict[str, Any]) -> list[str]:
+    return list(scenario.get("startup_session_ids", []))
 
 
 def _verify(manifest: dict[str, Any], docs: list[dict[str, Any]]) -> tuple[int, int]:
@@ -124,23 +119,23 @@ def _verify(manifest: dict[str, Any], docs: list[dict[str, Any]]) -> tuple[int, 
         sys.stderr.write("manifest has no results to verify\n")
         sys.exit(2)
 
-    prefixes = [scenario["session_prefix"] for scenario in scenarios]
-    buckets = _bucket_docs_by_prefix(docs, prefixes)
+    all_session_ids = sorted({session_id for scenario in scenarios for session_id in _scenario_session_ids(scenario)})
+    buckets = _bucket_docs_by_session_id(docs, all_session_ids)
 
     pass_count = 0
     fail_count = 0
 
     for scenario in scenarios:
         name = scenario["name"]
-        prefix = scenario["session_prefix"]
         expected = scenario["expected_event_count"]
+        session_ids = _scenario_session_ids(scenario)
 
         if scenario.get("verdict") == "FAIL":
             print(f"[{name}] FAIL  (smoke verdict was FAIL)")
             fail_count += 1
             continue
 
-        actual = len(buckets.get(prefix, []))
+        actual = sum(len(buckets.get(session_id, [])) for session_id in session_ids)
         if expected == 0:
             ok = actual == 0
             comparator = "=="

--- a/scripts/telemetry-smoke.md
+++ b/scripts/telemetry-smoke.md
@@ -23,9 +23,9 @@ Before driving the full script, send a single event and verify it lands in Kiban
 ```bash
 unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
 export NEMO_GUARDRAILS_SMOKE_STAGING_URL=<internal-staging-events-url>/v1.1/events/json
-NEMO_SESSION_PREFIX=preflight-$(date +%s)- \
 NEMO_GUARDRAILS_USAGE_STATS_SERVER="$NEMO_GUARDRAILS_SMOKE_STAGING_URL" \
   poetry run python - <<'PY'
+import json
 import time
 from nemoguardrails import LLMRails, RailsConfig, telemetry
 
@@ -39,12 +39,15 @@ while time.monotonic() < deadline:
 else:
     raise SystemExit(f"pre-flight audit event not observed at {audit_file}")
 
-time.sleep(6)
+time.sleep(20)
+lines = [json.loads(line) for line in audit_file.read_text().splitlines() if line.strip()]
+startup_ids = sorted({line["sessionId"] for line in lines if line.get("event") == "startup"})
 print(f"pre-flight audit event observed at {audit_file}")
+print("kibana filter: client.sessionId : (" + " or ".join(f'"{value}"' for value in startup_ids) + ")")
 PY
 ```
 
-The local audit-file poll proves the event was emitted before the process exits; the final short sleep gives the daemon network send a chance to complete. Then wait briefly for indexing and search Kibana for `client.sessionId : preflight-*`. If nothing lands, defer the full smoke run until SMS has confirmed the schema is registered in staging.
+The local audit-file poll proves the event was emitted before the process exits; the final sleep gives the daemon network send a chance to complete before the process is terminated. Then wait briefly for indexing and search Kibana with the exact `client.sessionId` filter printed by the command. If nothing lands, defer the full smoke run until SMS has confirmed the schema is registered in staging.
 Do not commit internal staging endpoint URLs to this repo; keep them in your shell, password manager, or internal runbook.
 
 ## Full run
@@ -91,7 +94,7 @@ poetry run python scripts/telemetry_smoke.py \
 
 The unreachable URL keeps receiver delivery out of scope; telemetry send failures are non-fatal, while the local audit-file schema and field assertions still run. `library_feature_aliases` covers documented built-in feature IDs for config-only rails, `library_v2_custom_flows` covers bundled Colang 2.x library-flow exclusion from custom-flow counts with a minimal fixture, `library_abc_v2` covers the same count on the realistic ABC Colang 2.x bot, `server_multi_config` covers paced server emissions across configs, `server_multi_worker` covers three Uvicorn workers with distinct API sessions, and `heartbeat` covers startup plus heartbeat delivery without a heartbeat burst during network settle.
 
-The driver prints per-scenario PASS/FAIL, the Kibana filter, and the offline verification command. It writes `<run_dir>/manifest.json` containing the run id, session-prefix root, per-scenario verdicts, audit-file paths, event counts, subprocess return codes, stderr tails, server POST results, expected assertion summaries, and the configured staging URL. Treat the manifest as local verification output and do not commit it.
+The driver prints per-scenario PASS/FAIL, the exact Kibana filter, and the offline verification command. It writes `<run_dir>/manifest.json` containing the run id, collected startup session IDs, per-scenario verdicts, audit-file paths, event counts, subprocess return codes, stderr tails, server POST results, expected assertion summaries, and the configured staging URL. Treat the manifest as local verification output and do not commit it.
 
 ## Scenarios covered
 
@@ -119,7 +122,7 @@ For every scenario:
 - Subprocess exit code is zero.
 - Audit-file event count matches expected.
 - Each emitted line validates against `schemas/anonymous_events.snapshot.json` using `jsonschema` Draft-07.
-- Common payload fields are structurally valid: source, event type, session prefix, version, Python version, platform, OS name, and timestamp.
+- Common payload fields are structurally valid: source, event type, non-empty session ID, version, Python version, platform, OS name, and timestamp.
 - Startup payload fields are asserted per fixture: deployment type, rails engine, providers, Colang version, rail counts/types, built-in features, tracing, knowledge base, streaming, and custom-flow count.
 - Distinct sessionId count for `server_multi_worker`.
 - Presence of `event=heartbeat` for `heartbeat`, with heartbeat and startup sharing the same sessionId.
@@ -133,10 +136,10 @@ For accounts that have Kibana Discover access but cannot issue API keys (no Secu
 1. Run the smoke driver; note the manifest path.
 2. Open Kibana Discover at the `<staging-telemetry-data-view>` data view.
 3. Wait roughly a minute for indexing lag to settle.
-4. Paste the filter into the KQL search bar (use the manifest's `session_prefix_root`):
+4. Paste the exact filter printed by the driver and saved as `kibana_filter` in the manifest:
 
    ```
-   client.sessionId : smoke-<run_id>-*
+   client.sessionId : ("id1" or "id2" or "id3")
    ```
 
 5. Click the checkbox in the document-table header to **select all visible rows**.
@@ -150,21 +153,17 @@ For accounts that have Kibana Discover access but cannot issue API keys (no Secu
      --export kibana.json
    ```
 
-The script reads the manifest, ignores any non-`guardrails_usage_event` documents in the export (Discover filters apply to *visible rows*; the Selected list may include sibling event types if the time range covers other products), buckets each remaining doc by which scenario prefix its `client.sessionId` matches, and asserts hit counts. Per-scenario PASS / FAIL summary. Exit code 0 on success, 1 on assertion failure, 2 on missing or malformed input files.
+The script reads the manifest, ignores any non-`guardrails_usage_event` documents in the export (Discover filters apply to *visible rows*; the Selected list may include sibling event types if the time range covers other products), matches each remaining doc by exact `client.sessionId`, and asserts hit counts. Per-scenario PASS / FAIL summary. Exit code 0 on success, 1 on assertion failure, 2 on missing or malformed input files.
 
 ### Last-resort: visual inspection
 
-If you cannot download an export at all, paste this into the Kibana search bar:
+If you cannot download an export at all, paste the driver's exact filter into the Kibana search bar:
 
 ```
-client.sessionId : smoke-<run_id>-*
+client.sessionId : ("id1" or "id2" or "id3")
 ```
 
-Per-scenario filter:
-
-```
-client.sessionId : smoke-<run_id>-<scenario_name>-*
-```
+Use each result's `startup_session_ids` in `manifest.json` for per-scenario inspection.
 
 Negative scenarios (`opt_out_*`) should match nothing.
 
@@ -185,5 +184,5 @@ The driver removes each known per-scenario directory before running that scenari
 ## Out of scope
 
 - Cron-scheduled smoke runs (CI auto-disables telemetry by design).
-- Live Kibana queries from the driver. Verification of events landing remains a manual paste of the session-prefix into Kibana.
+- Live Kibana queries from the driver. Verification of events landing remains a manual paste of the exact session-ID filter into Kibana.
 - Mock LLM. Library, CLI, and heartbeat scenarios construct `LLMRails` only. Server scenarios POST a request that triggers `_get_rails` and then intentionally fails before generation, so no API key is required. Configs that fail to *construct* (bad YAML, missing models field, etc.) are out of scope of the smoke test.

--- a/scripts/telemetry-smoke.md
+++ b/scripts/telemetry-smoke.md
@@ -67,7 +67,6 @@ poetry run python scripts/telemetry_smoke.py \
   --rich-config tests/telemetry/smoke_fixtures/rich \
   --feature-alias-config tests/telemetry/smoke_fixtures/feature_aliases \
   --v2-config tests/telemetry/smoke_fixtures/v2_custom_flow \
-  --abc-v2-config examples/bots/abc_v2 \
   --iorails-config examples/configs/nemoguards \
   --server-config-root tests/telemetry/smoke_fixtures
 ```
@@ -86,13 +85,12 @@ poetry run python scripts/telemetry_smoke.py \
   --run-dir /tmp/smoke-rewrite-check \
   --scenario library_feature_aliases \
   --scenario library_v2_custom_flows \
-  --scenario library_abc_v2 \
   --scenario server_multi_config \
   --scenario server_multi_worker \
   --scenario heartbeat
 ```
 
-The unreachable URL keeps receiver delivery out of scope; telemetry send failures are non-fatal, while the local audit-file schema and field assertions still run. `library_feature_aliases` covers documented built-in feature IDs for config-only rails, `library_v2_custom_flows` covers bundled Colang 2.x library-flow exclusion from custom-flow counts with a minimal fixture, `library_abc_v2` covers the same count on the realistic ABC Colang 2.x bot, `server_multi_config` covers paced server emissions across configs, `server_multi_worker` covers three Uvicorn workers with distinct API sessions, and `heartbeat` covers startup plus heartbeat delivery without a heartbeat burst during network settle.
+The unreachable URL keeps receiver delivery out of scope; telemetry send failures are non-fatal, while the local audit-file schema and field assertions still run. `library_feature_aliases` covers documented built-in feature IDs for config-only rails, `library_v2_custom_flows` covers bundled Colang 2.x library-flow exclusion from custom-flow counts with a minimal fixture, `server_multi_config` covers paced server emissions across configs, `server_multi_worker` covers three Uvicorn workers with distinct API sessions, and `heartbeat` covers startup plus heartbeat delivery without a heartbeat burst during network settle.
 
 The driver prints per-scenario PASS/FAIL, the exact Kibana filter, and the offline verification command. It writes `<run_dir>/manifest.json` containing the run id, collected startup session IDs, per-scenario verdicts, audit-file paths, event counts, subprocess return codes, stderr tails, server POST results, expected assertion summaries, and the configured staging URL. Treat the manifest as local verification output and do not commit it.
 
@@ -104,7 +102,6 @@ The driver prints per-scenario PASS/FAIL, the exact Kibana filter, and the offli
 | `library_rich_config` | 1 event with tracing, streaming, knowledge base, and custom-flow fields enabled |
 | `library_feature_aliases` | 1 event with config-only `builtinFeatures=["factchecking","patronusai","regex"]` |
 | `library_v2_custom_flows` | 1 event with `colangVersion=2.x` and `numCustomFlows=1` despite bundled `core` flows |
-| `library_abc_v2` | 1 event from `examples/bots/abc_v2`, `colangVersion=2.x`, `hasKnowledgeBase=true`, and `numCustomFlows=67` |
 | `library_iorails` | 1 event, `deploymentType=library`, `railsEngine=IORails` |
 | `server_single_config` | 1 event, `deploymentType=api`, `railsEngine=LLMRails` |
 | `server_multi_config` | 3 events, same sessionId, distinct `railTypesInUse` / `builtinFeatures` |

--- a/scripts/telemetry-smoke.md
+++ b/scripts/telemetry-smoke.md
@@ -1,0 +1,189 @@
+# Telemetry smoke test
+
+Operator-driven local script that fires every realistic deployment scenario against the staging telemetry endpoint, validates each emitted event against the vendored upstream schema, and writes a manifest the operator pastes into Kibana to verify events landed.
+
+The driver lives at [`scripts/telemetry_smoke.py`](../scripts/telemetry_smoke.py).
+
+## When to run
+
+- After any change to `nemoguardrails/telemetry.py`, `server/api.py`, `rails/llm/llmrails.py`, or `guardrails/guardrails.py` that touches the wire format.
+- Before merging the upstream `nemo-telemetry` MR or cutting a release that ships telemetry.
+- After SMS confirms our schema is registered in staging (run the pre-flight below first to verify).
+
+## Prerequisites
+
+- `poetry install --with dev` so `jsonschema` is available for local schema validation.
+- `tests/telemetry/smoke_fixtures/{cfg1,cfg2,cfg3,rich}/` and `examples/configs/nemoguards/` are present in the working tree.
+- `CI`, `GITHUB_ACTIONS`, and `PYTEST_CURRENT_TEST` must NOT be exported in the calling shell. The driver refuses to start otherwise. `unset` them first.
+
+## Pre-flight: one event by hand
+
+Before driving the full script, send a single event and verify it lands in Kibana. This proves staging is accepting our event_name.
+
+```bash
+unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
+export NEMO_GUARDRAILS_SMOKE_STAGING_URL=<internal-staging-events-url>/v1.1/events/json
+NEMO_SESSION_PREFIX=preflight-$(date +%s)- \
+NEMO_GUARDRAILS_USAGE_STATS_SERVER="$NEMO_GUARDRAILS_SMOKE_STAGING_URL" \
+  poetry run python - <<'PY'
+import time
+from nemoguardrails import LLMRails, RailsConfig, telemetry
+
+LLMRails(RailsConfig.from_path("examples/bots/abc"))
+audit_file = telemetry._get_audit_file()
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline:
+    if audit_file.exists() and audit_file.read_text().strip():
+        break
+    time.sleep(0.1)
+else:
+    raise SystemExit(f"pre-flight audit event not observed at {audit_file}")
+
+time.sleep(6)
+print(f"pre-flight audit event observed at {audit_file}")
+PY
+```
+
+The local audit-file poll proves the event was emitted before the process exits; the final short sleep gives the daemon network send a chance to complete. Then wait briefly for indexing and search Kibana for `client.sessionId : preflight-*`. If nothing lands, defer the full smoke run until SMS has confirmed the schema is registered in staging.
+Do not commit internal staging endpoint URLs to this repo; keep them in your shell, password manager, or internal runbook.
+
+## Full run
+
+```bash
+unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
+export NEMO_GUARDRAILS_SMOKE_STAGING_URL=<internal-staging-events-url>/v1.1/events/json
+poetry run python scripts/telemetry_smoke.py
+```
+
+To target a different endpoint or override config paths:
+
+```bash
+poetry run python scripts/telemetry_smoke.py \
+  --staging-url "$NEMO_GUARDRAILS_SMOKE_STAGING_URL" \
+  --library-config tests/telemetry/smoke_fixtures/cfg1 \
+  --rich-config tests/telemetry/smoke_fixtures/rich \
+  --feature-alias-config tests/telemetry/smoke_fixtures/feature_aliases \
+  --v2-config tests/telemetry/smoke_fixtures/v2_custom_flow \
+  --abc-v2-config examples/bots/abc_v2 \
+  --iorails-config examples/configs/nemoguards \
+  --server-config-root tests/telemetry/smoke_fixtures
+```
+
+To run a single scenario (useful while iterating):
+
+```bash
+poetry run python scripts/telemetry_smoke.py --scenario library_llmrails
+```
+
+For a quick local regression check while editing the smoke driver, use an intentionally unreachable telemetry URL and run the scenarios most likely to catch local regressions:
+
+```bash
+poetry run python scripts/telemetry_smoke.py \
+  --staging-url http://127.0.0.1:9 \
+  --run-dir /tmp/smoke-rewrite-check \
+  --scenario library_feature_aliases \
+  --scenario library_v2_custom_flows \
+  --scenario library_abc_v2 \
+  --scenario server_multi_config \
+  --scenario server_multi_worker \
+  --scenario heartbeat
+```
+
+The unreachable URL keeps receiver delivery out of scope; telemetry send failures are non-fatal, while the local audit-file schema and field assertions still run. `library_feature_aliases` covers documented built-in feature IDs for config-only rails, `library_v2_custom_flows` covers bundled Colang 2.x library-flow exclusion from custom-flow counts with a minimal fixture, `library_abc_v2` covers the same count on the realistic ABC Colang 2.x bot, `server_multi_config` covers paced server emissions across configs, `server_multi_worker` covers three Uvicorn workers with distinct API sessions, and `heartbeat` covers startup plus heartbeat delivery without a heartbeat burst during network settle.
+
+The driver prints per-scenario PASS/FAIL, the Kibana filter, and the offline verification command. It writes `<run_dir>/manifest.json` containing the run id, session-prefix root, per-scenario verdicts, audit-file paths, event counts, subprocess return codes, stderr tails, server POST results, expected assertion summaries, and the configured staging URL. Treat the manifest as local verification output and do not commit it.
+
+## Scenarios covered
+
+| Name | Expected wire shape |
+|---|---|
+| `library_llmrails` | 1 event, `deploymentType=library`, `railsEngine=LLMRails` |
+| `library_rich_config` | 1 event with tracing, streaming, knowledge base, and custom-flow fields enabled |
+| `library_feature_aliases` | 1 event with config-only `builtinFeatures=["factchecking","patronusai","regex"]` |
+| `library_v2_custom_flows` | 1 event with `colangVersion=2.x` and `numCustomFlows=1` despite bundled `core` flows |
+| `library_abc_v2` | 1 event from `examples/bots/abc_v2`, `colangVersion=2.x`, `hasKnowledgeBase=true`, and `numCustomFlows=67` |
+| `library_iorails` | 1 event, `deploymentType=library`, `railsEngine=IORails` |
+| `server_single_config` | 1 event, `deploymentType=api`, `railsEngine=LLMRails` |
+| `server_multi_config` | 3 events, same sessionId, distinct `railTypesInUse` / `builtinFeatures` |
+| `server_multi_worker` | 3 events from 3 Uvicorn workers, distinct sessionIds, `deploymentType=api` |
+| `cli_chat` | 1 event, `deploymentType=cli` |
+| `heartbeat` | 1 startup + at least 1 event with `event=heartbeat` |
+| `opt_out_explicit` | audit file empty (NEMO_GUARDRAILS_NO_USAGE_STATS=1) |
+| `opt_out_ci` | audit file empty (CI=true) |
+| `opt_out_pytest` | audit file empty (PYTEST_CURRENT_TEST=...) |
+
+## Local invariants the driver checks automatically
+
+For every scenario:
+
+- Subprocess exit code is zero.
+- Audit-file event count matches expected.
+- Each emitted line validates against `schemas/anonymous_events.snapshot.json` using `jsonschema` Draft-07.
+- Common payload fields are structurally valid: source, event type, session prefix, version, Python version, platform, OS name, and timestamp.
+- Startup payload fields are asserted per fixture: deployment type, rails engine, providers, Colang version, rail counts/types, built-in features, tracing, knowledge base, streaming, and custom-flow count.
+- Distinct sessionId count for `server_multi_worker`.
+- Presence of `event=heartbeat` for `heartbeat`, with heartbeat and startup sharing the same sessionId.
+
+## Kibana verification
+
+### Offline: copy documents as JSON, verify locally
+
+For accounts that have Kibana Discover access but cannot issue API keys (no Security → API Keys in Stack Management), use [`scripts/kibana_verify_export.py`](./kibana_verify_export.py):
+
+1. Run the smoke driver; note the manifest path.
+2. Open Kibana Discover at the `<staging-telemetry-data-view>` data view.
+3. Wait roughly a minute for indexing lag to settle.
+4. Paste the filter into the KQL search bar (use the manifest's `session_prefix_root`):
+
+   ```
+   client.sessionId : smoke-<run_id>-*
+   ```
+
+5. Click the checkbox in the document-table header to **select all visible rows**.
+6. In the table's toolbar a "**N Selected**" dropdown appears. Open it and choose **Copy documents as JSON**.
+7. Paste the clipboard into a local file (e.g. `kibana.json` in the repo root). The format is a JSON array where each element has `_index`, `_id`, and a `fields` dict. Kibana exports may contain internal staging telemetry documents; do not commit them.
+8. Run:
+
+   ```bash
+   poetry run python scripts/kibana_verify_export.py \
+     --manifest <run_dir>/manifest.json \
+     --export kibana.json
+   ```
+
+The script reads the manifest, ignores any non-`guardrails_usage_event` documents in the export (Discover filters apply to *visible rows*; the Selected list may include sibling event types if the time range covers other products), buckets each remaining doc by which scenario prefix its `client.sessionId` matches, and asserts hit counts. Per-scenario PASS / FAIL summary. Exit code 0 on success, 1 on assertion failure, 2 on missing or malformed input files.
+
+### Last-resort: visual inspection
+
+If you cannot download an export at all, paste this into the Kibana search bar:
+
+```
+client.sessionId : smoke-<run_id>-*
+```
+
+Per-scenario filter:
+
+```
+client.sessionId : smoke-<run_id>-<scenario_name>-*
+```
+
+Negative scenarios (`opt_out_*`) should match nothing.
+
+## Troubleshooting
+
+**"refusing to run: the driver inherited CI ..."**
+`unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST` in your shell and retry.
+
+**Driver passes locally but Kibana shows nothing**
+Staging may be rejecting unregistered events or indexing may be delayed. Confirm with SMS that the schema is registered in staging, then re-run the pre-flight and smoke driver.
+
+**Single scenario fails with "expected N events, got 0"**
+Usually means `LLMRails` failed at import or construction time. Check the manifest's `audit_file` for that scenario; if empty, look at the subprocess's `stderr_tail` in the result. Most common cause: a missing dependency or a config-validation error.
+
+**A reused `--run-dir` contains old events**
+The driver removes each known per-scenario directory before running that scenario, so rerunning with the same `--run-dir` is supported. If a run is interrupted before the script starts a scenario, only that unstarted scenario's old audit file can remain.
+
+## Out of scope
+
+- Cron-scheduled smoke runs (CI auto-disables telemetry by design).
+- Live Kibana queries from the driver. Verification of events landing remains a manual paste of the session-prefix into Kibana.
+- Mock LLM. Library, CLI, and heartbeat scenarios construct `LLMRails` only. Server scenarios POST a request that triggers `_get_rails` and then intentionally fails before generation, so no API key is required. Configs that fail to *construct* (bad YAML, missing models field, etc.) are out of scope of the smoke test.

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -103,18 +103,12 @@ DEFAULT_LIBRARY_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / 
 DEFAULT_RICH_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "rich"
 DEFAULT_FEATURE_ALIAS_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "feature_aliases"
 DEFAULT_V2_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "v2_custom_flow"
-DEFAULT_ABC_V2_CONFIG = REPO_ROOT / "examples" / "bots" / "abc_v2"
 DEFAULT_IORAILS_CONFIG = REPO_ROOT / "examples" / "configs" / "nemoguards"
 
 ENV_VARS_TO_STRIP = ("CI", "GITHUB_ACTIONS", "PYTEST_CURRENT_TEST")
 DEFAULT_AUDIT_TIMEOUT_S = 30.0
 DEFAULT_AUDIT_POLL_S = 0.1
 DEFAULT_NETWORK_SETTLE_S = 20.0
-
-
-# ---------------------------------------------------------------------------
-# Env + audit-file plumbing (shared by all scenario runners)
-# ---------------------------------------------------------------------------
 
 
 def _build_subprocess_env(
@@ -178,10 +172,6 @@ def _wait_for_audit_events(
 
 def _network_settle_s(scenario: dict[str, Any]) -> float:
     return float(scenario.get("settle_after_audit_s", DEFAULT_NETWORK_SETTLE_S))
-
-
-def _normalize_returncode(returncode: int) -> int:
-    return 0 if returncode == -15 else returncode
 
 
 def _make_validator():
@@ -340,11 +330,6 @@ def _summarize_assertions(scenario: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Real-server helpers: port allocation, readiness polling, POST a request
-# ---------------------------------------------------------------------------
-
-
 def _free_port() -> int:
     """Ask the OS for a free TCP port and release it.
 
@@ -362,7 +347,7 @@ def _wait_for_server(base_url: str, *, timeout: float = 30.0, poll: float = 0.5)
     url = base_url.rstrip("/") + "/v1/rails/configs"
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(url, timeout=2) as response:
+            with urllib.request.urlopen(url, timeout=5) as response:
                 if 200 <= response.status < 300:
                     return True
         except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError):
@@ -411,7 +396,8 @@ def _terminate(proc: subprocess.Popen, *, term_timeout: float = 10.0) -> int:
         return int(proc.returncode)
     proc.terminate()
     try:
-        return proc.wait(timeout=term_timeout)
+        returncode = proc.wait(timeout=term_timeout)
+        return 0 if returncode in {-15, 1} else returncode
     except subprocess.TimeoutExpired:
         proc.kill()
         try:
@@ -420,16 +406,11 @@ def _terminate(proc: subprocess.Popen, *, term_timeout: float = 10.0) -> int:
             return -1
 
 
-# ---------------------------------------------------------------------------
-# Scenario runners
-# ---------------------------------------------------------------------------
-
-
 def _run_subprocess(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
     """Run a ``kind=subprocess`` scenario: a Python -c script.
 
     Used for library and opt-out scenarios where we directly construct
-    LLMRails (library mode) or verify no event is emitted (opt-out).
+    rails from a config or verify no event is emitted (opt-out).
     """
     started_at = time.time()
     try:
@@ -442,7 +423,7 @@ def _run_subprocess(scenario: dict[str, Any], env: dict[str, str], audit_file: P
             cwd=str(REPO_ROOT),
         )
     except Exception as exc:
-        return {"returncode": -1, "duration_s": 0.0, "stderr_tail": [repr(exc)]}
+        return {"returncode": -1, "duration_s": time.time() - started_at, "stderr_tail": [repr(exc)]}
 
     expected_count = int(scenario["expected_count"])
     audit_timeout = float(scenario.get("audit_timeout_s", DEFAULT_AUDIT_TIMEOUT_S))
@@ -467,7 +448,7 @@ def _run_subprocess(scenario: dict[str, Any], env: dict[str, str], audit_file: P
         except Exception:
             pass
     return {
-        "returncode": _normalize_returncode(returncode),
+        "returncode": returncode,
         "duration_s": time.time() - started_at,
         "stderr_tail": stderr_tail,
     }
@@ -596,7 +577,7 @@ def _run_server(scenario: dict[str, Any], env: dict[str, str], audit_file: Path)
         except Exception:
             pass
     return {
-        "returncode": _normalize_returncode(rc),  # SIGTERM is expected
+        "returncode": rc,
         "duration_s": time.time() - started_at,
         "stderr_tail": stderr_tail,
         "server_post_results": post_results,
@@ -725,7 +706,7 @@ def _run_server_multi_worker(scenario: dict[str, Any], env: dict[str, str], audi
         except Exception:
             pass
     return {
-        "returncode": _normalize_returncode(rc),
+        "returncode": rc,
         "duration_s": time.time() - started_at,
         "stderr_tail": stderr_tail,
         "server_post_results": post_results,
@@ -777,7 +758,7 @@ def _run_cli(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) ->
         except Exception:
             pass
     return {
-        "returncode": _normalize_returncode(rc),
+        "returncode": rc,
         "duration_s": time.time() - started_at,
         "stderr_tail": stderr_tail,
     }
@@ -791,12 +772,13 @@ _RUNNERS = {
 }
 
 
-# ---------------------------------------------------------------------------
-# Scenario subprocess scripts (for kind=subprocess scenarios only)
-# ---------------------------------------------------------------------------
+def _script_construct_rails(config_path: str) -> str:
+    """Construct rails from a config and keep the subprocess alive.
 
-
-def _script_library_llmrails(config_path: str) -> str:
+    Scenario-specific behavior is controlled by the config path and
+    environment: opt-out scenarios suppress telemetry via env vars, and
+    the IORails scenario sets NEMO_GUARDRAILS_IORAILS_ENGINE=true.
+    """
     return f"""
 import time
 from nemoguardrails import LLMRails, RailsConfig
@@ -804,41 +786,6 @@ LLMRails(RailsConfig.from_path({config_path!r}))
 while True:
     time.sleep(3600)
 """
-
-
-def _script_library_iorails(config_path: str) -> str:
-    # NEMO_GUARDRAILS_IORAILS_ENGINE=true is set per-subprocess in the
-    # scenario's extra_env. It aliases ``from nemoguardrails import LLMRails``
-    # to the ``Guardrails`` wrapper at import time, which routes to
-    # IORails when the config qualifies (examples/configs/nemoguards
-    # does). Construction then calls report_usage with rails_engine="IORails".
-    return f"""
-import time
-from nemoguardrails import LLMRails, RailsConfig
-LLMRails(RailsConfig.from_path({config_path!r}))
-while True:
-    time.sleep(3600)
-"""
-
-
-def _script_opt_out(config_path: str) -> str:
-    # The opt-out signals (NEMO_GUARDRAILS_NO_USAGE_STATS, CI,
-    # PYTEST_CURRENT_TEST) are set in the scenario's extra_env. The
-    # subprocess still constructs LLMRails to prove the suppression
-    # path activates inside _is_usage_stats_enabled: the audit file
-    # must remain empty.
-    return f"""
-import time
-from nemoguardrails import LLMRails, RailsConfig
-LLMRails(RailsConfig.from_path({config_path!r}))
-while True:
-    time.sleep(3600)
-"""
-
-
-# ---------------------------------------------------------------------------
-# Scenario definitions
-# ---------------------------------------------------------------------------
 
 
 def _scenario(
@@ -986,20 +933,6 @@ def _v2_custom_flow_assertions() -> dict[str, Any]:
     )
 
 
-def _abc_v2_assertions() -> dict[str, Any]:
-    return _config_startup_assertions(
-        deployment_type="library",
-        rails_engine="LLMRails",
-        llm_providers=["openai"],
-        colang_version="2.x",
-        num_rails_configured=0,
-        rail_types_in_use=[],
-        builtin_features=[],
-        has_knowledge_base=True,
-        num_custom_flows=67,
-    )
-
-
 def _iorails_assertions() -> dict[str, Any]:
     return _config_startup_assertions(
         deployment_type="library",
@@ -1017,7 +950,6 @@ def _build_scenarios(
     rich_config: str,
     feature_alias_config: str,
     v2_config: str,
-    abc_v2_config: str,
     iorails_config: str,
     server_config_root: str,
 ) -> list[dict[str, Any]]:
@@ -1025,42 +957,35 @@ def _build_scenarios(
         _scenario(
             name="library_llmrails",
             kind="subprocess",
-            script=_script_library_llmrails(library_config),
+            script=_script_construct_rails(library_config),
             expected_count=1,
             startup_assertions=[_cfg1_assertions("library")],
         ),
         _scenario(
             name="library_rich_config",
             kind="subprocess",
-            script=_script_library_llmrails(rich_config),
+            script=_script_construct_rails(rich_config),
             expected_count=1,
             startup_assertions=[_rich_assertions()],
         ),
         _scenario(
             name="library_feature_aliases",
             kind="subprocess",
-            script=_script_library_llmrails(feature_alias_config),
+            script=_script_construct_rails(feature_alias_config),
             expected_count=1,
             startup_assertions=[_feature_alias_assertions()],
         ),
         _scenario(
             name="library_v2_custom_flows",
             kind="subprocess",
-            script=_script_library_llmrails(v2_config),
+            script=_script_construct_rails(v2_config),
             expected_count=1,
             startup_assertions=[_v2_custom_flow_assertions()],
         ),
         _scenario(
-            name="library_abc_v2",
-            kind="subprocess",
-            script=_script_library_llmrails(abc_v2_config),
-            expected_count=1,
-            startup_assertions=[_abc_v2_assertions()],
-        ),
-        _scenario(
             name="library_iorails",
             kind="subprocess",
-            script=_script_library_iorails(iorails_config),
+            script=_script_construct_rails(iorails_config),
             expected_count=1,
             startup_assertions=[_iorails_assertions()],
             extra_env={"NEMO_GUARDRAILS_IORAILS_ENGINE": "true"},
@@ -1106,13 +1031,13 @@ def _build_scenarios(
             config_ids_to_hit=["cfg1"],
             expected_count=2,  # one startup + one heartbeat
             startup_assertions=[_cfg1_assertions("api")],
-            audit_timeout_s=10.0,
+            audit_timeout_s=20.0,
             extra_env={"NEMO_GUARDRAILS_HEARTBEAT_INTERVAL_S": "8.0"},
         ),
         _scenario(
             name="opt_out_explicit",
             kind="subprocess",
-            script=_script_opt_out(library_config),
+            script=_script_construct_rails(library_config),
             expected_count=0,
             settle_after_action_s=1.0,
             extra_env={"NEMO_GUARDRAILS_NO_USAGE_STATS": "1"},
@@ -1120,7 +1045,7 @@ def _build_scenarios(
         _scenario(
             name="opt_out_ci",
             kind="subprocess",
-            script=_script_opt_out(library_config),
+            script=_script_construct_rails(library_config),
             expected_count=0,
             settle_after_action_s=1.0,
             extra_env={"CI": "true"},
@@ -1128,17 +1053,12 @@ def _build_scenarios(
         _scenario(
             name="opt_out_pytest",
             kind="subprocess",
-            script=_script_opt_out(library_config),
+            script=_script_construct_rails(library_config),
             expected_count=0,
             settle_after_action_s=1.0,
             extra_env={"PYTEST_CURRENT_TEST": "smoke_x"},
         ),
     ]
-
-
-# ---------------------------------------------------------------------------
-# Driver
-# ---------------------------------------------------------------------------
 
 
 def _sanity_check_driver_env() -> None:
@@ -1332,14 +1252,6 @@ def main() -> int:
         ),
     )
     parser.add_argument(
-        "--abc-v2-config",
-        default=str(DEFAULT_ABC_V2_CONFIG),
-        help=(
-            "Path to the realistic ABC Colang 2.x RailsConfig used by the library_abc_v2 scenario. "
-            f"Default: {DEFAULT_ABC_V2_CONFIG}."
-        ),
-    )
-    parser.add_argument(
         "--iorails-config",
         default=str(DEFAULT_IORAILS_CONFIG),
         help=(
@@ -1392,7 +1304,6 @@ def main() -> int:
     print(f"  rich config:        {args.rich_config}")
     print(f"  feature aliases:    {args.feature_alias_config}")
     print(f"  v2 config:          {args.v2_config}")
-    print(f"  abc v2 config:      {args.abc_v2_config}")
     print(f"  iorails config:     {args.iorails_config}")
     print(f"  server config root: {args.server_config_root}")
     print()
@@ -1404,7 +1315,6 @@ def main() -> int:
         rich_config=args.rich_config,
         feature_alias_config=args.feature_alias_config,
         v2_config=args.v2_config,
-        abc_v2_config=args.abc_v2_config,
         iorails_config=args.iorails_config,
         server_config_root=args.server_config_root,
     )

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -1,0 +1,1454 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local staging smoke-test driver for NeMo Guardrails telemetry.
+
+Drives several deployment scenarios that mirror real production paths:
+
+  - library scenarios construct ``LLMRails`` in a Python subprocess
+    (this is what library-mode users actually do).
+  - server scenarios start either a real ``python -m nemoguardrails server``
+    subprocess or a Uvicorn multi-worker subprocess, poll until it is
+    ready, hit ``/v1/chat/completions`` with one or more config_ids to
+    trigger ``_get_rails`` (which constructs ``LLMRails`` and emits
+    telemetry), then SIGTERM the server.
+  - the cli scenario spawns a real ``python -m nemoguardrails chat`` subprocess
+    so the typer entry point, ``set_deployment_type('cli')`` call,
+    and ``run_chat`` flow are all exercised. The driver holds stdin
+    open until the audit file contains the expected startup event, then
+    terminates the chat process.
+  - opt-out scenarios spawn a minimal subprocess with the relevant
+    suppression signal set, and assert the audit file stays empty.
+
+Each scenario runs with an isolated ``HOME`` / ``XDG_CONFIG_HOME`` so
+its audit file lands in its own per-scenario directory. The driver
+strips ``CI``, ``GITHUB_ACTIONS``, and ``PYTEST_CURRENT_TEST`` from
+each subprocess's env so the auto-disable in
+``_is_usage_stats_enabled`` does not silently no-op the positive
+scenarios. The driver itself refuses to start if any of those are
+exported in the calling shell.
+
+Pre-flight (do this once, by hand, before driving the script):
+
+    unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
+    NEMO_SESSION_PREFIX=preflight-$(date +%s)- \\
+    NEMO_GUARDRAILS_USAGE_STATS_SERVER=<staging-events-url>/v1.1/events/json \\
+    poetry run python - <<'PY'
+    import time
+    from nemoguardrails import LLMRails, RailsConfig, telemetry
+
+    LLMRails(RailsConfig.from_path("examples/bots/abc"))
+    audit_file = telemetry._get_audit_file()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if audit_file.exists() and audit_file.read_text().strip():
+            break
+        time.sleep(0.1)
+    else:
+        raise SystemExit(f"pre-flight audit event not observed at {audit_file}")
+    time.sleep(6)
+    print(f"pre-flight audit event observed at {audit_file}")
+    PY
+
+Then wait briefly for indexing and search Kibana for ``client.sessionId : preflight-*``. If
+nothing lands, defer the full smoke run until SMS has the schema
+registered.
+
+Driver invocation:
+
+    unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
+    poetry run python scripts/telemetry_smoke.py \\
+        --staging-url "$NEMO_GUARDRAILS_SMOKE_STAGING_URL"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT_PATH = REPO_ROOT / "schemas" / "anonymous_events.snapshot.json"
+DEFAULT_STAGING_URL = os.environ.get("NEMO_GUARDRAILS_SMOKE_STAGING_URL", "")
+DEFAULT_SERVER_CONFIG_ROOT = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures"
+DEFAULT_LIBRARY_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "cfg1"
+DEFAULT_RICH_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "rich"
+DEFAULT_FEATURE_ALIAS_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "feature_aliases"
+DEFAULT_V2_CONFIG = REPO_ROOT / "tests" / "telemetry" / "smoke_fixtures" / "v2_custom_flow"
+DEFAULT_ABC_V2_CONFIG = REPO_ROOT / "examples" / "bots" / "abc_v2"
+DEFAULT_IORAILS_CONFIG = REPO_ROOT / "examples" / "configs" / "nemoguards"
+
+ENV_VARS_TO_STRIP = ("CI", "GITHUB_ACTIONS", "PYTEST_CURRENT_TEST")
+DEFAULT_AUDIT_TIMEOUT_S = 30.0
+DEFAULT_AUDIT_POLL_S = 0.1
+DEFAULT_NETWORK_SETTLE_S = 6.0
+
+
+# ---------------------------------------------------------------------------
+# Env + audit-file plumbing (shared by all scenario runners)
+# ---------------------------------------------------------------------------
+
+
+def _build_subprocess_env(
+    parent_env: dict[str, str],
+    *,
+    staging_url: str,
+    session_prefix: str,
+    config_dir: Path,
+    extra: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Build the env for a scenario subprocess.
+
+    Strips CI / pytest signals so ``_is_usage_stats_enabled`` does not
+    auto-disable the run. Sets the staging endpoint, the session
+    prefix for Kibana grouping, and an isolated XDG_CONFIG_HOME so
+    each scenario's audit file lands in its own directory.
+    """
+    env = {key: value for key, value in parent_env.items() if key not in ENV_VARS_TO_STRIP}
+    env["NEMO_GUARDRAILS_USAGE_STATS_SERVER"] = staging_url
+    env["NEMO_SESSION_PREFIX"] = session_prefix
+    env["XDG_CONFIG_HOME"] = str(config_dir)
+    env["HOME"] = str(config_dir)
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _audit_file_for(config_dir: Path) -> Path:
+    return config_dir / ".config" / "nemoguardrails" / "usage_stats.json"
+
+
+def _read_audit_lines(audit_file: Path) -> list[dict[str, Any]]:
+    if not audit_file.exists():
+        return []
+    return [json.loads(line) for line in audit_file.read_text().splitlines() if line.strip()]
+
+
+def _wait_for_audit_events(
+    audit_file: Path,
+    expected_count: int,
+    *,
+    timeout: float = DEFAULT_AUDIT_TIMEOUT_S,
+    poll: float = DEFAULT_AUDIT_POLL_S,
+) -> list[dict[str, Any]]:
+    """Poll the audit JSONL file until at least ``expected_count`` events exist."""
+    deadline = time.monotonic() + timeout
+    last_lines: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        try:
+            last_lines = _read_audit_lines(audit_file)
+        except (json.JSONDecodeError, OSError):
+            # A writer may be in the middle of appending the last line.
+            pass
+        if len(last_lines) >= expected_count:
+            return last_lines
+        time.sleep(poll)
+
+    try:
+        return _read_audit_lines(audit_file)
+    except (json.JSONDecodeError, OSError):
+        return last_lines
+
+
+def _network_settle_s(scenario: dict[str, Any]) -> float:
+    return float(scenario.get("settle_after_audit_s", DEFAULT_NETWORK_SETTLE_S))
+
+
+def _normalize_returncode(returncode: int) -> int:
+    return 0 if returncode == -15 else returncode
+
+
+def _make_validator():
+    import jsonschema
+
+    snapshot = json.loads(SNAPSHOT_PATH.read_text())
+    return jsonschema.Draft7Validator(snapshot)
+
+
+def _validate_lines(lines: list[dict[str, Any]], validator) -> Optional[str]:
+    """Return None if all lines validate; otherwise a short error string."""
+    for index, line in enumerate(lines):
+        errors = list(validator.iter_errors(line))
+        if errors:
+            return f"line {index} fails schema: {errors[0].message}"
+    return None
+
+
+@dataclass(frozen=True)
+class FieldExpectation:
+    description: str
+    predicate: Callable[[Any], bool]
+
+
+def _expect_exact(expected: Any) -> FieldExpectation:
+    return FieldExpectation(repr(expected), lambda actual: actual == expected)
+
+
+def _expect_one_of(values: list[str]) -> FieldExpectation:
+    return FieldExpectation(f"one of {values!r}", lambda actual: actual in values)
+
+
+def _expect_non_empty_string() -> FieldExpectation:
+    return FieldExpectation("a non-empty string", lambda actual: isinstance(actual, str) and bool(actual))
+
+
+def _expect_positive_number() -> FieldExpectation:
+    return FieldExpectation(
+        "a positive number",
+        lambda actual: isinstance(actual, (int, float)) and not isinstance(actual, bool) and actual > 0,
+    )
+
+
+def _expect_startswith(prefix: str) -> FieldExpectation:
+    return FieldExpectation(
+        f"a string starting with {prefix!r}",
+        lambda actual: isinstance(actual, str) and actual.startswith(prefix),
+    )
+
+
+def _expect_list_contains(items: list[str]) -> FieldExpectation:
+    return FieldExpectation(
+        f"a list containing {items!r}",
+        lambda actual: isinstance(actual, list) and all(item in actual for item in items),
+    )
+
+
+def _expect_int_at_least(minimum: int) -> FieldExpectation:
+    return FieldExpectation(
+        f"an integer >= {minimum}",
+        lambda actual: isinstance(actual, int) and not isinstance(actual, bool) and actual >= minimum,
+    )
+
+
+def _expect_all(*expectations: FieldExpectation) -> FieldExpectation:
+    return FieldExpectation(
+        " and ".join(expectation.description for expectation in expectations),
+        lambda actual: all(expectation.predicate(actual) for expectation in expectations),
+    )
+
+
+def _as_expectation(expected: Any) -> FieldExpectation:
+    if isinstance(expected, FieldExpectation):
+        return expected
+    return _expect_exact(expected)
+
+
+def _validate_field(
+    scenario_name: str,
+    field: str,
+    actual: Any,
+    expected: Any,
+) -> Optional[str]:
+    expectation = _as_expectation(expected)
+    if not expectation.predicate(actual):
+        return f"{scenario_name}.{field}: expected {expectation.description}, got {actual!r}"
+    return None
+
+
+def _common_event_assertions(session_prefix: str) -> dict[str, FieldExpectation]:
+    return {
+        "nemoSource": _expect_exact("guardrails"),
+        "event": _expect_one_of(["startup", "heartbeat"]),
+        "sessionId": _expect_all(_expect_non_empty_string(), _expect_startswith(session_prefix)),
+        "nemoguardrailsVersion": _expect_non_empty_string(),
+        "pythonVersion": _expect_non_empty_string(),
+        "platform": _expect_non_empty_string(),
+        "osName": _expect_non_empty_string(),
+        "timestamp": _expect_positive_number(),
+    }
+
+
+def _validate_common_event_fields(
+    scenario_name: str,
+    event: dict[str, Any],
+    *,
+    session_prefix: str,
+) -> Optional[str]:
+    for field, expectation in _common_event_assertions(session_prefix).items():
+        error = _validate_field(scenario_name, field, event.get(field), expectation)
+        if error:
+            return error
+    return None
+
+
+def _validate_startup_events(
+    scenario_name: str,
+    startup_events: list[dict[str, Any]],
+    *,
+    session_prefix: str,
+    assertion_sets: list[dict[str, Any]],
+) -> Optional[str]:
+    """Validate startup events with exact, predicate, and list assertions."""
+    if len(startup_events) != len(assertion_sets):
+        return f"{scenario_name}.event: expected {len(assertion_sets)} startup event(s), got {len(startup_events)}"
+
+    for event in startup_events:
+        common_error = _validate_common_event_fields(scenario_name, event, session_prefix=session_prefix)
+        if common_error:
+            return common_error
+
+        startup_error = _validate_field(scenario_name, "event", event.get("event"), "startup")
+        if startup_error:
+            return startup_error
+
+    unmatched_assertions = list(assertion_sets)
+    for event in startup_events:
+        matched_index: Optional[int] = None
+        first_error: Optional[str] = None
+        for index, assertions in enumerate(unmatched_assertions):
+            errors = [
+                _validate_field(scenario_name, field, event.get(field), expected)
+                for field, expected in assertions.items()
+            ]
+            errors = [error for error in errors if error]
+            if not errors:
+                matched_index = index
+                break
+            if first_error is None:
+                first_error = errors[0]
+
+        if matched_index is None:
+            return first_error or f"{scenario_name}.startup: no assertion set matched {event!r}"
+        unmatched_assertions.pop(matched_index)
+
+    return None
+
+
+def _summarize_expectation(expected: Any) -> str:
+    return _as_expectation(expected).description
+
+
+def _summarize_assertions(scenario: dict[str, Any], *, session_prefix: str) -> dict[str, Any]:
+    return {
+        "common_event_fields": {
+            field: _summarize_expectation(expectation)
+            for field, expectation in _common_event_assertions(session_prefix).items()
+        },
+        "startup_events": [
+            {field: _summarize_expectation(expected) for field, expected in assertions.items()}
+            for assertions in scenario.get("startup_assertions", [])
+        ],
+        "distinct_startup_sessions": scenario.get("expects_distinct_sessions", 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Real-server helpers: port allocation, readiness polling, POST a request
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Ask the OS for a free TCP port and release it.
+
+    Small race window between release and reuse by the server, but
+    acceptable for a smoke driver.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_server(base_url: str, *, timeout: float = 30.0, poll: float = 0.5) -> bool:
+    """Poll ``/v1/rails/configs`` until 200 or timeout."""
+    deadline = time.monotonic() + timeout
+    url = base_url.rstrip("/") + "/v1/rails/configs"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if 200 <= response.status < 300:
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError):
+            pass
+        time.sleep(poll)
+    return False
+
+
+def _post_chat(base_url: str, config_id: str, *, timeout: float = 10.0) -> tuple[int, str]:
+    """POST to /v1/chat/completions. Returns (status, body preview).
+
+    The long thread_id passes request validation but fails after
+    ``_get_rails`` when no datastore is configured, so construction
+    emits telemetry without requiring or making a real model call.
+    """
+    url = base_url.rstrip("/") + "/v1/chat/completions"
+    body = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "smoke"}],
+        "guardrails": {
+            "config_ids": [config_id],
+            "options": {},
+            "thread_id": "smoke-thread-0001",
+        },
+    }
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", "Connection": "close"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read(500).decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        body_preview = exc.read(500).decode("utf-8", errors="replace") if exc.fp else ""
+        return exc.code, body_preview
+    except urllib.error.URLError as exc:
+        return -1, f"URLError: {exc.reason}"
+
+
+def _terminate(proc: subprocess.Popen, *, term_timeout: float = 10.0) -> int:
+    """SIGTERM then SIGKILL fallback. Returns the final exit code."""
+    if proc.poll() is not None:
+        return int(proc.returncode)
+    proc.terminate()
+    try:
+        return proc.wait(timeout=term_timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            return proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            return -1
+
+
+# ---------------------------------------------------------------------------
+# Scenario runners
+# ---------------------------------------------------------------------------
+
+
+def _run_subprocess(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
+    """Run a ``kind=subprocess`` scenario: a Python -c script.
+
+    Used for library and opt-out scenarios where we directly construct
+    LLMRails (library mode) or verify no event is emitted (opt-out).
+    """
+    started_at = time.time()
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", scenario["script"]],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except Exception as exc:
+        return {"returncode": -1, "duration_s": 0.0, "stderr_tail": [repr(exc)]}
+
+    expected_count = int(scenario["expected_count"])
+    audit_timeout = float(scenario.get("audit_timeout_s", DEFAULT_AUDIT_TIMEOUT_S))
+    try:
+        if expected_count > 0:
+            _wait_for_audit_events(audit_file, expected_count, timeout=audit_timeout)
+            settle = _network_settle_s(scenario)
+            if settle:
+                time.sleep(settle)
+        else:
+            time.sleep(float(scenario.get("settle_after_action_s", 1.0)))
+
+        returncode = _terminate(proc)
+    finally:
+        if proc.poll() is None:
+            returncode = _terminate(proc)
+
+    stderr_tail: list[str] = []
+    if proc.stderr is not None:
+        try:
+            stderr_tail = proc.stderr.read().splitlines()[-10:]
+        except Exception:
+            pass
+    return {
+        "returncode": _normalize_returncode(returncode),
+        "duration_s": time.time() - started_at,
+        "stderr_tail": stderr_tail,
+    }
+
+
+def _startup_session_ids(lines: list[dict[str, Any]]) -> set[str]:
+    return {line["sessionId"] for line in lines if line.get("event") == "startup" and line.get("sessionId")}
+
+
+def _wait_for_distinct_startup_sessions(
+    audit_file: Path,
+    expected_count: int,
+    *,
+    timeout: float = DEFAULT_AUDIT_TIMEOUT_S,
+    poll: float = DEFAULT_AUDIT_POLL_S,
+) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + timeout
+    last_lines: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        try:
+            last_lines = _read_audit_lines(audit_file)
+        except (json.JSONDecodeError, OSError):
+            pass
+        if len(_startup_session_ids(last_lines)) >= expected_count:
+            return last_lines
+        time.sleep(poll)
+
+    try:
+        return _read_audit_lines(audit_file)
+    except (json.JSONDecodeError, OSError):
+        return last_lines
+
+
+def _run_server(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
+    """Run a ``kind=server`` scenario: spin up ``python -m nemoguardrails server``.
+
+    Polls /v1/rails/configs until ready, POSTs to /v1/chat/completions
+    for each config_id in scenario["config_ids_to_hit"], polls the
+    audit file until the expected event count is observed, then SIGTERMs.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "nemoguardrails",
+            "server",
+            "--config",
+            scenario["server_config_root"],
+            "--port",
+            str(port),
+            "--disable-chat-ui",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    started_at = time.time()
+    post_results: list[dict[str, Any]] = []
+    try:
+        if not _wait_for_server(base_url, timeout=30):
+            _terminate(proc)
+            stderr_tail = proc.stderr.read().splitlines()[-10:] if proc.stderr else []
+            return {
+                "returncode": -1,
+                "duration_s": time.time() - started_at,
+                "stderr_tail": stderr_tail,
+                "server_post_results": post_results,
+                "early_failure": "server did not become ready within 30s",
+            }
+        audit_timeout = float(scenario.get("audit_timeout_s", DEFAULT_AUDIT_TIMEOUT_S))
+        config_ids = scenario["config_ids_to_hit"]
+        successful_posts = 0
+        for index, config_id in enumerate(config_ids, start=1):
+            status, body_preview = _post_chat(base_url, config_id)
+            post_results.append(
+                {
+                    "config_id": config_id,
+                    "status": status,
+                    "body_preview": body_preview[:500],
+                }
+            )
+            if status != -1:
+                successful_posts += 1
+                lines = _wait_for_audit_events(audit_file, successful_posts, timeout=audit_timeout)
+                if len(lines) >= successful_posts and index < len(config_ids):
+                    settle = _network_settle_s(scenario)
+                    if settle:
+                        time.sleep(settle)
+
+        unreachable = [result for result in post_results if result["status"] == -1]
+        if not unreachable:
+            _wait_for_audit_events(
+                audit_file,
+                int(scenario["expected_count"]),
+                timeout=audit_timeout,
+            )
+            settle = _network_settle_s(scenario)
+            if settle:
+                time.sleep(settle)
+    finally:
+        rc = _terminate(proc)
+    # Drain stderr so any warnings show up on FAIL.
+    stderr_tail: list[str] = []
+    if proc.stderr is not None:
+        try:
+            stderr_tail = proc.stderr.read().splitlines()[-10:]
+        except Exception:
+            pass
+    return {
+        "returncode": _normalize_returncode(rc),  # SIGTERM is expected
+        "duration_s": time.time() - started_at,
+        "stderr_tail": stderr_tail,
+        "server_post_results": post_results,
+        "post_reachability_failure": any(result["status"] == -1 for result in post_results),
+    }
+
+
+def _write_uvicorn_smoke_app(module_dir: Path) -> str:
+    """Create an importable FastAPI app module for Uvicorn worker smoke."""
+    module_name = "telemetry_smoke_uvicorn_app"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text(
+        """\
+import os
+
+os.environ["NEMO_GUARDRAILS_DISABLE_CHAT_UI"] = "true"
+
+from nemoguardrails.server import api
+from nemoguardrails.telemetry import set_deployment_type
+
+set_deployment_type("api")
+api.app.rails_config_path = os.environ["NEMO_GUARDRAILS_SMOKE_SERVER_CONFIG_ROOT"]
+api.app.disable_chat_ui = True
+app = api.app
+"""
+    )
+    return f"{module_name}:app"
+
+
+def _run_server_multi_worker(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
+    """Run a Uvicorn multi-worker server and require one event per worker."""
+    workers = int(scenario.get("worker_count", 3))
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    module_dir = audit_file.parent.parent.parent
+    app_import = _write_uvicorn_smoke_app(module_dir)
+    proc_env = env.copy()
+    proc_env["NEMO_GUARDRAILS_SMOKE_SERVER_CONFIG_ROOT"] = scenario["server_config_root"]
+    proc_env["NEMO_GUARDRAILS_DISABLE_CHAT_UI"] = "true"
+    pythonpath_parts = [str(module_dir), str(REPO_ROOT)]
+    if proc_env.get("PYTHONPATH"):
+        pythonpath_parts.append(proc_env["PYTHONPATH"])
+    proc_env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            app_import,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--workers",
+            str(workers),
+            "--log-level",
+            "info",
+        ],
+        env=proc_env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    started_at = time.time()
+    post_results: list[dict[str, Any]] = []
+    try:
+        if not _wait_for_server(base_url, timeout=45):
+            _terminate(proc)
+            stderr_tail = proc.stderr.read().splitlines()[-10:] if proc.stderr else []
+            return {
+                "returncode": -1,
+                "duration_s": time.time() - started_at,
+                "stderr_tail": stderr_tail,
+                "server_post_results": post_results,
+                "worker_count": workers,
+                "early_failure": "multi-worker server did not become ready within 45s",
+            }
+
+        config_id = scenario["config_ids_to_hit"][0]
+        audit_timeout = float(scenario.get("audit_timeout_s", DEFAULT_AUDIT_TIMEOUT_S))
+        expected_sessions = int(scenario.get("expects_distinct_sessions", workers))
+        max_posts = int(scenario.get("max_worker_posts", workers * 30))
+        deadline = time.monotonic() + audit_timeout
+        lines: list[dict[str, Any]] = []
+        for _ in range(max_posts):
+            status, body_preview = _post_chat(base_url, config_id)
+            post_results.append(
+                {
+                    "config_id": config_id,
+                    "status": status,
+                    "body_preview": body_preview[:500],
+                }
+            )
+            lines = _wait_for_distinct_startup_sessions(audit_file, expected_sessions, timeout=0.5)
+            if len(_startup_session_ids(lines)) >= expected_sessions:
+                break
+            if time.monotonic() >= deadline:
+                break
+
+        if not any(result["status"] == -1 for result in post_results):
+            remaining = max(0.0, deadline - time.monotonic())
+            if len(_startup_session_ids(lines)) < expected_sessions and remaining:
+                lines = _wait_for_distinct_startup_sessions(audit_file, expected_sessions, timeout=remaining)
+            if len(_startup_session_ids(lines)) >= expected_sessions:
+                settle = _network_settle_s(scenario)
+                if settle:
+                    time.sleep(settle)
+    finally:
+        rc = _terminate(proc)
+
+    stderr_tail: list[str] = []
+    if proc.stderr is not None:
+        try:
+            stderr_tail = proc.stderr.read().splitlines()[-10:]
+        except Exception:
+            pass
+    return {
+        "returncode": _normalize_returncode(rc),
+        "duration_s": time.time() - started_at,
+        "stderr_tail": stderr_tail,
+        "server_post_results": post_results,
+        "worker_count": workers,
+        "post_reachability_failure": any(result["status"] == -1 for result in post_results),
+    }
+
+
+def _run_cli(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
+    """Run a ``kind=cli`` scenario: spawn ``python -m nemoguardrails chat``.
+
+    Holds stdin open so ``LLMRails`` is constructed and the chat loop
+    blocks on input. The driver polls the audit file, then terminates.
+    """
+    started_at = time.time()
+    # Leave stdin open (PIPE but never written to) so the chat command's
+    # input("> ") at cli/chat.py:76 blocks forever. LLMRails is
+    # constructed at line 68 *before* that input call, so telemetry
+    # fires during the wait. Then we SIGTERM. Closing stdin instead
+    # would feed EOF to input(), raising EOFError and aborting before
+    # the daemon thread can flush the audit file reliably.
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "nemoguardrails", "chat", "--config", scenario["config_path"]],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    try:
+        _wait_for_audit_events(
+            audit_file,
+            int(scenario["expected_count"]),
+            timeout=float(scenario.get("audit_timeout_s", DEFAULT_AUDIT_TIMEOUT_S)),
+        )
+        settle = _network_settle_s(scenario)
+        if settle:
+            time.sleep(settle)
+    finally:
+        rc = _terminate(proc)
+    stderr_tail: list[str] = []
+    if proc.stderr is not None:
+        try:
+            stderr_tail = proc.stderr.read().splitlines()[-10:]
+        except Exception:
+            pass
+    return {
+        "returncode": _normalize_returncode(rc),
+        "duration_s": time.time() - started_at,
+        "stderr_tail": stderr_tail,
+    }
+
+
+_RUNNERS = {
+    "subprocess": _run_subprocess,
+    "server": _run_server,
+    "server_multi_worker": _run_server_multi_worker,
+    "cli": _run_cli,
+}
+
+
+# ---------------------------------------------------------------------------
+# Scenario subprocess scripts (for kind=subprocess scenarios only)
+# ---------------------------------------------------------------------------
+
+
+def _script_library_llmrails(config_path: str) -> str:
+    return f"""
+import time
+from nemoguardrails import LLMRails, RailsConfig
+LLMRails(RailsConfig.from_path({config_path!r}))
+while True:
+    time.sleep(3600)
+"""
+
+
+def _script_library_iorails(config_path: str) -> str:
+    # NEMO_GUARDRAILS_IORAILS_ENGINE=true is set per-subprocess in the
+    # scenario's extra_env. It aliases ``from nemoguardrails import LLMRails``
+    # to the ``Guardrails`` wrapper at import time, which routes to
+    # IORails when the config qualifies (examples/configs/nemoguards
+    # does). Construction then calls report_usage with rails_engine="IORails".
+    return f"""
+import time
+from nemoguardrails import LLMRails, RailsConfig
+LLMRails(RailsConfig.from_path({config_path!r}))
+while True:
+    time.sleep(3600)
+"""
+
+
+def _script_opt_out(config_path: str) -> str:
+    # The opt-out signals (NEMO_GUARDRAILS_NO_USAGE_STATS, CI,
+    # PYTEST_CURRENT_TEST) are set in the scenario's extra_env. The
+    # subprocess still constructs LLMRails to prove the suppression
+    # path activates inside _is_usage_stats_enabled: the audit file
+    # must remain empty.
+    return f"""
+import time
+from nemoguardrails import LLMRails, RailsConfig
+LLMRails(RailsConfig.from_path({config_path!r}))
+while True:
+    time.sleep(3600)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+
+def _scenario(
+    *,
+    name: str,
+    kind: str,
+    expected_count: int,
+    script: Optional[str] = None,
+    server_config_root: Optional[str] = None,
+    config_ids_to_hit: Optional[list[str]] = None,
+    worker_count: Optional[int] = None,
+    config_path: Optional[str] = None,
+    startup_assertions: Optional[list[dict[str, Any]]] = None,
+    audit_timeout_s: Optional[float] = None,
+    settle_after_audit_s: Optional[float] = None,
+    settle_after_action_s: Optional[float] = None,
+    extra_env: Optional[dict[str, str]] = None,
+    expects_distinct_sessions: int = 1,
+) -> dict[str, Any]:
+    scenario: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "expected_count": expected_count,
+        "startup_assertions": startup_assertions or [],
+        "extra_env": extra_env or {},
+        "expects_distinct_sessions": expects_distinct_sessions,
+    }
+    if script is not None:
+        scenario["script"] = script
+    if server_config_root is not None:
+        scenario["server_config_root"] = server_config_root
+    if config_ids_to_hit is not None:
+        scenario["config_ids_to_hit"] = config_ids_to_hit
+    if worker_count is not None:
+        scenario["worker_count"] = worker_count
+    if config_path is not None:
+        scenario["config_path"] = config_path
+    if audit_timeout_s is not None:
+        scenario["audit_timeout_s"] = audit_timeout_s
+    if settle_after_audit_s is not None:
+        scenario["settle_after_audit_s"] = settle_after_audit_s
+    if settle_after_action_s is not None:
+        scenario["settle_after_action_s"] = settle_after_action_s
+    return scenario
+
+
+def _config_startup_assertions(
+    *,
+    deployment_type: str,
+    rails_engine: str,
+    llm_providers: list[str],
+    colang_version: str = "1.0",
+    num_rails_configured: int,
+    rail_types_in_use: list[str],
+    builtin_features: Any,
+    tracing_enabled: bool = False,
+    has_knowledge_base: bool = False,
+    streaming_configured: bool = False,
+    num_custom_flows: Any = 0,
+) -> dict[str, Any]:
+    return {
+        "deploymentType": deployment_type,
+        "railsEngine": rails_engine,
+        "llmProviders": llm_providers,
+        "colangVersion": colang_version,
+        "numRailsConfigured": num_rails_configured,
+        "railTypesInUse": rail_types_in_use,
+        "builtinFeatures": builtin_features,
+        "tracingEnabled": tracing_enabled,
+        "hasKnowledgeBase": has_knowledge_base,
+        "streamingConfigured": streaming_configured,
+        "numCustomFlows": num_custom_flows,
+    }
+
+
+def _cfg1_assertions(deployment_type: str, rails_engine: str = "LLMRails") -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type=deployment_type,
+        rails_engine=rails_engine,
+        llm_providers=["openai"],
+        num_rails_configured=1,
+        rail_types_in_use=["input"],
+        builtin_features=_expect_list_contains(["self_check"]),
+    )
+
+
+def _cfg2_assertions(deployment_type: str, rails_engine: str = "LLMRails") -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type=deployment_type,
+        rails_engine=rails_engine,
+        llm_providers=["openai"],
+        num_rails_configured=1,
+        rail_types_in_use=["output"],
+        builtin_features=_expect_list_contains(["self_check"]),
+    )
+
+
+def _cfg3_assertions(deployment_type: str, rails_engine: str = "LLMRails") -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type=deployment_type,
+        rails_engine=rails_engine,
+        llm_providers=["openai"],
+        num_rails_configured=2,
+        rail_types_in_use=["input", "output"],
+        builtin_features=_expect_list_contains(["self_check"]),
+    )
+
+
+def _rich_assertions() -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type="library",
+        rails_engine="LLMRails",
+        llm_providers=["openai"],
+        num_rails_configured=2,
+        rail_types_in_use=["input", "output"],
+        builtin_features=_expect_list_contains(["self_check"]),
+        tracing_enabled=True,
+        has_knowledge_base=True,
+        streaming_configured=True,
+        num_custom_flows=_expect_int_at_least(1),
+    )
+
+
+def _feature_alias_assertions() -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type="library",
+        rails_engine="LLMRails",
+        llm_providers=["openai"],
+        num_rails_configured=0,
+        rail_types_in_use=[],
+        builtin_features=["factchecking", "patronusai", "regex"],
+    )
+
+
+def _v2_custom_flow_assertions() -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type="library",
+        rails_engine="LLMRails",
+        llm_providers=["openai"],
+        colang_version="2.x",
+        num_rails_configured=0,
+        rail_types_in_use=[],
+        builtin_features=[],
+        num_custom_flows=1,
+    )
+
+
+def _abc_v2_assertions() -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type="library",
+        rails_engine="LLMRails",
+        llm_providers=["openai"],
+        colang_version="2.x",
+        num_rails_configured=0,
+        rail_types_in_use=[],
+        builtin_features=[],
+        has_knowledge_base=True,
+        num_custom_flows=67,
+    )
+
+
+def _iorails_assertions() -> dict[str, Any]:
+    return _config_startup_assertions(
+        deployment_type="library",
+        rails_engine="IORails",
+        llm_providers=["nim"],
+        num_rails_configured=4,
+        rail_types_in_use=["input", "output"],
+        builtin_features=_expect_list_contains(["content_safety", "jailbreak_detection", "topic_safety"]),
+    )
+
+
+def _build_scenarios(
+    *,
+    library_config: str,
+    rich_config: str,
+    feature_alias_config: str,
+    v2_config: str,
+    abc_v2_config: str,
+    iorails_config: str,
+    server_config_root: str,
+) -> list[dict[str, Any]]:
+    return [
+        _scenario(
+            name="library_llmrails",
+            kind="subprocess",
+            script=_script_library_llmrails(library_config),
+            expected_count=1,
+            startup_assertions=[_cfg1_assertions("library")],
+        ),
+        _scenario(
+            name="library_rich_config",
+            kind="subprocess",
+            script=_script_library_llmrails(rich_config),
+            expected_count=1,
+            startup_assertions=[_rich_assertions()],
+        ),
+        _scenario(
+            name="library_feature_aliases",
+            kind="subprocess",
+            script=_script_library_llmrails(feature_alias_config),
+            expected_count=1,
+            startup_assertions=[_feature_alias_assertions()],
+        ),
+        _scenario(
+            name="library_v2_custom_flows",
+            kind="subprocess",
+            script=_script_library_llmrails(v2_config),
+            expected_count=1,
+            startup_assertions=[_v2_custom_flow_assertions()],
+        ),
+        _scenario(
+            name="library_abc_v2",
+            kind="subprocess",
+            script=_script_library_llmrails(abc_v2_config),
+            expected_count=1,
+            startup_assertions=[_abc_v2_assertions()],
+        ),
+        _scenario(
+            name="library_iorails",
+            kind="subprocess",
+            script=_script_library_iorails(iorails_config),
+            expected_count=1,
+            startup_assertions=[_iorails_assertions()],
+            extra_env={"NEMO_GUARDRAILS_IORAILS_ENGINE": "true"},
+        ),
+        _scenario(
+            name="server_single_config",
+            kind="server",
+            server_config_root=server_config_root,
+            config_ids_to_hit=["cfg1"],
+            expected_count=1,
+            startup_assertions=[_cfg1_assertions("api")],
+        ),
+        _scenario(
+            name="server_multi_config",
+            kind="server",
+            server_config_root=server_config_root,
+            config_ids_to_hit=["cfg1", "cfg2", "cfg3"],
+            expected_count=3,
+            startup_assertions=[_cfg1_assertions("api"), _cfg2_assertions("api"), _cfg3_assertions("api")],
+        ),
+        _scenario(
+            name="server_multi_worker",
+            kind="server_multi_worker",
+            server_config_root=server_config_root,
+            config_ids_to_hit=["cfg1"],
+            worker_count=3,
+            expected_count=3,
+            startup_assertions=[_cfg1_assertions("api"), _cfg1_assertions("api"), _cfg1_assertions("api")],
+            audit_timeout_s=45.0,
+            expects_distinct_sessions=3,
+        ),
+        _scenario(
+            name="cli_chat",
+            kind="cli",
+            config_path=library_config,
+            expected_count=1,
+            startup_assertions=[_cfg1_assertions("cli")],
+        ),
+        _scenario(
+            name="heartbeat",
+            kind="server",
+            server_config_root=server_config_root,
+            config_ids_to_hit=["cfg1"],
+            expected_count=2,  # one startup + one heartbeat
+            startup_assertions=[_cfg1_assertions("api")],
+            audit_timeout_s=10.0,
+            extra_env={"NEMO_GUARDRAILS_HEARTBEAT_INTERVAL_S": "8.0"},
+        ),
+        _scenario(
+            name="opt_out_explicit",
+            kind="subprocess",
+            script=_script_opt_out(library_config),
+            expected_count=0,
+            settle_after_action_s=1.0,
+            extra_env={"NEMO_GUARDRAILS_NO_USAGE_STATS": "1"},
+        ),
+        _scenario(
+            name="opt_out_ci",
+            kind="subprocess",
+            script=_script_opt_out(library_config),
+            expected_count=0,
+            settle_after_action_s=1.0,
+            extra_env={"CI": "true"},
+        ),
+        _scenario(
+            name="opt_out_pytest",
+            kind="subprocess",
+            script=_script_opt_out(library_config),
+            expected_count=0,
+            settle_after_action_s=1.0,
+            extra_env={"PYTEST_CURRENT_TEST": "smoke_x"},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _sanity_check_driver_env() -> None:
+    leaked = [name for name in ENV_VARS_TO_STRIP if os.environ.get(name)]
+    if leaked:
+        sys.stderr.write(
+            "refusing to run: the driver inherited " + ", ".join(leaked) + " in its environment.\n"
+            "  unset " + " ".join(leaked) + "\n"
+            "and re-invoke. The driver strips these from each subprocess, but if they "
+            "are exported in the calling shell some scenarios may behave unexpectedly.\n"
+        )
+        sys.exit(2)
+
+
+def _run_scenario(
+    scenario: dict[str, Any],
+    *,
+    run_id: str,
+    staging_url: str,
+    run_dir: Path,
+    validator,
+) -> dict[str, Any]:
+    config_dir = run_dir / scenario["name"]
+    if config_dir.exists():
+        shutil.rmtree(config_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    session_prefix = f"smoke-{run_id}-{scenario['name']}-"
+    env = _build_subprocess_env(
+        parent_env=os.environ.copy(),
+        staging_url=staging_url,
+        session_prefix=session_prefix,
+        config_dir=config_dir,
+        extra=scenario["extra_env"],
+    )
+
+    runner = _RUNNERS[scenario["kind"]]
+    audit_file = _audit_file_for(config_dir)
+    run_outcome = runner(scenario, env, audit_file)
+    try:
+        lines = _read_audit_lines(audit_file)
+    except json.JSONDecodeError as exc:
+        lines = []
+        audit_error = f"audit file is not valid JSONL: {exc}"
+    else:
+        audit_error = ""
+
+    result: dict[str, Any] = {
+        "name": scenario["name"],
+        "kind": scenario["kind"],
+        "session_prefix": session_prefix,
+        "audit_file": str(audit_file),
+        "subprocess_returncode": run_outcome["returncode"],
+        "subprocess_duration_s": round(run_outcome["duration_s"], 2),
+        "stderr_tail": run_outcome.get("stderr_tail", []),
+        "server_post_results": run_outcome.get("server_post_results", []),
+        "expected_event_count": scenario["expected_count"],
+        "actual_event_count": len(lines),
+        "expected_assertions": _summarize_assertions(scenario, session_prefix=session_prefix),
+    }
+    if "worker_count" in run_outcome:
+        result["worker_count"] = run_outcome["worker_count"]
+
+    if audit_error:
+        result["verdict"] = "FAIL"
+        result["reason"] = audit_error
+        return result
+
+    early = run_outcome.get("early_failure")
+    if early:
+        result["verdict"] = "FAIL"
+        result["reason"] = early
+        return result
+
+    if run_outcome.get("post_reachability_failure"):
+        result["verdict"] = "FAIL"
+        result["reason"] = "server POST could not reach the local server"
+        return result
+
+    if run_outcome["returncode"] != 0:
+        result["verdict"] = "FAIL"
+        result["reason"] = f"subprocess exited with code {run_outcome['returncode']}"
+        return result
+
+    if scenario["expected_count"] == 0:
+        result["verdict"] = "PASS" if not lines else "FAIL"
+        if lines:
+            result["reason"] = f"expected 0 events but found {len(lines)}"
+        return result
+
+    if len(lines) < scenario["expected_count"]:
+        result["verdict"] = "FAIL"
+        result["reason"] = f"expected {scenario['expected_count']} events, got {len(lines)}"
+        return result
+
+    schema_error = _validate_lines(lines, validator)
+    if schema_error:
+        result["verdict"] = "FAIL"
+        result["reason"] = schema_error
+        return result
+
+    for line in lines:
+        common_error = _validate_common_event_fields(scenario["name"], line, session_prefix=session_prefix)
+        if common_error:
+            result["verdict"] = "FAIL"
+            result["reason"] = common_error
+            return result
+
+    startup_lines = [line for line in lines if line.get("event") == "startup"]
+    startup_error = _validate_startup_events(
+        scenario["name"],
+        startup_lines,
+        session_prefix=session_prefix,
+        assertion_sets=scenario["startup_assertions"],
+    )
+    if startup_error:
+        result["verdict"] = "FAIL"
+        result["reason"] = startup_error
+        return result
+
+    distinct_sessions = {line.get("sessionId") for line in startup_lines}
+    expected_distinct_sessions = scenario.get("expects_distinct_sessions", 1)
+    if len(distinct_sessions) != expected_distinct_sessions:
+        result["verdict"] = "FAIL"
+        result["reason"] = (
+            f"distinct startup session IDs: expected {expected_distinct_sessions}, got {len(distinct_sessions)}"
+        )
+        return result
+
+    if scenario["name"] == "heartbeat":
+        heartbeat_lines = [line for line in lines if line.get("event") == "heartbeat"]
+        if not heartbeat_lines:
+            result["verdict"] = "FAIL"
+            result["reason"] = "no heartbeat event observed in audit file"
+            return result
+        startup_session_ids = {line.get("sessionId") for line in startup_lines}
+        heartbeat_session_ids = {line.get("sessionId") for line in heartbeat_lines}
+        if startup_session_ids != heartbeat_session_ids:
+            result["verdict"] = "FAIL"
+            result["reason"] = (
+                "heartbeat session IDs did not match startup session IDs: "
+                f"startup={sorted(startup_session_ids)}, heartbeat={sorted(heartbeat_session_ids)}"
+            )
+            return result
+
+    result["verdict"] = "PASS"
+    return result
+
+
+def _generate_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    suffix = secrets.token_hex(3)
+    return f"{timestamp}-{suffix}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--staging-url",
+        default=DEFAULT_STAGING_URL,
+        help=(
+            "Staging telemetry endpoint URL. If omitted, reads "
+            "NEMO_GUARDRAILS_SMOKE_STAGING_URL from the operator's environment."
+        ),
+    )
+    parser.add_argument(
+        "--library-config",
+        default=str(DEFAULT_LIBRARY_CONFIG),
+        help=(
+            f"Path to the RailsConfig used by library, cli, and opt-out scenarios. Default: {DEFAULT_LIBRARY_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--rich-config",
+        default=str(DEFAULT_RICH_CONFIG),
+        help=(
+            f"Path to the richer RailsConfig used by the library_rich_config scenario. Default: {DEFAULT_RICH_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--feature-alias-config",
+        default=str(DEFAULT_FEATURE_ALIAS_CONFIG),
+        help=(
+            "Path to the RailsConfig used by the library_feature_aliases scenario. "
+            f"Default: {DEFAULT_FEATURE_ALIAS_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--v2-config",
+        default=str(DEFAULT_V2_CONFIG),
+        help=(
+            "Path to the Colang 2.x RailsConfig used by the library_v2_custom_flows scenario. "
+            f"Default: {DEFAULT_V2_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--abc-v2-config",
+        default=str(DEFAULT_ABC_V2_CONFIG),
+        help=(
+            "Path to the realistic ABC Colang 2.x RailsConfig used by the library_abc_v2 scenario. "
+            f"Default: {DEFAULT_ABC_V2_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--iorails-config",
+        default=str(DEFAULT_IORAILS_CONFIG),
+        help=(
+            "Path to a RailsConfig whose flows are all IORails-compatible. "
+            "Used by library_iorails (subprocess sets NEMO_GUARDRAILS_IORAILS_ENGINE=true). "
+            f"Default: {DEFAULT_IORAILS_CONFIG}."
+        ),
+    )
+    parser.add_argument(
+        "--server-config-root",
+        default=str(DEFAULT_SERVER_CONFIG_ROOT),
+        help=(
+            "Path to the directory containing per-config subdirectories the server "
+            f"will list (parent of cfg1, cfg2, cfg3, rich). Default: {DEFAULT_SERVER_CONFIG_ROOT}."
+        ),
+    )
+    parser.add_argument(
+        "--run-dir",
+        default=None,
+        help="Directory to write per-scenario audit files and manifest.json into. Defaults to a tempdir.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=None,
+        help="Run only the named scenario(s). Repeatable. Default: all scenarios.",
+    )
+    args = parser.parse_args()
+
+    _sanity_check_driver_env()
+    if not args.staging_url:
+        sys.stderr.write(
+            "missing staging endpoint: pass --staging-url or set "
+            "NEMO_GUARDRAILS_SMOKE_STAGING_URL in your local environment.\n"
+            "Do not commit internal staging telemetry URLs to the repository.\n"
+        )
+        return 2
+
+    run_id = _generate_run_id()
+    run_dir = Path(args.run_dir) if args.run_dir else Path(tempfile.mkdtemp(prefix=f"smoke-{run_id}-"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        manifest_path.unlink()
+
+    print(f"smoke run: {run_id}")
+    print(f"  staging:            {args.staging_url}")
+    print(f"  run dir:            {run_dir}")
+    print(f"  library config:     {args.library_config}")
+    print(f"  rich config:        {args.rich_config}")
+    print(f"  feature aliases:    {args.feature_alias_config}")
+    print(f"  v2 config:          {args.v2_config}")
+    print(f"  abc v2 config:      {args.abc_v2_config}")
+    print(f"  iorails config:     {args.iorails_config}")
+    print(f"  server config root: {args.server_config_root}")
+    print()
+
+    validator = _make_validator()
+
+    all_scenarios = _build_scenarios(
+        library_config=args.library_config,
+        rich_config=args.rich_config,
+        feature_alias_config=args.feature_alias_config,
+        v2_config=args.v2_config,
+        abc_v2_config=args.abc_v2_config,
+        iorails_config=args.iorails_config,
+        server_config_root=args.server_config_root,
+    )
+    if args.scenario:
+        selected_names = set(args.scenario)
+        scenarios = [scenario for scenario in all_scenarios if scenario["name"] in selected_names]
+        unknown = selected_names - {scenario["name"] for scenario in all_scenarios}
+        if unknown:
+            sys.stderr.write(f"unknown scenario(s): {sorted(unknown)}\n")
+            return 2
+    else:
+        scenarios = all_scenarios
+
+    results: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        print(f"[{scenario['name']}] running ({scenario['kind']})...", flush=True)
+        result = _run_scenario(
+            scenario,
+            run_id=run_id,
+            staging_url=args.staging_url,
+            run_dir=run_dir,
+            validator=validator,
+        )
+        verdict = result["verdict"]
+        reason = result.get("reason", "")
+        suffix = f" ({reason})" if reason else ""
+        print(f"[{result['name']}] {verdict}{suffix}")
+        results.append(result)
+
+    manifest = {
+        "run_id": run_id,
+        "staging_url": args.staging_url,
+        "run_dir": str(run_dir),
+        "session_prefix_root": f"smoke-{run_id}-",
+        "results": results,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    print()
+    print("=== summary ===")
+    for result in results:
+        print(f"  {result['name']:24s} {result['verdict']}")
+    print()
+    print(f"manifest: {manifest_path}")
+    print(f"kibana filter: client.sessionId : smoke-{run_id}-*")
+    print(
+        "offline verify: poetry run python scripts/kibana_verify_export.py "
+        f"--manifest {manifest_path} --export kibana.json"
+    )
+
+    return 0 if all(result["verdict"] == "PASS" for result in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -43,9 +43,9 @@ exported in the calling shell.
 Pre-flight (do this once, by hand, before driving the script):
 
     unset CI GITHUB_ACTIONS PYTEST_CURRENT_TEST
-    NEMO_SESSION_PREFIX=preflight-$(date +%s)- \\
     NEMO_GUARDRAILS_USAGE_STATS_SERVER=<staging-events-url>/v1.1/events/json \\
     poetry run python - <<'PY'
+    import json
     import time
     from nemoguardrails import LLMRails, RailsConfig, telemetry
 
@@ -58,12 +58,15 @@ Pre-flight (do this once, by hand, before driving the script):
         time.sleep(0.1)
     else:
         raise SystemExit(f"pre-flight audit event not observed at {audit_file}")
-    time.sleep(6)
+    time.sleep(20)
+    lines = [json.loads(line) for line in audit_file.read_text().splitlines() if line.strip()]
+    startup_ids = sorted({line["sessionId"] for line in lines if line.get("event") == "startup"})
     print(f"pre-flight audit event observed at {audit_file}")
+    print("kibana filter: client.sessionId : (" + " or ".join(f'"{value}"' for value in startup_ids) + ")")
     PY
 
-Then wait briefly for indexing and search Kibana for ``client.sessionId : preflight-*``. If
-nothing lands, defer the full smoke run until SMS has the schema
+Then wait briefly for indexing and search Kibana with the exact printed
+``client.sessionId`` filter. If nothing lands, defer the full smoke run until SMS has the schema
 registered.
 
 Driver invocation:
@@ -106,7 +109,7 @@ DEFAULT_IORAILS_CONFIG = REPO_ROOT / "examples" / "configs" / "nemoguards"
 ENV_VARS_TO_STRIP = ("CI", "GITHUB_ACTIONS", "PYTEST_CURRENT_TEST")
 DEFAULT_AUDIT_TIMEOUT_S = 30.0
 DEFAULT_AUDIT_POLL_S = 0.1
-DEFAULT_NETWORK_SETTLE_S = 6.0
+DEFAULT_NETWORK_SETTLE_S = 20.0
 
 
 # ---------------------------------------------------------------------------
@@ -118,20 +121,18 @@ def _build_subprocess_env(
     parent_env: dict[str, str],
     *,
     staging_url: str,
-    session_prefix: str,
     config_dir: Path,
     extra: Optional[dict[str, str]] = None,
 ) -> dict[str, str]:
     """Build the env for a scenario subprocess.
 
     Strips CI / pytest signals so ``_is_usage_stats_enabled`` does not
-    auto-disable the run. Sets the staging endpoint, the session
-    prefix for Kibana grouping, and an isolated XDG_CONFIG_HOME so
-    each scenario's audit file lands in its own directory.
+    auto-disable the run. Sets the staging endpoint and an isolated
+    XDG_CONFIG_HOME so each scenario's audit file lands in its own
+    directory.
     """
     env = {key: value for key, value in parent_env.items() if key not in ENV_VARS_TO_STRIP}
     env["NEMO_GUARDRAILS_USAGE_STATS_SERVER"] = staging_url
-    env["NEMO_SESSION_PREFIX"] = session_prefix
     env["XDG_CONFIG_HOME"] = str(config_dir)
     env["HOME"] = str(config_dir)
     if extra:
@@ -224,13 +225,6 @@ def _expect_positive_number() -> FieldExpectation:
     )
 
 
-def _expect_startswith(prefix: str) -> FieldExpectation:
-    return FieldExpectation(
-        f"a string starting with {prefix!r}",
-        lambda actual: isinstance(actual, str) and actual.startswith(prefix),
-    )
-
-
 def _expect_list_contains(items: list[str]) -> FieldExpectation:
     return FieldExpectation(
         f"a list containing {items!r}",
@@ -242,13 +236,6 @@ def _expect_int_at_least(minimum: int) -> FieldExpectation:
     return FieldExpectation(
         f"an integer >= {minimum}",
         lambda actual: isinstance(actual, int) and not isinstance(actual, bool) and actual >= minimum,
-    )
-
-
-def _expect_all(*expectations: FieldExpectation) -> FieldExpectation:
-    return FieldExpectation(
-        " and ".join(expectation.description for expectation in expectations),
-        lambda actual: all(expectation.predicate(actual) for expectation in expectations),
     )
 
 
@@ -270,11 +257,11 @@ def _validate_field(
     return None
 
 
-def _common_event_assertions(session_prefix: str) -> dict[str, FieldExpectation]:
+def _common_event_assertions() -> dict[str, FieldExpectation]:
     return {
         "nemoSource": _expect_exact("guardrails"),
         "event": _expect_one_of(["startup", "heartbeat"]),
-        "sessionId": _expect_all(_expect_non_empty_string(), _expect_startswith(session_prefix)),
+        "sessionId": _expect_non_empty_string(),
         "nemoguardrailsVersion": _expect_non_empty_string(),
         "pythonVersion": _expect_non_empty_string(),
         "platform": _expect_non_empty_string(),
@@ -286,10 +273,8 @@ def _common_event_assertions(session_prefix: str) -> dict[str, FieldExpectation]
 def _validate_common_event_fields(
     scenario_name: str,
     event: dict[str, Any],
-    *,
-    session_prefix: str,
 ) -> Optional[str]:
-    for field, expectation in _common_event_assertions(session_prefix).items():
+    for field, expectation in _common_event_assertions().items():
         error = _validate_field(scenario_name, field, event.get(field), expectation)
         if error:
             return error
@@ -300,7 +285,6 @@ def _validate_startup_events(
     scenario_name: str,
     startup_events: list[dict[str, Any]],
     *,
-    session_prefix: str,
     assertion_sets: list[dict[str, Any]],
 ) -> Optional[str]:
     """Validate startup events with exact, predicate, and list assertions."""
@@ -308,7 +292,7 @@ def _validate_startup_events(
         return f"{scenario_name}.event: expected {len(assertion_sets)} startup event(s), got {len(startup_events)}"
 
     for event in startup_events:
-        common_error = _validate_common_event_fields(scenario_name, event, session_prefix=session_prefix)
+        common_error = _validate_common_event_fields(scenario_name, event)
         if common_error:
             return common_error
 
@@ -343,11 +327,10 @@ def _summarize_expectation(expected: Any) -> str:
     return _as_expectation(expected).description
 
 
-def _summarize_assertions(scenario: dict[str, Any], *, session_prefix: str) -> dict[str, Any]:
+def _summarize_assertions(scenario: dict[str, Any]) -> dict[str, Any]:
     return {
         "common_event_fields": {
-            field: _summarize_expectation(expectation)
-            for field, expectation in _common_event_assertions(session_prefix).items()
+            field: _summarize_expectation(expectation) for field, expectation in _common_event_assertions().items()
         },
         "startup_events": [
             {field: _summarize_expectation(expected) for field, expected in assertions.items()}
@@ -492,6 +475,13 @@ def _run_subprocess(scenario: dict[str, Any], env: dict[str, str], audit_file: P
 
 def _startup_session_ids(lines: list[dict[str, Any]]) -> set[str]:
     return {line["sessionId"] for line in lines if line.get("event") == "startup" and line.get("sessionId")}
+
+
+def _format_kibana_filter(session_ids: list[str]) -> str:
+    if not session_ids:
+        return "client.sessionId : (no startup session IDs collected)"
+    quoted = [json.dumps(session_id) for session_id in session_ids]
+    return "client.sessionId : (" + " or ".join(quoted) + ")"
 
 
 def _wait_for_distinct_startup_sessions(
@@ -1175,11 +1165,9 @@ def _run_scenario(
     if config_dir.exists():
         shutil.rmtree(config_dir)
     config_dir.mkdir(parents=True, exist_ok=True)
-    session_prefix = f"smoke-{run_id}-{scenario['name']}-"
     env = _build_subprocess_env(
         parent_env=os.environ.copy(),
         staging_url=staging_url,
-        session_prefix=session_prefix,
         config_dir=config_dir,
         extra=scenario["extra_env"],
     )
@@ -1194,11 +1182,12 @@ def _run_scenario(
         audit_error = f"audit file is not valid JSONL: {exc}"
     else:
         audit_error = ""
+    startup_session_ids = sorted(_startup_session_ids(lines))
 
     result: dict[str, Any] = {
         "name": scenario["name"],
         "kind": scenario["kind"],
-        "session_prefix": session_prefix,
+        "startup_session_ids": startup_session_ids,
         "audit_file": str(audit_file),
         "subprocess_returncode": run_outcome["returncode"],
         "subprocess_duration_s": round(run_outcome["duration_s"], 2),
@@ -1206,7 +1195,7 @@ def _run_scenario(
         "server_post_results": run_outcome.get("server_post_results", []),
         "expected_event_count": scenario["expected_count"],
         "actual_event_count": len(lines),
-        "expected_assertions": _summarize_assertions(scenario, session_prefix=session_prefix),
+        "expected_assertions": _summarize_assertions(scenario),
     }
     if "worker_count" in run_outcome:
         result["worker_count"] = run_outcome["worker_count"]
@@ -1250,7 +1239,7 @@ def _run_scenario(
         return result
 
     for line in lines:
-        common_error = _validate_common_event_fields(scenario["name"], line, session_prefix=session_prefix)
+        common_error = _validate_common_event_fields(scenario["name"], line)
         if common_error:
             result["verdict"] = "FAIL"
             result["reason"] = common_error
@@ -1260,7 +1249,6 @@ def _run_scenario(
     startup_error = _validate_startup_events(
         scenario["name"],
         startup_lines,
-        session_prefix=session_prefix,
         assertion_sets=scenario["startup_assertions"],
     )
     if startup_error:
@@ -1446,11 +1434,16 @@ def main() -> int:
         print(f"[{result['name']}] {verdict}{suffix}")
         results.append(result)
 
+    all_startup_session_ids = sorted(
+        {session_id for result in results for session_id in result.get("startup_session_ids", [])}
+    )
+    kibana_filter = _format_kibana_filter(all_startup_session_ids)
     manifest = {
         "run_id": run_id,
         "staging_url": args.staging_url,
         "run_dir": str(run_dir),
-        "session_prefix_root": f"smoke-{run_id}-",
+        "startup_session_ids": all_startup_session_ids,
+        "kibana_filter": kibana_filter,
         "results": results,
     }
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
@@ -1461,7 +1454,7 @@ def main() -> int:
         print(f"  {result['name']:24s} {result['verdict']}")
     print()
     print(f"manifest: {manifest_path}")
-    print(f"kibana filter: client.sessionId : smoke-{run_id}-*")
+    print(f"kibana filter: {kibana_filter}")
     print(
         "offline verify: poetry run python scripts/kibana_verify_export.py "
         f"--manifest {manifest_path} --export kibana.json"

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -525,28 +525,36 @@ def _run_server(scenario: dict[str, Any], env: dict[str, str], audit_file: Path)
     for each config_id in scenario["config_ids_to_hit"], polls the
     audit file until the expected event count is observed, then SIGTERMs.
     """
-    port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "nemoguardrails",
-            "server",
-            "--config",
-            scenario["server_config_root"],
-            "--port",
-            str(port),
-            "--disable-chat-ui",
-        ],
-        env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
     started_at = time.time()
     post_results: list[dict[str, Any]] = []
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "nemoguardrails",
+                "server",
+                "--config",
+                scenario["server_config_root"],
+                "--port",
+                str(port),
+                "--disable-chat-ui",
+            ],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except Exception as exc:
+        return {
+            "returncode": -1,
+            "duration_s": time.time() - started_at,
+            "stderr_tail": [repr(exc)],
+            "server_post_results": post_results,
+        }
     try:
         if not _wait_for_server(base_url, timeout=30):
             _terminate(proc)
@@ -630,6 +638,8 @@ app = api.app
 
 def _run_server_multi_worker(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) -> dict[str, Any]:
     """Run a Uvicorn multi-worker server and require one event per worker."""
+    started_at = time.time()
+    post_results: list[dict[str, Any]] = []
     workers = int(scenario.get("worker_count", 3))
     port = _free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -643,29 +653,36 @@ def _run_server_multi_worker(scenario: dict[str, Any], env: dict[str, str], audi
         pythonpath_parts.append(proc_env["PYTHONPATH"])
     proc_env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
 
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            app_import,
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--workers",
-            str(workers),
-            "--log-level",
-            "info",
-        ],
-        env=proc_env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
-    started_at = time.time()
-    post_results: list[dict[str, Any]] = []
+    try:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                app_import,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--workers",
+                str(workers),
+                "--log-level",
+                "info",
+            ],
+            env=proc_env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except Exception as exc:
+        return {
+            "returncode": -1,
+            "duration_s": time.time() - started_at,
+            "stderr_tail": [repr(exc)],
+            "server_post_results": post_results,
+            "worker_count": workers,
+        }
     try:
         if not _wait_for_server(base_url, timeout=45):
             _terminate(proc)
@@ -740,15 +757,18 @@ def _run_cli(scenario: dict[str, Any], env: dict[str, str], audit_file: Path) ->
     # fires during the wait. Then we SIGTERM. Closing stdin instead
     # would feed EOF to input(), raising EOFError and aborting before
     # the daemon thread can flush the audit file reliably.
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "nemoguardrails", "chat", "--config", scenario["config_path"]],
-        env=env,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "nemoguardrails", "chat", "--config", scenario["config_path"]],
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+    except Exception as exc:
+        return {"returncode": -1, "duration_s": time.time() - started_at, "stderr_tail": [repr(exc)]}
     try:
         _wait_for_audit_events(
             audit_file,

--- a/tests/telemetry/smoke_fixtures/README.md
+++ b/tests/telemetry/smoke_fixtures/README.md
@@ -1,0 +1,16 @@
+# Smoke-test fixture configs
+
+Minimal `RailsConfig` directories consumed by [`scripts/telemetry_smoke.py`](../../../scripts/telemetry_smoke.py) as a stable, version-controlled config root for the server and multi-config scenarios.
+
+| Dir | Rails | Why |
+|---|---|---|
+| `cfg1` | input only, `self check input` | distinguishable `railTypesInUse=["input"]` |
+| `cfg2` | output only, `self check output` | distinguishable `railTypesInUse=["output"]` |
+| `cfg3` | input + output, both `self check` flows | distinguishable `railTypesInUse=["input","output"]` |
+| `rich` | input + output, tracing, streaming, kb, custom flow | exercises telemetry fields the minimal fixtures intentionally leave false or zero |
+| `feature_aliases` | config-only fact-checking, Patronus, and regex settings | proves config-derived `builtinFeatures` use documented IDs (`factchecking`, `patronusai`, `regex`) |
+| `v2_custom_flow` | Colang 2.x config importing `core` plus one user flow | proves bundled v2 library flows are excluded from `numCustomFlows` |
+
+All fixtures use the same main model declaration (`openai / gpt-4o-mini`) so multi-config merges do not trip the model-conflict guard in `_join_rails_configs`. The configs are valid enough for `RailsConfig.from_path()` to parse and for `LLMRails(...)` to construct, but the smoke driver never makes a real LLM call: `LLMRails.__init__` emits telemetry before any `generate_async`, so the wire shape is exercised without needing an OpenAI key.
+
+If you tweak these, keep them minimal and self-contained. They are not production configs; if you want example bots, see `examples/bots/`.

--- a/tests/telemetry/smoke_fixtures/cfg1/config.yml
+++ b/tests/telemetry/smoke_fixtures/cfg1/config.yml
@@ -1,0 +1,13 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  input:
+    flows:
+      - self check input
+
+prompts:
+  - task: self_check_input
+    content: "Is this safe? {{ user_input }}. yes or no."

--- a/tests/telemetry/smoke_fixtures/cfg2/config.yml
+++ b/tests/telemetry/smoke_fixtures/cfg2/config.yml
@@ -1,0 +1,13 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  output:
+    flows:
+      - self check output
+
+prompts:
+  - task: self_check_output
+    content: "Is this safe? {{ bot_response }}. yes or no."

--- a/tests/telemetry/smoke_fixtures/cfg3/config.yml
+++ b/tests/telemetry/smoke_fixtures/cfg3/config.yml
@@ -1,0 +1,18 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  input:
+    flows:
+      - self check input
+  output:
+    flows:
+      - self check output
+
+prompts:
+  - task: self_check_input
+    content: "Is this safe? {{ user_input }}. yes or no."
+  - task: self_check_output
+    content: "Is this safe? {{ bot_response }}. yes or no."

--- a/tests/telemetry/smoke_fixtures/feature_aliases/config.yml
+++ b/tests/telemetry/smoke_fixtures/feature_aliases/config.yml
@@ -1,0 +1,20 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  config:
+    fact_checking:
+      parameters:
+        endpoint: "http://localhost:5123/alignscore_base"
+    patronus:
+      output:
+        evaluate_config:
+          params:
+            evaluators:
+              - evaluator: lynx
+    regex_detection:
+      input:
+        patterns:
+          - "secret"

--- a/tests/telemetry/smoke_fixtures/rich/config.yml
+++ b/tests/telemetry/smoke_fixtures/rich/config.yml
@@ -1,0 +1,23 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  input:
+    flows:
+      - self check input
+  output:
+    flows:
+      - self check output
+    streaming:
+      enabled: true
+
+tracing:
+  enabled: true
+
+prompts:
+  - task: self_check_input
+    content: "Is this safe? {{ user_input }}. yes or no."
+  - task: self_check_output
+    content: "Is this safe? {{ bot_response }}. yes or no."

--- a/tests/telemetry/smoke_fixtures/rich/kb/kb.md
+++ b/tests/telemetry/smoke_fixtures/rich/kb/kb.md
@@ -1,0 +1,3 @@
+# Smoke Knowledge Base
+
+This tiny document exists only to exercise telemetry knowledge-base detection.

--- a/tests/telemetry/smoke_fixtures/rich/rails.co
+++ b/tests/telemetry/smoke_fixtures/rich/rails.co
@@ -1,0 +1,9 @@
+define user ask smoke status
+  "smoke status"
+
+define bot answer smoke status
+  "smoke ready"
+
+define flow smoke status
+  user ask smoke status
+  bot answer smoke status

--- a/tests/telemetry/smoke_fixtures/v2_custom_flow/config.yml
+++ b/tests/telemetry/smoke_fixtures/v2_custom_flow/config.yml
@@ -1,0 +1,6 @@
+colang_version: "2.x"
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini

--- a/tests/telemetry/smoke_fixtures/v2_custom_flow/rails.co
+++ b/tests/telemetry/smoke_fixtures/v2_custom_flow/rails.co
@@ -1,0 +1,5 @@
+import core
+
+flow main
+  user said "hi"
+  bot say "Hello World!"

--- a/tests/telemetry/test_usage_reporting.py
+++ b/tests/telemetry/test_usage_reporting.py
@@ -1300,6 +1300,53 @@ class TestTelemetrySmokeDriver:
         assert error is not None
         assert "numCustomFlows" in error
 
+    @pytest.mark.parametrize(
+        ("runner_name", "scenario"),
+        [
+            (
+                "_run_server",
+                {
+                    "server_config_root": "root",
+                    "config_ids_to_hit": ["cfg1"],
+                    "expected_count": 1,
+                },
+            ),
+            (
+                "_run_server_multi_worker",
+                {
+                    "server_config_root": "root",
+                    "config_ids_to_hit": ["cfg1"],
+                    "expected_count": 3,
+                    "worker_count": 3,
+                },
+            ),
+            (
+                "_run_cli",
+                {
+                    "config_path": "cfg1",
+                    "expected_count": 1,
+                },
+            ),
+        ],
+    )
+    def test_process_runner_spawn_failures_return_structured_results(self, tmp_path, runner_name, scenario):
+        audit_file = tmp_path / "run" / "scenario" / "usage_stats.json"
+        runner = getattr(telemetry_smoke, runner_name)
+
+        with (
+            patch.object(telemetry_smoke, "_free_port", return_value=12345),
+            patch.object(telemetry_smoke.subprocess, "Popen", side_effect=FileNotFoundError("missing executable")),
+        ):
+            result = runner(scenario, {}, audit_file)
+
+        assert result["returncode"] == -1
+        assert result["duration_s"] >= 0
+        assert result["stderr_tail"] == ["FileNotFoundError('missing executable')"]
+        if runner_name in {"_run_server", "_run_server_multi_worker"}:
+            assert result["server_post_results"] == []
+        if runner_name == "_run_server_multi_worker":
+            assert result["worker_count"] == 3
+
 
 class TestKibanaVerifyExport:
     def test_verifier_buckets_by_client_session_id(self):

--- a/tests/telemetry/test_usage_reporting.py
+++ b/tests/telemetry/test_usage_reporting.py
@@ -1194,7 +1194,7 @@ class TestTelemetrySmokeDriver:
         event = {
             "nemoSource": "guardrails",
             "event": "startup",
-            "sessionId": "smoke-run-scenario-abc",
+            "sessionId": "2b8e9879-80be-42bb-ad3f-81db8ec28e15",
             "nemoguardrailsVersion": "0.21.0",
             "pythonVersion": "3.13.7",
             "platform": "test-platform",
@@ -1222,6 +1222,29 @@ class TestTelemetrySmokeDriver:
         assert "library_v2_custom_flows" in scenarios
         assert "library_abc_v2" in scenarios
 
+    def test_positive_scenarios_wait_for_daemon_sends(self):
+        scenarios = self._scenarios_by_name()
+
+        assert telemetry_smoke.DEFAULT_NETWORK_SETTLE_S == 20.0
+        assert "settle_after_audit_s" not in scenarios["library_llmrails"]
+        assert "settle_after_audit_s" not in scenarios["server_single_config"]
+
+    def test_kibana_filter_uses_exact_session_ids(self):
+        assert telemetry_smoke._format_kibana_filter(["id1", "id2"]) == 'client.sessionId : ("id1" or "id2")'
+
+    def test_common_assertions_require_non_empty_session_id_only(self):
+        scenario = self._scenarios_by_name()["library_feature_aliases"]
+        event = self._startup_event(sessionId="", builtinFeatures=["factchecking", "patronusai", "regex"])
+
+        error = telemetry_smoke._validate_startup_events(
+            scenario["name"],
+            [event],
+            assertion_sets=scenario["startup_assertions"],
+        )
+
+        assert error is not None
+        assert "sessionId" in error
+
     def test_feature_alias_smoke_assertions_require_documented_ids(self):
         scenario = self._scenarios_by_name()["library_feature_aliases"]
         event = self._startup_event(builtinFeatures=["factchecking", "patronusai", "regex"])
@@ -1230,7 +1253,6 @@ class TestTelemetrySmokeDriver:
             telemetry_smoke._validate_startup_events(
                 scenario["name"],
                 [event],
-                session_prefix="smoke-run-scenario-",
                 assertion_sets=scenario["startup_assertions"],
             )
             is None
@@ -1241,7 +1263,6 @@ class TestTelemetrySmokeDriver:
         error = telemetry_smoke._validate_startup_events(
             scenario["name"],
             [bad_event],
-            session_prefix="smoke-run-scenario-",
             assertion_sets=scenario["startup_assertions"],
         )
 
@@ -1256,7 +1277,6 @@ class TestTelemetrySmokeDriver:
             telemetry_smoke._validate_startup_events(
                 scenario["name"],
                 [event],
-                session_prefix="smoke-run-scenario-",
                 assertion_sets=scenario["startup_assertions"],
             )
             is None
@@ -1267,7 +1287,6 @@ class TestTelemetrySmokeDriver:
         error = telemetry_smoke._validate_startup_events(
             scenario["name"],
             [bad_event],
-            session_prefix="smoke-run-scenario-",
             assertion_sets=scenario["startup_assertions"],
         )
 
@@ -1282,7 +1301,6 @@ class TestTelemetrySmokeDriver:
             telemetry_smoke._validate_startup_events(
                 scenario["name"],
                 [event],
-                session_prefix="smoke-run-scenario-",
                 assertion_sets=scenario["startup_assertions"],
             )
             is None
@@ -1293,7 +1311,6 @@ class TestTelemetrySmokeDriver:
         error = telemetry_smoke._validate_startup_events(
             scenario["name"],
             [bad_event],
-            session_prefix="smoke-run-scenario-",
             assertion_sets=scenario["startup_assertions"],
         )
 
@@ -1349,12 +1366,12 @@ class TestTelemetrySmokeDriver:
 
 
 class TestKibanaVerifyExport:
-    def test_verifier_buckets_by_client_session_id(self):
+    def test_verifier_matches_exact_client_session_ids(self):
         manifest = {
             "results": [
                 {
                     "name": "library_llmrails",
-                    "session_prefix": "smoke-run-library_llmrails-",
+                    "startup_session_ids": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
                     "expected_event_count": 1,
                     "verdict": "PASS",
                 }
@@ -1364,7 +1381,7 @@ class TestKibanaVerifyExport:
             {
                 "fields": {
                     "eventName": ["guardrails_usage_event"],
-                    "client.sessionId": ["smoke-run-library_llmrails-abc"],
+                    "client.sessionId": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
                 }
             }
         ]
@@ -1374,12 +1391,12 @@ class TestKibanaVerifyExport:
         assert passed == 1
         assert failed == 0
 
-    def test_verifier_ignores_parameters_session_id(self):
+    def test_verifier_rejects_prefix_only_session_match(self):
         manifest = {
             "results": [
                 {
                     "name": "library_llmrails",
-                    "session_prefix": "smoke-run-library_llmrails-",
+                    "startup_session_ids": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
                     "expected_event_count": 1,
                     "verdict": "PASS",
                 }
@@ -1389,7 +1406,32 @@ class TestKibanaVerifyExport:
             {
                 "fields": {
                     "eventName": ["guardrails_usage_event"],
-                    "parameters.sessionId": ["smoke-run-library_llmrails-abc"],
+                    "client.sessionId": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15-extra"],
+                }
+            }
+        ]
+
+        passed, failed = kibana_verify_export._verify(manifest, docs)
+
+        assert passed == 0
+        assert failed == 1
+
+    def test_verifier_ignores_parameters_session_id(self):
+        manifest = {
+            "results": [
+                {
+                    "name": "library_llmrails",
+                    "startup_session_ids": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
+                    "expected_event_count": 1,
+                    "verdict": "PASS",
+                }
+            ]
+        }
+        docs = [
+            {
+                "fields": {
+                    "eventName": ["guardrails_usage_event"],
+                    "parameters.sessionId": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
                 }
             }
         ]
@@ -1404,7 +1446,7 @@ class TestKibanaVerifyExport:
             "results": [
                 {
                     "name": "library_llmrails",
-                    "session_prefix": "smoke-run-library_llmrails-",
+                    "startup_session_ids": ["2b8e9879-80be-42bb-ad3f-81db8ec28e15"],
                     "expected_event_count": 1,
                     "verdict": "FAIL",
                 }

--- a/tests/telemetry/test_usage_reporting.py
+++ b/tests/telemetry/test_usage_reporting.py
@@ -1092,19 +1092,6 @@ class TestBuiltinFeatures:
         assert len(config.flows) == 46
         assert data.num_custom_flows == 1
 
-    def test_abc_v2_counts_only_user_flows(self):
-        from nemoguardrails.rails.llm.config import RailsConfig
-
-        config_path = Path(__file__).parents[2] / "examples" / "bots" / "abc_v2"
-        config = RailsConfig.from_path(str(config_path))
-
-        data = _collect_usage_data(config, "library")
-
-        assert data.colang_version == "2.x"
-        assert len(config.flows) == 140
-        assert data.num_custom_flows == 67
-        assert data.has_knowledge_base is True
-
     def test_feature_alias_smoke_fixture_collects_documented_ids(self):
         from nemoguardrails.rails.llm.config import RailsConfig
 
@@ -1183,7 +1170,6 @@ class TestTelemetrySmokeDriver:
             rich_config="rich",
             feature_alias_config="feature_aliases",
             v2_config="v2_custom_flow",
-            abc_v2_config="abc_v2",
             iorails_config="iorails",
             server_config_root="root",
         )
@@ -1220,7 +1206,7 @@ class TestTelemetrySmokeDriver:
 
         assert "library_feature_aliases" in scenarios
         assert "library_v2_custom_flows" in scenarios
-        assert "library_abc_v2" in scenarios
+        assert "library_abc_v2" not in scenarios
 
     def test_positive_scenarios_wait_for_daemon_sends(self):
         scenarios = self._scenarios_by_name()
@@ -1293,33 +1279,16 @@ class TestTelemetrySmokeDriver:
         assert error is not None
         assert "numCustomFlows" in error
 
-    def test_abc_v2_smoke_assertions_require_realistic_v2_count_and_kb(self):
-        scenario = self._scenarios_by_name()["library_abc_v2"]
-        event = self._startup_event(colangVersion="2.x", hasKnowledgeBase=True, numCustomFlows=67)
-
-        assert (
-            telemetry_smoke._validate_startup_events(
-                scenario["name"],
-                [event],
-                assertion_sets=scenario["startup_assertions"],
-            )
-            is None
-        )
-
-        bad_event = dict(event)
-        bad_event["numCustomFlows"] = 140
-        error = telemetry_smoke._validate_startup_events(
-            scenario["name"],
-            [bad_event],
-            assertion_sets=scenario["startup_assertions"],
-        )
-
-        assert error is not None
-        assert "numCustomFlows" in error
-
     @pytest.mark.parametrize(
         ("runner_name", "scenario"),
         [
+            (
+                "_run_subprocess",
+                {
+                    "script": "pass",
+                    "expected_count": 1,
+                },
+            ),
             (
                 "_run_server",
                 {
@@ -1364,8 +1333,67 @@ class TestTelemetrySmokeDriver:
         if runner_name == "_run_server_multi_worker":
             assert result["worker_count"] == 3
 
+    def test_terminate_normalizes_windows_termination_code_only_after_terminating(self):
+        class NaturallyFailedProcess:
+            returncode = 1
+            terminated = False
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.terminated = True
+
+        class TerminatedProcess:
+            returncode = None
+            terminated = False
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.terminated = True
+
+            def wait(self, timeout):
+                self.returncode = 1
+                return self.returncode
+
+        naturally_failed = NaturallyFailedProcess()
+        assert telemetry_smoke._terminate(naturally_failed) == 1
+        assert naturally_failed.terminated is False
+
+        terminated = TerminatedProcess()
+        assert telemetry_smoke._terminate(terminated) == 0
+        assert terminated.terminated is True
+
 
 class TestKibanaVerifyExport:
+    def test_empty_manifest_raises_value_error(self):
+        with pytest.raises(ValueError, match="manifest has no results to verify"):
+            kibana_verify_export._verify({"results": []}, [])
+
+    def test_main_returns_2_for_empty_manifest(self, tmp_path, capsys):
+        manifest_path = tmp_path / "manifest.json"
+        export_path = tmp_path / "kibana.json"
+        manifest_path.write_text(json.dumps({"results": []}))
+        export_path.write_text(json.dumps([]))
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "kibana_verify_export.py",
+                "--manifest",
+                str(manifest_path),
+                "--export",
+                str(export_path),
+            ],
+        ):
+            assert kibana_verify_export.main() == 2
+
+        captured = capsys.readouterr()
+        assert "manifest has no results to verify" in captured.err
+
     def test_verifier_matches_exact_client_session_ids(self):
         manifest = {
             "results": [

--- a/tests/telemetry/test_usage_reporting.py
+++ b/tests/telemetry/test_usage_reporting.py
@@ -37,6 +37,7 @@ from nemoguardrails.telemetry import (
     report_usage,
     set_deployment_type,
 )
+from scripts import kibana_verify_export, telemetry_smoke
 
 
 @pytest.fixture(autouse=True)
@@ -949,6 +950,39 @@ class TestBuiltinFeatures:
         assert "jailbreak_detection" in result
         assert "sensitive_data_detection" in result
 
+    def test_config_feature_ids_are_normalized(self):
+        from nemoguardrails.rails.llm.config import (
+            FactCheckingRailConfig,
+            PatronusEvaluateApiParams,
+            PatronusEvaluateConfig,
+            PatronusRailConfig,
+            Rails,
+            RailsConfigData,
+            RegexDetection,
+            RegexDetectionOptions,
+        )
+
+        config_data = RailsConfigData(
+            fact_checking=FactCheckingRailConfig(parameters={"endpoint": "http://example.com"}),
+            patronus=PatronusRailConfig(
+                output=PatronusEvaluateConfig(
+                    evaluate_config=PatronusEvaluateApiParams(params={"criteria": "patronus:hallucination"})
+                )
+            ),
+            regex_detection=RegexDetection(input=RegexDetectionOptions(patterns=["secret"])),
+        )
+        config = MagicMock()
+        config.rails = Rails(config=config_data)
+
+        result = _detect_builtin_features(config)
+
+        assert "factchecking" in result
+        assert "patronusai" in result
+        assert "regex" in result
+        assert "fact_checking" not in result
+        assert "patronus" not in result
+        assert "regex_detection" not in result
+
     def test_detects_features_from_exact_flow_names(self):
         from nemoguardrails.rails.llm.config import Rails
 
@@ -1012,6 +1046,75 @@ class TestBuiltinFeatures:
         data = _collect_usage_data(config, "library")
         assert data.num_custom_flows == 2
 
+    def test_v2_library_flows_not_counted_as_custom(self, tmp_path):
+        from nemoguardrails.colang.v2_x.lang.colang_ast import Flow
+
+        config = MagicMock()
+        config.colang_version = "2.x"
+        config.models = []
+        config.rails = None
+        config.tracing = None
+        config.docs = None
+        config.flows = [
+            Flow(
+                name="_user_said",
+                file_info={"name": str(telemetry._COLANG_V2_LIBRARY_DIR / "core.co")},
+            ),
+            Flow(
+                name="main",
+                file_info={"name": str(tmp_path / "main.co")},
+            ),
+        ]
+
+        data = _collect_usage_data(config, "library")
+
+        assert data.num_custom_flows == 1
+
+    def test_real_v2_tutorial_counts_only_user_flows(self):
+        from nemoguardrails.rails.llm.config import RailsConfig
+
+        config_path = Path(__file__).parents[2] / "examples" / "v2_x" / "tutorial" / "hello_world_1"
+        config = RailsConfig.from_path(str(config_path))
+
+        data = _collect_usage_data(config, "library")
+
+        assert len(config.flows) == 46
+        assert data.num_custom_flows == 1
+
+    def test_v2_smoke_fixture_counts_only_user_flows(self):
+        from nemoguardrails.rails.llm.config import RailsConfig
+
+        config_path = Path(__file__).parent / "smoke_fixtures" / "v2_custom_flow"
+        config = RailsConfig.from_path(str(config_path))
+
+        data = _collect_usage_data(config, "library")
+
+        assert len(config.flows) == 46
+        assert data.num_custom_flows == 1
+
+    def test_abc_v2_counts_only_user_flows(self):
+        from nemoguardrails.rails.llm.config import RailsConfig
+
+        config_path = Path(__file__).parents[2] / "examples" / "bots" / "abc_v2"
+        config = RailsConfig.from_path(str(config_path))
+
+        data = _collect_usage_data(config, "library")
+
+        assert data.colang_version == "2.x"
+        assert len(config.flows) == 140
+        assert data.num_custom_flows == 67
+        assert data.has_knowledge_base is True
+
+    def test_feature_alias_smoke_fixture_collects_documented_ids(self):
+        from nemoguardrails.rails.llm.config import RailsConfig
+
+        config_path = Path(__file__).parent / "smoke_fixtures" / "feature_aliases"
+        config = RailsConfig.from_path(str(config_path))
+
+        data = _collect_usage_data(config, "library")
+
+        assert data.builtin_features == ["factchecking", "patronusai", "regex"]
+
     def test_included_in_usage_data(self):
         from nemoguardrails.rails.llm.config import JailbreakDetectionConfig, Rails, RailsConfigData
 
@@ -1070,3 +1173,198 @@ class TestUpstreamSchemaConformance:
         event = _collect_usage_data(mock_config, "library")
         event.rails_engine = RailsEngineEnum.LLMRAILS
         validator.validate(event.model_dump(by_alias=True))
+
+
+class TestTelemetrySmokeDriver:
+    @staticmethod
+    def _scenarios_by_name():
+        scenarios = telemetry_smoke._build_scenarios(
+            library_config="cfg1",
+            rich_config="rich",
+            feature_alias_config="feature_aliases",
+            v2_config="v2_custom_flow",
+            abc_v2_config="abc_v2",
+            iorails_config="iorails",
+            server_config_root="root",
+        )
+        return {scenario["name"]: scenario for scenario in scenarios}
+
+    @staticmethod
+    def _startup_event(**overrides):
+        event = {
+            "nemoSource": "guardrails",
+            "event": "startup",
+            "sessionId": "smoke-run-scenario-abc",
+            "nemoguardrailsVersion": "0.21.0",
+            "pythonVersion": "3.13.7",
+            "platform": "test-platform",
+            "osName": "Darwin",
+            "timestamp": 1700000000.0,
+            "deploymentType": "library",
+            "railsEngine": "LLMRails",
+            "llmProviders": ["openai"],
+            "colangVersion": "1.0",
+            "numRailsConfigured": 0,
+            "railTypesInUse": [],
+            "builtinFeatures": [],
+            "tracingEnabled": False,
+            "hasKnowledgeBase": False,
+            "streamingConfigured": False,
+            "numCustomFlows": 0,
+        }
+        event.update(overrides)
+        return event
+
+    def test_smoke_scenarios_cover_feature_aliases_and_v2_custom_flows(self):
+        scenarios = self._scenarios_by_name()
+
+        assert "library_feature_aliases" in scenarios
+        assert "library_v2_custom_flows" in scenarios
+        assert "library_abc_v2" in scenarios
+
+    def test_feature_alias_smoke_assertions_require_documented_ids(self):
+        scenario = self._scenarios_by_name()["library_feature_aliases"]
+        event = self._startup_event(builtinFeatures=["factchecking", "patronusai", "regex"])
+
+        assert (
+            telemetry_smoke._validate_startup_events(
+                scenario["name"],
+                [event],
+                session_prefix="smoke-run-scenario-",
+                assertion_sets=scenario["startup_assertions"],
+            )
+            is None
+        )
+
+        bad_event = dict(event)
+        bad_event["builtinFeatures"] = ["fact_checking", "patronus", "regex_detection"]
+        error = telemetry_smoke._validate_startup_events(
+            scenario["name"],
+            [bad_event],
+            session_prefix="smoke-run-scenario-",
+            assertion_sets=scenario["startup_assertions"],
+        )
+
+        assert error is not None
+        assert "builtinFeatures" in error
+
+    def test_v2_smoke_assertions_reject_bundled_library_flow_count(self):
+        scenario = self._scenarios_by_name()["library_v2_custom_flows"]
+        event = self._startup_event(colangVersion="2.x", numCustomFlows=1)
+
+        assert (
+            telemetry_smoke._validate_startup_events(
+                scenario["name"],
+                [event],
+                session_prefix="smoke-run-scenario-",
+                assertion_sets=scenario["startup_assertions"],
+            )
+            is None
+        )
+
+        bad_event = dict(event)
+        bad_event["numCustomFlows"] = 46
+        error = telemetry_smoke._validate_startup_events(
+            scenario["name"],
+            [bad_event],
+            session_prefix="smoke-run-scenario-",
+            assertion_sets=scenario["startup_assertions"],
+        )
+
+        assert error is not None
+        assert "numCustomFlows" in error
+
+    def test_abc_v2_smoke_assertions_require_realistic_v2_count_and_kb(self):
+        scenario = self._scenarios_by_name()["library_abc_v2"]
+        event = self._startup_event(colangVersion="2.x", hasKnowledgeBase=True, numCustomFlows=67)
+
+        assert (
+            telemetry_smoke._validate_startup_events(
+                scenario["name"],
+                [event],
+                session_prefix="smoke-run-scenario-",
+                assertion_sets=scenario["startup_assertions"],
+            )
+            is None
+        )
+
+        bad_event = dict(event)
+        bad_event["numCustomFlows"] = 140
+        error = telemetry_smoke._validate_startup_events(
+            scenario["name"],
+            [bad_event],
+            session_prefix="smoke-run-scenario-",
+            assertion_sets=scenario["startup_assertions"],
+        )
+
+        assert error is not None
+        assert "numCustomFlows" in error
+
+
+class TestKibanaVerifyExport:
+    def test_verifier_buckets_by_client_session_id(self):
+        manifest = {
+            "results": [
+                {
+                    "name": "library_llmrails",
+                    "session_prefix": "smoke-run-library_llmrails-",
+                    "expected_event_count": 1,
+                    "verdict": "PASS",
+                }
+            ]
+        }
+        docs = [
+            {
+                "fields": {
+                    "eventName": ["guardrails_usage_event"],
+                    "client.sessionId": ["smoke-run-library_llmrails-abc"],
+                }
+            }
+        ]
+
+        passed, failed = kibana_verify_export._verify(manifest, docs)
+
+        assert passed == 1
+        assert failed == 0
+
+    def test_verifier_ignores_parameters_session_id(self):
+        manifest = {
+            "results": [
+                {
+                    "name": "library_llmrails",
+                    "session_prefix": "smoke-run-library_llmrails-",
+                    "expected_event_count": 1,
+                    "verdict": "PASS",
+                }
+            ]
+        }
+        docs = [
+            {
+                "fields": {
+                    "eventName": ["guardrails_usage_event"],
+                    "parameters.sessionId": ["smoke-run-library_llmrails-abc"],
+                }
+            }
+        ]
+
+        passed, failed = kibana_verify_export._verify(manifest, docs)
+
+        assert passed == 0
+        assert failed == 1
+
+    def test_failed_smoke_scenarios_fail_verification(self):
+        manifest = {
+            "results": [
+                {
+                    "name": "library_llmrails",
+                    "session_prefix": "smoke-run-library_llmrails-",
+                    "expected_event_count": 1,
+                    "verdict": "FAIL",
+                }
+            ]
+        }
+
+        passed, failed = kibana_verify_export._verify(manifest, [])
+
+        assert passed == 0
+        assert failed == 1


### PR DESCRIPTION
## Stacked PR Note

This work is split into smaller stacked PRs:

- #1878 : core telemetry implementation and direct unit tests.
- This PR : smoke driver, Kibana export verifier, fixtures, and smoke runbook. Stacked 1878.
- #1891 : user-facing telemetry docs and README/legal notes. Stacked on 1878.



## Description

- Add the local smoke driver for library, API, CLI, fork, heartbeat, and opt-out paths. Use committed fixture configs, audit-file polling, schema validation, manifest output, and server POST capture.
- 
- Add a stdlib verifier that reads a smoke manifest and a copied Kibana JSON export, filters guardrails usage events, and checks per-scenario hit counts.
- 
- Document when and how to run the telemetry smoke driver, what each scenario covers, and how to verify receiver-side delivery from a Kibana JSON export.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry smoke-testing framework supporting multiple scenario types (library, server, CLI, multi-worker)
  * Offline verification tool to validate telemetry exports against Kibana data

* **Documentation**
  * Operator guide for running telemetry smoke tests against staging environments

* **Tests**
  * Comprehensive test coverage for smoke driver and export verification
  * Test fixtures for various configuration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->