### PR TITLE
feat(framework): support Azure as a first-class default framework preset

### DIFF
--- a/docs/about/supported-llms.md
+++ b/docs/about/supported-llms.md
@@ -36,7 +36,7 @@ Each engine is served by a framework that manages the underlying HTTP or SDK cal
 | Engine | Framework | Streaming | Tool calls | Reasoning models | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `anthropic` | LangChain (opt-in) | yes | yes | wrapper-dependent | Requires `pip install langchain langchain-anthropic`. |
-| `azure`, `azure_openai` | LangChain (opt-in) | yes | yes | yes | Azure OpenAI is OpenAI-compatible at the wire level. The LangChain path (`langchain-openai`) is the convenient default because it handles the deployment-name URL pattern and `api-version` query string for you. Azure is also reachable through the built-in client by setting `parameters.base_url` to the deployment URL and passing `api-version` via `default_query` and `api-key` via `default_headers`. |
+| `azure`, `azure_openai` | Built-in | yes | yes | yes | Native support for key-based Azure OpenAI authentication. Set `parameters.azure_endpoint` or `parameters.base_url` to the resource endpoint, plus `azure_deployment` and `api_version`; for Azure AD or token-based authentication, use manual `engine: openai` configuration or opt into LangChain. |
 | `cohere` | LangChain (opt-in) | yes | yes | n/a | Requires `pip install langchain langchain-cohere`. |
 | `google_genai` | LangChain (opt-in) | yes | yes | n/a | Requires `pip install langchain langchain-google-genai`. |
 | `huggingface_endpoint` | LangChain (opt-in) | varies | varies | varies | Default text-generation schema. If your endpoint exposes `/v1/chat/completions`, prefer `engine: openai` with `parameters.base_url` instead. |

--- a/docs/configure-rails/configuration-reference.md
+++ b/docs/configure-rails/configuration-reference.md
@@ -110,6 +110,7 @@ These engines work with `pip install nemoguardrails` and do not require extra pr
 
 | Engine | Description |
 | --- | --- |
+| `azure`, `azure_openai` | Azure OpenAI models with key-based authentication (`azure_endpoint` or `base_url`, `azure_deployment`, and `api_version`) |
 | `nim` | NVIDIA NIM microservices |
 | `nvidia_ai_endpoints` | Alias for `nim` |
 | `ollama` | Ollama OpenAI-compatible endpoint at `http://localhost:11434/v1` |
@@ -124,7 +125,6 @@ To use one of these engines, set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and in
 | Engine | Description |
 | --- | --- |
 | `anthropic` | Anthropic Claude models |
-| `azure` | Azure OpenAI models (deployment-name URL plus `api-version`) |
 | `cohere` | Cohere models |
 | `google_genai` | Google Generative AI through LangChain (requires `langchain-google-genai`) |
 | `huggingface_endpoint` | Hugging Face Inference Endpoints (default text-generation schema; if your endpoint exposes `/v1/chat/completions`, prefer `engine: openai` with `parameters.base_url` instead) |

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -105,12 +105,15 @@ models:
     engine: azure
     model: gpt-4
     parameters:
+      base_url: https://my-resource.openai.azure.com/
       azure_deployment: my-gpt4-deployment
-      azure_endpoint: https://my-resource.openai.azure.com
+      api_version: "2024-02-15-preview"
 ```
 
+Set `AZURE_OPENAI_API_KEY` in the environment, or set `api_key_env_var` on the model entry, or pass `parameters.api_key` directly. The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
+
 ```{note}
-Azure OpenAI is OpenAI-compatible at the wire level, but the LangChain path is the convenient default because `langchain-openai` handles the deployment-name URL pattern and `api-version` query string for you. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-openai`. Azure is also reachable through the built-in client with manual plumbing; see [Migrating to 0.22](../../migration/0.22.md#azure-openai).
+Azure OpenAI is supported natively on the default framework in v0.22 with key-based authentication. For Azure AD / token-based authentication, configure `engine: openai` manually or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. See [Migrating to 0.22](../../migration/0.22.md#azure-openai) for both alternatives.
 ```
 
 ### Anthropic

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -105,10 +105,12 @@ models:
     engine: azure
     model: gpt-4
     parameters:
-      base_url: https://my-resource.openai.azure.com/
+      azure_endpoint: https://my-resource.openai.azure.com/
       azure_deployment: my-gpt4-deployment
       api_version: "2024-02-15-preview"
 ```
+
+The resource endpoint can be supplied as `azure_endpoint` (preferred, matches the OpenAI Python SDK) or `base_url` (v0.21-compatibility alias). Both accept the resource URL only; the deployment path is composed by the framework. Setting both raises an error.
 
 Set `AZURE_OPENAI_API_KEY` in the environment, or set `api_key_env_var` on the model entry, or pass `parameters.api_key` directly. The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
 

--- a/docs/deployment/using-docker.md
+++ b/docs/deployment/using-docker.md
@@ -29,9 +29,9 @@ Ensure Docker is installed on your machine. If not, follow the [official Docker 
 
 ## LLM Framework Selection
 
-By default, NeMo Guardrails uses the lightweight default framework (httpx-based, no LangChain). It serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, and `ollama`, plus any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url` (for example self-hosted vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp).
+By default, NeMo Guardrails uses the lightweight default framework (httpx-based, no LangChain). It serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, `azure`, and `azure_openai`, plus any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url` (for example self-hosted vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp).
 
-To use LangChain-only engines whose API is not OpenAI-compatible (`vertexai`, `anthropic`, `cohere`, `azure`, `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, `self_hosted`, and the legacy `vllm_openai` LangChain wrapper), set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` in the container environment and add `langchain` plus the relevant provider packages to your image. For example:
+To use LangChain-only engines whose API is not OpenAI-compatible (`vertexai`, `anthropic`, `cohere`, `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, `self_hosted`, and the legacy `vllm_openai` LangChain wrapper), set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` in the container environment and add `langchain` plus the relevant provider packages to your image. For example:
 
 ```bash
 docker run \
@@ -41,7 +41,7 @@ docker run \
   nemoguardrails
 ```
 
-Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI, `COHERE_API_KEY` for Cohere, `AZURE_OPENAI_API_KEY` for Azure OpenAI).
+Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI or `COHERE_API_KEY` for Cohere).
 
 ## Build the Docker Images
 

--- a/docs/deployment/using-docker.md
+++ b/docs/deployment/using-docker.md
@@ -41,7 +41,7 @@ docker run \
   nemoguardrails
 ```
 
-Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI or `COHERE_API_KEY` for Cohere).
+Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI or `COHERE_API_KEY` for Cohere). For file-based credentials such as Vertex AI service-account JSON, mount the credential file into the container and set the environment variable to the in-container path; for example, bind-mount host `service-account.json` to `/secrets/service-account.json` and set `GOOGLE_APPLICATION_CREDENTIALS=/secrets/service-account.json`. Secure the host credential file and configure equivalent bind-mount and environment settings in `docker run` or Docker Compose.
 
 ## Build the Docker Images
 

--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -32,7 +32,7 @@ The following table summarizes the migration instructions by engine type.
 | `engine: vllm_openai` or another LangChain wrapper for an OpenAI-compatible provider such as DeepSeek, OpenRouter, Together.ai, Fireworks.ai, Groq, or `llama.cpp` | Rewrite the model entry. See [OpenAI-compatible providers](#openai-compatible-providers). |
 | `engine: openai` with LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, or `model_kwargs` | Rewrite the parameters. See [Mixed-shape configs](#mixed-shape-configs). |
 | `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain, or switch to an OpenAI-compatible endpoint if one exists. Refer to [Unsupported Engine on the Default Framework](#unsupported-engine-on-the-default-framework). |
-| `engine: azure` or `azure_openai` | Use LangChain for the Azure-specific helpers, or configure the default framework manually. See [Azure OpenAI](#azure-openai). |
+| `engine: azure` or `azure_openai` | No action required. Set `AZURE_OPENAI_API_KEY` and keep the v0.21 config shape. See [Azure OpenAI](#azure-openai). |
 | Custom provider registered in `config.py` | Match the provider class to the active framework. See [Custom providers](#custom-providers). |
 
 For the engine-by-engine matrix, see [Supported LLMs](../about/supported-llms.md).
@@ -192,13 +192,16 @@ NEMOGUARDRAILS_LLM_FRAMEWORK=langchain nemoguardrails find-providers
 
 ## Azure OpenAI
 
-Azure OpenAI is OpenAI-compatible at the wire level, but it uses a deployment-name URL pattern and an `api-version` query string.
-You can use either LangChain or the default framework.
+`engine: azure` and `engine: azure_openai` are supported natively on the default framework in v0.22.
+A v0.21 Azure config with `base_url`, `azure_deployment`, and `api_version` loads unchanged.
+The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
 
-A typical v0.21 Azure config looks like this:
+```bash
+export AZURE_OPENAI_API_KEY=<your-key>
+```
 
 ```{code-block} yaml
-:caption: Azure configuration before v0.22
+:caption: Azure configuration in v0.22 (works as-is from v0.21)
 
 - type: main
   engine: azure_openai
@@ -206,55 +209,15 @@ A typical v0.21 Azure config looks like this:
   parameters:
     base_url: "https://my-resource.openai.azure.com/"
     azure_deployment: gpt-4.1-mini
-    api_version: 2024-12-01-preview
-```
-
-### LangChain Path
-
-Use `langchain-openai` when you want Azure-specific helpers to build the deployment URL and `api-version` query string.
-
-```bash
-pip install langchain langchain-openai
-export NEMOGUARDRAILS_LLM_FRAMEWORK=langchain
-export AZURE_OPENAI_API_KEY=<your-key>
-```
-
-```{code-block} yaml
-:caption: Azure configuration with LangChain in v0.22
-
-- type: main
-  engine: azure_openai
-  model: gpt-4.1-mini
-  parameters:
-    azure_endpoint: "https://my-resource.openai.azure.com/"
-    azure_deployment: gpt-4.1-mini
     api_version: "2024-12-01-preview"
 ```
 
-For this path, rename `base_url` to `azure_endpoint`.
-The other Azure fields remain compatible with `langchain-openai`.
+Set `AZURE_OPENAI_API_KEY` in the environment (or set `api_key_env_var` or `parameters.api_key` on the model entry). The framework does not read `OPENAI_API_KEY` on the Azure path.
 
-### Default Framework Path
+### Azure AD / token-based authentication
 
-Use `engine: openai` when you want to avoid LangChain.
-In this path, include the deployment name in `base_url`, pass `api-version` through `default_query`, and pass the Azure key through `default_headers`.
-
-```{code-block} yaml
-:caption: Azure configuration with the default framework in v0.22
-
-- type: main
-  engine: openai
-  model: gpt-4.1-mini
-  parameters:
-    base_url: "https://my-resource.openai.azure.com/openai/deployments/gpt-4.1-mini"
-    default_query:
-      api-version: "2024-12-01-preview"
-    default_headers:
-      api-key: "<your-azure-key>"
-```
-
-Make sure `OPENAI_API_KEY` is unset when using this Azure configuration.
-Otherwise, the default framework also adds an `Authorization: Bearer` header from `OPENAI_API_KEY` alongside the Azure `api-key` header.
+The native Azure path uses key-based authentication only.
+For Azure AD or other token-based authentication, either configure `engine: openai` manually, or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and `langchain-openai`.
 
 ## Custom Providers
 

--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -193,7 +193,7 @@ NEMOGUARDRAILS_LLM_FRAMEWORK=langchain nemoguardrails find-providers
 ## Azure OpenAI
 
 `engine: azure` and `engine: azure_openai` are supported natively on the default framework in v0.22.
-A v0.21 Azure config with `base_url`, `azure_deployment`, and `api_version` loads unchanged.
+A v0.21 Azure config with `base_url` (or the preferred `azure_endpoint`), `azure_deployment`, and `api_version` loads unchanged.
 The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
 
 ```bash
@@ -201,16 +201,20 @@ export AZURE_OPENAI_API_KEY=<your-key>
 ```
 
 ```{code-block} yaml
-:caption: Azure configuration in v0.22 (works as-is from v0.21)
+:caption: Azure configuration in v0.22
 
 - type: main
   engine: azure_openai
   model: gpt-4.1-mini
   parameters:
-    base_url: "https://my-resource.openai.azure.com/"
+    azure_endpoint: "https://my-resource.openai.azure.com/"
     azure_deployment: gpt-4.1-mini
     api_version: "2024-12-01-preview"
 ```
+
+The resource endpoint accepts either `azure_endpoint` (preferred, matches the OpenAI Python SDK) or `base_url` (v0.21-compatibility alias for the same value).
+Both expect the resource URL only (for example `https://my-resource.openai.azure.com/`); the deployment path is composed by the framework.
+Setting both raises an error.
 
 Set `AZURE_OPENAI_API_KEY` in the environment (or set `api_key_env_var` or `parameters.api_key` on the model entry). The framework does not read `OPENAI_API_KEY` on the Azure path.
 

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -49,6 +49,7 @@ _LANGCHAIN_BASE_FLAGS = frozenset(
 )
 
 _PROVIDER_PREFIXED_ALIAS = re.compile(r"^(?P<prefix>[a-zA-Z]\w*?)_(?P<canonical>api_key|base_url|api_base|endpoint)$")
+_AZURE_PROVIDERS = frozenset({"azure", "azure_openai"})
 
 
 def _canonical_name_for(matched_canonical: str) -> str:
@@ -64,7 +65,7 @@ def _detect_provider_alias(name: str) -> Optional[str]:
     return _canonical_name_for(match.group("canonical"))
 
 
-def _violations_for(model_type: str, parameters: dict) -> List[Tuple[str, str]]:
+def _violations_for(model_type: str, engine: str, parameters: dict) -> List[Tuple[str, str]]:
     """Return a list of (model_type, action) tuples for one model."""
     out: List[Tuple[str, str]] = []
     for flag in sorted(_LANGCHAIN_BASE_FLAGS & set(parameters)):
@@ -77,6 +78,8 @@ def _violations_for(model_type: str, parameters: dict) -> List[Tuple[str, str]]:
             continue
         canonical = _detect_provider_alias(name)
         if canonical is None:
+            continue
+        if engine in _AZURE_PROVIDERS and name == "azure_endpoint":
             continue
         out.append((model_type, f"rename `{name}` to `{canonical}`"))
     return out
@@ -94,7 +97,7 @@ def check_langchain_kwargs(models: "Iterable[Model]", active_framework: str) -> 
     for model in models:
         if not model.parameters:
             continue
-        violations.extend(_violations_for(model.type, model.parameters))
+        violations.extend(_violations_for(model.type, model.engine, model.parameters))
     if not violations:
         return
     body = "\n".join(f"  models[{model_type}]: {action}" for model_type, action in violations)

--- a/nemoguardrails/_compat/langchain_kwargs.py
+++ b/nemoguardrails/_compat/langchain_kwargs.py
@@ -31,6 +31,8 @@ the user's signal to clean up.
 import re
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
+from nemoguardrails.llm.constants import AZURE_PROVIDERS
+
 if TYPE_CHECKING:
     from nemoguardrails.rails.llm.config import Model
 
@@ -49,7 +51,6 @@ _LANGCHAIN_BASE_FLAGS = frozenset(
 )
 
 _PROVIDER_PREFIXED_ALIAS = re.compile(r"^(?P<prefix>[a-zA-Z]\w*?)_(?P<canonical>api_key|base_url|api_base|endpoint)$")
-_AZURE_PROVIDERS = frozenset({"azure", "azure_openai"})
 
 
 def _canonical_name_for(matched_canonical: str) -> str:
@@ -79,7 +80,7 @@ def _violations_for(model_type: str, engine: str, parameters: dict) -> List[Tupl
         canonical = _detect_provider_alias(name)
         if canonical is None:
             continue
-        if engine in _AZURE_PROVIDERS and name == "azure_endpoint":
+        if engine in AZURE_PROVIDERS and name == "azure_endpoint":
             continue
         out.append((model_type, f"rename `{name}` to `{canonical}`"))
     return out

--- a/nemoguardrails/llm/constants.py
+++ b/nemoguardrails/llm/constants.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+AZURE_PROVIDERS = frozenset({"azure", "azure_openai"})

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -141,22 +141,37 @@ class DefaultFramework:
     def _prepare_azure_kwargs(self, provider_name: str, kwargs: Dict[str, Any]) -> None:
         """Reshape kwargs in place for the Azure preset.
 
-        Validates Azure-specific inputs (``base_url``, ``azure_deployment``,
-        ``api_version``, ``api_key``). Composes the deployment URL, sets
-        ``api-version`` in ``default_query``, and writes the ``api-key``
-        header so the standard create_model path can build the client
-        without an Azure-specific branch.
+        Validates Azure-specific inputs (``azure_endpoint`` or ``base_url``,
+        ``azure_deployment``, ``api_version``, ``api_key``). Composes the
+        deployment URL, sets ``api-version`` in ``default_query``, and writes
+        the ``api-key`` header so the standard create_model path can build
+        the client without an Azure-specific branch.
 
         Sets ``kwargs["api_key"] = None`` so the standard path does not emit
         the ``Authorization: Bearer`` header. Azure authenticates via the
         ``api-key`` header carried in ``default_headers``.
+
+        The resource endpoint can be supplied as ``azure_endpoint`` (preferred,
+        matches the OpenAI Python SDK) or ``base_url`` (compatibility alias for
+        v0.21 LangChain configs). Both accept the same value (a resource-only
+        URL such as ``https://my-resource.openai.azure.com/``); the deployment
+        path is composed by this preset. Setting both raises an error.
         """
+        azure_endpoint = kwargs.pop("azure_endpoint", None)
         base_url = kwargs.pop("base_url", None)
-        if not base_url:
+        if azure_endpoint and base_url:
             raise ValueError(
-                f"Provider '{provider_name}' requires parameters.base_url "
+                f"Provider '{provider_name}' accepts either parameters.azure_endpoint "
+                "or parameters.base_url, not both. Use azure_endpoint (preferred); "
+                "base_url is a v0.21-compatibility alias for the same value."
+            )
+        resource_endpoint = azure_endpoint or base_url
+        if not resource_endpoint:
+            raise ValueError(
+                f"Provider '{provider_name}' requires parameters.azure_endpoint "
                 "(your Azure OpenAI resource endpoint, "
-                "e.g. 'https://my-resource.openai.azure.com/')."
+                "e.g. 'https://my-resource.openai.azure.com/'). "
+                "parameters.base_url is also accepted as a v0.21-compatibility alias."
             )
 
         azure_deployment = kwargs.pop("azure_deployment", None)
@@ -189,7 +204,7 @@ class DefaultFramework:
         default_headers.setdefault("api-key", api_key)
 
         kwargs["api_key"] = None
-        kwargs["base_url"] = f"{base_url.rstrip('/')}/openai/deployments/{azure_deployment}"
+        kwargs["base_url"] = f"{resource_endpoint.rstrip('/')}/openai/deployments/{azure_deployment}"
         kwargs["default_query"] = default_query
         kwargs["default_headers"] = default_headers
 

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -197,7 +197,8 @@ class DefaultFramework:
 
         default_headers = dict(kwargs.pop("default_headers", None) or {})
         api_key = kwargs.pop("api_key", _UNSET)
-        if "api-key" not in default_headers:
+        header_names = {name.lower() for name in default_headers}
+        if "api-key" not in header_names:
             if api_key is _UNSET:
                 api_key = _resolve_api_key(provider_name)
             if not api_key:

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -19,6 +19,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from nemoguardrails.llm.clients.openai_compatible import OpenAICompatibleClient
+from nemoguardrails.llm.constants import AZURE_PROVIDERS
 from nemoguardrails.llm.models.openai_chat import OpenAIChatModel
 from nemoguardrails.types import LLMModel
 
@@ -38,8 +39,6 @@ _API_KEY_ENV_VARS: Dict[str, str] = {
     "azure": "AZURE_OPENAI_API_KEY",
     "azure_openai": "AZURE_OPENAI_API_KEY",
 }
-
-_AZURE_PROVIDERS = frozenset({"azure", "azure_openai"})
 
 _UNSET: Any = object()
 
@@ -114,7 +113,7 @@ class DefaultFramework:
         if provider_name in self._providers:
             return self._providers[provider_name](model=model_name, **kwargs)
 
-        if provider_name in _AZURE_PROVIDERS:
+        if provider_name in AZURE_PROVIDERS:
             self._prepare_azure_kwargs(provider_name, kwargs)
 
         base_url = kwargs.pop("base_url", None) or _resolve_base_url(provider_name)
@@ -188,20 +187,26 @@ class DefaultFramework:
                 "(the Azure OpenAI API version, e.g. '2024-02-15-preview')."
             )
 
-        api_key = kwargs.pop("api_key", _UNSET)
-        if api_key is _UNSET:
-            api_key = _resolve_api_key(provider_name)
-        if not api_key:
-            raise ValueError(
-                f"Provider '{provider_name}' requires an API key. "
-                "Set AZURE_OPENAI_API_KEY in the environment, or set "
-                "api_key_env_var (or parameters.api_key) on the model entry."
-            )
-
         default_query = dict(kwargs.pop("default_query", None) or {})
-        default_query.setdefault("api-version", api_version)
+        if "api-version" in default_query and default_query["api-version"] != api_version:
+            raise ValueError(
+                f"Provider '{provider_name}' received conflicting Azure API versions. "
+                "parameters.api_version must match default_query['api-version']."
+            )
+        default_query["api-version"] = api_version
+
         default_headers = dict(kwargs.pop("default_headers", None) or {})
-        default_headers.setdefault("api-key", api_key)
+        api_key = kwargs.pop("api_key", _UNSET)
+        if "api-key" not in default_headers:
+            if api_key is _UNSET:
+                api_key = _resolve_api_key(provider_name)
+            if not api_key:
+                raise ValueError(
+                    f"Provider '{provider_name}' requires an API key. "
+                    "Set AZURE_OPENAI_API_KEY in the environment, or set "
+                    "api_key_env_var (or parameters.api_key) on the model entry."
+                )
+            default_headers["api-key"] = api_key
 
         kwargs["api_key"] = None
         kwargs["base_url"] = f"{resource_endpoint.rstrip('/')}/openai/deployments/{azure_deployment}"
@@ -212,7 +217,7 @@ class DefaultFramework:
         self._providers[name] = provider_cls
 
     def get_provider_names(self) -> List[str]:
-        return sorted({*_DEFAULT_BASE_URLS, *_AZURE_PROVIDERS, *self._providers})
+        return sorted({*_DEFAULT_BASE_URLS, *AZURE_PROVIDERS, *self._providers})
 
     async def aclose(self) -> None:
         """Close all pooled HTTP clients and drop them from the pool.

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -197,8 +197,13 @@ class DefaultFramework:
 
         default_headers = dict(kwargs.pop("default_headers", None) or {})
         api_key = kwargs.pop("api_key", _UNSET)
-        header_names = {name.lower() for name in default_headers}
-        if "api-key" not in header_names:
+        api_key_header_name = next((name for name in default_headers if name.lower() == "api-key"), None)
+        if api_key is not _UNSET and api_key_header_name is not None:
+            raise ValueError(
+                f"Provider '{provider_name}' received conflicting Azure API keys. "
+                "Set either parameters.api_key or default_headers['api-key'], not both."
+            )
+        if api_key_header_name is None:
             if api_key is _UNSET:
                 api_key = _resolve_api_key(provider_name)
             if not api_key:

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -35,7 +35,13 @@ _API_KEY_ENV_VARS: Dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "nim": "NVIDIA_API_KEY",
     "nvidia_ai_endpoints": "NVIDIA_API_KEY",
+    "azure": "AZURE_OPENAI_API_KEY",
+    "azure_openai": "AZURE_OPENAI_API_KEY",
 }
+
+_AZURE_PROVIDERS = frozenset({"azure", "azure_openai"})
+
+_UNSET: Any = object()
 
 
 def _resolve_base_url(provider_name: str) -> str:
@@ -108,8 +114,18 @@ class DefaultFramework:
         if provider_name in self._providers:
             return self._providers[provider_name](model=model_name, **kwargs)
 
+        if provider_name in _AZURE_PROVIDERS:
+            self._prepare_azure_kwargs(provider_name, kwargs)
+
         base_url = kwargs.pop("base_url", None) or _resolve_base_url(provider_name)
-        api_key = kwargs.pop("api_key", None) or _resolve_api_key(provider_name)
+
+        # Sentinel-based pop so the Azure preset can set kwargs["api_key"] = None
+        # to suppress Authorization: Bearer without falling back to the env-var
+        # resolver. A missing key still resolves through _resolve_api_key.
+        api_key = kwargs.pop("api_key", _UNSET)
+        if api_key is _UNSET:
+            api_key = _resolve_api_key(provider_name)
+
         timeout = kwargs.pop("timeout", None)
         connect_timeout = kwargs.pop("connect_timeout", None)
         max_retries = kwargs.pop("max_retries", None)
@@ -122,11 +138,66 @@ class DefaultFramework:
 
         return OpenAIChatModel(client=client, model=model_name, provider_name=provider_name, **kwargs)
 
+    def _prepare_azure_kwargs(self, provider_name: str, kwargs: Dict[str, Any]) -> None:
+        """Reshape kwargs in place for the Azure preset.
+
+        Validates Azure-specific inputs (``base_url``, ``azure_deployment``,
+        ``api_version``, ``api_key``). Composes the deployment URL, sets
+        ``api-version`` in ``default_query``, and writes the ``api-key``
+        header so the standard create_model path can build the client
+        without an Azure-specific branch.
+
+        Sets ``kwargs["api_key"] = None`` so the standard path does not emit
+        the ``Authorization: Bearer`` header. Azure authenticates via the
+        ``api-key`` header carried in ``default_headers``.
+        """
+        base_url = kwargs.pop("base_url", None)
+        if not base_url:
+            raise ValueError(
+                f"Provider '{provider_name}' requires parameters.base_url "
+                "(your Azure OpenAI resource endpoint, "
+                "e.g. 'https://my-resource.openai.azure.com/')."
+            )
+
+        azure_deployment = kwargs.pop("azure_deployment", None)
+        if not azure_deployment:
+            raise ValueError(
+                f"Provider '{provider_name}' requires parameters.azure_deployment "
+                "(the deployment name configured in your Azure OpenAI resource)."
+            )
+
+        api_version = kwargs.pop("api_version", None)
+        if not api_version:
+            raise ValueError(
+                f"Provider '{provider_name}' requires parameters.api_version "
+                "(the Azure OpenAI API version, e.g. '2024-02-15-preview')."
+            )
+
+        api_key = kwargs.pop("api_key", _UNSET)
+        if api_key is _UNSET:
+            api_key = _resolve_api_key(provider_name)
+        if not api_key:
+            raise ValueError(
+                f"Provider '{provider_name}' requires an API key. "
+                "Set AZURE_OPENAI_API_KEY in the environment, or set "
+                "api_key_env_var (or parameters.api_key) on the model entry."
+            )
+
+        default_query = dict(kwargs.pop("default_query", None) or {})
+        default_query.setdefault("api-version", api_version)
+        default_headers = dict(kwargs.pop("default_headers", None) or {})
+        default_headers.setdefault("api-key", api_key)
+
+        kwargs["api_key"] = None
+        kwargs["base_url"] = f"{base_url.rstrip('/')}/openai/deployments/{azure_deployment}"
+        kwargs["default_query"] = default_query
+        kwargs["default_headers"] = default_headers
+
     def register_provider(self, name: str, provider_cls: Any) -> None:
         self._providers[name] = provider_cls
 
     def get_provider_names(self) -> List[str]:
-        return sorted({*_DEFAULT_BASE_URLS, *self._providers})
+        return sorted({*_DEFAULT_BASE_URLS, *_AZURE_PROVIDERS, *self._providers})
 
     async def aclose(self) -> None:
         """Close all pooled HTTP clients and drop them from the pool.

--- a/tests/_compat/test_langchain_kwargs.py
+++ b/tests/_compat/test_langchain_kwargs.py
@@ -79,10 +79,17 @@ class TestProviderAliasPatternDetection:
                 active_framework="default",
             )
 
-    def test_azure_endpoint_detected_and_collapsed_to_base_url(self):
+    @pytest.mark.parametrize("engine", ["azure", "azure_openai"])
+    def test_azure_endpoint_allowed_for_azure_engines(self, engine):
+        check_langchain_kwargs(
+            [_model(engine=engine, parameters={"azure_endpoint": "https://..."})],
+            active_framework="default",
+        )
+
+    def test_azure_endpoint_detected_and_collapsed_to_base_url_for_non_azure_engine(self):
         with pytest.raises(ValueError, match=r"azure_endpoint.*to.*base_url"):
             check_langchain_kwargs(
-                [_model(engine="azure", parameters={"azure_endpoint": "https://..."})],
+                [_model(engine="openai", parameters={"azure_endpoint": "https://..."})],
                 active_framework="default",
             )
 

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -337,12 +337,54 @@ class TestDefaultFramework:
             await fw.reset()
 
     @pytest.mark.asyncio
+    async def test_azure_default_query_api_version_conflict_raises(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match=r"conflicting Azure API versions"):
+                fw.create_model(
+                    "gpt-4o-mini",
+                    "azure",
+                    {
+                        "base_url": "https://my-resource.openai.azure.com/",
+                        "azure_deployment": "d",
+                        "api_version": "2024-02-15-preview",
+                        "api_key": "k",
+                        "default_query": {"api-version": "2023-05-15"},
+                    },
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_default_headers_api_key_satisfies_auth(self, monkeypatch):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure",
+                {
+                    "base_url": "https://my-resource.openai.azure.com/",
+                    "azure_deployment": "d",
+                    "api_version": "2024-02-15-preview",
+                    "default_headers": {"api-key": "header-key"},
+                },
+            )
+            assert model._client._custom_headers == {"api-key": "header-key"}
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
     async def test_azure_missing_endpoint_raises(self):
         from nemoguardrails.llm.frameworks.default import DefaultFramework
 
         fw = DefaultFramework()
         try:
-            with pytest.raises(ValueError, match="requires parameters.azure_endpoint"):
+            with pytest.raises(ValueError, match=r"requires parameters\.azure_endpoint"):
                 fw.create_model(
                     "gpt",
                     "azure",
@@ -378,7 +420,7 @@ class TestDefaultFramework:
 
         fw = DefaultFramework()
         try:
-            with pytest.raises(ValueError, match="either parameters.azure_endpoint or parameters.base_url"):
+            with pytest.raises(ValueError, match=r"either parameters\.azure_endpoint or parameters\.base_url"):
                 fw.create_model(
                     "gpt",
                     "azure",
@@ -399,7 +441,7 @@ class TestDefaultFramework:
 
         fw = DefaultFramework()
         try:
-            with pytest.raises(ValueError, match="requires parameters.azure_deployment"):
+            with pytest.raises(ValueError, match=r"requires parameters\.azure_deployment"):
                 fw.create_model(
                     "gpt",
                     "azure",
@@ -414,7 +456,7 @@ class TestDefaultFramework:
 
         fw = DefaultFramework()
         try:
-            with pytest.raises(ValueError, match="requires parameters.api_version"):
+            with pytest.raises(ValueError, match=r"requires parameters\.api_version"):
                 fw.create_model(
                     "gpt",
                     "azure",

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -248,6 +248,165 @@ class TestDefaultFramework:
             await fw.reset()
 
     @pytest.mark.asyncio
+    async def test_creates_azure(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure",
+                {
+                    "base_url": "https://my-resource.openai.azure.com/",
+                    "azure_deployment": "my-deployment",
+                    "api_version": "2024-02-15-preview",
+                    "api_key": "test-azure-key",
+                },
+            )
+
+            assert isinstance(model, OpenAIChatModel)
+            assert model.provider_url == "https://my-resource.openai.azure.com/openai/deployments/my-deployment"
+            assert model._client._api_key is None
+            assert model._client._custom_headers == {"api-key": "test-azure-key"}
+            assert model._client._custom_query == {"api-version": "2024-02-15-preview"}
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_openai_alias(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure_openai",
+                {
+                    "base_url": "https://my-resource.openai.azure.com",
+                    "azure_deployment": "deploy-2",
+                    "api_version": "2024-12-01-preview",
+                    "api_key": "k",
+                },
+            )
+
+            assert model.provider_url == "https://my-resource.openai.azure.com/openai/deployments/deploy-2"
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_resolves_api_key_from_env(self, monkeypatch):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "env-key-value")
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure",
+                {
+                    "base_url": "https://my-resource.openai.azure.com/",
+                    "azure_deployment": "d",
+                    "api_version": "2024-02-15-preview",
+                },
+            )
+            assert model._client._custom_headers["api-key"] == "env-key-value"
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_user_headers_and_query_preserved(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure",
+                {
+                    "base_url": "https://my-resource.openai.azure.com/",
+                    "azure_deployment": "d",
+                    "api_version": "2024-02-15-preview",
+                    "api_key": "k",
+                    "default_headers": {"X-Custom": "value"},
+                    "default_query": {"trace-id": "abc"},
+                },
+            )
+            assert model._client._custom_headers == {"X-Custom": "value", "api-key": "k"}
+            assert model._client._custom_query == {"trace-id": "abc", "api-version": "2024-02-15-preview"}
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_missing_base_url_raises(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="requires parameters.base_url"):
+                fw.create_model(
+                    "gpt",
+                    "azure",
+                    {"azure_deployment": "d", "api_version": "v", "api_key": "k"},
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_missing_deployment_raises(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="requires parameters.azure_deployment"):
+                fw.create_model(
+                    "gpt",
+                    "azure",
+                    {"base_url": "https://x", "api_version": "v", "api_key": "k"},
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_missing_api_version_raises(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="requires parameters.api_version"):
+                fw.create_model(
+                    "gpt",
+                    "azure",
+                    {"base_url": "https://x", "azure_deployment": "d", "api_key": "k"},
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_missing_api_key_raises(self, monkeypatch):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="requires an API key"):
+                fw.create_model(
+                    "gpt",
+                    "azure",
+                    {"base_url": "https://x", "azure_deployment": "d", "api_version": "v"},
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_listed_in_provider_names(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        names = fw.get_provider_names()
+        assert "azure" in names
+        assert "azure_openai" in names
+
+    @pytest.mark.asyncio
     async def test_pools_clients(self):
         from nemoguardrails.llm.frameworks.default import DefaultFramework
 

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -379,6 +379,28 @@ class TestDefaultFramework:
         finally:
             await fw.reset()
 
+    @pytest.mark.parametrize("header_name", ["api-key", "Api-Key", "API-KEY"])
+    @pytest.mark.asyncio
+    async def test_azure_api_key_and_default_headers_api_key_conflict_raises(self, header_name):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="conflicting Azure API keys"):
+                fw.create_model(
+                    "gpt-4o-mini",
+                    "azure",
+                    {
+                        "base_url": "https://my-resource.openai.azure.com/",
+                        "azure_deployment": "d",
+                        "api_version": "2024-02-15-preview",
+                        "api_key": "param-key",
+                        "default_headers": {header_name: "header-key"},
+                    },
+                )
+        finally:
+            await fw.reset()
+
     @pytest.mark.asyncio
     async def test_azure_missing_endpoint_raises(self):
         from nemoguardrails.llm.frameworks.default import DefaultFramework

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -337,16 +337,58 @@ class TestDefaultFramework:
             await fw.reset()
 
     @pytest.mark.asyncio
-    async def test_azure_missing_base_url_raises(self):
+    async def test_azure_missing_endpoint_raises(self):
         from nemoguardrails.llm.frameworks.default import DefaultFramework
 
         fw = DefaultFramework()
         try:
-            with pytest.raises(ValueError, match="requires parameters.base_url"):
+            with pytest.raises(ValueError, match="requires parameters.azure_endpoint"):
                 fw.create_model(
                     "gpt",
                     "azure",
                     {"azure_deployment": "d", "api_version": "v", "api_key": "k"},
+                )
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_endpoint_alias(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            model = fw.create_model(
+                "gpt-4o-mini",
+                "azure",
+                {
+                    "azure_endpoint": "https://my-resource.openai.azure.com/",
+                    "azure_deployment": "my-deployment",
+                    "api_version": "2024-02-15-preview",
+                    "api_key": "k",
+                },
+            )
+            assert model.provider_url == "https://my-resource.openai.azure.com/openai/deployments/my-deployment"
+            assert model._client._custom_headers == {"api-key": "k"}
+        finally:
+            await fw.reset()
+
+    @pytest.mark.asyncio
+    async def test_azure_endpoint_and_base_url_both_set_raises(self):
+        from nemoguardrails.llm.frameworks.default import DefaultFramework
+
+        fw = DefaultFramework()
+        try:
+            with pytest.raises(ValueError, match="either parameters.azure_endpoint or parameters.base_url"):
+                fw.create_model(
+                    "gpt",
+                    "azure",
+                    {
+                        "azure_endpoint": "https://x.openai.azure.com/",
+                        "base_url": "https://x.openai.azure.com/",
+                        "azure_deployment": "d",
+                        "api_version": "v",
+                        "api_key": "k",
+                    },
                 )
         finally:
             await fw.reset()

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -357,8 +357,9 @@ class TestDefaultFramework:
         finally:
             await fw.reset()
 
+    @pytest.mark.parametrize("header_name", ["api-key", "Api-Key", "API-KEY"])
     @pytest.mark.asyncio
-    async def test_azure_default_headers_api_key_satisfies_auth(self, monkeypatch):
+    async def test_azure_default_headers_api_key_satisfies_auth(self, monkeypatch, header_name):
         from nemoguardrails.llm.frameworks.default import DefaultFramework
 
         monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
@@ -371,10 +372,10 @@ class TestDefaultFramework:
                     "base_url": "https://my-resource.openai.azure.com/",
                     "azure_deployment": "d",
                     "api_version": "2024-02-15-preview",
-                    "default_headers": {"api-key": "header-key"},
+                    "default_headers": {header_name: "header-key"},
                 },
             )
-            assert model._client._custom_headers == {"api-key": "header-key"}
+            assert model._client._custom_headers == {header_name: "header-key"}
         finally:
             await fw.reset()
 


### PR DESCRIPTION
## Description

Add `azure` and `azure_openai` to the default framework's known providers. The framework reads `base_url`, `azure_deployment`, `api_version`, and an api key from the model entry; constructs the deployment URL; sets `api-version` as a query parameter; and authenticates with the `api-key` header. The Authorization: Bearer header is suppressed on the Azure path.


A v0.21 Azure config with the standard `azure_endpoint` + `azure_deployment` + `api_version` shape now loads on the default framework without changes and without the LangChain stack. AZURE_OPENAI_API_KEY is the default env var name; api_key_env_var and parameters.api_key continue to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Azure OpenAI is now natively supported in the default framework, eliminating the need for LangChain integration.

* **Documentation**
  * Updated configuration guides covering Azure OpenAI setup with native parameter support (`azure_endpoint`, `azure_deployment`, `api_version`), Docker deployment options, and migration guidance for users upgrading to native Azure support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->