### PR TITLE
feat(api): canonical top-level imports for LLM types and registry functions

### DIFF
--- a/docs/configure-rails/custom-initialization/custom-llm-framework.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-framework.md
@@ -66,7 +66,7 @@ A custom framework implements four methods.
 ```python
 from typing import Any, Dict, List, Optional
 
-from nemoguardrails.types import LLMModel
+from nemoguardrails import LLMModel
 
 
 class MyFramework:
@@ -133,8 +133,7 @@ my_config/
 ```python
 from typing import Any, Dict, List, Optional
 
-from nemoguardrails.llm.frameworks import register_framework, set_default_framework
-from nemoguardrails.types import LLMModel, LLMResponse, LLMResponseChunk
+from nemoguardrails import LLMModel, LLMResponse, LLMResponseChunk, register_framework, set_default_framework
 
 
 class EchoLLMModel:

--- a/docs/configure-rails/custom-initialization/custom-llm-model.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-model.md
@@ -52,7 +52,7 @@ A custom model class must implement two async methods and three properties.
 ```python
 from typing import AsyncIterator, List, Optional, Union
 
-from nemoguardrails.types import (
+from nemoguardrails import (
     ChatMessage,
     LLMResponse,
     LLMResponseChunk,
@@ -197,13 +197,13 @@ my_config/
 import asyncio
 from typing import Any, AsyncIterator, List, Optional, Union
 
-from nemoguardrails.llm.providers import register_provider
-from nemoguardrails.types import (
+from nemoguardrails import (
     ChatMessage,
     LLMResponse,
     LLMResponseChunk,
     UsageInfo,
 )
+from nemoguardrails.llm.providers import register_provider
 
 
 class EchoLLMModel:

--- a/docs/configure-rails/custom-initialization/custom-llm-model.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-model.md
@@ -202,8 +202,8 @@ from nemoguardrails import (
     LLMResponse,
     LLMResponseChunk,
     UsageInfo,
+    register_provider,
 )
-from nemoguardrails.llm.providers import register_provider
 
 
 class EchoLLMModel:

--- a/docs/user-guides/testing-your-config.md
+++ b/docs/user-guides/testing-your-config.md
@@ -179,8 +179,8 @@ passing `llm_responses` (full `LLMResponse` objects) instead of `responses`
 (plain strings):
 
 ```python
+from nemoguardrails import LLMResponse
 from nemoguardrails.testing import FakeLLMModel
-from nemoguardrails.types import LLMResponse
 
 
 fake = FakeLLMModel(

--- a/nemoguardrails/__init__.py
+++ b/nemoguardrails/__init__.py
@@ -53,11 +53,33 @@ from nemoguardrails.llm.frameworks import (  # noqa: E402
     register_framework,
     set_default_framework,
 )
+from nemoguardrails.types import (  # noqa: E402
+    ChatMessage,
+    FinishReason,
+    LLMFramework,
+    LLMModel,
+    LLMResponse,
+    LLMResponseChunk,
+    Role,
+    ToolCall,
+    ToolCallFunction,
+    UsageInfo,
+)
 
 __version__ = version("nemoguardrails")
 __all__ = [
+    "ChatMessage",
+    "FinishReason",
+    "LLMFramework",
+    "LLMModel",
     "LLMRails",
+    "LLMResponse",
+    "LLMResponseChunk",
     "RailsConfig",
+    "Role",
+    "ToolCall",
+    "ToolCallFunction",
+    "UsageInfo",
     "get_default_framework",
     "register_framework",
     "set_default_framework",

--- a/nemoguardrails/__init__.py
+++ b/nemoguardrails/__init__.py
@@ -53,6 +53,7 @@ from nemoguardrails.llm.frameworks import (  # noqa: E402
     register_framework,
     set_default_framework,
 )
+from nemoguardrails.llm.providers import register_provider  # noqa: E402
 from nemoguardrails.types import (  # noqa: E402
     ChatMessage,
     FinishReason,
@@ -82,5 +83,6 @@ __all__ = [
     "UsageInfo",
     "get_default_framework",
     "register_framework",
+    "register_provider",
     "set_default_framework",
 ]

--- a/nemoguardrails/llm/__init__.py
+++ b/nemoguardrails/llm/__init__.py
@@ -12,3 +12,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from nemoguardrails.llm.frameworks import (
+    get_default_framework,
+    register_framework,
+    set_default_framework,
+)
+from nemoguardrails.types import (
+    ChatMessage,
+    FinishReason,
+    LLMFramework,
+    LLMModel,
+    LLMResponse,
+    LLMResponseChunk,
+    Role,
+    ToolCall,
+    ToolCallFunction,
+    UsageInfo,
+)
+
+__all__ = [
+    "ChatMessage",
+    "FinishReason",
+    "LLMFramework",
+    "LLMModel",
+    "LLMResponse",
+    "LLMResponseChunk",
+    "Role",
+    "ToolCall",
+    "ToolCallFunction",
+    "UsageInfo",
+    "get_default_framework",
+    "register_framework",
+    "set_default_framework",
+]

--- a/nemoguardrails/llm/__init__.py
+++ b/nemoguardrails/llm/__init__.py
@@ -18,6 +18,7 @@ from nemoguardrails.llm.frameworks import (
     register_framework,
     set_default_framework,
 )
+from nemoguardrails.llm.providers import register_provider
 from nemoguardrails.types import (
     ChatMessage,
     FinishReason,
@@ -44,5 +45,6 @@ __all__ = [
     "UsageInfo",
     "get_default_framework",
     "register_framework",
+    "register_provider",
     "set_default_framework",
 ]

--- a/nemoguardrails/types.py
+++ b/nemoguardrails/types.py
@@ -13,10 +13,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Public LLM types for NeMo Guardrails.
+
+This module defines the stable, public dataclasses and Protocols that make
+up the LLM interop surface for NeMo Guardrails. The types are implemented
+as plain Python dataclasses (not Pydantic) so they remain lightweight and
+introduce no additional runtime dependencies for downstream integrators.
+
+The public surface defined here is stable across minor versions: breaking
+changes are reserved for major version bumps. Custom ``LLMModel`` and
+``LLMFramework`` implementations should import the relevant types from
+this module so they stay aligned with the canonical definitions.
+"""
+
 import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Protocol, Union, runtime_checkable
+
+__all__ = [
+    "ChatMessage",
+    "FinishReason",
+    "LLMFramework",
+    "LLMModel",
+    "LLMResponse",
+    "LLMResponseChunk",
+    "Role",
+    "ToolCall",
+    "ToolCallFunction",
+    "UsageInfo",
+]
 
 
 class Role(str, Enum):

--- a/tests/test_types_exports.py
+++ b/tests/test_types_exports.py
@@ -86,35 +86,38 @@ def test_direct_from_imports_llm_subpackage():
     )
 
 
-REGISTRY_FUNCTION_NAMES = [
-    "get_default_framework",
-    "register_framework",
-    "set_default_framework",
+# Registry functions and the submodule that owns each one.
+REGISTRY_FUNCTIONS = [
+    ("get_default_framework", "nemoguardrails.llm.frameworks"),
+    ("register_framework", "nemoguardrails.llm.frameworks"),
+    ("set_default_framework", "nemoguardrails.llm.frameworks"),
+    ("register_provider", "nemoguardrails.llm.providers"),
 ]
 
 
-@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
-def test_registry_function_top_level_export(name):
+@pytest.mark.parametrize("name,canonical_module", REGISTRY_FUNCTIONS)
+def test_registry_function_top_level_export(name, canonical_module):
     import nemoguardrails
 
     assert hasattr(nemoguardrails, name), f"nemoguardrails is missing {name}"
     assert name in nemoguardrails.__all__
 
 
-@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
-def test_registry_function_llm_subpackage_export(name):
+@pytest.mark.parametrize("name,canonical_module", REGISTRY_FUNCTIONS)
+def test_registry_function_llm_subpackage_export(name, canonical_module):
     import nemoguardrails.llm as llm
 
     assert hasattr(llm, name), f"nemoguardrails.llm is missing {name}"
     assert name in llm.__all__
 
 
-@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
-def test_registry_function_paths_resolve_to_same_object(name):
+@pytest.mark.parametrize("name,canonical_module", REGISTRY_FUNCTIONS)
+def test_registry_function_paths_resolve_to_same_object(name, canonical_module):
+    import importlib
+
     import nemoguardrails
     import nemoguardrails.llm as llm
-    import nemoguardrails.llm.frameworks as frameworks
 
-    canonical = getattr(frameworks, name)
+    canonical = getattr(importlib.import_module(canonical_module), name)
     assert getattr(nemoguardrails, name) is canonical
     assert getattr(llm, name) is canonical

--- a/tests/test_types_exports.py
+++ b/tests/test_types_exports.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+PUBLIC_TYPE_NAMES = [
+    "ChatMessage",
+    "FinishReason",
+    "LLMFramework",
+    "LLMModel",
+    "LLMResponse",
+    "LLMResponseChunk",
+    "Role",
+    "ToolCall",
+    "ToolCallFunction",
+    "UsageInfo",
+]
+
+
+@pytest.mark.parametrize("name", PUBLIC_TYPE_NAMES)
+def test_top_level_export(name):
+    import nemoguardrails
+
+    assert hasattr(nemoguardrails, name), f"nemoguardrails is missing {name}"
+    assert name in nemoguardrails.__all__
+
+
+@pytest.mark.parametrize("name", PUBLIC_TYPE_NAMES)
+def test_llm_subpackage_export(name):
+    import nemoguardrails.llm as llm
+
+    assert hasattr(llm, name), f"nemoguardrails.llm is missing {name}"
+    assert name in llm.__all__
+
+
+@pytest.mark.parametrize("name", PUBLIC_TYPE_NAMES)
+def test_top_level_and_llm_export_same_object(name):
+    import nemoguardrails
+    import nemoguardrails.llm as llm
+    import nemoguardrails.types as types_mod
+
+    canonical = getattr(types_mod, name)
+    assert getattr(nemoguardrails, name) is canonical
+    assert getattr(llm, name) is canonical
+
+
+def test_direct_from_imports_top_level():
+    from nemoguardrails import (  # noqa: F401
+        ChatMessage,
+        FinishReason,
+        LLMFramework,
+        LLMModel,
+        LLMResponse,
+        LLMResponseChunk,
+        Role,
+        ToolCall,
+        ToolCallFunction,
+        UsageInfo,
+    )
+
+
+def test_direct_from_imports_llm_subpackage():
+    from nemoguardrails.llm import (  # noqa: F401
+        ChatMessage,
+        FinishReason,
+        LLMFramework,
+        LLMModel,
+        LLMResponse,
+        LLMResponseChunk,
+        Role,
+        ToolCall,
+        ToolCallFunction,
+        UsageInfo,
+    )
+
+
+REGISTRY_FUNCTION_NAMES = [
+    "get_default_framework",
+    "register_framework",
+    "set_default_framework",
+]
+
+
+@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
+def test_registry_function_top_level_export(name):
+    import nemoguardrails
+
+    assert hasattr(nemoguardrails, name), f"nemoguardrails is missing {name}"
+    assert name in nemoguardrails.__all__
+
+
+@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
+def test_registry_function_llm_subpackage_export(name):
+    import nemoguardrails.llm as llm
+
+    assert hasattr(llm, name), f"nemoguardrails.llm is missing {name}"
+    assert name in llm.__all__
+
+
+@pytest.mark.parametrize("name", REGISTRY_FUNCTION_NAMES)
+def test_registry_function_paths_resolve_to_same_object(name):
+    import nemoguardrails
+    import nemoguardrails.llm as llm
+    import nemoguardrails.llm.frameworks as frameworks
+
+    canonical = getattr(frameworks, name)
+    assert getattr(nemoguardrails, name) is canonical
+    assert getattr(llm, name) is canonical


### PR DESCRIPTION
## Description

Make `from nemoguardrails import ...` the canonical user-facing path for the integrator-facing surface of v0.22:

- LLM types from `nemoguardrails.types` (ChatMessage, FinishReason, LLMFramework, LLMModel, LLMResponse, LLMResponseChunk, Role, ToolCall, ToolCallFunction, UsageInfo) are re-exported from both `nemoguardrails` (top-level) and `nemoguardrails.llm`.

- Framework registry functions from `nemoguardrails.llm.frameworks` (register_framework, set_default_framework, get_default_framework) are also re-exported from `nemoguardrails.llm`. They were already exported from `nemoguardrails` top-level.

Custom LLM Framework, Custom LLM Model, and testing-your-config doc examples switch their import lines to the top-level form so the "integrator constructs value types and protocol classes" path uses one import statement.

`nemoguardrails/types.py` gains a module-level docstring documenting it as the stable public LLM interop surface, plus an explicit `__all__` listing the public names.

Parametrized exports tests verify each name is exposed on every supported import path and resolves to the same canonical object.



<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded the public API to expose core LLM types and framework utilities directly from the main package, eliminating the need for deep module imports and improving developer experience.

* **Documentation**
  * Updated all code examples, guides, and initialization tutorials to reflect the new simplified import patterns for better discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1882)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->