### PR TITLE
feat(cli): add --workers flag to server command

### DIFF
--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -149,6 +149,15 @@ def server(
         default="",
         help="A prefix that should be added to all server paths. Should start with '/'.",
     ),
+    workers: int = typer.Option(
+        default=1,
+        min=1,
+        help=(
+            "Number of uvicorn worker processes. When greater than 1, the "
+            "server is launched via an import string and CLI configuration "
+            "is propagated to workers through environment variables."
+        ),
+    ),
 ):
     """Start a NeMo Guardrails server."""
 
@@ -156,6 +165,32 @@ def server(
     # module-load time, before the chainlit mount happens.
     if disable_chat_ui:
         os.environ["NEMO_GUARDRAILS_DISABLE_CHAT_UI"] = "true"
+
+    # When running with multiple workers, uvicorn spawns child processes that
+    # re-import the app fresh, so any setattr-based config done in this
+    # process is not visible inside the workers. Propagate config through
+    # environment variables (inherited by the child processes) instead, and
+    # let api.py pick them up at module-init time.
+    if workers > 1:
+        if prefix:
+            typer.secho(
+                "The --prefix option is not supported with --workers > 1.",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(1)
+
+        if config:
+            os.environ["NEMO_GUARDRAILS_CONFIG_PATH"] = os.path.expanduser(config[0].rstrip(os.path.sep))
+        else:
+            local_configs_path = os.path.join(os.getcwd(), "config")
+            if os.path.exists(local_configs_path):
+                os.environ["NEMO_GUARDRAILS_CONFIG_PATH"] = local_configs_path
+
+        if default_config_id:
+            os.environ["NEMO_GUARDRAILS_DEFAULT_CONFIG_ID"] = default_config_id
+
+        if auto_reload:
+            os.environ["NEMO_GUARDRAILS_AUTO_RELOAD"] = "true"
 
     try:
         import uvicorn
@@ -175,6 +210,21 @@ def server(
     # lifespan may not run before request handling.
     set_deployment_type(DeploymentTypeEnum.API.value)
 
+    if verbose:
+        logging.getLogger().setLevel(logging.INFO)
+
+    if workers > 1:
+        # Pass the import string (not the app object) so each worker can
+        # re-import the app and read the env vars set above.
+        uvicorn.run(
+            "nemoguardrails.server.api:app",
+            port=port,
+            log_level="info",
+            host="0.0.0.0",
+            workers=workers,
+        )
+        return
+
     if config:
         # We make sure there is no trailing separator, as that might break things in
         # single config mode.
@@ -190,9 +240,6 @@ def server(
 
         if os.path.exists(local_configs_path):
             setattr(api.app, "rails_config_path", local_configs_path)
-
-    if verbose:
-        logging.getLogger().setLevel(logging.INFO)
 
     if disable_chat_ui:
         setattr(api.app, "disable_chat_ui", True)

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -206,13 +206,18 @@ if ENABLE_CORS:
         allow_headers=["*"],
     )
 
-app.default_config_id = None
+# `default_config_id`, `rails_config_path` and `auto_reload` can also be set
+# via environment variables. This is needed for multi-worker deployments
+# (`nemoguardrails server --workers > 1`), where the CLI cannot reach the
+# worker processes via setattr, so config is propagated through env vars
+# inherited by the children.
+app.default_config_id = os.getenv("NEMO_GUARDRAILS_DEFAULT_CONFIG_ID") or None
 
 # By default, we use the rails in the examples folder
-app.rails_config_path = utils.get_examples_data_path("bots")
+app.rails_config_path = os.getenv("NEMO_GUARDRAILS_CONFIG_PATH") or utils.get_examples_data_path("bots")
 
 # auto reload flag
-app.auto_reload = False
+app.auto_reload = os.getenv("NEMO_GUARDRAILS_AUTO_RELOAD", "false").lower() == "true"
 
 # stop signal for observer
 app.stop_signal = False

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -279,6 +279,64 @@ class TestServerCommand:
             telemetry._deployment_type_override = None
             telemetry._lock = telemetry.threading.Lock()
 
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_default_workers_passes_app_object(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server"])
+        assert result.exit_code == 0
+        mock_uvicorn.assert_called_once()
+        call_args = mock_uvicorn.call_args
+        # By default (workers == 1) the existing flow hands the app object
+        # to uvicorn and does not pass a workers kwarg.
+        assert not isinstance(call_args[0][0], str)
+        assert "workers" not in call_args[1]
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_with_workers_uses_import_string(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server", "--workers=4"])
+        assert result.exit_code == 0
+        mock_uvicorn.assert_called_once_with(
+            "nemoguardrails.server.api:app",
+            port=8000,
+            log_level="info",
+            host="0.0.0.0",
+            workers=4,
+        )
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    @patch("os.path.exists")
+    @patch("os.path.expanduser")
+    def test_server_with_workers_propagates_config_via_env(self, mock_expanduser, mock_exists, mock_app, mock_uvicorn):
+        mock_expanduser.return_value = "/path/to/config"
+        mock_exists.return_value = True
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NEMO_GUARDRAILS_CONFIG_PATH", None)
+            os.environ.pop("NEMO_GUARDRAILS_DEFAULT_CONFIG_ID", None)
+            os.environ.pop("NEMO_GUARDRAILS_AUTO_RELOAD", None)
+            result = runner.invoke(
+                app,
+                [
+                    "server",
+                    "--workers=2",
+                    "--config=/path/to/config",
+                    "--default-config-id=test_config",
+                    "--auto-reload",
+                ],
+            )
+            assert result.exit_code == 0
+            assert os.environ.get("NEMO_GUARDRAILS_CONFIG_PATH") == "/path/to/config"
+            assert os.environ.get("NEMO_GUARDRAILS_DEFAULT_CONFIG_ID") == "test_config"
+            assert os.environ.get("NEMO_GUARDRAILS_AUTO_RELOAD") == "true"
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
+    def test_server_with_workers_rejects_prefix(self, mock_app, mock_uvicorn):
+        result = runner.invoke(app, ["server", "--workers=2", "--prefix=/api/v1"])
+        assert result.exit_code != 0
+        mock_uvicorn.assert_not_called()
+
 
 class TestConvertCommand:
     def test_convert_missing_path(self):


### PR DESCRIPTION
Closes #1746.

Adds a `--workers` flag to `nemoguardrails server` so it can run uvicorn with multiple worker processes.

The catch with uvicorn's multi-worker mode is that each worker is spawned in its own process and re-imports the FastAPI app from scratch, so the existing setattr-based config done in the CLI process (`api.app.rails_config_path = ...`, etc.) is invisible to the workers.

To make it work end to end without breaking the single-worker flow:

- `--workers` defaults to `1`, in which case the existing setattr-based path is used unchanged.
- When `--workers > 1`, the CLI propagates config via env vars (`NEMO_GUARDRAILS_CONFIG_PATH`, `NEMO_GUARDRAILS_DEFAULT_CONFIG_ID`, `NEMO_GUARDRAILS_AUTO_RELOAD`) before importing `api`, and hands uvicorn the import string `"nemoguardrails.server.api:app"` instead of the app object.
- `api.py` now reads those same env vars at module-init time, following the existing `NEMO_GUARDRAILS_DISABLE_CHAT_UI` pattern.
- `--prefix` is rejected with `--workers > 1` because the `FastAPI().mount(...)` wrapping happens in the CLI process and does not carry across to workers; failing closed is clearer than silently dropping the prefix.

Tests added in `tests/cli/test_cli_main.py`:
- Default (`workers=1`) keeps passing the app object, no `workers` kwarg.
- `--workers=4` calls uvicorn with the import string and `workers=4`.
- `--workers=2` with `--config`, `--default-config-id`, `--auto-reload` sets the corresponding env vars.
- `--workers=2 --prefix=/api/v1` exits non-zero and never calls uvicorn.

`ruff check` and `ruff format --check` pass on all touched files. Pytest could not run locally (this environment has Python 3.9 and 3.14 installed and the project requires `>=3.10,<3.14`), so the new tests will be confirmed by CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--workers` option to the server CLI command to support multi-worker deployments (default: 1, minimum: 1).
  * Server configuration now reads from environment variables, enabling settings propagation across worker processes.
  * Configuration validation: `--prefix` option is incompatible with multi-worker mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->