### PR TITLE
feat(config): forbade extra fields in GLiNER rails configs

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -331,6 +331,8 @@ class PrivateAIDetection(BaseModel):
 class GLiNERDetectionOptions(BaseModel):
     """Configuration options for GLiNER."""
 
+    model_config = ConfigDict(extra="forbid")
+    
     entities: List[str] = Field(
         default_factory=list,
         description="The list of entity labels to detect (e.g., 'email', 'phone_number', 'ssn').",
@@ -340,6 +342,8 @@ class GLiNERDetectionOptions(BaseModel):
 class GLiNERDetection(BaseModel):
     """Configuration for GLiNER PII detection."""
 
+    model_config = ConfigDict(extra="forbid")
+    
     server_endpoint: str = Field(
         default="http://localhost:8000/v1/chat/completions",
         description=(

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -332,7 +332,7 @@ class GLiNERDetectionOptions(BaseModel):
     """Configuration options for GLiNER."""
 
     model_config = ConfigDict(extra="forbid")
-    
+
     entities: List[str] = Field(
         default_factory=list,
         description="The list of entity labels to detect (e.g., 'email', 'phone_number', 'ssn').",
@@ -343,7 +343,7 @@ class GLiNERDetection(BaseModel):
     """Configuration for GLiNER PII detection."""
 
     model_config = ConfigDict(extra="forbid")
-    
+
     server_endpoint: str = Field(
         default="http://localhost:8000/v1/chat/completions",
         description=(

--- a/tests/test_gliner.py
+++ b/tests/test_gliner.py
@@ -544,6 +544,40 @@ def _build_gliner_config_for_api_key_tests(api_key_env_var: Optional[str] = None
 
 
 @pytest.mark.unit
+def test_gliner_config_rejects_unsupported_engine():
+    with pytest.raises(ValueError, match="rails.config.gliner.engine"):
+        RailsConfig.from_content(
+            yaml_content="""
+                models: []
+                rails:
+                  config:
+                    gliner:
+                      engine: nvcf
+                      input:
+                        entities:
+                          - email
+            """,
+        )
+
+
+@pytest.mark.unit
+def test_gliner_config_rejects_unknown_nested_option():
+    with pytest.raises(ValueError, match="rails.config.gliner.input.unknown_option"):
+        RailsConfig.from_content(
+            yaml_content="""
+                models: []
+                rails:
+                  config:
+                    gliner:
+                      input:
+                        entities:
+                          - email
+                        unknown_option: true
+            """,
+        )
+
+
+@pytest.mark.unit
 def test_resolve_api_key_env_var_not_configured(monkeypatch, caplog):
     """No api_key_env_var set => returns None, no warning logged."""
     from nemoguardrails.library.gliner.actions import _resolve_api_key


### PR DESCRIPTION
## Description

Modified the GLiNERDetectionOptions and GLiNERDetection classes in the config.py file to include a model_config that forbids extra fields. This ensures that any additional fields not defined in the model will raise an error, helping to maintain strict validation of the configuration.

@Pouyanpi, please review. 

## Related Issue(s)

<!--
  - Fixes [this issue](https://docs.google.com/document/d/1rals2uX9D4VPANxb6p0sgGNttbwthdr2enoY3xyqxRI/edit?disco=AAAB6eqPJm4) in the VDR Interim Report
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable. [NA]
- [x] I've added tests if applicable. [NA]
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation for GLiNER detection settings. Invalid or unrecognized configuration fields are now rejected, preventing silent failures from misconfigured parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->