### PR TITLE
fix(iorails): Add all LLMRails methods to Guardrails facade

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -22,15 +22,18 @@ LLM responses with programmable guardrails.
 """
 
 import logging
-from typing import AsyncIterator, Optional, Tuple, Union, cast, overload
+from typing import Any, AsyncIterator, Callable, List, Optional, Tuple, Type, Union, cast, overload
 
+from nemoguardrails.colang.v2_x.runtime.flows import State
+from nemoguardrails.embeddings.index import EmbeddingsIndex
+from nemoguardrails.embeddings.providers.base import EmbeddingModel
 from nemoguardrails.guardrails import configure_logging
 from nemoguardrails.guardrails.guardrails_types import LLMMessages
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
 from nemoguardrails.rails.llm.llmrails import LLMRails
-from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.rails.llm.options import GenerationResponse, RailsResult, RailType
 from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
@@ -207,6 +210,166 @@ class Guardrails:
         # self.rails_engine must be LLMRails since we raise above if we're using IORails
         llmrails = cast(LLMRails, self.rails_engine)
         llmrails.update_llm(llm)
+
+    async def generate_events_async(self, events: List[dict]) -> List[dict]:
+        """Generate the next events based on the provided history.
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support generate_events_async()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return await llmrails.generate_events_async(events)
+
+    def generate_events(self, events: List[dict]) -> List[dict]:
+        """Synchronous version of generate_events_async.
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support generate_events()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.generate_events(events)
+
+    async def process_events_async(
+        self,
+        events: List[dict],
+        state: Union[Optional[dict], State] = None,
+        blocking: bool = False,
+    ) -> Tuple[List[dict], Union[dict, State]]:
+        """Process a sequence of events in a given state.
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support process_events_async()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return await llmrails.process_events_async(events, state, blocking)
+
+    def process_events(
+        self,
+        events: List[dict],
+        state: Union[Optional[dict], State] = None,
+        blocking: bool = False,
+    ) -> Tuple[List[dict], Union[dict, State]]:
+        """Synchronous version of process_events_async.
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support process_events()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.process_events(events, state, blocking)
+
+    async def check_async(
+        self,
+        messages: List[dict],
+        rail_types: Optional[List[RailType]] = None,
+    ) -> RailsResult:
+        """Run rails on messages based on their content (asynchronous).
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support check_async()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return await llmrails.check_async(messages, rail_types=rail_types)
+
+    def check(
+        self,
+        messages: List[dict],
+        rail_types: Optional[List[RailType]] = None,
+    ) -> RailsResult:
+        """Synchronous version of check_async.
+        Only supported for LLMRails.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support check()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.check(messages, rail_types=rail_types)
+
+    def register_action(self, action: Callable, name: Optional[str] = None) -> LLMRails:
+        """Register a custom action for the rails configuration.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_action()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_action(action, name)
+
+    def register_action_param(self, name: str, value: Any) -> LLMRails:
+        """Register a custom action parameter.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_action_param()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_action_param(name, value)
+
+    def register_filter(self, filter_fn: Callable, name: Optional[str] = None) -> LLMRails:
+        """Register a custom filter for the rails configuration.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_filter()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_filter(filter_fn, name)
+
+    def register_output_parser(self, output_parser: Callable, name: str) -> LLMRails:
+        """Register a custom output parser for the rails configuration.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_output_parser()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_output_parser(output_parser, name)
+
+    def register_prompt_context(self, name: str, value_or_fn: Any) -> LLMRails:
+        """Register a value to be included in the prompt context.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_prompt_context()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_prompt_context(name, value_or_fn)
+
+    def register_embedding_search_provider(self, name: str, cls: Type[EmbeddingsIndex]) -> LLMRails:
+        """Register a new embedding search provider.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_embedding_search_provider()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_embedding_search_provider(name, cls)
+
+    def register_embedding_provider(self, cls: Type[EmbeddingModel], name: Optional[str] = None) -> LLMRails:
+        """Register a custom embedding provider.
+        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support register_embedding_provider()")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.register_embedding_provider(cls, name)
+
+    def __getstate__(self):
+        """Pickle support: only the config is preserved (mirrors LLMRails)."""
+        return {"config": self.config}
+
+    def __setstate__(self, state):
+        """Pickle support: rebuild from config (mirrors LLMRails)."""
+        if state["config"].config_path:
+            config = RailsConfig.from_path(state["config"].config_path)
+        else:
+            config = state["config"]
+        self.__init__(config=config, verbose=False)
 
     async def startup(self) -> None:
         """Lifecycle method to start the rails engine.

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -375,20 +375,25 @@ class Guardrails:
         return self
 
     def __getstate__(self):
-        """Pickle support: preserve config and use_iorails so the rebuilt
+        """Pickle support: preserve config, verbose, and use_iorails so the rebuilt
         instance lands on the same engine. The llm is dropped (matches LLMRails).
         """
-        return {"config": self.config, "use_iorails": self.use_iorails_engine}
+        return {"config": self.config, "verbose": self.verbose, "use_iorails": self.use_iorails_engine}
 
     def __setstate__(self, state):
-        """Pickle support: rebuild from config + use_iorails. Older pickles
-        without use_iorails default to True for backwards compatibility.
+        """Pickle support: rebuild from config + verbose + use_iorails. Older
+        pickles missing these keys default to False/True respectively for
+        backwards compatibility.
         """
         if state["config"].config_path:
             config = RailsConfig.from_path(state["config"].config_path)
         else:
             config = state["config"]
-        self.__init__(config=config, verbose=False, use_iorails=state.get("use_iorails", True))
+        self.__init__(
+            config=config,
+            verbose=state.get("verbose", False),
+            use_iorails=state.get("use_iorails", True),
+        )
 
     async def startup(self) -> None:
         """Lifecycle method to start the rails engine.

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -24,6 +24,8 @@ LLM responses with programmable guardrails.
 import logging
 from typing import Any, AsyncIterator, Callable, List, Optional, Tuple, Type, Union, cast, overload
 
+from typing_extensions import Self
+
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.embeddings.index import EmbeddingsIndex
 from nemoguardrails.embeddings.providers.base import EmbeddingModel
@@ -60,6 +62,11 @@ class Guardrails:
 
         self.config = config
         self.verbose = verbose
+        # Stored so pickle round-trips preserve the user's engine preference;
+        # without this, __setstate__ would default use_iorails=True and silently
+        # switch a use_iorails=False instance onto IORails when the config is
+        # IORails-compatible.
+        self.use_iorails = use_iorails
 
         if verbose:
             configure_logging(logging.DEBUG)
@@ -289,87 +296,98 @@ class Guardrails:
         llmrails = cast(LLMRails, self.rails_engine)
         return llmrails.check(messages, rail_types=rail_types)
 
-    def register_action(self, action: Callable, name: Optional[str] = None) -> LLMRails:
+    def register_action(self, action: Callable, name: Optional[str] = None) -> Self:
         """Register a custom action for the rails configuration.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_action()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_action(action, name)
+        llmrails.register_action(action, name)
+        return self
 
-    def register_action_param(self, name: str, value: Any) -> LLMRails:
+    def register_action_param(self, name: str, value: Any) -> Self:
         """Register a custom action parameter.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_action_param()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_action_param(name, value)
+        llmrails.register_action_param(name, value)
+        return self
 
-    def register_filter(self, filter_fn: Callable, name: Optional[str] = None) -> LLMRails:
+    def register_filter(self, filter_fn: Callable, name: Optional[str] = None) -> Self:
         """Register a custom filter for the rails configuration.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_filter()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_filter(filter_fn, name)
+        llmrails.register_filter(filter_fn, name)
+        return self
 
-    def register_output_parser(self, output_parser: Callable, name: str) -> LLMRails:
+    def register_output_parser(self, output_parser: Callable, name: str) -> Self:
         """Register a custom output parser for the rails configuration.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_output_parser()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_output_parser(output_parser, name)
+        llmrails.register_output_parser(output_parser, name)
+        return self
 
-    def register_prompt_context(self, name: str, value_or_fn: Any) -> LLMRails:
+    def register_prompt_context(self, name: str, value_or_fn: Any) -> Self:
         """Register a value to be included in the prompt context.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_prompt_context()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_prompt_context(name, value_or_fn)
+        llmrails.register_prompt_context(name, value_or_fn)
+        return self
 
-    def register_embedding_search_provider(self, name: str, cls: Type[EmbeddingsIndex]) -> LLMRails:
+    def register_embedding_search_provider(self, name: str, cls: Type[EmbeddingsIndex]) -> Self:
         """Register a new embedding search provider.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_embedding_search_provider()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_embedding_search_provider(name, cls)
+        llmrails.register_embedding_search_provider(name, cls)
+        return self
 
-    def register_embedding_provider(self, cls: Type[EmbeddingModel], name: Optional[str] = None) -> LLMRails:
+    def register_embedding_provider(self, cls: Type[EmbeddingModel], name: Optional[str] = None) -> Self:
         """Register a custom embedding provider.
-        Only supported for LLMRails. Returns the underlying LLMRails instance.
+        Only supported for LLMRails. Returns self so calls can be chained.
         """
         if isinstance(self.rails_engine, IORails):
             raise NotImplementedError("IORails doesn't support register_embedding_provider()")
 
         llmrails = cast(LLMRails, self.rails_engine)
-        return llmrails.register_embedding_provider(cls, name)
+        llmrails.register_embedding_provider(cls, name)
+        return self
 
     def __getstate__(self):
-        """Pickle support: only the config is preserved (mirrors LLMRails)."""
-        return {"config": self.config}
+        """Pickle support: preserve config and use_iorails so the rebuilt
+        instance lands on the same engine. The llm is dropped (matches LLMRails).
+        """
+        return {"config": self.config, "use_iorails": self.use_iorails}
 
     def __setstate__(self, state):
-        """Pickle support: rebuild from config (mirrors LLMRails)."""
+        """Pickle support: rebuild from config + use_iorails. Older pickles
+        without use_iorails default to True for backwards compatibility.
+        """
         if state["config"].config_path:
             config = RailsConfig.from_path(state["config"].config_path)
         else:
             config = state["config"]
-        self.__init__(config=config, verbose=False)
+        self.__init__(config=config, verbose=False, use_iorails=state.get("use_iorails", True))
 
     async def startup(self) -> None:
         """Lifecycle method to start the rails engine.

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -50,6 +50,10 @@ IORAILS_OUTPUT_FLOWS = {"content safety check output"}
 class Guardrails:
     """Top-level interface for NeMo Guardrails functionality."""
 
+    config: RailsConfig
+    verbose: bool
+    use_iorails_engine: bool
+
     def __init__(
         self,
         config: RailsConfig,
@@ -62,11 +66,6 @@ class Guardrails:
 
         self.config = config
         self.verbose = verbose
-        # Stored so pickle round-trips preserve the user's engine preference;
-        # without this, __setstate__ would default use_iorails=True and silently
-        # switch a use_iorails=False instance onto IORails when the config is
-        # IORails-compatible.
-        self.use_iorails = use_iorails
 
         if verbose:
             configure_logging(logging.DEBUG)
@@ -76,6 +75,8 @@ class Guardrails:
         # Whether to use IORailsEngine for inference requests
         use_iorails_engine = use_iorails and llm is None and self._has_only_iorails_flows()
         self._rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
+        # Store engine used so pickle restores the correct engine
+        self.use_iorails_engine = use_iorails_engine
 
         # Track whether startup() has been called (supports lazy initialization)
         self._started = False
@@ -377,7 +378,7 @@ class Guardrails:
         """Pickle support: preserve config and use_iorails so the rebuilt
         instance lands on the same engine. The llm is dropped (matches LLMRails).
         """
-        return {"config": self.config, "use_iorails": self.use_iorails}
+        return {"config": self.config, "use_iorails": self.use_iorails_engine}
 
     def __setstate__(self, state):
         """Pickle support: rebuild from config + use_iorails. Older pickles

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1324,16 +1324,38 @@ class TestGuardrailsPickle:
         state = guardrails.__getstate__()
         assert state == {"config": _nemoguards_rails_config}
 
-    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
-    def test_setstate_rebuilds_from_in_memory_config(self, mock_llmrails_class, _nemoguards_rails_config):
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_setstate_rebuilds_from_in_memory_config_iorails(self, mock_iorails_init, _nemoguards_rails_config):
         """__setstate__ uses the pickled config directly when config_path is unset
-        (in-memory configs from RailsConfig.from_content)."""
-        mock_llmrails_class.return_value = MagicMock()
-
+        (in-memory configs from RailsConfig.from_content). NEMOGUARDS_CONFIG is
+        IORails-compatible and __setstate__ uses the default use_iorails=True, so
+        the rebuilt wrapper lands on IORails."""
         guardrails = Guardrails.__new__(Guardrails)
         guardrails.__setstate__({"config": _nemoguards_rails_config})
 
         assert guardrails.config is _nemoguards_rails_config
         assert guardrails.verbose is False
-        # __init__ runs, so LLMRails is instantiated by the patched class
-        mock_llmrails_class.assert_called_once()
+        # __init__ runs and routes to IORails for this config
+        assert isinstance(guardrails.rails_engine, IORails)
+        mock_iorails_init.assert_called_once_with(_nemoguards_rails_config)
+
+    @patch.object(LLMRails, "__init__", return_value=None)
+    def test_setstate_rebuilds_from_in_memory_config_llmrails(self, mock_llmrails_init):
+        """When the config has flows not supported by IORails, __setstate__ rebuilds
+        the wrapper onto LLMRails (the fallback engine)."""
+        llmrails_only_config = _make_iorails_config(
+            rails={
+                "input": {"flows": ["self check input"]},
+                "output": {"flows": ["content safety check output $model=content_safety"]},
+            },
+            extra_prompts=[{"task": "self_check_input", "content": "placeholder"}],
+        )
+
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": llmrails_only_config})
+
+        assert guardrails.config is llmrails_only_config
+        assert guardrails.verbose is False
+        # 'self check input' is not in IORAILS_INPUT_FLOWS, so the wrapper falls back to LLMRails
+        assert isinstance(guardrails.rails_engine, LLMRails)
+        mock_llmrails_init.assert_called_once_with(llmrails_only_config, None, False)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1068,3 +1068,272 @@ class TestStreamAsyncIORails:
                 options=None,
                 include_metadata=False,
             )
+
+
+class TestLLMRailsOnlyMethods:
+    """Tests for methods that exist on LLMRails but not IORails.
+
+    Under LLMRails, each method must delegate to the underlying instance.
+    Under IORails, each must raise NotImplementedError.
+    """
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_generate_events_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.generate_events.return_value = [{"type": "BotMessage"}]
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        events = [{"type": "UtteranceUserActionFinished", "final_transcript": "hi"}]
+        result = guardrails.generate_events(events)
+
+        mock_llmrails_instance.generate_events.assert_called_once_with(events)
+        assert result == [{"type": "BotMessage"}]
+
+    @pytest.mark.asyncio
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    async def test_generate_events_async_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.generate_events_async = AsyncMock(return_value=[{"type": "BotMessage"}])
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        events = [{"type": "UtteranceUserActionFinished", "final_transcript": "hi"}]
+        result = await guardrails.generate_events_async(events)
+
+        mock_llmrails_instance.generate_events_async.assert_called_once_with(events)
+        assert result == [{"type": "BotMessage"}]
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_process_events_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.process_events.return_value = ([{"type": "BotMessage"}], {})
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        events = [{"type": "UtteranceUserActionFinished"}]
+        result = guardrails.process_events(events, state={"foo": "bar"}, blocking=True)
+
+        mock_llmrails_instance.process_events.assert_called_once_with(events, {"foo": "bar"}, True)
+        assert result == ([{"type": "BotMessage"}], {})
+
+    @pytest.mark.asyncio
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    async def test_process_events_async_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.process_events_async = AsyncMock(return_value=([{"type": "BotMessage"}], {}))
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        events = [{"type": "UtteranceUserActionFinished"}]
+        result = await guardrails.process_events_async(events, state={"foo": "bar"}, blocking=True)
+
+        mock_llmrails_instance.process_events_async.assert_called_once_with(events, {"foo": "bar"}, True)
+        assert result == ([{"type": "BotMessage"}], {})
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_check_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
+
+        sentinel = RailsResult(status=RailStatus.PASSED, content="ok")
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.check.return_value = sentinel
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        messages = [{"role": "user", "content": "hi"}]
+        result = guardrails.check(messages, rail_types=[RailType.INPUT])
+
+        mock_llmrails_instance.check.assert_called_once_with(messages, rail_types=[RailType.INPUT])
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    async def test_check_async_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
+
+        sentinel = RailsResult(status=RailStatus.PASSED, content="ok")
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.check_async = AsyncMock(return_value=sentinel)
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        messages = [{"role": "user", "content": "hi"}]
+        result = await guardrails.check_async(messages, rail_types=[RailType.OUTPUT])
+
+        mock_llmrails_instance.check_async.assert_called_once_with(messages, rail_types=[RailType.OUTPUT])
+        assert result is sentinel
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_action_delegates_and_returns_llmrails(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_action.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+
+        def my_action():
+            pass
+
+        result = guardrails.register_action(my_action, name="my_action")
+
+        mock_llmrails_instance.register_action.assert_called_once_with(my_action, "my_action")
+        assert result is mock_llmrails_instance  # Pass-through, not Guardrails self
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_action_param_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_action_param.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        result = guardrails.register_action_param("my_param", 42)
+
+        mock_llmrails_instance.register_action_param.assert_called_once_with("my_param", 42)
+        assert result is mock_llmrails_instance
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_filter_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_filter.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+
+        def my_filter(x):
+            return x
+
+        result = guardrails.register_filter(my_filter, name="my_filter")
+
+        mock_llmrails_instance.register_filter.assert_called_once_with(my_filter, "my_filter")
+        assert result is mock_llmrails_instance
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_output_parser_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_output_parser.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+
+        def my_parser(s):
+            return s
+
+        result = guardrails.register_output_parser(my_parser, "my_parser")
+
+        mock_llmrails_instance.register_output_parser.assert_called_once_with(my_parser, "my_parser")
+        assert result is mock_llmrails_instance
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_prompt_context_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_prompt_context.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        result = guardrails.register_prompt_context("user_name", "alice")
+
+        mock_llmrails_instance.register_prompt_context.assert_called_once_with("user_name", "alice")
+        assert result is mock_llmrails_instance
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_embedding_search_provider_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        from nemoguardrails.embeddings.index import EmbeddingsIndex
+
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_embedding_search_provider.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+
+        class FakeIndex(EmbeddingsIndex):
+            pass
+
+        result = guardrails.register_embedding_search_provider("fake", FakeIndex)
+
+        mock_llmrails_instance.register_embedding_search_provider.assert_called_once_with("fake", FakeIndex)
+        assert result is mock_llmrails_instance
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_register_embedding_provider_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
+        from nemoguardrails.embeddings.providers.base import EmbeddingModel
+
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.register_embedding_provider.return_value = mock_llmrails_instance
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+
+        class FakeModel(EmbeddingModel):
+            engine_name = "fake"
+            model = "fake"
+
+            async def encode_async(self, documents):
+                return []
+
+            def encode(self, documents):
+                return []
+
+        result = guardrails.register_embedding_provider(FakeModel, name="fake")
+
+        mock_llmrails_instance.register_embedding_provider.assert_called_once_with(FakeModel, "fake")
+        assert result is mock_llmrails_instance
+
+    @pytest.mark.parametrize(
+        "method_name,args,is_async",
+        [
+            ("generate_events", ([],), False),
+            ("generate_events_async", ([],), True),
+            ("process_events", ([],), False),
+            ("process_events_async", ([],), True),
+            ("check", ([{"role": "user", "content": "hi"}],), False),
+            ("check_async", ([{"role": "user", "content": "hi"}],), True),
+            ("register_action", (lambda: None,), False),
+            ("register_action_param", ("p", 1), False),
+            ("register_filter", (lambda x: x,), False),
+            ("register_output_parser", (lambda x: x, "p"), False),
+            ("register_prompt_context", ("n", "v"), False),
+            ("register_embedding_search_provider", ("n", type("X", (), {})), False),
+            ("register_embedding_provider", (type("X", (), {}),), False),
+        ],
+    )
+    @pytest.mark.asyncio
+    @patch.object(IORails, "__init__", return_value=None)
+    async def test_iorails_raises_not_implemented(
+        self, mock_iorails_init, _content_safety_rails_config, method_name, args, is_async
+    ):
+        """Every LLMRails-only method must raise NotImplementedError under IORails."""
+        guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+
+        method = getattr(guardrails, method_name)
+        with pytest.raises(NotImplementedError, match=f"IORails doesn't support {method_name}"):
+            if is_async:
+                await method(*args)
+            else:
+                method(*args)
+
+
+class TestGuardrailsPickle:
+    """Tests for __getstate__ / __setstate__ pickle support on Guardrails."""
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_getstate_returns_only_config(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_class.return_value = MagicMock()
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        state = guardrails.__getstate__()
+        assert state == {"config": _nemoguards_rails_config}
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_setstate_rebuilds_from_in_memory_config(self, mock_llmrails_class, _nemoguards_rails_config):
+        """__setstate__ uses the pickled config directly when config_path is unset
+        (in-memory configs from RailsConfig.from_content)."""
+        mock_llmrails_class.return_value = MagicMock()
+
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": _nemoguards_rails_config})
+
+        assert guardrails.config is _nemoguards_rails_config
+        assert guardrails.verbose is False
+        # __init__ runs, so LLMRails is instantiated by the patched class
+        mock_llmrails_class.assert_called_once()

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1354,7 +1354,7 @@ class TestGuardrailsPickle:
         guardrails = Guardrails.__new__(Guardrails)
         guardrails.__setstate__({"config": _nemoguards_rails_config})  # no use_iorails key
 
-        assert guardrails.use_iorails is True
+        assert guardrails.use_iorails_engine is True
         assert isinstance(guardrails.rails_engine, IORails)
 
     @patch.object(IORails, "__init__", return_value=None)
@@ -1414,3 +1414,46 @@ class TestGuardrailsPickle:
         mock_from_path.assert_called_once_with("/some/path/to/config")
         assert guardrails.config is _nemoguards_rails_config
         assert isinstance(guardrails.rails_engine, IORails)
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_pickle_preserves_iorails_round_trip(self, mock_iorails_init, _nemoguards_rails_config):
+        """Full round-trip on the only permutation that produces IORails:
+        Guardrails(use_iorails=True) without an llm on an IORails-compatible config.
+        Verifies (1) the IORails branch of __getstate__ saves use_iorails=True,
+        and (2) __setstate__ rebuilds onto IORails. This is the symmetric counterpart
+        to test_pickle_preserves_llmrails_when_llm_was_passed."""
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+
+        state = guardrails.__getstate__()
+        assert state["use_iorails"] is True
+
+        restored = Guardrails.__new__(Guardrails)
+        restored.__setstate__(state)
+        assert isinstance(restored.rails_engine, IORails)
+        # Called twice: once during initial Guardrails(...), once during __setstate__
+        assert mock_iorails_init.call_count == 2
+
+    @patch.object(LLMRails, "__init__", return_value=None)
+    def test_pickle_preserves_llmrails_when_llm_was_passed(
+        self, mock_llmrails_init, _content_safety_rails_config, mock_llm
+    ):
+        """Regression (CodeRabbit P0): when an explicit LLM is passed, Guardrails uses
+        LLMRails even with use_iorails=True and an IORails-compatible config (the llm
+        argument forces LLMRails). Pickle drops the llm — so __getstate__ must save the
+        *effective* engine choice (not the user kwarg), otherwise __setstate__ would
+        rebuild with llm=None + use_iorails=True and silently switch to IORails."""
+        # Initial wrapper: LLMRails despite use_iorails=True (because llm was passed)
+        guardrails = Guardrails(config=_content_safety_rails_config, llm=mock_llm, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, LLMRails)
+
+        # __getstate__ saves effective engine (False = LLMRails), not the user kwarg (True)
+        state = guardrails.__getstate__()
+        assert state["use_iorails"] is False
+
+        # __setstate__ rebuilds onto LLMRails — engine choice survives the round-trip
+        restored = Guardrails.__new__(Guardrails)
+        restored.__setstate__(state)
+        assert isinstance(restored.rails_engine, LLMRails)
+        # Called twice: once during initial Guardrails(...), once during __setstate__
+        assert mock_llmrails_init.call_count == 2

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1165,7 +1165,7 @@ class TestLLMRailsOnlyMethods:
         assert result is sentinel
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
-    def test_register_action_delegates_and_returns_llmrails(self, mock_llmrails_class, _nemoguards_rails_config):
+    def test_register_action_delegates_and_returns_self(self, mock_llmrails_class, _nemoguards_rails_config):
         mock_llmrails_instance = MagicMock()
         mock_llmrails_instance.register_action.return_value = mock_llmrails_instance
         mock_llmrails_class.return_value = mock_llmrails_instance
@@ -1178,7 +1178,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_action(my_action, name="my_action")
 
         mock_llmrails_instance.register_action.assert_called_once_with(my_action, "my_action")
-        assert result is mock_llmrails_instance  # Pass-through, not Guardrails self
+        assert result is guardrails  # Returns Guardrails facade for chaining
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_action_param_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1190,7 +1190,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_action_param("my_param", 42)
 
         mock_llmrails_instance.register_action_param.assert_called_once_with("my_param", 42)
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_filter_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1206,7 +1206,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_filter(my_filter, name="my_filter")
 
         mock_llmrails_instance.register_filter.assert_called_once_with(my_filter, "my_filter")
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_output_parser_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1222,7 +1222,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_output_parser(my_parser, "my_parser")
 
         mock_llmrails_instance.register_output_parser.assert_called_once_with(my_parser, "my_parser")
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_prompt_context_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1234,7 +1234,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_prompt_context("user_name", "alice")
 
         mock_llmrails_instance.register_prompt_context.assert_called_once_with("user_name", "alice")
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_embedding_search_provider_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1252,7 +1252,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_embedding_search_provider("fake", FakeIndex)
 
         mock_llmrails_instance.register_embedding_search_provider.assert_called_once_with("fake", FakeIndex)
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_register_embedding_provider_delegates(self, mock_llmrails_class, _nemoguards_rails_config):
@@ -1277,7 +1277,7 @@ class TestLLMRailsOnlyMethods:
         result = guardrails.register_embedding_provider(FakeModel, name="fake")
 
         mock_llmrails_instance.register_embedding_provider.assert_called_once_with(FakeModel, "fake")
-        assert result is mock_llmrails_instance
+        assert result is guardrails
 
     @pytest.mark.parametrize(
         "method_name,args,is_async",
@@ -1318,11 +1318,44 @@ class TestGuardrailsPickle:
     """Tests for __getstate__ / __setstate__ pickle support on Guardrails."""
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
-    def test_getstate_returns_only_config(self, mock_llmrails_class, _nemoguards_rails_config):
+    def test_getstate_preserves_config_and_use_iorails(self, mock_llmrails_class, _nemoguards_rails_config):
+        """__getstate__ preserves both config and use_iorails so the rebuilt
+        instance lands on the same engine after a pickle round-trip."""
         mock_llmrails_class.return_value = MagicMock()
         guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
         state = guardrails.__getstate__()
-        assert state == {"config": _nemoguards_rails_config}
+        assert state == {"config": _nemoguards_rails_config, "use_iorails": False}
+
+    @patch.object(LLMRails, "__init__", return_value=None)
+    def test_setstate_preserves_llmrails_on_iorails_compatible_config(
+        self, mock_llmrails_init, _nemoguards_rails_config
+    ):
+        """Regression: a Guardrails(use_iorails=False) wrapper on an IORails-compatible
+        config must rebuild as LLMRails, not silently switch to IORails. Without
+        preserving use_iorails in pickle state, __setstate__ would default to True
+        and route to IORails, making all LLMRails-only methods raise NotImplementedError.
+
+        We patch LLMRails.__init__ (not the class itself) to keep class identity intact
+        so isinstance() works against the real LLMRails.
+        """
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": _nemoguards_rails_config, "use_iorails": False})
+
+        assert guardrails.config is _nemoguards_rails_config
+        assert isinstance(guardrails.rails_engine, LLMRails)
+        mock_llmrails_init.assert_called_once_with(_nemoguards_rails_config, None, False)
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_setstate_backwards_compat_old_pickle_without_use_iorails(
+        self, mock_iorails_init, _nemoguards_rails_config
+    ):
+        """Older pickles (pre-fix) only serialized {"config": ...}. __setstate__ must
+        still accept them, defaulting use_iorails to True."""
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": _nemoguards_rails_config})  # no use_iorails key
+
+        assert guardrails.use_iorails is True
+        assert isinstance(guardrails.rails_engine, IORails)
 
     @patch.object(IORails, "__init__", return_value=None)
     def test_setstate_rebuilds_from_in_memory_config_iorails(self, mock_iorails_init, _nemoguards_rails_config):

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1392,3 +1392,25 @@ class TestGuardrailsPickle:
         # 'self check input' is not in IORAILS_INPUT_FLOWS, so the wrapper falls back to LLMRails
         assert isinstance(guardrails.rails_engine, LLMRails)
         mock_llmrails_init.assert_called_once_with(llmrails_only_config, None, False)
+
+    @patch.object(IORails, "__init__", return_value=None)
+    @patch("nemoguardrails.guardrails.guardrails.RailsConfig.from_path")
+    def test_setstate_reloads_from_path_when_config_path_set(
+        self, mock_from_path, mock_iorails_init, _nemoguards_rails_config
+    ):
+        """When the pickled config has a config_path, __setstate__ reloads it
+        from disk (picks up any on-disk changes since the pickle was written)
+        rather than using the in-memory snapshot."""
+        # Pickled config carries only the on-disk location.
+        pickled_config = MagicMock()
+        pickled_config.config_path = "/some/path/to/config"
+
+        # Reload returns the fresh in-memory config.
+        mock_from_path.return_value = _nemoguards_rails_config
+
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": pickled_config, "use_iorails": True})
+
+        mock_from_path.assert_called_once_with("/some/path/to/config")
+        assert guardrails.config is _nemoguards_rails_config
+        assert isinstance(guardrails.rails_engine, IORails)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1319,12 +1319,12 @@ class TestGuardrailsPickle:
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_getstate_preserves_config_and_use_iorails(self, mock_llmrails_class, _nemoguards_rails_config):
-        """__getstate__ preserves both config and use_iorails so the rebuilt
+        """__getstate__ preserves config, verbose, and use_iorails so the rebuilt
         instance lands on the same engine after a pickle round-trip."""
         mock_llmrails_class.return_value = MagicMock()
         guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
         state = guardrails.__getstate__()
-        assert state == {"config": _nemoguards_rails_config, "use_iorails": False}
+        assert state == {"config": _nemoguards_rails_config, "verbose": False, "use_iorails": False}
 
     @patch.object(LLMRails, "__init__", return_value=None)
     def test_setstate_preserves_llmrails_on_iorails_compatible_config(
@@ -1457,3 +1457,41 @@ class TestGuardrailsPickle:
         assert isinstance(restored.rails_engine, LLMRails)
         # Called twice: once during initial Guardrails(...), once during __setstate__
         assert mock_llmrails_init.call_count == 2
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_getstate_preserves_verbose_true(self, mock_iorails_init, _nemoguards_rails_config):
+        """__getstate__ captures verbose=True so a verbose Guardrails round-trips
+        with logging configuration intact."""
+        guardrails = Guardrails(config=_nemoguards_rails_config, verbose=True)
+        state = guardrails.__getstate__()
+        assert state["verbose"] is True
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_setstate_restores_verbose_true(self, mock_iorails_init, _nemoguards_rails_config):
+        """__setstate__ restores verbose=True so the rebuilt instance still has
+        verbose logging active (rather than silently dropping back to False)."""
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": _nemoguards_rails_config, "verbose": True, "use_iorails": True})
+        assert guardrails.verbose is True
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_pickle_round_trip_preserves_verbose(self, mock_iorails_init, _nemoguards_rails_config):
+        """Full round-trip: a Guardrails constructed with verbose=True must come
+        back from __getstate__/__setstate__ with verbose=True. Regression for the
+        bug where verbose was hardcoded to False on restore, silently obscuring
+        debugging sessions for users who pickled a verbose wrapper."""
+        guardrails = Guardrails(config=_nemoguards_rails_config, verbose=True)
+        assert guardrails.verbose is True
+
+        state = guardrails.__getstate__()
+        restored = Guardrails.__new__(Guardrails)
+        restored.__setstate__(state)
+        assert restored.verbose is True
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_setstate_backwards_compat_old_pickle_without_verbose(self, mock_iorails_init, _nemoguards_rails_config):
+        """Older pickles (pre-fix) didn't serialize verbose. __setstate__ must
+        still accept them, defaulting verbose to False."""
+        guardrails = Guardrails.__new__(Guardrails)
+        guardrails.__setstate__({"config": _nemoguards_rails_config, "use_iorails": True})
+        assert guardrails.verbose is False


### PR DESCRIPTION
## Description

This PR completes the Guardrails public API to match LLMRails. The subset of methods supported by IORails are delegated to the IORails instance if possible, otherwise a `NotImplementedError` is thrown. 

Method signatures are respected. Where LLMRails returns `self` (to allow chaining of calls), Guardrails also returns `self` rather than self.LLMRails to route through the facade.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
..............................................ssss............................................... [  2%]
..........................................s...................................................... [  4%]
................................................................................................. [  6%]
................................................................................................. [  9%]
................................................................................................. [ 11%]
................................................................................................. [ 13%]
................................................................................................. [ 15%]
................................................................................................. [ 18%]
................................................................................................. [ 20%]
................................................................................................. [ 22%]
.......................................................................................s......ss. [ 24%]
..................sssssss........................................................................ [ 27%]
.......................................................s.......s................................. [ 29%]
................................................................................................. [ 31%]
................................................................................................. [ 33%]
...................................................s............................................. [ 36%]
................................................................................................. [ 38%]
................................................................................................. [ 40%]
..........................................................................ssssssss......ssssss..s [ 42%]
s.s.............ssssssss......................................................................... [ 45%]
................................................................................................. [ 47%]
.................ss...........................s...............s.......sssss...................... [ 49%]
...........................s......................................................ss........ss... [ 51%]
ss............................................s.................................................. [ 54%]
...s............s................................................................................ [ 56%]
................................................................................................. [ 58%]
................................................................................................. [ 60%]
...............................................sssss......ssssssssssssssssss..........sssss...... [ 63%]
..............................................................................s...........ss..... [ 65%]
............................................sssssssss.ssssssssss................................. [ 67%]
......s...................................................s....s................................. [ 69%]
.......................ssssssss..............sss...ss...ss.....sssssssssssss..................... [ 72%]
................................................................................................. [ 74%]
..................................s.............................................................. [ 76%]
................................................s....................ssssssss.........ss......... [ 78%]
................................................................................................. [ 81%]
.........................sssssss.............................................................s... [ 83%]
................................................................................................. [ 85%]
................................................................................................. [ 87%]
................................................................................................. [ 90%]
................................................................................................. [ 92%]
...............................................................s................................. [ 94%]
................................................................................................. [ 96%]
................................................................................................. [ 99%]
.................................                                                                 [100%]
4137 passed, 164 skipped in 115.24s (0:01:55)
```

### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
➜  guardrails-llmrails-methods git:(fix/guardrails-llmrails-methods) NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-05-13 15:29:01 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-05-13 15:29:01 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-05-13 15:29:01 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-05-13 15:29:01 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-13 15:29:01 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-05-13 15:29:04 INFO: [5ff8955f3a2dd554] generate_async called
2026-05-13 15:29:04 INFO: [5ff8955f3a2dd554] Running input rails
2026-05-13 15:29:04 INFO: [5ff8955f3a2dd554] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 15:29:05 INFO: [5ff8955f3a2dd554] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-05-13 15:29:05 INFO: [5ff8955f3a2dd554] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-13 15:29:06 INFO: [5ff8955f3a2dd554] Calling main LLM
2026-05-13 15:29:06 INFO: [5ff8955f3a2dd554] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-05-13 15:29:07 INFO: [5ff8955f3a2dd554] Running output rails
2026-05-13 15:29:07 INFO: [5ff8955f3a2dd554] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 15:29:07 INFO: [5ff8955f3a2dd554] generate_async completed time=3271.7ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-05-13 15:29:12 INFO: [0d97f25378f29c6a] generate_async called
2026-05-13 15:29:12 INFO: [0d97f25378f29c6a] Running input rails
2026-05-13 15:29:12 INFO: [0d97f25378f29c6a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 15:29:13 INFO: [0d97f25378f29c6a] Input flow content safety check input $model=content_safety blocked
2026-05-13 15:29:13 INFO: [0d97f25378f29c6a] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-05-13 15:29:13 INFO: [0d97f25378f29c6a] generate_async completed time=451.0ms
I'm sorry, I can't respond to that.
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event generation and processing for LLM-driven workflows.
  * Added message rail checking for validation and safety.
  * Added registration helpers for custom actions, parameters, filters, output parsers, prompt context, and embedding providers.
  * Serialization now preserves the selected engine across save/restore.

* **Tests**
  * Added tests covering engine routing, LLM-only method behavior, and pickle compatibility for configuration and engine selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1886)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->