### PR TITLE
fix!: reject Colang 2.0 public runtime state

### DIFF
--- a/docs/reference/api-server-endpoints/index.md
+++ b/docs/reference/api-server-endpoints/index.md
@@ -69,7 +69,7 @@ with guardrails-specific fields nested under a `guardrails` object.
 * - `messages`
   - array of objects
   - No
-  - The list of messages in the current conversation. Each message has `role` and `content` fields. Although the OpenAI API requires this field, the Guardrails server treats it as optional to support stateful continuation via `guardrails.state`. When omitted, defaults to an empty list.
+  - The list of messages in the current conversation. Each message has `role` and `content` fields. Although the OpenAI API requires this field, the Guardrails server treats it as optional. When omitted, defaults to an empty list.
 
 * - `stream`
   - boolean
@@ -133,7 +133,7 @@ Guardrails-specific fields are nested under the `guardrails` object in the reque
 * - `guardrails.thread_id`
   - string
   - No
-  - ID of an existing thread for conversation persistence. Must be 16-255 characters.
+  - ID of an existing thread for Colang 1.0 conversation persistence. Must be 16-255 characters. Colang 2.0 requests with `thread_id` return HTTP 422.
 
 * - `guardrails.context`
   - object
@@ -148,7 +148,7 @@ Guardrails-specific fields are nested under the `guardrails` object in the reque
 * - `guardrails.state`
   - object
   - No
-  - A state object to continue a previous interaction. Must contain an `events` or `state` key, or be an empty dict `{}` to start a new conversation.
+  - Colang 1.0 transcript state for continuing a previous interaction. Must be an empty dict `{}` to start a new conversation or contain an `events` list to continue one. Public Colang 2.0 runtime state is not accepted over HTTP; use the trusted in-process Python API with `process_events_async` and a live `State` object for Colang 2.0 stateful continuation.
 ```
 
 ### Generation Options
@@ -346,7 +346,7 @@ The response follows the standard OpenAI `ChatCompletion` format with an additio
 
 * - `guardrails.state`
   - object
-  - State object for continuing the conversation in future requests.
+  - Colang 1.0 transcript state for continuing the conversation in future HTTP requests, when available. Colang 2.0 responses do not return public runtime state.
 
 * - `guardrails.llm_output`
   - object
@@ -702,11 +702,35 @@ When `thread_id` is less than 16 characters:
 
 ### Invalid State Format
 
-When the `guardrails.state` object does not contain an `events` or `state` key, the server returns an HTTP 422 error:
+When the `guardrails.state` object is non-empty and does not contain an `events` list, the server returns an HTTP 422 error:
 
 ```json
 {
-  "detail": "Invalid state format: state must contain 'events' or 'state' key. Use an empty dict {} to start a new conversation."
+  "detail": "Invalid state format: state must contain an 'events' key. Use an empty dict {} to start a new conversation."
+}
+```
+
+Colang 2.0 public runtime state is not accepted over HTTP:
+
+```json
+{
+  "detail": "Caller-supplied state is not accepted for Colang 2.0 over HTTP. Full Colang 2.0 flow-state continuation over HTTP is not currently supported."
+}
+```
+
+When a Colang 2.0 configuration receives Colang 1.0-style `events` state, the server returns HTTP 422:
+
+```json
+{
+  "detail": "Stateful continuation over HTTP is not supported for Colang 2.0."
+}
+```
+
+When a Colang 2.0 configuration receives `thread_id`, the server returns HTTP 422:
+
+```json
+{
+  "detail": "thread_id message-history replay is not supported for Colang 2.0."
 }
 ```
 

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -18,6 +18,7 @@ __all__ = [
     "ConfigurationError",
     "InvalidModelConfigurationError",
     "InvalidRailsConfigurationError",
+    "InvalidStateError",
     "LLMCallException",
     "LLMClientError",
     "LLMAuthenticationError",
@@ -62,6 +63,18 @@ class InvalidRailsConfigurationError(ConfigurationError):
 
 class StreamingNotSupportedError(InvalidRailsConfigurationError):
     """Raised when streaming is requested but not supported by the configuration."""
+
+    pass
+
+
+class InvalidStateError(ValueError):
+    """Raised when a caller-supplied `state` argument is not valid public input.
+
+    The serialized Colang 2.0 runtime State carries trusted control-plane fields
+    (`flow_configs`, `rails_config`, in-flight flow execution) and must not come
+    from an untrusted caller. Stateful 2.x execution uses `process_events_async`,
+    which keeps a live `State` object in the trusted Python process.
+    """
 
     pass
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -56,10 +56,6 @@ from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id, compute
 from nemoguardrails.colang.v1_0.runtime.runtime import Runtime, RuntimeV1_0
 from nemoguardrails.colang.v2_x.runtime.flows import Action, State
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
-from nemoguardrails.colang.v2_x.runtime.serialization import (
-    json_to_state,
-    state_to_json,
-)
 from nemoguardrails.context import (
     explain_info_var,
     generation_options_var,
@@ -73,6 +69,7 @@ from nemoguardrails.embeddings.providers.base import EmbeddingModel
 from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidRailsConfigurationError,
+    InvalidStateError,
     StreamingNotSupportedError,
 )
 from nemoguardrails.kb.kb import KnowledgeBase
@@ -772,6 +769,21 @@ class LLMRails:
 
         return explain_info
 
+    def _validate_public_state(self, state: Optional[Union[dict, State]]) -> None:
+        """Reject public dict state for Colang 2.0 stateful continuation."""
+        if not isinstance(state, dict) or not state:
+            return
+
+        if self.config.colang_version != "2.x" and state.get("version") != "2.x":
+            return
+
+        raise InvalidStateError(
+            "Colang 2.0 dict state is not supported by generate/generate_async. "
+            "Use rails.process_events_async(events, state) with a live State object "
+            "for trusted in-process multi-turn execution. Public serialized Colang "
+            "2.0 runtime state is not accepted."
+        )
+
     async def generate_async(
         self,
         prompt: Optional[str] = None,
@@ -821,9 +833,7 @@ class LLMRails:
         # This is because we want the output to be a GenerationResponse which will contain
         # the output state.
         if state is not None:
-            # We deserialize the state if needed.
-            if isinstance(state, dict) and state.get("version", "1.0") == "2.x":
-                state = json_to_state(state["state"])
+            self._validate_public_state(state)
 
             if options is None:
                 gen_options = GenerationOptions()
@@ -928,11 +938,13 @@ class LLMRails:
             # Compute the new events.
             # In generation mode, the processing is always blocking, i.e., it waits for
             # all local actions (sync and async).
-            new_events, output_state = await runtime.process_events(
+            new_events, _output_state = await runtime.process_events(
                 events, state=state, instant_actions=instant_actions, blocking=True
             )
-            # We also encode the output state as a JSON
-            output_state = {"state": state_to_json(output_state), "version": "2.x"}
+            # The runtime State for 2.x is not publicly exposed through generate_async.
+            # Callers that need stateful 2.x execution use process_events_async, which
+            # returns the live State object directly.
+            output_state = None
 
         # Extract and join all the messages from StartUtteranceBotAction events as the response.
         responses = []
@@ -1246,6 +1258,7 @@ class LLMRails:
             include_metadata = include_generation_metadata
 
         self._validate_streaming_with_output_rails()
+        self._validate_public_state(state)
         # if an external generator is provided, use it directly
         if generator:
             if self.config.rails.output.streaming and self.config.rails.output.streaming.enabled:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -770,11 +770,22 @@ class LLMRails:
         return explain_info
 
     def _validate_public_state(self, state: Optional[Union[dict, State]]) -> None:
-        """Reject public dict state for Colang 2.0 stateful continuation."""
+        """Validate public dict state passed through generate/generate_async."""
         if not isinstance(state, dict) or not state:
             return
 
-        if self.config.colang_version != "2.x" and state.get("version") != "2.x":
+        if self.config.colang_version == "1.0" and state.get("version") != "2.x":
+            if "state" in state:
+                raise InvalidStateError(
+                    "Invalid Colang 1.0 state format: expected transcript state with an 'events' list."
+                )
+            if "events" not in state:
+                raise InvalidStateError(
+                    "Invalid Colang 1.0 state format: state must contain an 'events' key. "
+                    "Use an empty dict {} to start a new conversation."
+                )
+            if not isinstance(state["events"], list):
+                raise InvalidStateError("Invalid Colang 1.0 state format: 'events' must be a list.")
             return
 
         raise InvalidStateError(

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -80,6 +80,37 @@ class GuardrailsApp(FastAPI):
 # backends and storage engines.
 registered_loggers: List[Callable] = []
 
+
+def _raise_invalid_state(detail: str) -> None:
+    raise HTTPException(status_code=422, detail=detail)
+
+
+def _validate_public_state_shape(state: Optional[dict]) -> None:
+    """Validate request state shape before loading rails config.
+
+    At the public HTTP boundary, the only accepted non-empty dict state shape is
+    Colang 1.0 transcript state: {"events": [...]}. Colang 2.0 has no safe
+    public dict state shape.
+    """
+    if state is None or state == {}:
+        return
+
+    if state.get("version") == "2.x" or "state" in state:
+        _raise_invalid_state(
+            "Caller-supplied state is not accepted for Colang 2.0 over HTTP. "
+            "Full Colang 2.0 flow-state continuation over HTTP is not currently supported."
+        )
+
+    if "events" not in state:
+        _raise_invalid_state(
+            "Invalid state format: state must contain an 'events' key. "
+            "Use an empty dict {} to start a new conversation."
+        )
+
+    if not isinstance(state["events"], list):
+        _raise_invalid_state("Invalid state format: 'events' must be a list.")
+
+
 api_description = """Guardrails Server API."""
 
 # The headers for each request
@@ -467,6 +498,8 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
                 detail="No guardrails config_id provided and server has no default configuration",
             )
 
+    _validate_public_state_shape(body.guardrails.state)
+
     try:
         llm_rails = await _get_rails(config_ids, model_name=body.model)
 
@@ -476,6 +509,22 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             model=body.model,
             error_message=f"Could not load the {config_ids} guardrails configuration. An internal error has occurred.",
             config_id=config_ids[0] if config_ids else None,
+        )
+
+    # Version-aware state validation, now that the config is loaded.
+    # 1.0 accepts the pre-validated {"events": [...]} transcript. 2.0 has no
+    # valid public dict state shape.
+    if body.guardrails.state is not None and body.guardrails.state != {}:
+        if llm_rails.config.colang_version != "1.0":
+            raise HTTPException(
+                status_code=422,
+                detail="Stateful continuation over HTTP is not supported for Colang 2.0.",
+            )
+
+    if body.guardrails.thread_id and llm_rails.config.colang_version != "1.0":
+        raise HTTPException(
+            status_code=422,
+            detail="thread_id message-history replay is not supported for Colang 2.0.",
         )
 
     try:
@@ -506,14 +555,6 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             messages = thread_messages + messages
 
         generation_options = body.guardrails.options
-
-        # Validate state format if provided
-        if body.guardrails.state is not None and body.guardrails.state != {}:
-            if "events" not in body.guardrails.state and "state" not in body.guardrails.state:
-                raise HTTPException(
-                    status_code=422,
-                    detail="Invalid state format: state must contain 'events' or 'state' key. Use an empty dict {} to start a new conversation.",
-                )
 
         # Initialize llm_params if not already set
         if generation_options.llm_params is None:

--- a/tests/server/test_server_calls_with_state.py
+++ b/tests/server/test_server_calls_with_state.py
@@ -172,3 +172,16 @@ def test_invalid_state_shape_rejected_before_model_init():
 
     assert response.status_code == 422
     assert "events" in response.json()["detail"]
+
+
+def test_invalid_events_state_type_rejected_before_model_init():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    os.environ.pop("MAIN_MODEL_BASE_URL", None)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {"events": "not-a-list"}),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid state format: 'events' must be a list."

--- a/tests/server/test_server_calls_with_state.py
+++ b/tests/server/test_server_calls_with_state.py
@@ -20,6 +20,7 @@ pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
 from nemoguardrails.server import api
+from nemoguardrails.server.datastore.memory_store import MemoryStore
 
 client = TestClient(api.app)
 
@@ -27,32 +28,46 @@ client = TestClient(api.app)
 @pytest.fixture(scope="function", autouse=True)
 def setup_test_env():
     original_engine = os.environ.get("MAIN_MODEL_ENGINE")
+    original_base_url = os.environ.get("MAIN_MODEL_BASE_URL")
+    original_datastore = api.datastore
     os.environ["MAIN_MODEL_ENGINE"] = "custom_llm"
+    os.environ["MAIN_MODEL_BASE_URL"] = "http://localhost:8000"
+    api.datastore = None
     api.llm_rails_instances.clear()
     yield
     api.llm_rails_instances.clear()
+    api.datastore = original_datastore
     if original_engine is not None:
         os.environ["MAIN_MODEL_ENGINE"] = original_engine
     else:
         os.environ.pop("MAIN_MODEL_ENGINE", None)
+    if original_base_url is not None:
+        os.environ["MAIN_MODEL_BASE_URL"] = original_base_url
+    else:
+        os.environ.pop("MAIN_MODEL_BASE_URL", None)
+
+
+def _chat_payload(config_id, state, stream=False):
+    return {
+        "model": "gpt-4o",
+        "stream": stream,
+        "messages": [
+            {
+                "content": "hi",
+                "role": "user",
+            }
+        ],
+        "guardrails": {
+            "config_id": config_id,
+            "state": state,
+        },
+    }
 
 
 def _test_call(config_id):
     response = client.post(
         "/v1/chat/completions",
-        json={
-            "model": "gpt-4o",
-            "messages": [
-                {
-                    "content": "hi",
-                    "role": "user",
-                }
-            ],
-            "guardrails": {
-                "config_id": config_id,
-                "state": {},
-            },
-        },
+        json=_chat_payload(config_id, {}),
     )
     assert response.status_code == 200
     res = response.json()
@@ -63,20 +78,9 @@ def _test_call(config_id):
 
     response = client.post(
         "/v1/chat/completions",
-        json={
-            "model": "gpt-4o",
-            "messages": [
-                {
-                    "content": "hi",
-                    "role": "user",
-                }
-            ],
-            "guardrails": {
-                "config_id": config_id,
-                "state": res["guardrails"]["state"],
-            },
-        },
+        json=_chat_payload(config_id, res["guardrails"]["state"]),
     )
+    assert response.status_code == 200
     res = response.json()
     assert res["choices"][0]["message"]["content"] == "Hello again!"
 
@@ -86,6 +90,85 @@ def test_1():
     _test_call("config_1")
 
 
-def test_2():
+def test_2_x_empty_state_runs_without_returning_state():
     api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
-    _test_call("config_2")
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {}),
+    )
+
+    assert response.status_code == 200
+    res = response.json()
+    assert res["choices"][0]["message"]["content"] == "Hello!"
+    assert "state" not in res["guardrails"]
+
+
+def test_2_x_raw_state_rejected_at_server():
+    """Colang 2.0 stateful continuation over HTTP is no longer supported.
+
+    The serialized 2.0 State carried trusted control-plane fields, so the server
+    rejects any 2.0-shaped state with a 422 instead of forwarding it to the core.
+    """
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {"version": "2.x", "state": "{}"}),
+    )
+    assert response.status_code == 422
+    assert "Colang 2.0" in response.json()["detail"]
+
+
+def test_2_x_raw_state_rejected_at_server_streaming():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {"version": "2.x", "state": "{}"}, stream=True),
+    )
+
+    assert response.status_code == 422
+    assert "Colang 2.0" in response.json()["detail"]
+
+
+def test_2_x_events_state_rejected_after_config_load():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {"events": []}),
+    )
+
+    assert response.status_code == 422
+    assert "Colang 2.0" in response.json()["detail"]
+
+
+def test_2_x_thread_id_rejected_after_config_load():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    api.datastore = MemoryStore()
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o",
+            "messages": [{"content": "hi", "role": "user"}],
+            "guardrails": {
+                "config_id": "config_2",
+                "thread_id": "state-bug-thread-0001",
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "thread_id" in response.json()["detail"]
+    assert "Colang 2.0" in response.json()["detail"]
+
+
+def test_invalid_state_shape_rejected_before_model_init():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
+    os.environ.pop("MAIN_MODEL_BASE_URL", None)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json=_chat_payload("config_2", {"unexpected": "value"}),
+    )
+
+    assert response.status_code == 422
+    assert "events" in response.json()["detail"]

--- a/tests/test_state_api_1_0.py
+++ b/tests/test_state_api_1_0.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from nemoguardrails import RailsConfig
+from nemoguardrails.exceptions import InvalidStateError
 from tests.utils import TestChat
 
 config = RailsConfig.from_content(
@@ -93,3 +96,24 @@ def test_2():
     res = rails.generate(messages=messages, state=res.state)
 
     assert res.response == [{"role": "assistant", "content": "Hey again!"}]
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"unexpected": "value"},
+        {"state": "serialized_payload"},
+        {"events": "not-a-list"},
+    ],
+)
+def test_invalid_state_shape_rejected(state):
+    chat = TestChat(config, llm_completions=[])
+    rails = chat.app
+
+    with pytest.raises(InvalidStateError) as exc_info:
+        rails.generate(
+            messages=[{"role": "user", "content": "Hi 1!"}],
+            state=state,
+        )
+
+    assert "Invalid Colang 1.0 state format" in str(exc_info.value)

--- a/tests/v2_x/test_python_api.py
+++ b/tests/v2_x/test_python_api.py
@@ -15,7 +15,8 @@
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
-from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.exceptions import InvalidStateError
+from nemoguardrails.utils import new_event_dict
 from tests.utils import TestChat
 
 config = RailsConfig.from_content(
@@ -69,65 +70,122 @@ def test_exception_1():
         assert "not supported for Colang 2.0" in str(exc_info.value)
 
 
-def test_state_return():
+def test_state_multi_turn_via_process_events():
+    """Colang 2.0 in-process multi-turn keeps a live State across calls.
+
+    Mirrors the pattern at nemoguardrails/cli/chat.py: the live Python State
+    object is held in memory between calls and handed back to process_events
+    each turn. The second `user said "hi"` only matches the second branch of
+    the greeting flow because the State carries the flow position forward.
+    """
+    chat = TestChat(config, llm_completions=[])
+
+    # The State exists from TestChat's initial process_events([], None) bootstrap.
+    assert chat.state is not None
+
+    # First turn: "hi" → "Hello!"
+    chat >> "hi"
+    chat << "Hello!"
+
+    # Second turn relies on the State surviving across the call; without it
+    # the greeting flow would emit "Hello!" again instead of advancing.
+    chat >> "hi"
+    chat << "Hello again!"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"version": "2.x", "state": "{}"},
+        {"events": []},
+        {"unexpected": "value"},
+    ],
+)
+def test_dict_state_rejected_2_x(state):
+    """Caller-supplied dict state for Colang 2.0 must be refused at the API boundary.
+
+    The serialized State contains trusted control-plane fields (flow_configs,
+    rails_config) and cannot come from an untrusted caller.
+    """
+    rails = LLMRails(config=config)
+    messages = [{"role": "user", "content": "hi"}]
+
+    with pytest.raises(InvalidStateError) as exc_info:
+        rails.generate(
+            messages=messages,
+            state=state,
+        )
+
+    assert "process_events_async" in str(exc_info.value)
+
+
+def test_state_not_returned_for_2_x():
+    """generate_async no longer returns a continuation state for Colang 2.0.
+
+    Stateful 2.x execution moved to process_events_async (see test above).
+    """
     rails = LLMRails(config=config)
     messages = [{"role": "user", "content": "hi"}]
 
     res = rails.generate(messages=messages, state={})
 
-    assert isinstance(res, GenerationResponse)
-    assert res.response == [{"role": "assistant", "content": "Hello!"}]
-
-    # We submit a new message using the returned state
-    res = rails.generate(messages=messages, state=res.state)
-
-    assert res.response == [{"role": "assistant", "content": "Hello again!"}]
+    assert res.state is None
 
 
-def test_actions_1():
+def test_stream_async_dict_state_rejected_2_x():
     rails = LLMRails(config=config)
-    messages = [{"role": "user", "content": "what is 2+2"}]
 
-    res = rails.generate(messages=messages, state={})
+    with pytest.raises(InvalidStateError):
+        rails.stream_async(
+            messages=[{"role": "user", "content": "hi"}],
+            state={"events": []},
+        )
 
-    # We replace the id so that we can make a simple comparison
-    tool_call_id = res.response[0]["tool_calls"][0]["id"]
-    res.response[0]["tool_calls"][0]["id"] = "..."
 
-    assert res.response == [
-        {
-            "tool_calls": [
-                {
-                    "id": "...",
-                    "type": "function",
-                    "function": {
-                        "arguments": {"query": "what is 2+2"},
-                        "name": "WolframAlphaAction",
-                    },
-                }
-            ],
-            "content": "Let me think.",
-            "role": "assistant",
-        }
-    ]
+def test_actions_continue_with_live_state_via_process_events():
+    """Tool/action pause and resume still works with trusted in-process State."""
+    rails = LLMRails(config=config)
 
-    res = rails.generate(
-        messages=[
+    output_events, state = rails.process_events(
+        [{"type": "UtteranceUserActionFinished", "final_transcript": "what is 2+2"}],
+        state={},
+        blocking=True,
+    )
+    assert output_events[0]["type"] == "StartUtteranceBotAction"
+    assert output_events[0]["script"] == "Let me think."
+
+    output_events, state = rails.process_events(
+        [
+            new_event_dict(
+                "UtteranceBotActionFinished",
+                action_uid=output_events[0]["action_uid"],
+                is_success=True,
+                final_script="Let me think.",
+            )
+        ],
+        state=state,
+        blocking=True,
+    )
+    assert output_events[0]["type"] == "StartWolframAlphaAction"
+    assert output_events[0]["query"] == "what is 2+2"
+
+    output_events, state = rails.process_events(
+        [
             {
-                "tool_call_id": tool_call_id,
-                "role": "tool",
-                "content": "The result is 4.",
+                "type": "WolframAlphaActionFinished",
+                "action_uid": output_events[0]["action_uid"],
+                "action_name": "WolframAlphaAction",
+                "status": "success",
+                "is_success": True,
+                "return_value": "The result is 4.",
+                "events": [],
             }
         ],
-        state=res.state,
+        state=state,
+        blocking=True,
     )
-
-    assert res.response == [
-        {
-            "content": "The result is 4.",
-            "role": "assistant",
-        }
-    ]
+    assert output_events[0]["type"] == "StartUtteranceBotAction"
+    assert output_events[0]["script"] == "The result is 4."
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description


Reject public dict state for Colang 2.0 at generate/generate_async and HTTP boundaries so serialized runtime State is not trusted from callers.

Trusted in-process multi-turn remains available through `process_events_async` with a live `State` object. 





- [ ] Release notes should document this as a security-relevant breaking fix before release.



<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference for the chat completions endpoint with refined guidance on state and thread_id handling for Colang 1.0 vs 2.0, including new HTTP 422 error cases.

* **Bug Fixes**
  * Added validation to reject unsupported Colang 2.0 runtime state and thread_id-based continuation mechanisms over HTTP; state requests now require Colang 1.0 transcript format.

* **Tests**
  * Enhanced test coverage for state validation and multi-turn conversation handling across HTTP and Python APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1885)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->