### PR TITLE
fix(iorails): Annotate cancelled OTEL spans with error

### DIFF
--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -406,7 +406,7 @@ def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
         span.set_attribute("request.id", req_id)
         try:
             yield span, req_id
-        except Exception as exc:
+        except BaseException as exc:
             record_span_error(span, exc)
             raise
 
@@ -495,7 +495,7 @@ def llm_call_span(
         span.set_attribute(GenAIAttributes.GEN_AI_PROVIDER_NAME, provider_name)
         try:
             yield span
-        except Exception as exc:
+        except BaseException as exc:
             record_span_error(span, exc)
             raise
 
@@ -712,7 +712,7 @@ def request_metrics() -> Generator[None, None, None]:
     instruments.requests_active.add(1)
     try:
         yield
-    except Exception as exc:
+    except BaseException as exc:
         record_request_error(exc)
         raise
     finally:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -434,7 +434,7 @@ def rail_span(
         span.set_attribute(GuardrailsAttributes.RAIL_NAME, flow)
         try:
             yield span
-        except Exception as exc:
+        except BaseException as exc:
             record_span_error(span, exc)
             raise
 
@@ -457,7 +457,7 @@ def action_span(tracer: Optional["Tracer"], action_name: str) -> Generator[Optio
         span.set_attribute(GuardrailsAttributes.ACTION_NAME, action_name)
         try:
             yield span
-        except Exception as exc:
+        except BaseException as exc:
             record_span_error(span, exc)
             raise
 
@@ -522,7 +522,7 @@ def api_call_span(tracer: Optional["Tracer"], api_name: str) -> Generator[Option
         span.set_attribute(GuardrailsAttributes.API_NAME, api_name)
         try:
             yield span
-        except Exception as exc:
+        except BaseException as exc:
             record_span_error(span, exc)
             raise
 

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -498,7 +498,7 @@ def llm_operation_duration(
     exc_type: Optional[str] = None
     try:
         yield
-    except Exception as exc:
+    except BaseException as exc:
         exc_type = type(exc).__name__
         raise
     finally:

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -15,6 +15,7 @@
 
 """Unit tests for nemoguardrails.guardrails.telemetry module."""
 
+import asyncio
 import re
 from unittest.mock import MagicMock, patch
 
@@ -190,6 +191,39 @@ class TestRequestSpan:
         exception_events = [e for e in events if e.name == "exception"]
         assert len(exception_events) == 1
         assert "boom" in exception_events[0].attributes["exception.message"]
+
+    def test_records_error_type_on_cancelled_error(self, otel_provider):
+        """Consumer-cancelled streams raise ``asyncio.CancelledError``
+        inside the SERVER span.  Span must still be marked ERROR with
+        ``error.type=CancelledError`` so traces can be filtered to
+        cancelled requests.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(asyncio.CancelledError):
+            with request_span(tracer) as _:
+                raise asyncio.CancelledError()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, otel_provider):
+        """``GeneratorExit`` (raised when the async generator wrapping
+        the request is closed) must mark the SERVER span ERROR with
+        ``error.type=GeneratorExit``.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(GeneratorExit):
+            with request_span(tracer) as _:
+                raise GeneratorExit()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "GeneratorExit"
 
     def test_span_ended_on_success(self, otel_provider):
         provider, exporter = otel_provider

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -15,6 +15,7 @@
 
 """Unit tests for the OTEL metrics API in nemoguardrails.guardrails.telemetry."""
 
+import asyncio
 from typing import cast
 from unittest.mock import patch
 
@@ -310,6 +311,43 @@ class TestLLMOperationDuration:
         error_types = {obs.attributes.get("error.type") for obs in observations}
         assert error_types == {None, "ValueError"}
 
+    def test_records_error_type_on_cancelled_error(self, meter_reader):
+        """Consumer-cancelled streams raise ``asyncio.CancelledError`` —
+        a ``BaseException`` subclass — inside the context manager.  The
+        duration record must still carry ``error.type=CancelledError``
+        so dashboards can distinguish cancelled streams from successful
+        ones (NGUARD-776 plan #6).
+        """
+        with pytest.raises(asyncio.CancelledError):
+            with llm_operation_duration("model-x", "openai", "chat"):
+                raise asyncio.CancelledError()
+        points = collect_metric_points(meter_reader)
+        assert len(points["gen_ai.client.operation.duration"]) == 1
+        attrs = points["gen_ai.client.operation.duration"][0].attributes
+        assert attrs["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, meter_reader):
+        """``GeneratorExit`` (raised when an async generator is closed)
+        is a ``BaseException`` subclass and must also tag the duration
+        record with ``error.type=GeneratorExit``.
+        """
+        with pytest.raises(GeneratorExit):
+            with llm_operation_duration("model-x", "openai", "chat"):
+                raise GeneratorExit()
+        points = collect_metric_points(meter_reader)
+        assert len(points["gen_ai.client.operation.duration"]) == 1
+        attrs = points["gen_ai.client.operation.duration"][0].attributes
+        assert attrs["error.type"] == "GeneratorExit"
+
+    def test_cancelled_error_propagates(self, meter_reader):
+        """The context manager must re-raise ``CancelledError`` so the
+        surrounding asyncio task is actually cancelled — swallowing it
+        would break cancel semantics.
+        """
+        with pytest.raises(asyncio.CancelledError):
+            with llm_operation_duration("model-x", "openai", "chat"):
+                raise asyncio.CancelledError()
+
     def test_no_op_when_otel_unavailable(self):
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             telemetry._meter = None
@@ -427,6 +465,42 @@ class TestRequestMetrics:
                 raise ValueError("boom")
         points = collect_metric_points(meter_reader)
         assert points["guardrails.request.duration"][0].value == 1
+
+    def test_errors_counter_increments_on_cancelled_error(self, meter_reader):
+        """When a consumer cancels a streaming request the surrounding
+        ``request_metrics`` scope exits via ``asyncio.CancelledError``
+        (a ``BaseException`` subclass).  The errors counter must still
+        bump with ``error.type=CancelledError`` so cancellation volume
+        is visible on the dashboard.
+        """
+        with pytest.raises(asyncio.CancelledError):
+            with request_metrics():
+                raise asyncio.CancelledError()
+        points = collect_metric_points(meter_reader)
+        assert len(points["guardrails.requests.errors"]) == 1
+        assert points["guardrails.requests.errors"][0].value == 1
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "CancelledError"
+
+    def test_errors_counter_increments_on_generator_exit(self, meter_reader):
+        """A closed async generator surfaces as ``GeneratorExit`` inside
+        the ``request_metrics`` scope.  The errors counter must bump
+        with ``error.type=GeneratorExit``.
+        """
+        with pytest.raises(GeneratorExit):
+            with request_metrics():
+                raise GeneratorExit()
+        points = collect_metric_points(meter_reader)
+        assert len(points["guardrails.requests.errors"]) == 1
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "GeneratorExit"
+
+    def test_cancelled_error_propagates(self, meter_reader):
+        """``request_metrics`` must re-raise ``CancelledError`` — swallowing
+        it would prevent the surrounding asyncio task from being
+        cancelled.
+        """
+        with pytest.raises(asyncio.CancelledError):
+            with request_metrics():
+                raise asyncio.CancelledError()
 
     def test_requests_active_nets_to_zero_after_completed_scope(self, meter_reader):
         """+1 on entry, -1 on exit → net 0 for a completed scope."""

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -79,6 +79,36 @@ class TestRailSpan:
         spans = exporter.get_finished_spans()
         assert spans[0].status.status_code == StatusCode.ERROR
 
+    def test_records_error_type_on_cancelled_error(self, otel_provider):
+        """A consumer cancel that propagates through a rail span must
+        mark it ERROR with ``error.type=CancelledError`` — otherwise
+        the rail leg of a cancelled-request trace is silently untagged.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(asyncio.CancelledError):
+            with rail_span(tracer, "some flow", RailDirection.INPUT):
+                raise asyncio.CancelledError()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, otel_provider):
+        """``GeneratorExit`` propagating through a rail span must mark
+        it ERROR with ``error.type=GeneratorExit``."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(GeneratorExit):
+            with rail_span(tracer, "some flow", RailDirection.INPUT):
+                raise GeneratorExit()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "GeneratorExit"
+
 
 class TestActionSpan:
     def test_creates_internal_span(self, otel_provider):
@@ -120,6 +150,34 @@ class TestActionSpan:
         exc_events = [e for e in span.events if e.name == "exception"]
         assert len(exc_events) == 1
         assert exc_events[0].attributes["exception.type"] == "RuntimeError"
+
+    def test_records_error_type_on_cancelled_error(self, otel_provider):
+        """A consumer cancel propagating through an action span must
+        mark it ERROR with ``error.type=CancelledError``."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(asyncio.CancelledError):
+            with action_span(tracer, "some action"):
+                raise asyncio.CancelledError()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, otel_provider):
+        """``GeneratorExit`` propagating through an action span must
+        mark it ERROR with ``error.type=GeneratorExit``."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(GeneratorExit):
+            with action_span(tracer, "some action"):
+                raise GeneratorExit()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "GeneratorExit"
 
 
 class TestLlmCallSpan:
@@ -241,6 +299,35 @@ class TestApiCallSpan:
         span = exporter.get_finished_spans()[0]
         assert span.status.status_code == StatusCode.ERROR
         assert span.attributes["error.type"] == "ValueError"
+
+    def test_records_error_type_on_cancelled_error(self, otel_provider):
+        """A consumer cancel propagating through an api-call span
+        (e.g. an in-flight jailbreak-detection HTTP request) must mark
+        it ERROR with ``error.type=CancelledError``."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(asyncio.CancelledError):
+            with api_call_span(tracer, "jailbreak_detection"):
+                raise asyncio.CancelledError()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, otel_provider):
+        """``GeneratorExit`` propagating through an api-call span must
+        mark it ERROR with ``error.type=GeneratorExit``."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(GeneratorExit):
+            with api_call_span(tracer, "jailbreak_detection"):
+                raise GeneratorExit()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "GeneratorExit"
 
     def test_noop_when_tracer_none(self):
         with api_call_span(None, "jailbreak_detection") as span:

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -15,6 +15,8 @@
 
 """Unit tests for telemetry span helpers: rail_span, action_span, llm_call_span, api_call_span."""
 
+import asyncio
+
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -164,6 +166,38 @@ class TestLlmCallSpan:
         span = exporter.get_finished_spans()[0]
         assert span.status.status_code == StatusCode.ERROR
         assert span.attributes["error.type"] == "ConnectionError"
+
+    def test_records_error_type_on_cancelled_error(self, otel_provider):
+        """Consumer-cancelled streams raise ``asyncio.CancelledError``
+        inside the LLM CLIENT span.  Span must still be marked ERROR
+        with ``error.type=CancelledError`` so trace queries can
+        correlate cancelled streams to their LLM-call leg.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(asyncio.CancelledError):
+            with llm_call_span(tracer, "model", "nim"):
+                raise asyncio.CancelledError()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "CancelledError"
+
+    def test_records_error_type_on_generator_exit(self, otel_provider):
+        """``GeneratorExit`` raised inside the LLM CLIENT span must
+        also flip the span to ERROR with ``error.type=GeneratorExit``.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(GeneratorExit):
+            with llm_call_span(tracer, "model", "nim"):
+                raise GeneratorExit()
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "GeneratorExit"
 
     def test_noop_when_tracer_none(self):
         with llm_call_span(None, "model", "nim") as span:


### PR DESCRIPTION
## Description

Bug report: `gen_ai.client.operation.duration` was emitted without the error.type attribute when a streaming consumer cancelled mid-stream, making cancelled streams indistinguishable from successful ones.

  Root cause: seven OTEL context managers in nemoguardrails/tracing/constants.py (llm_operation_duration) and nemoguardrails/guardrails/telemetry.py (request_span, rail_span, action_span, llm_call_span, api_call_span, request_metrics) caught only Exception, but asyncio.CancelledError and  GeneratorExit derive from BaseException — so the tagging branch was skipped on cancel while the finally still emitted the metric / closed the span, untagged.

The fix widens except Exception to except BaseException at all seven sites; the raise is unchanged so cancel still propagates correctly. Adds 16 new unit tests covering both CancelledError and GeneratorExit paths for each site (14 assert the new tagging, 2 guard against accidentally swallowing cancel).

## Related Issue(s)

NVBug: 6180323

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
..............................................ssss.........................................................................................s..... [  3%]
................................................................................................................................................. [  6%]
................................................................................................................................................. [  9%]
................................................................................................................................................. [ 13%]
................................................................................................................................................. [ 16%]
................................................................................................................................................. [ 19%]
................................................................................................................................................. [ 23%]
...............................................................s......ss...................sssssss............................................... [ 26%]
................................................................................s.......s........................................................ [ 29%]
................................................................................................................................................. [ 33%]
.............................................................................s................................................................... [ 36%]
................................................................................................................................................. [ 39%]
.....................................................................................................ssssssss......ssssss..ss.s.............sssss [ 43%]
sss.............................................................................................................................................. [ 46%]
.............................................ss...........................s...............s.......sssss.......................................... [ 49%]
.............s......................................................ss........ss...ss............................................s............... [ 52%]
......................................s............s............................................................................................. [ 56%]
................................................................................................................................................. [ 59%]
...................................................................................sssss......ssssssssssssssssss..........sssss.................. [ 62%]
..................................................................s...........ss.................................................sssssssss.ssssss [ 66%]
ssss.......................................s...................................................s....s............................................ [ 69%]
............ssssssss..............sss...ss...ss.....sssssssssssss................................................................................ [ 72%]
........................................................................s........................................................................ [ 76%]
......................................s....................ssssssss.........ss................................................................... [ 79%]
................................................................sssssss................................................................s......... [ 82%]
................................................................................................................................................. [ 86%]
................................................................................................................................................. [ 89%]
................................................................................................................................................. [ 92%]
...........................................................s..................................................................................... [ 96%]
................................................................................................................................................. [ 99%]
..............................                                                                                                                    [100%]
4216 passed, 164 skipped in 114.52s (0:01:54)
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-05-18 10:46:36 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-05-18 10:46:36 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-05-18 10:46:36 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-05-18 10:46:36 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-18 10:46:36 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-05-18 10:46:38 INFO: [6500230d56cedcc5] generate_async called
2026-05-18 10:46:38 INFO: [6500230d56cedcc5] Running input rails
2026-05-18 10:46:38 INFO: [6500230d56cedcc5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-18 10:46:38 INFO: [6500230d56cedcc5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-05-18 10:46:39 INFO: [6500230d56cedcc5] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-05-18 10:46:39 INFO: [6500230d56cedcc5] Calling main LLM
2026-05-18 10:46:39 INFO: [6500230d56cedcc5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-05-18 10:46:40 INFO: [6500230d56cedcc5] Running output rails
2026-05-18 10:46:40 INFO: [6500230d56cedcc5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-18 10:46:41 INFO: [6500230d56cedcc5] generate_async completed time=3409.6ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-05-18 10:46:45 INFO: [686e58b8baf8b516] generate_async called
2026-05-18 10:46:45 INFO: [686e58b8baf8b516] Running input rails
2026-05-18 10:46:45 INFO: [686e58b8baf8b516] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-05-18 10:46:46 INFO: [686e58b8baf8b516] Input flow content safety check input $model=content_safety blocked
2026-05-18 10:46:46 INFO: [686e58b8baf8b516] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-05-18 10:46:46 INFO: [686e58b8baf8b516] generate_async completed time=456.4ms
I'm sorry, I can't respond to that.
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced telemetry error recording to capture cancellation and generator exit events, improving system observability and error tracking across distributed tracing and metrics.

* **Tests**
  * Added comprehensive test coverage for telemetry error handling with cancellation and generator exit scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->