### PR TITLE
docs(iorails): Use Guardrails entry-point not IORails

### DIFF
--- a/docs/observability/metrics/opentelemetry-integration.md
+++ b/docs/observability/metrics/opentelemetry-integration.md
@@ -83,7 +83,7 @@ metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[read
 
 # Configure NeMo Guardrails afterwards.
 from nemoguardrails import RailsConfig
-from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.guardrails.guardrails import Guardrails
 
 config_yaml = """
 models:
@@ -96,7 +96,7 @@ metrics:
 """
 
 config = RailsConfig.from_content(yaml_content=config_yaml)
-rails = IORails(config)
+rails = Guardrails(config, use_iorails=True)
 ```
 
 ### OTLP Exporter (Production)

--- a/docs/observability/metrics/opentelemetry-integration.md
+++ b/docs/observability/metrics/opentelemetry-integration.md
@@ -22,7 +22,7 @@ content:
 # OpenTelemetry Metrics Integration
 
 The NeMo Guardrails library follows OpenTelemetry best practices: the library uses only the API, and the host application configures the SDK.
-The following sections explain how to install and configure the OpenTelemetry SDK for metrics export from IORails.
+The following sections explain how to install and configure the OpenTelemetry SDK for metrics export from the Guardrails IORails engine.
 
 ## Installation
 
@@ -56,8 +56,8 @@ metrics:
   enabled: true
 ```
 
-When `metrics.enabled` is `true` and `opentelemetry-api` is installed, IORails emits metrics through the active `MeterProvider`.
-When `opentelemetry-api` is not installed, IORails emits a `UserWarning` at construction time and runs without metrics.
+When `metrics.enabled` is `true` and `opentelemetry-api` is installed, the IORails engine emits metrics through the active `MeterProvider`.
+When `opentelemetry-api` is not installed, the IORails engine emits a `UserWarning` at construction time and runs without metrics.
 
 ## Configuration Examples
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,7 +148,7 @@ $ pip install "nemoguardrails[tracing]"
 ### Metrics Are Emitted but Never Reach the Backend
 
 Verify that the exporter target is reachable.
-Test with `ConsoleMetricExporter` first to confirm IORails-side emission, then swap in the production exporter.
+Test with `ConsoleMetricExporter` first to confirm IORails engine emission, then swap in the production exporter.
 
 ### `LLMRails` Produces No Metrics
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,7 +120,7 @@ Fix the configuration by choosing one path:
 
 ### No Metrics Appear in Your Backend
 
-Call `set_meter_provider(...)` before constructing `IORails(config)`.
+Call `set_meter_provider(...)` before constructing `Guardrails(config, use_iorails=True)` (or `LLMRails(config)` when running with `NEMO_GUARDRAILS_IORAILS_ENGINE=1`).
 Then verify that `metrics.enabled: true` is set in the configuration.
 
 ### Metrics Are Silently Missing
@@ -129,7 +129,7 @@ When `metrics.enabled: true` but no `MeterProvider` is configured, the OpenTelem
 The library does not log a warning.
 
 Verify locally with `ConsoleMetricExporter` first.
-Then ensure `set_meter_provider(...)` runs before constructing `IORails(config)`.
+Then ensure `set_meter_provider(...)` runs before constructing `Guardrails(config, use_iorails=True)` (or `LLMRails(config)` when running with `NEMO_GUARDRAILS_IORAILS_ENGINE=1`).
 
 ### Metrics Dependency Is Missing
 
@@ -152,12 +152,12 @@ Test with `ConsoleMetricExporter` first to confirm IORails-side emission, then s
 
 ### `LLMRails` Produces No Metrics
 
-Metrics are emitted only by `IORails`.
-Switch to `IORails` and use `generate_async` or `stream_async`.
+Metrics are emitted only by the IORails engine.
+Enable it either by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` (which redirects `LLMRails(config)` to the IORails engine) or by constructing `Guardrails(config, use_iorails=True)` directly, and use `generate_async` or `stream_async`.
 
-### Synchronous `IORails.generate()` Produces No Metrics
+### Synchronous `generate()` Produces No Metrics
 
-Telemetry is disabled for the ephemeral `IORails` constructed by the synchronous `generate()` shim.
+Telemetry is disabled for the ephemeral engine constructed by the synchronous `generate()` shim.
 Use `generate_async` or `stream_async` for production paths.
 
 ### `gen_ai.client.token.usage` Is Missing for Streaming Requests


### PR DESCRIPTION
## Description

The docs contained several references to creating IORails(config) directly. IORails shouldn't be created directly in this way, there are two possible options:

1. Backwards-compatible: Existing apps importing LLMRails, which is [redirected to Guardrails](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/__init__.py#L37-L49) when the `NEMO_GUARDRAILS_IORAILS_ENGINE=1`.
2. New apps: Use the [Guardrails](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/guardrails/guardrails.py) wrapper with [`use_iorails`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/guardrails/guardrails.py#L54) set. This will use IORails if possible, falling back to LLMRails if needed.

## Related Issue(s)

VDR Issue 8

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
