### PR TITLE
docs(telemetry): document anonymous usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,27 +309,28 @@ To the best of our knowledge, the NeMo Guardrails library is the only guardrails
 - [FAQs](https://docs.nvidia.com/nemo/guardrails/faqs.html)
 - [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/security/guidelines.html)
 
-## Telemetry
+## Telemetry and Privacy
 
-NeMo Guardrails collects anonymous telemetry to help us understand which deployment patterns and safety features are most used. One usage event is emitted at each `LLMRails` / `Guardrails` instantiation, plus periodic heartbeats from a single daemon thread per process. It is **separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html)**: tracing that you configure in your guardrails config goes to your own observability backend, whereas this telemetry is a minimal anonymous ping to NVIDIA.
+The NVIDIA NeMo Guardrails library collects anonymous telemetry to help NVIDIA understand which deployment patterns and safety features are most used. The library emits one usage event when you instantiate `LLMRails` or `Guardrails`, then emits periodic heartbeats from a single daemon thread per process. This telemetry is separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html). You configure tracing in your guardrails config and send it to your own observability backend. Telemetry is a minimal anonymous ping to NVIDIA.
 
-We collect:
+The telemetry includes:
 
-- Installed NeMo Guardrails version, Python version, operating system, and platform string
+- Installed library version, Python version, operating system, and platform string
 - Colang language version in use (1.0 or 2.x)
-- Names of LLM engine providers configured (e.g. `openai`, `nim`, `nvidia_ai_endpoints`), never model names or credentials
+- Names of configured LLM engine providers, such as `openai`, `nim`, or `nvidia_ai_endpoints`, never model names or credentials
 - Counts of configured rail flows for input, output, retrieval, and tool rails, plus which rail categories are active
-- Names of built-in library features that are active (e.g. `jailbreak_detection`, `content_safety`, `topic_safety`)
+- Names of built-in library features that are active, such as `jailbreak_detection`, `content_safety`, or `topic_safety`
 - Count of user-defined Colang flows (count only, never flow names or contents)
 - Whether tracing, streaming, or a knowledge base is configured
+- How you deployed guardrails (`library`, `api`, or `cli` server)
 - Which rails engine is in use (`LLMRails` or `IORails`)
-- A random per-process UUID for correlating events from the same instance; it is generated in memory and not stored for reuse across restarts, but it is included in audit records and transmitted telemetry events
+- A random per-process UUID for correlating events from the same instance. The library generates it in memory and does not store it for reuse across restarts, but includes it in audit records and transmitted telemetry events
 
-**No user content is collected in the event payload.** The payload does not include model names, API keys, endpoints, prompts, completions, token counts, per-request metrics, file paths, usernames, or IP addresses. The data is used in aggregate to prioritize engineering work and share adoption trends with the community.
+**No user content is collected in the event payload.** The payload does not include model names, API keys, endpoints, prompts, completions, token counts, per-request metrics, file paths, usernames, or IP addresses. NVIDIA uses the data in aggregate to prioritize engineering work and will share adoption trends with the community.
 
-Telemetry also attempts to write each event payload to a local audit file at `~/.config/nemoguardrails/usage_stats.json`. The audit file stores the event JSONL, not the full NVIDIA telemetry envelope; audit writes are best-effort and telemetry send still proceeds if local audit writing fails.
+The library also attempts to write each event payload to a local audit file at `~/.config/nemoguardrails/usage_stats.json`. The audit file stores the event JSONL, not the full NVIDIA telemetry envelope. Audit writes are best effort, and telemetry transmission still proceeds if local audit writing fails.
 
-To disable telemetry, any one of the following works:
+Set any one of the following options to disable telemetry:
 
 ```bash
 export NEMO_GUARDRAILS_NO_USAGE_STATS=1
@@ -339,9 +340,13 @@ export DO_NOT_TRACK=1
 mkdir -p ~/.config/nemoguardrails && touch ~/.config/nemoguardrails/do_not_track
 ```
 
-Set the opt-out before NeMo Guardrails starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
+Set the opt-out before the NVIDIA NeMo Guardrails library starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
 
-See [docs/telemetry.md](./docs/telemetry.md) for the full schema and field-by-field descriptions.
+Refer to [docs/telemetry.md](https://docs.nvidia.com/nemo/guardrails/latest/telemetry.html) for the full schema and field-by-field descriptions.
+
+You may opt out of telemetry collection at any time. Opting out applies only to data collection by the NVIDIA NeMo Guardrails library itself.
+
+Third-party endpoints have separate terms and privacy practices. The NVIDIA NeMo Guardrails library can use inference endpoints such as NVIDIA Build (`build.nvidia.com`). If you use NVIDIA Build or another third-party endpoint, that endpoint's terms of service and privacy practices apply independently of the library. Any telemetry opt-out in the NVIDIA NeMo Guardrails library does not extend to the endpoint you choose. NVIDIA Build is intended for evaluation and testing only and must not be used in production environments. Do not submit confidential information or personal data when using NVIDIA Build.
 
 ## Inviting the community to contribute
 
@@ -375,11 +380,3 @@ If you use the NeMo Guardrails library, cite the [EMNLP 2023 paper](https://acla
     pages = "431--445",
 }
 ```
-
-## Telemetry & privacy
-
-NeMo Guardrails includes an optional function to share anonymous telemetry data with NVIDIA for product improvement. Data collected is limited to configuration and environment metrics (such as library version, Python version, operating system, Colang version, LLM engine names, rail configuration, active features, and deployment context). No user or device information is collected. This data is used to prioritize product improvements and will be shared in aggregate with the community. It is not used to track any individual user behavior.
-
-You may opt out of telemetry collection at any time. Opting out applies only to data collection by the NeMo Guardrails library itself.
-
-Use of third-party endpoints, including NVIDIA Build: NeMo Guardrails can be configured to use various inference endpoints, including build.nvidia.com (NVIDIA Build). If you choose to use NVIDIA Build or any other third-party endpoint, that endpoint's own terms of service and privacy practices apply independently of this library. Any opt-out you exercise within NeMo Guardrails does not extend to data collection by your chosen endpoint. NVIDIA Build is intended for evaluation and testing purposes only and may not be used in production environments. Do not submit any confidential information or personal data when using NVIDIA Build.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,40 @@ To the best of our knowledge, the NeMo Guardrails library is the only guardrails
 - [FAQs](https://docs.nvidia.com/nemo/guardrails/faqs.html)
 - [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/security/guidelines.html)
 
+## Telemetry
+
+NeMo Guardrails collects anonymous telemetry to help us understand which deployment patterns and safety features are most used. One usage event is emitted at each `LLMRails` / `Guardrails` instantiation, plus periodic heartbeats from a single daemon thread per process. It is **separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html)**: tracing that you configure in your guardrails config goes to your own observability backend, whereas this telemetry is a minimal anonymous ping to NVIDIA.
+
+We collect:
+
+- Installed NeMo Guardrails version, Python version, operating system, and platform string
+- Colang language version in use (1.0 or 2.x)
+- Names of LLM engine providers configured (e.g. `openai`, `nim`, `nvidia_ai_endpoints`), never model names or credentials
+- Counts of configured rail flows for input, output, retrieval, and tool rails, plus which rail categories are active
+- Names of built-in library features that are active (e.g. `jailbreak_detection`, `content_safety`, `topic_safety`)
+- Count of user-defined Colang flows (count only, never flow names or contents)
+- Whether tracing, streaming, or a knowledge base is configured
+- Which rails engine is in use (`LLMRails` or `IORails`)
+- A random per-process UUID for correlating events from the same instance; it is generated in memory and not stored for reuse across restarts, but it is included in audit records and transmitted telemetry events
+
+**No user content is collected in the event payload.** The payload does not include model names, API keys, endpoints, prompts, completions, token counts, per-request metrics, file paths, usernames, or IP addresses. The data is used in aggregate to prioritize engineering work and share adoption trends with the community.
+
+Telemetry also attempts to write each event payload to a local audit file at `~/.config/nemoguardrails/usage_stats.json`. The audit file stores the event JSONL, not the full NVIDIA telemetry envelope; audit writes are best-effort and telemetry send still proceeds if local audit writing fails.
+
+To disable telemetry, any one of the following works:
+
+```bash
+export NEMO_GUARDRAILS_NO_USAGE_STATS=1
+# or
+export DO_NOT_TRACK=1
+# or
+mkdir -p ~/.config/nemoguardrails && touch ~/.config/nemoguardrails/do_not_track
+```
+
+Set the opt-out before NeMo Guardrails starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
+
+See [docs/telemetry.md](./docs/telemetry.md) for the full schema and field-by-field descriptions.
+
 ## Inviting the community to contribute
 
 The example rails residing in the repository are excellent starting points. We enthusiastically invite the community to contribute towards making the power of trustworthy, safe, and secure LLMs accessible to everyone. For guidance on setting up a development environment and how to contribute to the NeMo Guardrails library, see the [contributing guidelines](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -375,3 +375,11 @@ If you use the NeMo Guardrails library, cite the [EMNLP 2023 paper](https://acla
     pages = "431--445",
 }
 ```
+
+## Telemetry & privacy
+
+NeMo Guardrails includes an optional function to share anonymous telemetry data with NVIDIA for product improvement. Data collected is limited to configuration and environment metrics (such as library version, Python version, operating system, Colang version, LLM engine names, rail configuration, active features, and deployment context). No user or device information is collected. This data is used to prioritize product improvements and will be shared in aggregate with the community. It is not used to track any individual user behavior.
+
+You may opt out of telemetry collection at any time. Opting out applies only to data collection by the NeMo Guardrails library itself.
+
+Use of third-party endpoints, including NVIDIA Build: NeMo Guardrails can be configured to use various inference endpoints, including build.nvidia.com (NVIDIA Build). If you choose to use NVIDIA Build or any other third-party endpoint, that endpoint's own terms of service and privacy practices apply independently of this library. Any opt-out you exercise within NeMo Guardrails does not extend to data collection by your chosen endpoint. NVIDIA Build is intended for evaluation and testing purposes only and may not be used in production environments. Do not submit any confidential information or personal data when using NVIDIA Build.

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,6 +233,7 @@ Overview <observability/index.md>
 Logging <observability/logging/index.md>
 Tracing <observability/tracing/index.md>
 Metrics <observability/metrics/index.md>
+Usage Telemetry <telemetry.md>
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,7 +233,7 @@ Overview <observability/index.md>
 Logging <observability/logging/index.md>
 Tracing <observability/tracing/index.md>
 Metrics <observability/metrics/index.md>
-Usage Telemetry <telemetry.md>
+Telemetry <telemetry.md>
 ```
 
 ```{toctree}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,19 +1,21 @@
 # Telemetry
 
-NeMo Guardrails collects anonymous telemetry to help the engineering team understand which deployment patterns and safety features are most widely used. The event payload is transparent and does not contain user content or direct user identifiers such as usernames, API keys, or IP addresses.
+The NVIDIA NeMo Guardrails library collects anonymous telemetry to help the NVIDIA engineering team understand which deployment patterns and safety features are most widely used. The event payload is transparent and does not contain user content or direct user identifiers such as usernames, API keys, or IP addresses.
 
-A subset of the data, after cleaning and aggregation, may be shared publicly with the community (for example, adoption charts showing which built-in safety features are most used).
+After cleaning and aggregation, NVIDIA might share a subset of the data with the community, such as adoption charts that show which built-in safety features are most used. NVIDIA will not share any user content or direct user identifiers such as usernames, API keys, or IP addresses.
 
-> **Not to be confused with tracing.** This page is about anonymous usage telemetry (emitted at each `LLMRails` / `Guardrails` instantiation and as periodic heartbeats, sent to NVIDIA). It is separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html), which you enable in your guardrails config to emit OpenTelemetry spans to your own observability backend.
+:::{note}
+Telemetry is not to be confused with tracing. This page covers anonymous usage telemetry, which the library emits when you instantiate `LLMRails` or `Guardrails` and through periodic heartbeats that it sends to NVIDIA. It is separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html), which you enable in your guardrails config to emit OpenTelemetry spans to your own observability backend.
+:::
 
-## What is collected?
+## Data Collected by Telemetry
 
-The data is collected when `LLMRails` / `Guardrails` is constructed and as periodic heartbeats. It describes the deployment, not individual requests.
+The library collects data when you construct `LLMRails` or `Guardrails` and through periodic heartbeats. The data describes the deployment, not individual requests.
 
-In this context, a **session is the lifetime of a single Python process** running NeMo Guardrails: the session ID is generated in memory when telemetry starts and is not stored for reuse across process restarts. The session ID is an optional non-sensitive prefix from `NEMO_SESSION_PREFIX` plus a random UUID4. The same session ID is included in local audit records and transmitted telemetry events so startup and heartbeat events from one process can be correlated. Two runs of guardrails by the same user produce two unrelated session IDs.
+In this context, a *session* is the lifetime of a single Python process running the NVIDIA NeMo Guardrails library. The library generates the session ID in memory when telemetry starts and does not store it for reuse across process restarts. The session ID is an optional non-sensitive prefix from `NEMO_SESSION_PREFIX` plus a random UUID4. The same session ID appears in local audit records and transmitted telemetry events so startup and heartbeat events from one process can be correlated. Two guardrails runs by the same user produce two unrelated session IDs.
 
 | Field | Type | Example | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `sessionId` | string | `"2b8e9879-80be-42bb-ad3f-81db8ec28e15"` (or `"smoke-run-2b8e9879-80be-42bb-ad3f-81db8ec28e15"` when `NEMO_SESSION_PREFIX` is set) | Session ID. Optional non-sensitive prefix plus a random UUID4 generated in memory when telemetry starts. Shared by all events from the same process and included in audit records and transmitted events, but not stored for reuse across restarts. |
 | `nemoguardrailsVersion` | string | `"0.21.0"` | Installed package version. `"unknown"` if unavailable. |
 | `pythonVersion` | string | `"3.13.7"` | Python interpreter version. |
@@ -24,23 +26,23 @@ In this context, a **session is the lifetime of a single Python process** runnin
 | `numRailsConfigured` | integer | `4` | Count of configured rail flows for input, output, retrieval, tool input, and tool output rails. Dialog usage is represented in `railTypesInUse` but not counted as a flow. |
 | `railTypesInUse` | array of strings | `["input", "output"]` | Active rail categories from `input`, `output`, `retrieval`, `tool_input`, `tool_output`, `dialog`. |
 | `tracingEnabled` | boolean | `false` | Whether the tracing subsystem is enabled. |
-| `deploymentType` | string | `"library"` | How guardrails was deployed: `"library"` (direct `LLMRails` use), `"api"` (FastAPI server), `"cli"` (interactive `nemoguardrails chat`). |
-| `nemoSource` | string | `"guardrails"` | The NeMo product that produced the event. Always `"guardrails"` for this event type. Mirrors the shared `NemoSourceEnum` from the nemo-telemetry repo. |
+| `deploymentType` | string | `"library"` | How you deployed guardrails: `"library"` (direct `LLMRails` use), `"api"` (FastAPI server), or `"cli"` (interactive `nemoguardrails chat`). |
+| `nemoSource` | string | `"guardrails"` | The NVIDIA NeMo product that produced the event. Always `"guardrails"` for this event type. Mirrors the shared `NemoSourceEnum` from the nemo-telemetry repository. |
 | `railsEngine` | string | `"LLMRails"` | Which rails engine is in use: `"LLMRails"` or `"IORails"`. |
 | `hasKnowledgeBase` | boolean | `false` | Whether a knowledge base is configured. |
 | `streamingConfigured` | boolean | `false` | Whether streaming output is enabled. |
-| `builtinFeatures` | array of strings | `["content_safety", "jailbreak_detection"]` | Active built-in library features, sorted (see list below). |
+| `builtinFeatures` | array of strings | `["content_safety", "jailbreak_detection"]` | Active built-in library features, sorted. Refer to the list below. |
 | `numCustomFlows` | integer | `0` | Count of user-defined Colang flows. Never flow names or contents. |
 | `timestamp` | number | `1775716074.855979` | Unix timestamp when the event was collected. |
 | `event` | string | `"startup"` | Event type: `"startup"` for the initial report, `"heartbeat"` for periodic pings. |
 
-### Possible values for `builtinFeatures`
+### Possible Values for Built-In Features
 
-Each corresponds to a directory under `nemoguardrails/library/`:
+Each value corresponds to a directory under `nemoguardrails/library/`. This list reflects the current release; the directories under `nemoguardrails/library/` are the authoritative source.
 
 `activefence`, `ai_defense`, `autoalign`, `clavata`, `cleanlab`, `content_safety`, `crowdstrike_aidr`, `factchecking`, `fiddler`, `gliner`, `guardrails_ai`, `hallucination`, `injection_detection`, `jailbreak_detection`, `llama_guard`, `pangea`, `patronusai`, `policyai`, `prompt_security`, `regex`, `self_check`, `sensitive_data_detection`, `topic_safety`, `trend_micro`.
 
-## What is NOT collected
+## Data That Is Not Collected
 
 - Model names, model paths, or model parameters
 - API keys, endpoints, URLs, or credentials
@@ -51,8 +53,7 @@ Each corresponds to a directory under `nemoguardrails/library/`:
 
 The schema is designed to avoid user content and direct user identifiers. Review the audit file to confirm the exact event fields emitted by your local configuration.
 
-
-## Sample payloads
+## Sample Payloads
 
 **Startup event:**
 
@@ -91,21 +92,21 @@ The schema is designed to avoid user content and direct user identifiers. Review
 }
 ```
 
-Each event is wrapped in the shared NVIDIA telemetry envelope (protocol v1.6) with `nemoSource: "guardrails"` before it is transmitted.
+Before transmission, the telemetry client wraps each event in the shared NVIDIA telemetry envelope (protocol v1.6) with `nemoSource: "guardrails"`.
 
-## Inspecting what is sent
+## Inspect What Is Sent
 
-Telemetry attempts to write each outgoing event payload to a local audit file before it is sent over the network:
+The telemetry client attempts to write each outgoing event payload to a local audit file before sending it over the network:
 
 ```bash
 cat ~/.config/nemoguardrails/usage_stats.json
 ```
 
-The file is JSON lines format (one event per line), bounded at 10 MB with automatic rotation. It stores the inner event payload, not the full NVIDIA telemetry envelope. Audit writes are best-effort; if local audit writing fails, the telemetry send still proceeds.
+The file uses JSON Lines format with one event per line and automatic rotation at 10 MB. It stores the inner event payload, not the full NVIDIA telemetry envelope. Audit writes are best effort. If local audit writing fails, telemetry transmission still proceeds.
 
-## Opting out
+## Opt Out
 
-Any one of the following disables telemetry:
+Set one of the following options to opt out of telemetry collection:
 
 ```bash
 # Product-specific:
@@ -118,19 +119,19 @@ export DO_NOT_TRACK=1
 mkdir -p ~/.config/nemoguardrails && touch ~/.config/nemoguardrails/do_not_track
 ```
 
-When any opt-out is active, no daemon thread is spawned, no audit file is written, and no network request is made.
+When any opt-out is active, the library does not start the heartbeat daemon thread, does not write to the audit file, and does not make any network requests.
 
-Set the opt-out before NeMo Guardrails starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
+Set the opt-out before the NVIDIA NeMo Guardrails library starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
 
-### Automatic suppression in test and CI environments
+### Automatic Suppression in Test and CI Environments
 
-Telemetry is also automatically disabled, with no configuration required, when either of the following environment variables is set:
+The telemetry client also disables telemetry automatically, with no configuration required, when either of the following environment variables is set:
 
 - `CI` (truthy: `1` or `true`). Set by GitHub Actions, GitLab CI, CircleCI, Travis, Buildkite, and most other CI runners. Honoring this is the same convention used by Homebrew, npm, conda, and others.
 - `PYTEST_CURRENT_TEST`. Set by pytest while a test is running. Suppresses telemetry from your test suite even outside CI.
 
-The intent is that adoption metrics reflect real deployments only, not synthetic test or CI traffic. If you genuinely want telemetry from a CI run (rare), unset `CI` for that step.
+This behavior keeps adoption metrics focused on real deployments, not synthetic test or CI traffic. If you genuinely want telemetry from a CI run, unset `CI` for that step.
 
-## Schema and source code
+## Schema and Source Code
 
-The Python source for the event lives in [`nemoguardrails/telemetry.py`](../nemoguardrails/telemetry.py). A vendored snapshot of the wire-format schema is at [`schemas/anonymous_events.snapshot.json`](../schemas/anonymous_events.snapshot.json) and is used by the conformance test in [`tests/telemetry/test_usage_reporting.py`](../tests/telemetry/test_usage_reporting.py) to validate emitted payloads against the canonical contract.
+The Python source for the event lives in [`nemoguardrails/telemetry.py`](../nemoguardrails/telemetry.py). A vendored snapshot of the wire-format schema is at [`schemas/anonymous_events.snapshot.json`](../schemas/anonymous_events.snapshot.json). The conformance test in [`tests/telemetry/test_usage_reporting.py`](../tests/telemetry/test_usage_reporting.py) uses that snapshot to validate emitted payloads against the canonical contract.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -14,7 +14,7 @@ In this context, a **session is the lifetime of a single Python process** runnin
 
 | Field | Type | Example | Description |
 |---|---|---|---|
-| `sessionId` | string | `"smoke-run-2b8e9879-80be-42bb-ad3f-81db8ec28e15"` | Session ID. Optional non-sensitive prefix plus a random UUID4 generated in memory when telemetry starts. Shared by all events from the same process and included in audit records and transmitted events, but not stored for reuse across restarts. |
+| `sessionId` | string | `"2b8e9879-80be-42bb-ad3f-81db8ec28e15"` (or `"smoke-run-2b8e9879-80be-42bb-ad3f-81db8ec28e15"` when `NEMO_SESSION_PREFIX` is set) | Session ID. Optional non-sensitive prefix plus a random UUID4 generated in memory when telemetry starts. Shared by all events from the same process and included in audit records and transmitted events, but not stored for reuse across restarts. |
 | `nemoguardrailsVersion` | string | `"0.21.0"` | Installed package version. `"unknown"` if unavailable. |
 | `pythonVersion` | string | `"3.13.7"` | Python interpreter version. |
 | `platform` | string | `"Linux-5.15.0-x86_64-with-glibc2.35"` | OS and architecture string. |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -42,7 +42,9 @@ Each value corresponds to a directory under `nemoguardrails/library/`. This list
 
 `activefence`, `ai_defense`, `autoalign`, `clavata`, `cleanlab`, `content_safety`, `crowdstrike_aidr`, `factchecking`, `fiddler`, `gliner`, `guardrails_ai`, `hallucination`, `injection_detection`, `jailbreak_detection`, `llama_guard`, `pangea`, `patronusai`, `policyai`, `prompt_security`, `regex`, `self_check`, `sensitive_data_detection`, `topic_safety`, `trend_micro`.
 
-## Data That Is Not Collected
+## Data Not Collected by Telemetry
+
+Telemetry excludes the following data from event payloads:
 
 - Model names, model paths, or model parameters
 - API keys, endpoints, URLs, or credentials
@@ -54,6 +56,8 @@ Each value corresponds to a directory under `nemoguardrails/library/`. This list
 The schema is designed to avoid user content and direct user identifiers. Review the audit file to confirm the exact event fields emitted by your local configuration.
 
 ## Sample Payloads
+
+The following examples show the startup and heartbeat event payloads:
 
 **Startup event:**
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -133,4 +133,4 @@ The intent is that adoption metrics reflect real deployments only, not synthetic
 
 ## Schema and source code
 
-The Python source for the event lives in [`nemoguardrails/telemetry.py`](../nemoguardrails/telemetry.py). A vendored snapshot of the wire-format schema is at [`schemas/anonymous_events.snapshot.json`](../schemas/anonymous_events.snapshot.json) and is used by the conformance test in [`tests/telemetry/test_telemetry.py`](../tests/telemetry/test_telemetry.py) to validate emitted payloads against the canonical contract.
+The Python source for the event lives in [`nemoguardrails/telemetry.py`](../nemoguardrails/telemetry.py). A vendored snapshot of the wire-format schema is at [`schemas/anonymous_events.snapshot.json`](../schemas/anonymous_events.snapshot.json) and is used by the conformance test in [`tests/telemetry/test_usage_reporting.py`](../tests/telemetry/test_usage_reporting.py) to validate emitted payloads against the canonical contract.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,136 @@
+# Telemetry
+
+NeMo Guardrails collects anonymous telemetry to help the engineering team understand which deployment patterns and safety features are most widely used. The event payload is transparent and does not contain user content or direct user identifiers such as usernames, API keys, or IP addresses.
+
+A subset of the data, after cleaning and aggregation, may be shared publicly with the community (for example, adoption charts showing which built-in safety features are most used).
+
+> **Not to be confused with tracing.** This page is about anonymous usage telemetry (emitted at each `LLMRails` / `Guardrails` instantiation and as periodic heartbeats, sent to NVIDIA). It is separate from per-request [tracing](https://docs.nvidia.com/nemo/guardrails/latest/observability/tracing/index.html), which you enable in your guardrails config to emit OpenTelemetry spans to your own observability backend.
+
+## What is collected?
+
+The data is collected when `LLMRails` / `Guardrails` is constructed and as periodic heartbeats. It describes the deployment, not individual requests.
+
+In this context, a **session is the lifetime of a single Python process** running NeMo Guardrails: the session ID is generated in memory when telemetry starts and is not stored for reuse across process restarts. The session ID is an optional non-sensitive prefix from `NEMO_SESSION_PREFIX` plus a random UUID4. The same session ID is included in local audit records and transmitted telemetry events so startup and heartbeat events from one process can be correlated. Two runs of guardrails by the same user produce two unrelated session IDs.
+
+| Field | Type | Example | Description |
+|---|---|---|---|
+| `sessionId` | string | `"smoke-run-2b8e9879-80be-42bb-ad3f-81db8ec28e15"` | Session ID. Optional non-sensitive prefix plus a random UUID4 generated in memory when telemetry starts. Shared by all events from the same process and included in audit records and transmitted events, but not stored for reuse across restarts. |
+| `nemoguardrailsVersion` | string | `"0.21.0"` | Installed package version. `"unknown"` if unavailable. |
+| `pythonVersion` | string | `"3.13.7"` | Python interpreter version. |
+| `platform` | string | `"Linux-5.15.0-x86_64-with-glibc2.35"` | OS and architecture string. |
+| `osName` | string | `"Linux"` | Operating system name (`"Darwin"`, `"Linux"`, `"Windows"`). |
+| `colangVersion` | string | `"1.0"` | Colang version in use (`"1.0"` or `"2.x"`). |
+| `llmProviders` | array of strings | `["nim", "openai"]` | LLM engine names, sorted. Engine identifiers, not model names. |
+| `numRailsConfigured` | integer | `4` | Count of configured rail flows for input, output, retrieval, tool input, and tool output rails. Dialog usage is represented in `railTypesInUse` but not counted as a flow. |
+| `railTypesInUse` | array of strings | `["input", "output"]` | Active rail categories from `input`, `output`, `retrieval`, `tool_input`, `tool_output`, `dialog`. |
+| `tracingEnabled` | boolean | `false` | Whether the tracing subsystem is enabled. |
+| `deploymentType` | string | `"library"` | How guardrails was deployed: `"library"` (direct `LLMRails` use), `"api"` (FastAPI server), `"cli"` (interactive `nemoguardrails chat`). |
+| `nemoSource` | string | `"guardrails"` | The NeMo product that produced the event. Always `"guardrails"` for this event type. Mirrors the shared `NemoSourceEnum` from the nemo-telemetry repo. |
+| `railsEngine` | string | `"LLMRails"` | Which rails engine is in use: `"LLMRails"` or `"IORails"`. |
+| `hasKnowledgeBase` | boolean | `false` | Whether a knowledge base is configured. |
+| `streamingConfigured` | boolean | `false` | Whether streaming output is enabled. |
+| `builtinFeatures` | array of strings | `["content_safety", "jailbreak_detection"]` | Active built-in library features, sorted (see list below). |
+| `numCustomFlows` | integer | `0` | Count of user-defined Colang flows. Never flow names or contents. |
+| `timestamp` | number | `1775716074.855979` | Unix timestamp when the event was collected. |
+| `event` | string | `"startup"` | Event type: `"startup"` for the initial report, `"heartbeat"` for periodic pings. |
+
+### Possible values for `builtinFeatures`
+
+Each corresponds to a directory under `nemoguardrails/library/`:
+
+`activefence`, `ai_defense`, `autoalign`, `clavata`, `cleanlab`, `content_safety`, `crowdstrike_aidr`, `factchecking`, `fiddler`, `gliner`, `guardrails_ai`, `hallucination`, `injection_detection`, `jailbreak_detection`, `llama_guard`, `pangea`, `patronusai`, `policyai`, `prompt_security`, `regex`, `self_check`, `sensitive_data_detection`, `topic_safety`, `trend_micro`.
+
+## What is NOT collected
+
+- Model names, model paths, or model parameters
+- API keys, endpoints, URLs, or credentials
+- Rail definitions, Colang source code, or YAML configuration contents
+- Prompts, completions, or any user messages
+- Token counts, request latency, or per-request metrics
+- File paths, usernames, or IP addresses
+
+The schema is designed to avoid user content and direct user identifiers. Review the audit file to confirm the exact event fields emitted by your local configuration.
+
+
+## Sample payloads
+
+**Startup event:**
+
+```json
+{
+  "sessionId": "2b8e9879-80be-42bb-ad3f-81db8ec28e15",
+  "nemoguardrailsVersion": "0.21.0",
+  "pythonVersion": "3.13.7",
+  "platform": "Linux-5.15.0-x86_64-with-glibc2.35",
+  "osName": "Linux",
+  "colangVersion": "1.0",
+  "llmProviders": ["nim"],
+  "numRailsConfigured": 4,
+  "railTypesInUse": ["input", "output"],
+  "tracingEnabled": false,
+  "deploymentType": "library",
+  "nemoSource": "guardrails",
+  "railsEngine": "LLMRails",
+  "hasKnowledgeBase": false,
+  "streamingConfigured": false,
+  "builtinFeatures": ["content_safety", "jailbreak_detection", "topic_safety"],
+  "numCustomFlows": 0,
+  "timestamp": 1775716074.855979,
+  "event": "startup"
+}
+```
+
+**Heartbeat event (every 10 minutes):**
+
+```json
+{
+  "sessionId": "2b8e9879-80be-42bb-ad3f-81db8ec28e15",
+  "nemoSource": "guardrails",
+  "timestamp": 1775716674.123456,
+  "event": "heartbeat"
+}
+```
+
+Each event is wrapped in the shared NVIDIA telemetry envelope (protocol v1.6) with `nemoSource: "guardrails"` before it is transmitted.
+
+## Inspecting what is sent
+
+Telemetry attempts to write each outgoing event payload to a local audit file before it is sent over the network:
+
+```bash
+cat ~/.config/nemoguardrails/usage_stats.json
+```
+
+The file is JSON lines format (one event per line), bounded at 10 MB with automatic rotation. It stores the inner event payload, not the full NVIDIA telemetry envelope. Audit writes are best-effort; if local audit writing fails, the telemetry send still proceeds.
+
+## Opting out
+
+Any one of the following disables telemetry:
+
+```bash
+# Product-specific:
+export NEMO_GUARDRAILS_NO_USAGE_STATS=1
+
+# Industry standard:
+export DO_NOT_TRACK=1
+
+# File-based:
+mkdir -p ~/.config/nemoguardrails && touch ~/.config/nemoguardrails/do_not_track
+```
+
+When any opt-out is active, no daemon thread is spawned, no audit file is written, and no network request is made.
+
+Set the opt-out before NeMo Guardrails starts. Changing environment variables or creating `do_not_track` after telemetry has started does not stop an already-running heartbeat thread.
+
+### Automatic suppression in test and CI environments
+
+Telemetry is also automatically disabled, with no configuration required, when either of the following environment variables is set:
+
+- `CI` (truthy: `1` or `true`). Set by GitHub Actions, GitLab CI, CircleCI, Travis, Buildkite, and most other CI runners. Honoring this is the same convention used by Homebrew, npm, conda, and others.
+- `PYTEST_CURRENT_TEST`. Set by pytest while a test is running. Suppresses telemetry from your test suite even outside CI.
+
+The intent is that adoption metrics reflect real deployments only, not synthetic test or CI traffic. If you genuinely want telemetry from a CI run (rare), unset `CI` for that step.
+
+## Schema and source code
+
+The Python source for the event lives in [`nemoguardrails/telemetry.py`](../nemoguardrails/telemetry.py). A vendored snapshot of the wire-format schema is at [`schemas/anonymous_events.snapshot.json`](../schemas/anonymous_events.snapshot.json) and is used by the conformance test in [`tests/telemetry/test_telemetry.py`](../tests/telemetry/test_telemetry.py) to validate emitted payloads against the canonical contract.


### PR DESCRIPTION
## Stacked PR Note

This work is split into smaller stacked PRs:

- #1878 : core telemetry implementation and direct unit tests.
- #1879 : smoke driver, Kibana export verifier, fixtures, and smoke runbook. Stacked 1878.
- This PR : user-facing telemetry docs and README/legal notes. Stacked on 1878.



## Description

Add the README summary and detailed telemetry reference covering collected fields, omitted data, local audit files, and opt-out options.


