### PR TITLE
fix(iorails): Add LLMRails `llm` and `runtime` getters

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -26,6 +26,7 @@ from typing import Any, AsyncIterator, Callable, List, Optional, Tuple, Type, Un
 
 from typing_extensions import Self
 
+from nemoguardrails.colang.runtime import Runtime
 from nemoguardrails.colang.v2_x.runtime.flows import State
 from nemoguardrails.embeddings.index import EmbeddingsIndex
 from nemoguardrails.embeddings.providers.base import EmbeddingModel
@@ -85,6 +86,26 @@ class Guardrails:
     def rails_engine(self) -> IORails | LLMRails:
         """Get immutable LLMRails object"""
         return self._rails_engine
+
+    @property
+    def llm(self) -> Optional[LLMModel]:
+        """The main LLM in use. Only supported for LLMRails.
+        Read-only; use ``update_llm()`` to replace it.
+        """
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support llm attribute access")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.llm
+
+    @property
+    def runtime(self) -> Runtime:
+        """The Colang runtime backing the rails engine. Only supported for LLMRails."""
+        if isinstance(self.rails_engine, IORails):
+            raise NotImplementedError("IORails doesn't support runtime attribute access")
+
+        llmrails = cast(LLMRails, self.rails_engine)
+        return llmrails.runtime
 
     @staticmethod
     def _convert_to_messages(prompt: str | None = None, messages: LLMMessages | None = None) -> LLMMessages:

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -746,6 +746,87 @@ class TestUtilityMethods:
         mock_llmrails_instance.explain.assert_called_once()
 
 
+class TestGuardrailsAttributes:
+    """Tests for the llm, runtime, and config attribute accessors on Guardrails.
+
+    Under LLMRails, llm/runtime delegate to the underlying instance.
+    Under IORails, llm/runtime raise NotImplementedError. config is a plain
+    attribute on Guardrails and is available under both engines.
+    """
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_llm_property_delegates_to_llmrails(self, mock_llmrails_class, _nemoguards_rails_config):
+        """guardrails.llm returns the underlying LLMRails.llm."""
+        sentinel_llm = MagicMock()
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.llm = sentinel_llm
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        assert guardrails.llm is sentinel_llm
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_runtime_property_delegates_to_llmrails(self, mock_llmrails_class, _nemoguards_rails_config):
+        """guardrails.runtime returns the underlying LLMRails.runtime."""
+        sentinel_runtime = MagicMock()
+        mock_llmrails_instance = MagicMock()
+        mock_llmrails_instance.runtime = sentinel_runtime
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        assert guardrails.runtime is sentinel_runtime
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_llm_property_reflects_update_llm(self, mock_llmrails_class, _nemoguards_rails_config):
+        """After update_llm() swaps the LLM on LLMRails, guardrails.llm reads through
+        to the new value (no caching on the facade)."""
+        mock_llmrails_instance = MagicMock()
+        initial_llm = MagicMock(name="initial")
+        mock_llmrails_instance.llm = initial_llm
+        mock_llmrails_class.return_value = mock_llmrails_instance
+
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        assert guardrails.llm is initial_llm
+
+        # Simulate update_llm flipping the underlying attribute
+        new_llm = MagicMock(name="new")
+        mock_llmrails_instance.llm = new_llm
+        guardrails.update_llm(new_llm)
+        assert guardrails.llm is new_llm
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_config_attribute_on_llmrails(self, mock_llmrails_class, _nemoguards_rails_config):
+        """guardrails.config is the same RailsConfig instance passed in."""
+        mock_llmrails_class.return_value = MagicMock()
+        guardrails = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        assert guardrails.config is _nemoguards_rails_config
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_llm_property_raises_on_iorails(self, mock_iorails_init, _content_safety_rails_config):
+        """guardrails.llm raises NotImplementedError when running on IORails."""
+        guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+
+        with pytest.raises(NotImplementedError, match="IORails doesn't support llm attribute access"):
+            _ = guardrails.llm
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_runtime_property_raises_on_iorails(self, mock_iorails_init, _content_safety_rails_config):
+        """guardrails.runtime raises NotImplementedError when running on IORails."""
+        guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+
+        with pytest.raises(NotImplementedError, match="IORails doesn't support runtime attribute access"):
+            _ = guardrails.runtime
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_config_attribute_on_iorails(self, mock_iorails_init, _content_safety_rails_config):
+        """guardrails.config is accessible regardless of which engine is in use."""
+        guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
+        assert isinstance(guardrails.rails_engine, IORails)
+        assert guardrails.config is _content_safety_rails_config
+
+
 class TestGuardrailsLifecycle:
     """Test that startup/shutdown delegate to the rails engine."""
 


### PR DESCRIPTION
## Description

**Stacked PR**: Stacked on top of #1886 . Please review #1886 first before this one.

LLMRails has [three public attributes](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/llmrails.py#L141-L143): 

*`config: RailsConfig`: The RailsConfig configuration used by LLMRails.
* `llm: Optional[LLMModel]`: An optional LLM which can be passed into LLMRails rather than constructed from a config.
* `runtime: Runtime`: The Colang runtime inside LLMRails that is used to schedule workflows for input, output, dialog, etc rails.

This PR adds getters for the `llm` and `runtime` attributes.
There's no setter for the `llm` attribute since there's already an [`update_llm`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/llmrails.py#L340) method which acts as a setter.
And no setter for `runtime` since that's fixed by the RailsConfig itself, and can't be changed once the LLMRails object is constructed.

## Related Issue(s)

Fixes [NGUARD-771](https://jirasw.nvidia.com/browse/NGUARD-771)
Fixes [NGUARD-770](https://jirasw.nvidia.com/browse/NGUARD-770)

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
..............................................ssss....................................................... [  2%]
..................................s...................................................................... [  4%]
......................................................................................................... [  7%]
......................................................................................................... [  9%]
......................................................................................................... [ 12%]
......................................................................................................... [ 14%]
......................................................................................................... [ 17%]
......................................................................................................... [ 19%]
......................................................................................................... [ 21%]
......................................................................................................... [ 24%]
..............s......ss...................sssssss........................................................ [ 26%]
.......................................................................s.......s......................... [ 29%]
......................................................................................................... [ 31%]
......................................................................................................... [ 34%]
...........................................s............................................................. [ 36%]
......................................................................................................... [ 38%]
......................................................................................................... [ 41%]
..........................................ssssssss......ssssss..ss.s.............ssssssss................ [ 43%]
......................................................................................................... [ 46%]
..................................................................ss...........................s......... [ 48%]
......s.......sssss.................................................s.................................... [ 51%]
..................ss........ss...ss............................................s......................... [ 53%]
............................s............s............................................................... [ 56%]
......................................................................................................... [ 58%]
......................................................................................................... [ 60%]
................................................sssss......ssssssssssssssssss..........sssss............. [ 63%]
.......................................................................s...........ss.................... [ 65%]
.............................sssssssss.ssssssssss.......................................s................ [ 68%]
...................................s....s........................................................ssssssss [ 70%]
..............sss...ss...ss.....sssssssssssss............................................................ [ 73%]
............................................................................................s............ [ 75%]
..................................................................................................s...... [ 77%]
..............ssssssss.........ss........................................................................ [ 80%]
...........................................................sssssss....................................... [ 82%]
......................s.................................................................................. [ 85%]
......................................................................................................... [ 87%]
......................................................................................................... [ 90%]
......................................................................................................... [ 92%]
.........................................................s............................................... [ 95%]
......................................................................................................... [ 97%]
......................................................................................................... [ 99%]
...                                                                                                       [100%]
4144 passed, 164 skipped in 113.87s (0:01:53)
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-05-13 16:24:54 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-05-13 16:24:54 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-05-13 16:24:54 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-05-13 16:24:54 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-13 16:24:54 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello
2026-05-13 16:24:56 INFO: [6b6297db6f8e355f] generate_async called
2026-05-13 16:24:56 INFO: [6b6297db6f8e355f] Running input rails
2026-05-13 16:24:56 INFO: [6b6297db6f8e355f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 16:24:57 INFO: [6b6297db6f8e355f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-05-13 16:24:58 INFO: [6b6297db6f8e355f] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-13 16:24:59 INFO: [6b6297db6f8e355f] Calling main LLM
2026-05-13 16:24:59 INFO: [6b6297db6f8e355f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-05-13 16:25:02 INFO: [6b6297db6f8e355f] Running output rails
2026-05-13 16:25:02 INFO: [6b6297db6f8e355f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 16:25:03 INFO: [6b6297db6f8e355f] generate_async completed time=6907.1ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-05-13 16:25:07 INFO: [798e0967f7ee3824] generate_async called
2026-05-13 16:25:07 INFO: [798e0967f7ee3824] Running input rails
2026-05-13 16:25:07 INFO: [798e0967f7ee3824] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-13 16:25:08 INFO: [798e0967f7ee3824] Input flow content safety check input $model=content_safety blocked
2026-05-13 16:25:08 INFO: [798e0967f7ee3824] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-05-13 16:25:08 INFO: [798e0967f7ee3824] generate_async completed time=501.0ms
I'm sorry, I can't respond to that.

```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Guardrails` class now exposes read-only `llm` and `runtime` properties
  * Added event generation and processing methods for enhanced workflow control
  * Added message rail checking capability
  * Added configuration registration helpers for actions, filters, parsers, and embedding providers
  * Improved serialization support for pickling and unpickling instances

* **Tests**
  * Comprehensive test coverage for new properties and methods
  * Added backward-compatible pickle round-trip tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1889)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->