### PR TITLE
docs(migration): explain the "No default base_url" config-load error

### DIFF
--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -141,6 +141,20 @@ Rename `openai_api_base` to `base_url`.
 Remove LangChain runtime flags and provider-prefixed aliases.
 Streaming still uses the `stream_async` API.
 
+## Unsupported Engine on the Default Framework
+
+If a v0.21 config uses an engine whose API is not OpenAI-compatible (`anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, `self_hosted`, ...) and you load it on v0.22 without opting into LangChain, configuration load fails with:
+
+```text
+No default base_url for provider 'cohere'. If your endpoint is OpenAI-compatible, set parameters.base_url. Otherwise, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain and install the matching langchain-<provider> package (see migration guide).
+```
+
+The provider name in the message changes to match your `engine:` value.
+Two remediations apply, depending on what you want:
+
+- **Keep the LangChain provider class.** Install `langchain` and the matching `langchain-<provider>` package, then set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. See [Using LangChain](#using-langchain) for the full procedure.
+- **Switch to an OpenAI-compatible endpoint.** If the same model is reachable through an OpenAI-compatible HTTP route (a self-hosted gateway, a proxy, or a hosted provider that exposes `/v1/chat/completions`), set `engine: openai` plus `parameters.base_url`. See [OpenAI-Compatible Providers](#openai-compatible-providers).
+
 ## Using LangChain
 
 If your engine's API is not OpenAI-compatible, keep using LangChain.

--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -31,7 +31,7 @@ The following table summarizes the migration instructions by engine type.
 | `engine: openai`, `nim`, `nvidia_ai_endpoints`, or `ollama` with standard OpenAI-compatible parameters | No action required. |
 | `engine: vllm_openai` or another LangChain wrapper for an OpenAI-compatible provider such as DeepSeek, OpenRouter, Together.ai, Fireworks.ai, Groq, or `llama.cpp` | Rewrite the model entry. See [OpenAI-compatible providers](#openai-compatible-providers). |
 | `engine: openai` with LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, or `model_kwargs` | Rewrite the parameters. See [Mixed-shape configs](#mixed-shape-configs). |
-| `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain, or switch to an OpenAI-compatible endpoint if one exists. See [Unsupported Engine on the Default Framework](#unsupported-engine-on-the-default-framework). |
+| `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain, or switch to an OpenAI-compatible endpoint if one exists. Refer to [Unsupported Engine on the Default Framework](#unsupported-engine-on-the-default-framework). |
 | `engine: azure` or `azure_openai` | Use LangChain for the Azure-specific helpers, or configure the default framework manually. See [Azure OpenAI](#azure-openai). |
 | Custom provider registered in `config.py` | Match the provider class to the active framework. See [Custom providers](#custom-providers). |
 
@@ -143,17 +143,18 @@ Streaming still uses the `stream_async` API.
 
 ## Unsupported Engine on the Default Framework
 
-If a v0.21 config uses an engine whose API is not OpenAI-compatible (`anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, `self_hosted`, ...) and you load it on v0.22 without opting into LangChain, configuration load fails with:
+If a v0.21 config uses an engine whose API is not OpenAI-compatible, configuration load fails on v0.22 unless you opt into LangChain.
+Engines that are not OpenAI-compatible include `anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, and `self_hosted`.
 
 ```text
 ValueError: No default base_url for provider 'cohere'. If your endpoint is OpenAI-compatible, set parameters.base_url. Otherwise, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain and install the matching langchain-<provider> package (see migration guide).
 ```
 
 The provider name in the message changes to match your `engine:` value.
-Two remediations apply, depending on what you want:
+Choose one remediation path based on your migration goal:
 
-- **Keep the LangChain provider class.** Install `langchain` and the matching `langchain-<provider>` package, then set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. See [Using LangChain](#using-langchain) for the full procedure.
-- **Switch to an OpenAI-compatible endpoint.** If the same model is reachable through an OpenAI-compatible HTTP route (a self-hosted gateway, a proxy, or a hosted provider that exposes `/v1/chat/completions`), set `engine: openai` plus `parameters.base_url`. See [OpenAI-Compatible Providers](#openai-compatible-providers).
+- Keep the LangChain provider class. Install `langchain` and the matching `langchain-<provider>` package, and then set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. Refer to [Using LangChain](#using-langchain) for the full procedure.
+- Switch to an OpenAI-compatible endpoint. If the same model is reachable through an OpenAI-compatible HTTP route, set `engine: openai` plus `parameters.base_url`. This includes self-hosted gateways, proxies, and hosted providers that expose `/v1/chat/completions`. Refer to [OpenAI-Compatible Providers](#openai-compatible-providers).
 
 ## Using LangChain
 

--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -31,7 +31,7 @@ The following table summarizes the migration instructions by engine type.
 | `engine: openai`, `nim`, `nvidia_ai_endpoints`, or `ollama` with standard OpenAI-compatible parameters | No action required. |
 | `engine: vllm_openai` or another LangChain wrapper for an OpenAI-compatible provider such as DeepSeek, OpenRouter, Together.ai, Fireworks.ai, Groq, or `llama.cpp` | Rewrite the model entry. See [OpenAI-compatible providers](#openai-compatible-providers). |
 | `engine: openai` with LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, or `model_kwargs` | Rewrite the parameters. See [Mixed-shape configs](#mixed-shape-configs). |
-| `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain. See [Using LangChain](#using-langchain). |
+| `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain, or switch to an OpenAI-compatible endpoint if one exists. See [Unsupported Engine on the Default Framework](#unsupported-engine-on-the-default-framework). |
 | `engine: azure` or `azure_openai` | Use LangChain for the Azure-specific helpers, or configure the default framework manually. See [Azure OpenAI](#azure-openai). |
 | Custom provider registered in `config.py` | Match the provider class to the active framework. See [Custom providers](#custom-providers). |
 
@@ -146,7 +146,7 @@ Streaming still uses the `stream_async` API.
 If a v0.21 config uses an engine whose API is not OpenAI-compatible (`anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, `self_hosted`, ...) and you load it on v0.22 without opting into LangChain, configuration load fails with:
 
 ```text
-No default base_url for provider 'cohere'. If your endpoint is OpenAI-compatible, set parameters.base_url. Otherwise, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain and install the matching langchain-<provider> package (see migration guide).
+ValueError: No default base_url for provider 'cohere'. If your endpoint is OpenAI-compatible, set parameters.base_url. Otherwise, set NEMOGUARDRAILS_LLM_FRAMEWORK=langchain and install the matching langchain-<provider> package (see migration guide).
 ```
 
 The provider name in the message changes to match your `engine:` value.


### PR DESCRIPTION
## Description


VDR feedback: developers hitting `No default base_url for provider 'X'.` on v0.22 couldn't find the verbatim error in the migration guide and had nothing to search for. Add a new "Unsupported Engine on the Default Framework" section that quotes the error verbatim and points at the two real remediations (LangChain opt-in or OpenAI-compatible base_url).



<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guide section documenting unsupported engine configuration scenarios in version 0.22, including error details and remediation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1881)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->