### PR TITLE
docs: expand 0.22 release notes

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -130,7 +130,7 @@ For a complete record of changes in a release, refer to the
   information, refer to
   [Check Messages](../run-rails/using-python-apis/check-messages.md)
   ([#1813](https://github.com/NVIDIA-NeMo/Guardrails/pull/1813)).
-- Fixed issues in the [Colang 1.0 Hello World tutorial](../configure-rails/colang/colang-1/tutorials/1-hello-world/README.md) and companion notebook.
+- Fixed issues in the [Colang 1.0 Hello World tutorial](../configure-rails/colang/colang-1/tutorials/1-hello-world/README.md) and companion notebook
   ([#1834](https://github.com/NVIDIA-NeMo/Guardrails/pull/1834)).
 
 ---

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -41,8 +41,8 @@ For a complete record of changes in a release, refer to the
   in-process Hugging Face, TensorRT-LLM, and others) keep working through
   LangChain when you opt in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and
   install the matching provider package. Most 0.21 configurations keep working
-  unchanged; some shapes need a YAML rewrite. For recipes, see
-  [Migrating to 0.22](../migration/0.22.md), the
+  unchanged; some shapes need a YAML rewrite. For recipes, refer to
+  [Migrating to v0.22.0](../migration/0.22.md), the
   [Supported LLMs](./supported-llms.md) matrix, and
   [Model Configuration](../configure-rails/yaml-schema/model-configuration.md)
   ([#1854](https://github.com/NVIDIA-NeMo/Guardrails/pull/1854),
@@ -57,7 +57,7 @@ For a complete record of changes in a release, refer to the
   `engine: azure_openai`, and documents how to migrate provider-specific
   LangChain parameters to the new `base_url`-based configuration shape. For
   more information, refer to
-  [Migrating to 0.22](../migration/0.22.md),
+  [Migrating to v0.22.0](../migration/0.22.md),
   [Model Configuration](../configure-rails/yaml-schema/model-configuration.md),
   [Configuration Reference](../configure-rails/configuration-reference.md), and
   [Using Docker](../deployment/using-docker.md)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -34,148 +34,110 @@ For a complete record of changes in a release, refer to the
 ### Key Features
 
 - LangChain is now optional. `pip install nemoguardrails` no longer pulls
-  LangChain or any provider-specific `langchain-*` packages. The library ships
-  with a built-in client that talks to OpenAI-compatible endpoints directly
-  over `httpx`. Engines whose API isn't OpenAI-compatible (Anthropic, Cohere,
-  Vertex AI, Google Generative AI, in-process Hugging Face, TensorRT-LLM,
-  and others) keep working through LangChain when you opt in with
-  `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching provider
-  package. Most 0.21 configurations keep working unchanged; some shapes need
-  a YAML rewrite. For recipes, see [Migrating to 0.22](../migration/0.22.md).
+  LangChain or any provider-specific `langchain-*` packages. The NVIDIA NeMo
+  Guardrails library ships with a built-in client that talks to
+  OpenAI-compatible endpoints directly over `httpx`. Engines whose API isn't
+  OpenAI-compatible (Anthropic, Cohere, Vertex AI, Google Generative AI,
+  in-process Hugging Face, TensorRT-LLM, and others) keep working through
+  LangChain when you opt in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and
+  install the matching provider package. Most 0.21 configurations keep working
+  unchanged; some shapes need a YAML rewrite. For recipes, see
+  [Migrating to 0.22](../migration/0.22.md), the
+  [Supported LLMs](./supported-llms.md) matrix, and
+  [Model Configuration](../configure-rails/yaml-schema/model-configuration.md)
+  ([#1854](https://github.com/NVIDIA-NeMo/Guardrails/pull/1854),
+  [#1855](https://github.com/NVIDIA-NeMo/Guardrails/pull/1855),
+  [#1856](https://github.com/NVIDIA-NeMo/Guardrails/pull/1856),
+  [#1858](https://github.com/NVIDIA-NeMo/Guardrails/pull/1858),
+  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881)).
+
+- OpenAI-compatible service support is improved in the default framework.
+  The default framework now supports OpenAI-compatible providers directly,
+  includes native Azure OpenAI support through `engine: azure` and
+  `engine: azure_openai`, and documents how to migrate provider-specific
+  LangChain parameters to the new `base_url`-based configuration shape. For
+  more information, refer to
+  [Migrating to 0.22](../migration/0.22.md),
+  [Model Configuration](../configure-rails/yaml-schema/model-configuration.md),
+  [Configuration Reference](../configure-rails/configuration-reference.md), and
+  [Using Docker](../deployment/using-docker.md)
+  ([#1854](https://github.com/NVIDIA-NeMo/Guardrails/pull/1854),
+  [#1855](https://github.com/NVIDIA-NeMo/Guardrails/pull/1855),
+  [#1857](https://github.com/NVIDIA-NeMo/Guardrails/pull/1857),
+  [#1858](https://github.com/NVIDIA-NeMo/Guardrails/pull/1858),
+  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881),
+  [#1896](https://github.com/NVIDIA-NeMo/Guardrails/pull/1896)).
+
+- `IORails` observability is expanded with OpenTelemetry logging, tracing, and
+  metrics guidance. The documentation now covers OTLP setup, Prometheus client
+  installation, request-level and token-level metrics, and the recommended
+  `Guardrails` entry point for the optimized input and output rails engine. For
+  more information, refer to
+  [Observability](../observability/index.md),
+  [OpenTelemetry Logs](../observability/tracing/opentelemetry-logs.md),
+  [OpenTelemetry Tracing](../observability/tracing/opentelemetry-integration.md),
+  [OpenTelemetry Metrics](../observability/metrics/opentelemetry-integration.md),
+  [Enable Metrics](../observability/metrics/enable-metrics.md), and the
+  [Metrics Reference](../observability/metrics/reference.md)
+  ([#1807](https://github.com/NVIDIA-NeMo/Guardrails/pull/1807),
+  [#1864](https://github.com/NVIDIA-NeMo/Guardrails/pull/1864),
+  [#1884](https://github.com/NVIDIA-NeMo/Guardrails/pull/1884),
+  [#1892](https://github.com/NVIDIA-NeMo/Guardrails/pull/1892),
+  [#1893](https://github.com/NVIDIA-NeMo/Guardrails/pull/1893),
+  [#1894](https://github.com/NVIDIA-NeMo/Guardrails/pull/1894)).
+
+- Anonymous usage reporting is documented with clear privacy boundaries and
+  opt-out controls. The telemetry reference explains what fields are collected,
+  what data is excluded, how local audit files work, and how to opt out with
+  `NEMO_GUARDRAILS_NO_USAGE_STATS=1`, `DO_NOT_TRACK=1`, or the
+  `~/.config/nemoguardrails/do_not_track` file. For more information, refer to
+  [Telemetry](../telemetry.md)
+  ([#1891](https://github.com/NVIDIA-NeMo/Guardrails/pull/1891)).
+
+- The GLiNER PII connector documentation and notebook are updated for the new
+  GLiNER PII NIM. The examples cover both remote and local deployment modes
+  and API key configuration for the connector. For more information, refer to
+  [GLiNER](../configure-rails/guardrail-catalog/community/gliner.md) and
+  [PII Detection](../configure-rails/guardrail-catalog/pii-detection.md)
+  ([#1845](https://github.com/NVIDIA-NeMo/Guardrails/pull/1845)).
 
 - Public extension points for LLM integration. Two new protocols, `LLMModel`
   and `LLMFramework` in `nemoguardrails.types`, let you plug in a custom
-  backend or a whole alternative framework without touching internals.
+  backend or a whole alternative framework without touching internals. For more
+  information, refer to
+  [Custom LLM Models](../configure-rails/custom-initialization/custom-llm-model.md)
+  and
+  [Custom LLM Frameworks](../configure-rails/custom-initialization/custom-llm-framework.md)
+  ([#1857](https://github.com/NVIDIA-NeMo/Guardrails/pull/1857),
+  [#1882](https://github.com/NVIDIA-NeMo/Guardrails/pull/1882)).
 
 - Public testing surface. The `nemoguardrails.testing` module exposes
   `FakeLLMModel`, `TestChat`, and pytest fixtures for writing tests against a
   guardrails configuration without calling a real model.
 
-(v0-21-0)=
+(v0-22-0-doc-and-behavior-fixes)=
 
-## 0.21.0
+### Documentation and Behavior Fixes
 
-(v0-21-0-features)=
-
-### Key Features
-
-- Added the `IORails` class, a new optimized execution engine that runs NemoGuard input and output rails, such as
-  content-safety, topic-safety, and jailbreak detection, in parallel. The engine is opt-in:
-  set `NEMO_GUARDRAILS_IORAILS_ENGINE=1` to enable it. When enabled, the configuration is
-  validated for compatibility and falls back to LLMRails if unsupported flows are detected.
-  For more information, refer to [](../configure-rails/yaml-schema/guardrails-configuration/parallel-rails.md#iorails-engine).
-
-- Added the `check_async()` and `check()` methods on `LLMRails` to enable validating messages against input and output rails without triggering full LLM generation.
-  Returns a `RailsResult` with `PASSED`, `MODIFIED`, or `BLOCKED` status.
-  For more information, refer to [](../run-rails/using-python-apis/check-messages.md).
-
-- The guardrails server now exposes a fully OpenAI-compatible
-  REST API. The `/v1/chat/completions` endpoint accepts standard `ChatCompletion` requests with a
-  `guardrails` field for config selection. A new `/v1/models` endpoint lists available models from the
-  configured provider. The `openai` package is now a required component of the optional `server` extra ([#1623](https://github.com/NVIDIA-NeMo/Guardrails/pull/1623)).
-  For more information, refer to [](../run-rails/using-fastapi-server/overview.md).
-
-- Added the `GuardrailsMiddleware` class, a new middleware that integrates with
-  LangChain's Agent Middleware protocol, applying input and output rail checks before and after
-  every model call in the agent loop. It includes the `InputRailsMiddleware` and `OutputRailsMiddleware`
-  convenience subclasses (requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`).
-  For more information, refer to [](../integration/langchain/agent-middleware.md).
-
-- Added three new community rails:
-  [PolicyAI](../configure-rails/guardrail-catalog/community/policyai.md) for policy-based content moderation,
-  [CrowdStrike AIDR](../configure-rails/guardrail-catalog/community/crowdstrike-aidr.md) for AI-powered detection and response, and
-  [Regex Detection](../configure-rails/guardrail-catalog/community/regex.md) for pattern-based content filtering on input, output, and retrieval.
-
-- Jailbreak detection configuration is now validated at
-  create-time. Invalid thresholds and malformed URLs raise errors immediately.
-  For more information, refer to [](../configure-rails/guardrail-catalog/jailbreak-protection.md#configuration-validation).
-
-- Embedding indexes are now initialized lazily.
-  FastEmbed models are only downloaded when semantic search is needed, reducing startup time for
-  configurations that use only input and output rails.
-
-(v0-21-0-breaking-changes)=
-
-### Breaking Changes
-
-- Streaming metadata parameter renamed. The `include_generation_metadata` parameter on
-  `LLMRails.stream_async()` and `StreamingHandler` is deprecated in favor of `include_metadata`.
-  The `generation_info` field in streaming chunk dicts is renamed to `metadata`.
-  The deprecated parameter still works and emits a `DeprecationWarning`.
-
-  ```python
-  # Before (deprecated)
-  async for chunk in rails.stream_async(messages=messages, include_generation_metadata=True):
-      info = chunk["generation_info"]
-
-  # After
-  async for chunk in rails.stream_async(messages=messages, include_metadata=True):
-      info = chunk["metadata"]
-  ```
-
-- `StreamingHandler` no longer inherits from LangChain `AsyncCallbackHandler`.
-  Streaming now uses `llm.astream()` with direct `push_chunk()` calls.
-  If your code depends on `StreamingHandler` as a LangChain callback, update it to use the
-  new `push_chunk()` interface.
-
-- Removed the `stream_usage` parameter. The `stream_usage=True` parameter is no longer
-  automatically added to LLM call kwargs. Streaming metadata is now captured through
-  `response_metadata` and `usage_metadata` on final chunks.
-
-- Server request and response format changed. The `/v1/chat/completions` endpoint now uses
-  OpenAI-compatible request and response schemas. The previous `RequestBody` and `ResponseBody`
-  classes are removed. For the new format, refer to
-  [](../run-rails/using-fastapi-server/overview.md).
-
-- ChatNVIDIA streaming patch removed. The custom
-  `_langchain_nvidia_ai_endpoints_patch.py` module is removed.
-  The standard `ChatNVIDIA` from `langchain_nvidia_ai_endpoints` is used directly.
-
-(v0-21-0-bug-fixes)=
-
-### Bug Fixes
-
-- Fixed a naming mismatch where the `generate_next_step` action did not match the
-  `generate_next_steps` task enum value, which prevented task-specific LLM configuration
-  from working correctly ([#1603](https://github.com/NVIDIA-NeMo/Guardrails/pull/1603)).
-- Added the `valid` alias to action results in the GuardrailsAI integration so that
-  Colang flows checking `$result["valid"]` work as expected ([#1611](https://github.com/NVIDIA-NeMo/Guardrails/pull/1611)).
-- Filtered the `stop` parameter for OpenAI reasoning models (such as GPT-5) that do not
-  accept it, preventing `400` errors during dialogue rail execution ([#1653](https://github.com/NVIDIA-NeMo/Guardrails/pull/1653)).
-- Fixed GLiNER PII detection to use "bot refuse to respond" instead of
-  "bot inform answer unknown", which returned a misleading "I don't know" message ([#1671](https://github.com/NVIDIA-NeMo/Guardrails/pull/1671)).
-- Fixed a `TypeError` when `stop=None` is passed to `StreamingHandler` by coercing
-  `None` to an empty list ([#1685](https://github.com/NVIDIA-NeMo/Guardrails/pull/1685)).
-- Fixed a `TypeError` in `RollingBuffer.format_chunks` when `include_metadata=True` is used
-  with output rail streaming enabled. Dict chunks are now normalized to strings at the
-  input boundary ([#1687](https://github.com/NVIDIA-NeMo/Guardrails/pull/1687)).
-- Fixed `GuardrailsMiddleware` silently dropping content when rails return `MODIFIED` status.
-  Input rails now replace the last user message and output rails replace the last AI
-  message with the sanitized content ([#1714](https://github.com/NVIDIA-NeMo/Guardrails/pull/1714)).
-- Cache hit statistics are now visible in the Stats log line. Cache stats are also
-  visible in verbose mode ([#1666](https://github.com/NVIDIA-NeMo/Guardrails/pull/1666), [#1667](https://github.com/NVIDIA-NeMo/Guardrails/pull/1667)).
-
-(v0-21-0-other-changes)=
-
-### Other Changes
-
-- Updated the Fiddler Guardrails API to match the new specification: the `prompt` field is
-  renamed to `input`, faithfulness uses strings instead of lists, and a new `fdl_roleplaying`
-  category is added ([#1619](https://github.com/NVIDIA-NeMo/Guardrails/pull/1619)).
-- Updated the Trend Micro Vision One AI Guard integration from the beta endpoint to the
-  officially released GA endpoint. A required `TMV1-Application-Name` header is added and the
-  request key is changed from `guard` to `prompt` ([#1546](https://github.com/NVIDIA-NeMo/Guardrails/pull/1546)).
-- Added a Locust stress-test benchmark for load testing ([#1629](https://github.com/NVIDIA-NeMo/Guardrails/pull/1629)).
-- Removed the `multi_kb` example ([#1673](https://github.com/NVIDIA-NeMo/Guardrails/pull/1673)).
-- Removed the AI Virtual Assistant Blueprint notebook ([#1682](https://github.com/NVIDIA-NeMo/Guardrails/pull/1682)).
-- Updated the Pangea User-Agent repo URL ([#1610](https://github.com/NVIDIA-NeMo/Guardrails/pull/1610)).
-- Updated dependencies for the jailbreak detection Docker container ([#1596](https://github.com/NVIDIA-NeMo/Guardrails/pull/1596)).
-- Major documentation revamp with improved structure and navigation.
+- Fixed the example query and expected output in the Guardrails Agent
+  Middleware integration guide so the example matches the configured blocked
+  response behavior. For more information, refer to
+  [Guardrails Agent Middleware](../integration/langchain/agent-middleware.md)
+  ([#1784](https://github.com/NVIDIA-NeMo/Guardrails/pull/1784)).
+- A warning about a missing main LLM is now emitted only when generation is
+  actually attempted and the generation path needs the main LLM. Check-only
+  configurations no longer emit the warning during initialization. For more
+  information, refer to
+  [Check Messages](../run-rails/using-python-apis/check-messages.md)
+  ([#1813](https://github.com/NVIDIA-NeMo/Guardrails/pull/1813)).
+- Fixed issues in the [Colang 1.0 Hello World tutorial](../configure-rails/colang/colang-1/tutorials/1-hello-world/README.md) and companion notebook.
+  ([#1834](https://github.com/NVIDIA-NeMo/Guardrails/pull/1834)).
 
 ---
 
 ## Previous Release Notes
 
+- [0.21.0](https://docs.nvidia.com/nemo/guardrails/0.21.0/release-notes.html)
 - [0.20.0](https://docs.nvidia.com/nemo/guardrails/0.20.0/release-notes.html)
 - [0.19.0](https://docs.nvidia.com/nemo/guardrails/0.19.0/release-notes.html)
 - [0.18.0](https://docs.nvidia.com/nemo/guardrails/0.18.0/release-notes.html)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -65,11 +65,10 @@ For a complete record of changes in a release, refer to the
   [#1855](https://github.com/NVIDIA-NeMo/Guardrails/pull/1855),
   [#1857](https://github.com/NVIDIA-NeMo/Guardrails/pull/1857),
   [#1858](https://github.com/NVIDIA-NeMo/Guardrails/pull/1858),
-  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881),
-  [#1896](https://github.com/NVIDIA-NeMo/Guardrails/pull/1896)).
+  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881)).
 
-- `IORails` observability is expanded with OpenTelemetry logging, tracing, and
-  metrics guidance. The documentation now covers OTLP setup, Prometheus client
+- `IORails` adds OpenTelemetry observability with logging, tracing, and
+  metrics support. The documentation covers OTLP setup, Prometheus client
   installation, request-level and token-level metrics, and the recommended
   `Guardrails` entry point for the optimized input and output rails engine. For
   more information, refer to
@@ -93,6 +92,19 @@ For a complete record of changes in a release, refer to the
   `~/.config/nemoguardrails/do_not_track` file. For more information, refer to
   [Telemetry](../telemetry.md)
   ([#1891](https://github.com/NVIDIA-NeMo/Guardrails/pull/1891)).
+
+(v0-22-0-breaking-changes)=
+
+### Breaking Changes
+
+- Moved `AsyncWorkQueue` from the top-level `Guardrails` object to
+  `IORails`. This removes buffering for non-streaming `LLMRails` requests when
+  you use the top-level `Guardrails` object. This change only affects existing implementations that
+  set `NEMO_GUARDRAILS_IORAILS_ENGINE=1` or instantiate `Guardrails` directly.
+
+(v0-22-0-enhancements)=
+
+### Enhancements
 
 - The GLiNER PII connector documentation and notebook are updated for the new
   GLiNER PII NIM. The examples cover both remote and local deployment modes

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -44,12 +44,7 @@ For a complete record of changes in a release, refer to the
   unchanged; some shapes need a YAML rewrite. For recipes, refer to
   [Migrating to v0.22.0](../migration/0.22.md), the
   [Supported LLMs](./supported-llms.md) matrix, and
-  [Model Configuration](../configure-rails/yaml-schema/model-configuration.md)
-  ([#1854](https://github.com/NVIDIA-NeMo/Guardrails/pull/1854),
-  [#1855](https://github.com/NVIDIA-NeMo/Guardrails/pull/1855),
-  [#1856](https://github.com/NVIDIA-NeMo/Guardrails/pull/1856),
-  [#1858](https://github.com/NVIDIA-NeMo/Guardrails/pull/1858),
-  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881)).
+  [Model Configuration](../configure-rails/yaml-schema/model-configuration.md).
 
 - OpenAI-compatible service support is improved in the default framework.
   The default framework now supports OpenAI-compatible providers directly,
@@ -60,12 +55,17 @@ For a complete record of changes in a release, refer to the
   [Migrating to v0.22.0](../migration/0.22.md),
   [Model Configuration](../configure-rails/yaml-schema/model-configuration.md),
   [Configuration Reference](../configure-rails/configuration-reference.md), and
-  [Using Docker](../deployment/using-docker.md)
-  ([#1854](https://github.com/NVIDIA-NeMo/Guardrails/pull/1854),
-  [#1855](https://github.com/NVIDIA-NeMo/Guardrails/pull/1855),
-  [#1857](https://github.com/NVIDIA-NeMo/Guardrails/pull/1857),
-  [#1858](https://github.com/NVIDIA-NeMo/Guardrails/pull/1858),
-  [#1881](https://github.com/NVIDIA-NeMo/Guardrails/pull/1881)).
+  [Using Docker](../deployment/using-docker.md).
+
+- `IORails` adds streaming support, reasoning-model support, and speculative
+  generation support. The optimized input and output rails engine now supports
+  streaming output rails, `stream_async()` integration in chat and server flows,
+  non-streaming and streaming reasoning-model responses, and speculative
+  generation for non-streaming `generate_async()` calls. For more information,
+  refer to
+  [Parallel Rails](../configure-rails/yaml-schema/guardrails-configuration/parallel-rails.md),
+  [Streaming](../run-rails/using-python-apis/streaming.md), and
+  [Speculative Generation](../configure-rails/yaml-schema/guardrails-configuration/speculative-generation.md).
 
 - `IORails` adds OpenTelemetry observability with logging, tracing, and
   metrics support. The documentation covers OTLP setup, Prometheus client
@@ -77,21 +77,14 @@ For a complete record of changes in a release, refer to the
   [OpenTelemetry Tracing](../observability/tracing/opentelemetry-integration.md),
   [OpenTelemetry Metrics](../observability/metrics/opentelemetry-integration.md),
   [Enable Metrics](../observability/metrics/enable-metrics.md), and the
-  [Metrics Reference](../observability/metrics/reference.md)
-  ([#1807](https://github.com/NVIDIA-NeMo/Guardrails/pull/1807),
-  [#1864](https://github.com/NVIDIA-NeMo/Guardrails/pull/1864),
-  [#1884](https://github.com/NVIDIA-NeMo/Guardrails/pull/1884),
-  [#1892](https://github.com/NVIDIA-NeMo/Guardrails/pull/1892),
-  [#1893](https://github.com/NVIDIA-NeMo/Guardrails/pull/1893),
-  [#1894](https://github.com/NVIDIA-NeMo/Guardrails/pull/1894)).
+  [Metrics Reference](../observability/metrics/reference.md).
 
 - Anonymous usage reporting is documented with clear privacy boundaries and
   opt-out controls. The telemetry reference explains what fields are collected,
   what data is excluded, how local audit files work, and how to opt out with
   `NEMO_GUARDRAILS_NO_USAGE_STATS=1`, `DO_NOT_TRACK=1`, or the
   `~/.config/nemoguardrails/do_not_track` file. For more information, refer to
-  [Telemetry](../telemetry.md)
-  ([#1891](https://github.com/NVIDIA-NeMo/Guardrails/pull/1891)).
+  [Telemetry](../telemetry.md).
 
 (v0-22-0-breaking-changes)=
 
@@ -110,8 +103,7 @@ For a complete record of changes in a release, refer to the
   GLiNER PII NIM. The examples cover both remote and local deployment modes
   and API key configuration for the connector. For more information, refer to
   [GLiNER](../configure-rails/guardrail-catalog/community/gliner.md) and
-  [PII Detection](../configure-rails/guardrail-catalog/pii-detection.md)
-  ([#1845](https://github.com/NVIDIA-NeMo/Guardrails/pull/1845)).
+  [PII Detection](../configure-rails/guardrail-catalog/pii-detection.md).
 
 - Public extension points for LLM integration. Two new protocols, `LLMModel`
   and `LLMFramework` in `nemoguardrails.types`, let you plug in a custom
@@ -119,9 +111,7 @@ For a complete record of changes in a release, refer to the
   information, refer to
   [Custom LLM Models](../configure-rails/custom-initialization/custom-llm-model.md)
   and
-  [Custom LLM Frameworks](../configure-rails/custom-initialization/custom-llm-framework.md)
-  ([#1857](https://github.com/NVIDIA-NeMo/Guardrails/pull/1857),
-  [#1882](https://github.com/NVIDIA-NeMo/Guardrails/pull/1882)).
+  [Custom LLM Frameworks](../configure-rails/custom-initialization/custom-llm-framework.md).
 
 - Public testing surface. The `nemoguardrails.testing` module exposes
   `FakeLLMModel`, `TestChat`, and pytest fixtures for writing tests against a
@@ -134,16 +124,13 @@ For a complete record of changes in a release, refer to the
 - Fixed the example query and expected output in the Guardrails Agent
   Middleware integration guide so the example matches the configured blocked
   response behavior. For more information, refer to
-  [Guardrails Agent Middleware](../integration/langchain/agent-middleware.md)
-  ([#1784](https://github.com/NVIDIA-NeMo/Guardrails/pull/1784)).
+  [Guardrails Agent Middleware](../integration/langchain/agent-middleware.md).
 - A warning about a missing main LLM is now emitted only when generation is
   actually attempted and the generation path needs the main LLM. Check-only
   configurations no longer emit the warning during initialization. For more
   information, refer to
-  [Check Messages](../run-rails/using-python-apis/check-messages.md)
-  ([#1813](https://github.com/NVIDIA-NeMo/Guardrails/pull/1813)).
-- Fixed issues in the [Colang 1.0 Hello World tutorial](../configure-rails/colang/colang-1/tutorials/1-hello-world/README.md) and companion notebook
-  ([#1834](https://github.com/NVIDIA-NeMo/Guardrails/pull/1834)).
+  [Check Messages](../run-rails/using-python-apis/check-messages.md).
+- Fixed issues in the [Colang 1.0 Hello World tutorial](../configure-rails/colang/colang-1/tutorials/1-hello-world/README.md) and companion notebook.
 
 ---
 

--- a/docs/about/supported-llms.md
+++ b/docs/about/supported-llms.md
@@ -14,17 +14,17 @@ content:
 
 # Supported LLMs
 
-The NeMo Guardrails library supports a wide range of LLM providers and models. This includes base models, instruct-tuned, and reasoning models. These models can be served locally on the same machine as NeMo Guardrails, or at a remote endpoint accessible from Guardrails over a network. This flexible approach allows Guardrails to be used for a range of applications: from edge deployments on resource-constrained devices, to horizontally-scalable backend clusters.
+The NVIDIA NeMo Guardrails library supports a wide range of LLM providers and models, including base, instruct-tuned, and reasoning models. You can serve these models locally on the same machine as the library or at a remote network endpoint. This flexible approach supports applications from edge deployments on resource-constrained devices to horizontally scalable backend clusters.
 
 ## LLM Types
 
-Integrating NeMo Guardrails improves safety and security of an Application LLM, which is responsible for generating responses to the end-user. NeMo Guardrails can also use the same Application LLM to run guardrails, simplifying deployments and reducing friction to on-ramp. Two examples of this are self-check rails and dialog rails. Self-check rails use the Application LLM to decide whether a user request or LLM response is safe. Dialog rails use the Application LLM to guide the user through a pre-defined conversational flow.
+Integrating the library improves the safety and security of an application LLM, which generates responses to the end user. The library can also use the same application LLM to run guardrails, which simplifies deployments and reduces onboarding friction. Two examples are self-check rails and dialog rails. Self-check rails use the application LLM to decide whether a user request or LLM response is safe. Dialog rails use the application LLM to guide the user through a predefined conversational flow.
 
-NeMo Guardrails can also call models for a specific guardrail on behalf of the client. Having guardrail-specific models allows the use of smaller fine-tuned models, which are specialized on the guardrails task. For example the NVIDIA Nemoguard collection of models includes [content-safety](https://build.nvidia.com/nvidia/llama-3_1-nemotron-safety-guard-8b-v3), [topic-control](https://build.nvidia.com/nvidia/llama-3_1-nemoguard-8b-topic-control), and [jailbreak-detect](https://build.nvidia.com/nvidia/nemoguard-jailbreak-detect) models. These models can be accessed on [build.nvidia.com](https://build.nvidia.com/) for rapid prototyping, or on [NGC Catalog](https://catalog.ngc.nvidia.com/) for deployment with NIM Docker containers.
+The library can also call models for a specific guardrail on behalf of the client. Guardrail-specific models let you use smaller fine-tuned models that specialize in the guardrails task. For example, the NVIDIA NemoGuard collection of models includes [content-safety](https://build.nvidia.com/nvidia/llama-3_1-nemotron-safety-guard-8b-v3), [topic-control](https://build.nvidia.com/nvidia/llama-3_1-nemoguard-8b-topic-control), and [jailbreak-detect](https://build.nvidia.com/nvidia/nemoguard-jailbreak-detect) models. You can access these models on [build.nvidia.com](https://build.nvidia.com/) for rapid prototyping or on [NGC Catalog](https://catalog.ngc.nvidia.com/) for deployment with NIM Docker containers.
 
 ## Inference Providers
 
-Each engine is served by a framework that manages the underlying HTTP or SDK calls. NeMo Guardrails ships with a built-in framework that talks to OpenAI-compatible endpoints over `httpx` with no LangChain dependency. For engines whose API is not OpenAI-compatible, opt into the LangChain framework by setting `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and installing the matching `langchain-<provider>` package. To add a custom framework, implement the `LLMFramework` protocol from `nemoguardrails.types`.
+Each engine is served by a framework that manages the underlying HTTP or SDK calls. The library ships with a built-in framework that talks to OpenAI-compatible endpoints over `httpx` with no LangChain dependency. For engines whose API is not OpenAI-compatible, opt into the LangChain framework by setting `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and installing the matching `langchain-<provider>` package. To add a custom framework, implement the `LLMFramework` protocol from `nemoguardrails.types`.
 
 ```{raw} html
 <button type="button" class="table-expand-button" data-table-title="Inference Providers">
@@ -53,11 +53,11 @@ For migration recipes between the built-in path and the LangChain path, see [Mig
 
 ## LangChain-Backed Providers
 
-The NeMo Guardrails library supports LLM providers from the LangChain Community, including both text completion and chat completion providers. Refer to [Chat model integrations](https://python.langchain.com/docs/integrations/chat/) in the LangChain documentation. You can also use the [`nemoguardrails find-providers`](find-providers-command) CLI command to discover available providers.
+The library supports LLM providers from the LangChain Community, including text completion and chat completion providers. Refer to [Chat model integrations](https://python.langchain.com/docs/integrations/chat/) in the LangChain documentation. You can also use the [`nemoguardrails find-providers`](find-providers-command) CLI command to discover available providers.
 
 ## Embedding Model Providers
 
-The NeMo Guardrails library uses embedding models for vector similarity search in dialog rails, `embeddings_only` intent matching, and knowledge base retrieval. The following table lists the supported embedding model providers and their corresponding engine names.
+The library uses embedding models for vector similarity search in dialog rails, `embeddings_only` intent matching, and knowledge base retrieval. The following table lists the supported embedding model providers and their corresponding engine names.
 
 | Provider | Engine | Notes |
 | --- | --- | --- |
@@ -70,4 +70,4 @@ The NeMo Guardrails library uses embedding models for vector similarity search i
 | SentenceTransformers | `sentence_transformers` | SentenceTransformers embedding model provider |
 | Google | `google` | Google embedding model provider |
 
-For more information on configuring embedding providers, refer to [Embedding Search Providers](../configure-rails/other-configurations/embedding-search-providers.md).
+For more information about configuring embedding providers, refer to [Embedding Search Providers](../configure-rails/other-configurations/embedding-search-providers.md).

--- a/docs/configure-rails/configuration-reference.md
+++ b/docs/configure-rails/configuration-reference.md
@@ -27,7 +27,7 @@ This reference documents all configuration options for `config.yml`, derived fro
 
 ## Models Configuration
 
-The `models` key defines LLM providers and models used by NeMo Guardrails.
+The `models` key defines LLM providers and models used by the NVIDIA NeMo Guardrails library.
 
 ### Model Schema
 
@@ -55,7 +55,7 @@ models:
 | `models.engine` | string | ✓ | LLM provider (see [Engines](#engines)) |
 | `models.mode` | string | | Completion mode: `chat` or `text` (default: `chat`) |
 | `models.model` | string | ✓ | Model name (can also be in `parameters.model_name`) |
-| `models.parameters` | object | | Provider-specific parameters. For engines served by the built-in client (any OpenAI-compatible endpoint), the runtime forwards `parameters` to the OpenAI-compatible HTTP request (for example `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, `default_headers`). For engines served by LangChain (opt-in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`), the runtime forwards `parameters` to the underlying LangChain class. For the engine-by-engine matrix, see [Inference Providers](../about/supported-llms.md#inference-providers). |
+| `models.parameters` | object | | Provider-specific parameters. For engines served by the built-in client, such as any OpenAI-compatible endpoint, the runtime forwards `parameters` to the OpenAI-compatible HTTP request. Examples include `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, and `default_headers`. For engines served by LangChain, opt in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`; the runtime forwards `parameters` to the underlying LangChain class. For the engine-by-engine matrix, refer to [Inference Providers](../about/supported-llms.md#inference-providers). |
 | `models.type` | string | ✓ | Model identifier (see [Model Types](#model-types)) |
 
 ### Model Types
@@ -64,7 +64,7 @@ The `type` field is a free-form string identifier. Certain types have special ha
 
 #### Reserved Types
 
-These types have special handling in the NeMo Guardrails runtime:
+These types have special handling in the runtime:
 
 | Type | Description |
 | --- | --- |
@@ -102,7 +102,7 @@ The runtime validates that any `$model=<type>` reference in flows has a matching
 
 ### Engines
 
-Starting with version 0.22, NeMo Guardrails serves engines through either the built-in OpenAI-compatible client or LangChain. Use the built-in client whenever the underlying wire protocol is OpenAI-compatible. Opt into LangChain only for engines whose API is not OpenAI-compatible, such as Vertex AI, Anthropic, Cohere, and the in-process Hugging Face pipeline. For the full mapping see [Inference Providers](../about/supported-llms.md#inference-providers); for migration recipes see [Migrating to 0.22](../migration/0.22.md).
+Starting with v0.22, the library serves engines through either the built-in OpenAI-compatible client or LangChain. Use the built-in client whenever the underlying wire protocol is OpenAI-compatible. Opt into LangChain only for engines whose API is not OpenAI-compatible, such as Vertex AI, Anthropic, Cohere, and the in-process Hugging Face pipeline. For the full mapping, refer to [Inference Providers](../about/supported-llms.md#inference-providers). For migration recipes, refer to [Migrating to 0.22](../migration/0.22.md).
 
 #### Built-in Engines
 
@@ -133,7 +133,7 @@ To use one of these engines, set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and in
 | `self_hosted` | Generic self-hosted LangChain wrapper |
 | `trt_llm` | TensorRT-LLM in-process |
 | `vertexai` | Google Vertex AI through LangChain (requires `langchain-google-vertexai`) |
-| `vllm_openai` | Legacy LangChain wrapper for vLLM. For new configs, prefer `engine: openai` with `parameters.base_url` |
+| `vllm_openai` | Legacy LangChain wrapper for vLLM. For new configurations, prefer `engine: openai` with `parameters.base_url` |
 
 #### Embedding Engines
 
@@ -502,7 +502,7 @@ The multilingual feature supports the following languages:
 | Spanish | `es` |
 | Thai | `th` |
 
-If the detected language is not in this list, English is used as the fallback. For more details, refer to [Multilingual Content Safety](./guardrail-catalog/content-safety.md#multilingual-refusal-messages).
+If the detected language is not in this list, English is used as the fallback. For more information, refer to [Multilingual Content Safety](./guardrail-catalog/content-safety.md#multilingual-refusal-messages).
 
 #### Third-Party Integrations
 

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -23,11 +23,11 @@ content:
 
 # Model Configuration
 
-In this section, learn how to configure the models used in your guardrails configuration. For a complete reference of all configuration options, refer to the [](../configuration-reference.md).
+In this page, learn how to configure the `models` section in your Guardrails `config.yml` file. For a complete reference of all configuration options, refer to the [Configuration YAML Schema Reference](../configuration-reference.md).
 
 ## NVIDIA NIM Configuration
 
-The NeMo Guardrails library provides seamless integration with NVIDIA NIM microservices:
+The NVIDIA NeMo Guardrails library integrates with NVIDIA NIM microservices:
 
 ```yaml
 models:
@@ -38,13 +38,13 @@ models:
 
 This provides access to:
 
-- **Locally-deployed NIMs**: Run models on your own infrastructure with optimized inference.
-- **NVIDIA API Catalog**: Access hosted models on [build.nvidia.com](https://build.nvidia.com/models).
-- **Specialized NIMs**: NemoGuard Content Safety, Topic Control, and Jailbreak Detect.
+- Locally deployed NIMs. You can run models on your own infrastructure with optimized inference.
+- NVIDIA API Catalog. You can access hosted models on [build.nvidia.com](https://build.nvidia.com/models).
+- Specialized NIMs. Includes NemoGuard Content Safety, Topic Control, and Jailbreak Detect.
 
 ### Local NIM Deployment
 
-For locally-deployed NIMs, specify the base URL:
+For locally deployed NIMs, specify the base URL:
 
 ```yaml
 models:
@@ -110,12 +110,12 @@ models:
       api_version: "2024-02-15-preview"
 ```
 
-The resource endpoint can be supplied as `azure_endpoint` (preferred, matches the OpenAI Python SDK) or `base_url` (v0.21-compatibility alias). Both accept the resource URL only; the deployment path is composed by the framework. Setting both raises an error.
+You can supply the resource endpoint as `azure_endpoint` (preferred, matches the OpenAI Python SDK) or `base_url` (v0.21-compatibility alias). Both fields accept only the resource URL. The framework composes the deployment path. Setting both raises an error.
 
-Set `AZURE_OPENAI_API_KEY` in the environment, or set `api_key_env_var` on the model entry, or pass `parameters.api_key` directly. The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
+Set `AZURE_OPENAI_API_KEY` in the environment, set `api_key_env_var` on the model entry, or pass `parameters.api_key` directly. The framework constructs the deployment URL, sets `api-version` as a query parameter, and authenticates with the `api-key` header.
 
 ```{note}
-Azure OpenAI is supported natively on the default framework in v0.22 with key-based authentication. For Azure AD / token-based authentication, configure `engine: openai` manually or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. See [Migrating to 0.22](../../migration/0.22.md#azure-openai) for both alternatives.
+Azure OpenAI is supported natively on the default framework in v0.22 with key-based authentication. For Azure AD or token-based authentication, configure `engine: openai` manually or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. Refer to [Migrating to 0.22](../../migration/0.22.md#azure-openai) for both alternatives.
 ```
 
 ### Anthropic
@@ -130,7 +130,7 @@ models:
 ```
 
 ```{note}
-Anthropic's API isn't OpenAI-compatible, so this engine is opt-in: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-anthropic`. For background, see [Migrating to 0.22](../../migration/0.22.md#using-langchain).
+Anthropic's API is not OpenAI-compatible, so this engine is opt-in. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-anthropic`. For background, refer to [Migrating to 0.22](../../migration/0.22.md#using-langchain).
 ```
 
 ### vLLM (OpenAI-Compatible)
@@ -159,7 +159,7 @@ models:
       api_key: EMPTY
 ```
 
-When self-hosted vLLM does not enforce authentication, set `parameters.api_key` to any non-empty placeholder such as `EMPTY`. If your deployment requires a real token, replace `parameters.api_key` with the literal token, or omit it and set `api_key_env_var` at the **top level** of the model entry (not inside `parameters:`):
+When self-hosted vLLM does not enforce authentication, set `parameters.api_key` to a non-empty placeholder such as `EMPTY`. If your deployment requires a real token, replace `parameters.api_key` with the literal token, or omit it and set `api_key_env_var` at the top level of the model entry, not inside `parameters`:
 
 ```yaml
 - type: main
@@ -171,16 +171,16 @@ When self-hosted vLLM does not enforce authentication, set `parameters.api_key` 
 ```
 
 ```{note}
-The referenced environment variable must be set before `RailsConfig.from_content` or `RailsConfig.from_path` is called. Otherwise, config loading fails with `Model API Key environment variable 'X' not set.`. This is a Pydantic validator on the model schema; the check is eager, not lazy.
+Set the referenced environment variable before calling `RailsConfig.from_content` or `RailsConfig.from_path`. Otherwise, config loading fails with `Model API Key environment variable 'X' not set.`. A Pydantic validator on the model schema performs the check eagerly.
 ```
 
 ```{note}
 The legacy `engine: vllm_openai` with `parameters.openai_api_base` form is only needed when running under `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. For new configurations, prefer the form above.
 ```
 
-### Other OpenAI-compatible endpoints
+### Other OpenAI-Compatible Endpoints
 
-The same `engine: openai` plus `parameters.base_url` pattern works for any provider whose wire protocol is OpenAI-compatible, including OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek's hosted API at `https://api.deepseek.com/v1`, TGI deployments that expose `/v1/chat/completions`, and `llama.cpp` server with `--api`. Provide `parameters.base_url` and either `parameters.api_key` or a top-level `api_key_env_var`.
+The same `engine: openai` plus `parameters.base_url` pattern works for any provider whose wire protocol is OpenAI-compatible. Examples include OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek's hosted API at `https://api.deepseek.com/v1`, TGI deployments that expose `/v1/chat/completions`, and the `llama.cpp` server with `--api`. Provide `parameters.base_url` and either `parameters.api_key` or a top-level `api_key_env_var`.
 
 ### Google Vertex AI
 
@@ -194,7 +194,7 @@ models:
 ```
 
 ```{note}
-Vertex AI's API isn't OpenAI-compatible, so this engine is opt-in: set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-google-vertexai`. For background, see [Migrating to 0.22](../../migration/0.22.md#using-langchain).
+Vertex AI's API is not OpenAI-compatible, so this engine is opt-in. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-google-vertexai`. For background, refer to [Migrating to 0.22](../../migration/0.22.md#using-langchain).
 ```
 
 ### Complete Example
@@ -231,7 +231,7 @@ models:
 
 ## Model Parameters
 
-Pass additional parameters to the underlying LLM client. For engines served by the built-in client (any OpenAI-compatible endpoint), parameters are forwarded to the OpenAI-compatible HTTP request (for example, `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, `default_headers`). For LangChain engines, parameters follow the conventions of the underlying LangChain class.
+Pass additional parameters to the underlying LLM client. For engines served by the built-in client, such as any OpenAI-compatible endpoint, the runtime forwards parameters to the OpenAI-compatible HTTP request. Examples include `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, and `default_headers`. For LangChain engines, parameters follow the conventions of the underlying LangChain class.
 
 ```yaml
 models:

--- a/docs/deployment/using-docker.md
+++ b/docs/deployment/using-docker.md
@@ -1,8 +1,8 @@
 ---
 title:
-  page: Deploy NeMo Guardrails Library with Docker
+  page: Deploy the NeMo Guardrails Library with Docker
   nav: Docker
-description: Build and run NeMo Guardrails Docker images for rapid deployment and testing.
+description: Build and run NeMo Guardrails Docker images for deployment and testing.
 topics:
 - Deployment
 - AI Safety
@@ -19,19 +19,19 @@ content:
   - DevOps Engineer
 ---
 
-# Deploy NeMo Guardrails Library with Docker
+# Deploy the NeMo Guardrails Library with Docker
 
-This guide provides step-by-step instructions for running the NeMo Guardrails library using Docker. Docker offers a seamless and rapid deployment method for getting started with the NeMo Guardrails library.
+This guide shows how to run the NVIDIA NeMo Guardrails library using Docker. Docker provides a direct deployment method for getting started with the library.
 
 ## Prerequisites
 
-Ensure Docker is installed on your machine. If not, follow the [official Docker installation guide](https://docs.docker.com/get-docker/) for your respective platform.
+Ensure Docker is installed on your machine. If Docker is not installed, follow the [official Docker installation guide](https://docs.docker.com/get-docker/) for your platform.
 
 ## LLM Framework Selection
 
-By default, NeMo Guardrails uses the lightweight default framework (httpx-based, no LangChain). It serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, `azure`, and `azure_openai`, plus any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url` (for example self-hosted vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp).
+By default, the library uses the lightweight default framework, which is based on `httpx` and does not require LangChain. It serves engines such as `openai`, `nim`, `nvidia_ai_endpoints`, `ollama`, `azure`, and `azure_openai`. It also serves any other OpenAI-compatible provider configured with `engine: openai` and `parameters.base_url`, such as self-hosted vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, or `llama.cpp`.
 
-To use LangChain-only engines whose API is not OpenAI-compatible (`vertexai`, `anthropic`, `cohere`, `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, `self_hosted`, and the legacy `vllm_openai` LangChain wrapper), set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` in the container environment and add `langchain` plus the relevant provider packages to your image. For example:
+To use LangChain-only engines whose API is not OpenAI-compatible, set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` in the container environment and add `langchain` plus the relevant provider packages to your image. These engines include `vertexai`, `anthropic`, `cohere`, `huggingface_pipeline`, `huggingface_endpoint` with the default text-generation schema, `trt_llm`, `self_hosted`, and the legacy `vllm_openai` LangChain wrapper. For example:
 
 ```bash
 docker run \
@@ -41,65 +41,67 @@ docker run \
   nemoguardrails
 ```
 
-Replace `ANTHROPIC_API_KEY` with the credential your provider uses (for example, `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI or `COHERE_API_KEY` for Cohere). For file-based credentials such as Vertex AI service-account JSON, mount the credential file into the container and set the environment variable to the in-container path; for example, bind-mount host `service-account.json` to `/secrets/service-account.json` and set `GOOGLE_APPLICATION_CREDENTIALS=/secrets/service-account.json`. Secure the host credential file and configure equivalent bind-mount and environment settings in `docker run` or Docker Compose.
+Replace `ANTHROPIC_API_KEY` with the credential your provider uses, such as `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI or `COHERE_API_KEY` for Cohere. For file-based credentials such as Vertex AI service-account JSON, mount the credential file into the container and set the environment variable to the in-container path. For example, bind-mount host `service-account.json` to `/secrets/service-account.json` and set `GOOGLE_APPLICATION_CREDENTIALS=/secrets/service-account.json`. Secure the host credential file and configure equivalent bind-mount and environment settings in `docker run` or Docker Compose.
 
 ## Build the Docker Images
 
-### 1. Clone the repository
+To build the Docker images, complete the following steps:
 
-Start by cloning the NeMo Guardrails repository:
+1. Clone the repository.
 
-```bash
-git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
-```
+   ```bash
+   git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
+   ```
 
-And change directory into the repository:
+1. Change directory into the repository.
 
-```bash
-cd nemoguardrails
-```
+   ```bash
+   cd nemoguardrails
+   ```
 
-### 2. Build the Docker image
+1. Build the `nemoguardrails` Docker image.
 
-Build the `nemoguardrails` Docker image:
+   ```bash
+   docker build -t nemoguardrails .
+   ```
 
-```bash
-docker build -t nemoguardrails .
-```
+1. Optional: Build the AlignScore server image.
 
-### 3. \[Optional] Build the AlignScore Server Image
+   If you want to use AlignScore-based fact-checking, you can also build a Docker image using the provided [Dockerfile](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/nemoguardrails/library/factchecking/align_score/Dockerfile).
 
-If you want to use AlignScore-based fact-checking, you can also build a Docker image using the provided [Dockerfile](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/nemoguardrails/library/factchecking/align_score/Dockerfile).
+   ```bash
+   cd nemoguardrails/library/factchecking/align_score
+   docker build -t alignscore-server .
+   ```
 
-```bash
-cd nemoguardrails/library/factchecking/align_score
-docker build -t alignscore-server .
-```
+   ```{note}
+   The provided Dockerfile downloads only the `base` AlignScore image. For large model support, uncomment the corresponding line in the Dockerfile.
+   ```
 
-NOTE: the provided Dockerfile downloads only the `base` AlignScore image. If you want support for the large model, uncomment the corresponding line in the Dockerfile.
+1. Optional: Build the jailbreak detection heuristics server image.
 
-### 4. \[Optional] Build the Jailbreak Detection Heuristics Server Image
+   If you want to use the jailbreak detection heuristics server, you can also build a Docker image using the provided [Dockerfile](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/nemoguardrails/library/jailbreak_detection/Dockerfile).
 
-If you want to use the jailbreak detection heuristics server, you can also build a Docker image using the provided [Dockerfile](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/nemoguardrails/library/jailbreak_detection/Dockerfile).
+   ```bash
+   cd nemoguardrails/library/jailbreak_detection
+   docker build -t jailbreak_detection_heuristics .
+   ```
 
-```bash
-cd nemoguardrails/library/jailbreak_detection
-docker build -t jailbreak_detection_heuristics .
-```
+## Run Using Docker
 
-## Running using Docker
-
-To run the NeMo Guardrails library server using the Docker image, run the following command:
+To run the library server using the Docker image, run the following command:
 
 ```bash
 docker run -p 8000:8000 -e OPENAI_API_KEY=$OPENAI_API_KEY nemoguardrails
 ```
 
-This will start the NeMo Guardrails library server with the example configurations. The Chat UI will be accessible at `http://localhost:8000`.
+This command starts the library server with the example configurations. The Chat UI is accessible at `http://localhost:8000`.
 
-NOTE: Since the example configurations use OpenAI models (such as `gpt-3.5-turbo-instruct` and `gpt-4`), you need to provide an `OPENAI_API_KEY`.
+```{note}
+Because the example configurations use OpenAI models such as `gpt-3.5-turbo-instruct` and `gpt-4`, you must provide an `OPENAI_API_KEY`.
+```
 
-To specify your own config folder for the server, you have to mount your local configuration into the `/config` path into the container:
+To specify your own config folder for the server, mount your local configuration into the `/config` path in the container:
 
 ```bash
 docker run \
@@ -118,15 +120,15 @@ docker run -it \
   nemoguardrails chat --config=/config --verbose
 ```
 
-## AlignScore Fact-checking
+## AlignScore Fact-Checking
 
-If one of your configurations uses the AlignScore fact-checking model, you can run the AlignScore server in a separate container:
+If one of your configurations uses the AlignScore fact-checking model, run the AlignScore server in a separate container:
 
 ```bash
 docker run -p 5000:5000 alignscore-server
 ```
 
-This will start the AlignScore server on port `5000`. You can then specify the AlignScore server URL in your configuration file:
+This command starts the AlignScore server on port `5000`. You can then specify the AlignScore server URL in your configuration file:
 
 ```yaml
 rails:

--- a/docs/migration/0.22.md
+++ b/docs/migration/0.22.md
@@ -12,14 +12,14 @@ content:
   audience: ["engineer"]
 ---
 
-# Migrating to 0.22
+# Migrating to v0.22.0
 
-Starting with 0.22, `pip install nemoguardrails` no longer installs LangChain or provider-specific `langchain-*` packages.
+Starting with v0.22.0, `pip install nemoguardrails` no longer installs LangChain or provider-specific `langchain-*` packages.
 NeMo Guardrails includes a default LLM framework that calls OpenAI-compatible endpoints directly.
 LangChain remains supported for engines whose APIs are not OpenAI-compatible, but you must opt in.
 
 Most configurations continue to work without changes.
-Some v0.21 configurations need a YAML update or an explicit LangChain opt-in.
+Some v0.21.0 configurations need a YAML update or an explicit LangChain opt-in.
 Use this guide to identify your configuration shape and apply the matching migration recipe.
 
 ## Migration Summary
@@ -29,13 +29,13 @@ The following table summarizes the migration instructions by engine type.
 | v0.21 Configurations | Action |
 | --- | --- |
 | `engine: openai`, `nim`, `nvidia_ai_endpoints`, or `ollama` with standard OpenAI-compatible parameters | No action required. |
-| `engine: vllm_openai` or another LangChain wrapper for an OpenAI-compatible provider such as DeepSeek, OpenRouter, Together.ai, Fireworks.ai, Groq, or `llama.cpp` | Rewrite the model entry. See [OpenAI-compatible providers](#openai-compatible-providers). |
-| `engine: openai` with LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, or `model_kwargs` | Rewrite the parameters. See [Mixed-shape configs](#mixed-shape-configs). |
+| `engine: vllm_openai` or another LangChain wrapper for an OpenAI-compatible provider such as DeepSeek, OpenRouter, Together.ai, Fireworks.ai, Groq, or `llama.cpp` | Rewrite the model entry. Refer to [OpenAI-compatible providers](#openai-compatible-providers). |
+| `engine: openai` with LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, or `model_kwargs` | Rewrite the parameters. Refer to [Mixed-shape configs](#mixed-shape-configs). |
 | `engine: anthropic`, `cohere`, `vertexai`, `google_genai`, `huggingface_*`, `trt_llm`, or `self_hosted` | Opt into LangChain, or switch to an OpenAI-compatible endpoint if one exists. Refer to [Unsupported Engine on the Default Framework](#unsupported-engine-on-the-default-framework). |
-| `engine: azure` or `azure_openai` | No action required. Set `AZURE_OPENAI_API_KEY` and keep the v0.21 config shape. See [Azure OpenAI](#azure-openai). |
-| Custom provider registered in `config.py` | Match the provider class to the active framework. See [Custom providers](#custom-providers). |
+| `engine: azure` or `azure_openai` | No action required. Set `AZURE_OPENAI_API_KEY` and keep the v0.21 config shape. Refer to [Azure OpenAI](#azure-openai). |
+| Custom provider registered in `config.py` | Match the provider class to the active framework. Refer to [Custom providers](#custom-providers). |
 
-For the engine-by-engine matrix, see [Supported LLMs](../about/supported-llms.md).
+For the engine-by-engine matrix, refer to [Supported LLMs](../about/supported-llms.md).
 
 ## OpenAI-Compatible Providers
 
@@ -83,7 +83,7 @@ If your deployment requires a token, replace `EMPTY` with the token value or set
 ```
 
 ```{note}
-The referenced environment variable must be set before `RailsConfig.from_content` or `RailsConfig.from_path` is called. Otherwise, config loading fails with `Model API Key environment variable 'X' not set.`. This is a Pydantic validator on the model schema; the check is eager, not lazy.
+Set the referenced environment variable before calling `RailsConfig.from_content` or `RailsConfig.from_path`. Otherwise, config loading fails with `Model API Key environment variable 'X' not set.`. A Pydantic validator on the model schema performs the check eagerly.
 ```
 
 ### Hosted OpenAI-Compatible Providers
@@ -117,7 +117,7 @@ Set `parameters.base_url` to the provider's OpenAI-compatible base URL and provi
 ## Mixed-Shape Configs
 
 Some v0.21 configs already use `engine: openai` but pass LangChain-only parameters such as `openai_api_base`, `streaming`, `verbose`, `cache`, `callbacks`, `tags`, `metadata`, `model_kwargs`, or provider-prefixed aliases such as `*_api_key` and `*_base_url`.
-The 0.22 default framework forwards `parameters` to the OpenAI-compatible HTTP request, so those LangChain-only keys do not apply.
+The v0.22 default framework forwards `parameters` to the OpenAI-compatible HTTP request, so those LangChain-only keys do not apply.
 
 ```{code-block} yaml
 :caption: Configuration before v0.22
@@ -158,7 +158,7 @@ The provider name in the message changes to match your `engine:` value.
 Choose one remediation path based on your migration goal:
 
 - Keep the LangChain provider class. Install `langchain` and the matching `langchain-<provider>` package, and then set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. Refer to [Using LangChain](#using-langchain) for the full procedure.
-- Switch to an OpenAI-compatible endpoint. If the same model is reachable through an OpenAI-compatible HTTP route, set `engine: openai` plus `parameters.base_url`. This includes self-hosted gateways, proxies, and hosted providers that expose `/v1/chat/completions`. Refer to [OpenAI-Compatible Providers](#openai-compatible-providers).
+- Switch to an OpenAI-compatible endpoint. If the same model is reachable through an OpenAI-compatible HTTP route, set `engine: openai` plus `parameters.base_url`. This includes self-hosted gateways, proxies, and hosted providers that expose `/v1/chat/completions`. For more information, refer to [OpenAI-Compatible Providers](#openai-compatible-providers).
 
 ## Using LangChain
 
@@ -213,15 +213,15 @@ export AZURE_OPENAI_API_KEY=<your-key>
 ```
 
 The resource endpoint accepts either `azure_endpoint` (preferred, matches the OpenAI Python SDK) or `base_url` (v0.21-compatibility alias for the same value).
-Both expect the resource URL only (for example `https://my-resource.openai.azure.com/`); the deployment path is composed by the framework.
+Both expect the resource URL only, such as `https://my-resource.openai.azure.com/`. The framework composes the deployment path.
 Setting both raises an error.
 
 Set `AZURE_OPENAI_API_KEY` in the environment (or set `api_key_env_var` or `parameters.api_key` on the model entry). The framework does not read `OPENAI_API_KEY` on the Azure path.
 
-### Azure AD / token-based authentication
+### Azure AD and Token-Based Authentication
 
 The native Azure path uses key-based authentication only.
-For Azure AD or other token-based authentication, either configure `engine: openai` manually, or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and `langchain-openai`.
+For Azure AD or other token-based authentication, configure `engine: openai` manually or use LangChain with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and `langchain-openai`.
 
 ## Custom Providers
 
@@ -234,8 +234,8 @@ Custom provider migration depends on which framework the provider class targets.
 The registration call applies to the active framework for the process.
 A LangChain provider class does not become a default-framework provider automatically.
 
-For LangChain provider examples, see [Custom LLM Providers](../configure-rails/custom-initialization/custom-llm-providers.md).
-For the default framework interface, see the `LLMModel` and `LLMFramework` protocols in `nemoguardrails.types`.
+For LangChain provider examples, refer to [Custom LLM Providers](../configure-rails/custom-initialization/custom-llm-providers.md).
+For the default framework interface, refer to the `LLMModel` and `LLMFramework` protocols in `nemoguardrails.types`.
 
 ## What Did Not Change
 

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -23,11 +23,11 @@ content:
 
 # Observability Overview
 
-The NeMo Guardrails library exposes three observability signals so you can debug locally during development and monitor behavior in production: logs, traces, and metrics.
+The NVIDIA NeMo Guardrails library exposes three observability signals so you can debug locally during development and monitor behavior in production: logs, traces, and metrics.
 Each signal targets a different question and can be enabled independently of the others.
 
-| Signal | Best for | Page |
-|--------|----------|------|
+| Signal | Best For | Page |
+| --- | --- | --- |
 | **Logging** | Debugging a single request with verbose console output, the `explain()` method, and the `log` generation option for structured per-request data. | [](logging/index.md) |
 | **Tracing** | Following a request through the rails it activated and the LLM calls it issued, with full OpenTelemetry semantic-convention support. | [](tracing/index.md) |
 | **Metrics** | Tracking aggregate behavior, including request volume, latency distributions, error rates, saturation, and per-LLM-call token usage for SLO dashboards and alerting. | [](metrics/index.md) |

--- a/docs/observability/metrics/enable-metrics.md
+++ b/docs/observability/metrics/enable-metrics.md
@@ -40,9 +40,10 @@ IORails is an early-release feature, and metric names can change as the OpenTele
     The `[tracing]` extra installs `opentelemetry-api`, which is the only OpenTelemetry dependency the library itself takes.
 
 2. Save the following to `metrics_example.py`.
-The script issues a single request and exports metrics once per second to both stdout and `metrics.json`.
-The `provider.shutdown()` call flushes the metrics to disk.
-Long-running services typically do not need this call.
+
+    The script issues a single request and exports metrics once per second to both stdout and `metrics.json`.
+    The `provider.shutdown()` call flushes the metrics to disk.
+    Long-running services typically do not need this call.
 
     ```python
     # metrics_example.py
@@ -144,7 +145,7 @@ Long-running services typically do not need this call.
 
     Each object is one aggregation of the `gen_ai.client.token.usage` histogram. The fields are:
 
-    - `type`: Value of the required [`gen_ai.token.type`](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage) label. Values are either `input` or `output`.
+    - `type`: Value of the required [`gen_ai.token.type`](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage) label. Values are `input` or `output`.
     - `count`: Number of observations recorded for this token type. Each LLM call records one `input` observation and one `output` observation, giving `count: 1` per type.
     - `sum`: Total tokens across those observations.
 

--- a/docs/observability/metrics/opentelemetry-integration.md
+++ b/docs/observability/metrics/opentelemetry-integration.md
@@ -21,12 +21,12 @@ content:
 
 # OpenTelemetry Metrics Integration
 
-The NeMo Guardrails library follows OpenTelemetry best practices: the library uses only the API, and the host application configures the SDK.
-The following sections explain how to install and configure the OpenTelemetry SDK for metrics export from the Guardrails IORails engine.
+The NVIDIA NeMo Guardrails library follows OpenTelemetry best practices. The library uses only the API, and the host application configures the SDK.
+The following sections explain how to install and configure the OpenTelemetry SDK for metrics export from the NeMo Guardrails IORails engine.
 
 ## Installation
 
-Choose one of the following options for installing the NeMo Guardrails library, the OpenTelemetry SDK, and an exporter.
+Choose one of the following options for installing the library, the OpenTelemetry SDK, and an exporter.
 
 - For development with the OpenTelemetry SDK (console exporter only):
 

--- a/docs/observability/metrics/reference.md
+++ b/docs/observability/metrics/reference.md
@@ -31,7 +31,7 @@ Metrics fall into two families:
 ## Request-Level Metrics
 
 | Metric | Instrument | Unit | Labels | Description |
-|--------|------------|------|--------|-------------|
+| --- | --- | --- | --- | --- |
 | `guardrails.requests` | Counter | `1` | — | Total IORails requests handled, incremented on entry. |
 | `guardrails.requests.errors` | Counter | `1` | `error.type` | Requests that ended in an unhandled error. `error.type` is the exception class name (for example `QueueFull`, `TimeoutError`). |
 | `guardrails.requests.blocked` | Counter | `1` | `rail.type` | Requests blocked by an input or output rail. `rail.type` is `input` or `output`. |
@@ -53,7 +53,7 @@ These metrics expose the internal admission paths so you can detect overload bef
 ### Non-Streaming Path (Admission Queue)
 
 | Metric | Instrument | Unit | Description |
-|--------|------------|------|-------------|
+| --- | --- | --- | --- |
 | `guardrails.nonstream.queued` | ObservableGauge | `1` | Requests buffered in the admission queue, not yet picked up by a worker. |
 | `guardrails.nonstream.active` | ObservableGauge | `1` | Requests currently executing on a worker. |
 | `guardrails.nonstream.rejections` | Counter | `1` | Submissions rejected with `QueueFull` because the admission queue exceeded its depth limit. |
@@ -64,7 +64,7 @@ After `IORails.stop()` is called, both gauges return no observations rather than
 ### Streaming Path (Concurrency Semaphore)
 
 | Metric | Instrument | Unit | Description |
-|--------|------------|------|-------------|
+| --- | --- | --- | --- |
 | `guardrails.stream.active` | UpDownCounter | `1` | In-progress streaming requests holding a semaphore permit. |
 | `guardrails.stream.rejections` | Counter | `1` | Streaming requests rejected because the streaming concurrency semaphore was fully occupied. |
 
@@ -94,7 +94,7 @@ This is intentional: dashboards built around either signal alone still reflect t
 These metrics are recorded once per downstream LLM call, not once per IORails request, and follow the OpenTelemetry GenAI semantic conventions.
 
 | Metric | Instrument | Unit | Labels | Description |
-|--------|------------|------|--------|-------------|
+| --- | --- | --- | --- | --- |
 | `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.token.type` | Number of tokens consumed by an LLM call. Each call records two observations distinguished by the required `gen_ai.token.type` label (`input` or `output`). |
 | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, optionally `error.type` | Wall-clock duration of one LLM call. `error.type` is added as a conditional label only when the call raises. |
 | `gen_ai.client.operation.time_to_first_chunk` | Histogram | `s` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` | Streaming-only. Time from request issue to the first content-bearing chunk. |
@@ -124,19 +124,19 @@ Both match the spec exactly so backends auto-render the distributions correctly.
 ### Streaming vs. Non-Streaming Emission
 
 | Metric | Non-streaming | Streaming |
-|--------|:---:|:---:|
+| --- | :---: | :---: |
 | `gen_ai.client.token.usage` | ✓ | ✓ (when the upstream provider returns usage) |
 | `gen_ai.client.operation.duration` | ✓ | ✓ |
 | `gen_ai.client.operation.time_to_first_chunk` | — | ✓ |
 | `gen_ai.client.operation.time_per_output_chunk` | — | ✓ |
 
-For streaming responses, `token.usage` is emitted only when the upstream provider returns a `usage` field — common when `stream_options.include_usage=true` is forwarded.
+For streaming responses, `token.usage` is emitted only when the upstream provider returns a `usage` field. This is common when `stream_options.include_usage=true` is forwarded.
 When usage is absent, no observation is recorded; "no observation" is deliberately distinct from "0 tokens".
 
 ## Common Label Reference
 
 | Label | Used On | Values | Notes |
-|-------|---------|--------|-------|
+| --- | --- | --- | --- |
 | `error.type` | `guardrails.requests.errors`, `gen_ai.client.operation.duration` (on error) | Exception class name | For example `QueueFull`, `TimeoutError`, `ValueError`. |
 | `rail.type` | `guardrails.requests.blocked` | `input`, `output` | Identifies whether an input or output rail blocked the request. |
 | `gen_ai.operation.name` | All `gen_ai.client.*` | For example `chat`, `completion`, `embedding` | OpenTelemetry GenAI operation name. |

--- a/docs/observability/tracing/opentelemetry-integration.md
+++ b/docs/observability/tracing/opentelemetry-integration.md
@@ -22,11 +22,11 @@ content:
 
 # OpenTelemetry Integration
 
-The NeMo Guardrails library follows OpenTelemetry best practices; libraries use only the API while applications configure the SDK. The following sections explain how to install and configure the OpenTelemetry SDK.
+The NVIDIA NeMo Guardrails library follows OpenTelemetry best practices. The library uses only the API, and the host application configures the SDK. The following sections explain how to install and configure the OpenTelemetry SDK.
 
 ## Installation
 
-Choose one of the following options for installing the NeMo Guardrails library with tracing support, the OpenTelemetry SDK, and the OpenTelemetry Protocol (OTLP) exporter.
+Choose one of the following options for installing the library with tracing support, the OpenTelemetry SDK, and the OpenTelemetry Protocol (OTLP) exporter.
 
 - For basic tracing support in the NeMo Guardrails library:
 
@@ -48,7 +48,7 @@ Choose one of the following options for installing the NeMo Guardrails library w
 
 ## Configuration Examples
 
-The following examples show how to configure the NeMo Guardrails library with the OpenTelemetry SDK for development and production use cases.
+The following examples show how to configure the library with the OpenTelemetry SDK for development and production use cases.
 
 ### Console Output (Development)
 
@@ -107,13 +107,15 @@ tracer_provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
 
 ## OpenTelemetry Ecosystem Compatibility
 
-The NeMo Guardrails library works with the entire OpenTelemetry ecosystem including:
+The library works with the entire OpenTelemetry ecosystem, including the following components.
 
-- **Exporters**: Jaeger, Zipkin, Prometheus, New Relic, Datadog, AWS X-Ray, Google Cloud Trace
-- **Collectors**: OpenTelemetry Collector, vendor-specific collectors
-- **Backends**: Any system accepting OpenTelemetry traces
+| Component | Examples |
+| --- | --- |
+| Exporters | Jaeger, Zipkin, Prometheus, New Relic, Datadog, AWS X-Ray, and Google Cloud Trace. |
+| Collectors | OpenTelemetry Collector and vendor-specific collectors. |
+| Backends | Any system that accepts OpenTelemetry traces. |
 
-See the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the complete list.
+Refer to the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the complete list.
 
 ## Exporting Logs
 

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -21,18 +21,18 @@ content:
 
 # Exporting Guardrails Logs to OpenTelemetry
 
-The NeMo Guardrails library emits operational logs through Python's standard `logging` module. When you have OpenTelemetry tracing configured, you can forward those log records into the same backend as your traces with a few lines of application code. Records emitted inside an active guardrails span automatically carry the span's `trace_id` and `span_id`, so every log line correlates to the request that produced it.
+The NVIDIA NeMo Guardrails library emits operational logs through Python's standard `logging` module. When you have OpenTelemetry tracing configured, you can forward those log records into the same backend as your traces with a few lines of application code. Records emitted inside an active guardrails span automatically carry the span's `trace_id` and `span_id`, so every log line correlates to the request that produced it.
 
 This page covers the setup. For plain Python logging (verbose mode, explain, generation options), refer to [](../logging/index.md).
 
 ## API and SDK Responsibilities
 
-The NeMo Guardrails library follows the OpenTelemetry library-instrumentation pattern.
+The library follows the OpenTelemetry library-instrumentation pattern.
 
-- The library depends on the OpenTelemetry API only. It creates spans, emits log records, and otherwise participates in whatever OTEL pipeline the host application provides.
+- The library depends on the OpenTelemetry API only. It creates spans, emits log records, and participates in whatever OTEL pipeline the host application provides.
 - The host application owns the SDK. Configuring a `TracerProvider`, a `LoggerProvider`, exporters, and attaching handlers to Python's `logging` tree are all the application's responsibility.
 
-This split is deliberate. It lets the NeMo Guardrails library stay decoupled from SDK-version churn, avoids the library injecting itself into a host's observability stack without opt-in, and gives applications full control over where their telemetry is exported.
+This split is deliberate. It lets the library stay decoupled from SDK version churn, avoids injecting the library into a host's observability stack without opt-in, and gives applications full control over where their telemetry is exported.
 
 The three-line recipe below is therefore a user-side setup, not something the library does for you.
 
@@ -63,7 +63,7 @@ logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
 
 Each line does the following:
 
-- `logging.getLogger("nemoguardrails")` selects the logger namespace that catches most records emitted by the NeMo Guardrails library. Submodules that use `logging.getLogger(__name__)` inherit this handler. Verbose mode (`nemoguardrails.logging.verbose`) is the known exception. It writes to the root logger, so attach the handler to the root logger as well if you need verbose output forwarded.
+- `logging.getLogger("nemoguardrails")` selects the logger namespace that catches most records emitted by the library. Submodules that use `logging.getLogger(__name__)` inherit this handler. Verbose mode (`nemoguardrails.logging.verbose`) is the known exception. It writes to the root logger, so attach the handler to the root logger as well if you need verbose output forwarded.
 - `LoggingHandler()` is an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. On first emit it resolves the active `LoggerProvider` through `get_logger_provider()`, caches the resulting logger, and attaches trace context automatically.
 - `.addHandler(...)` attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, and so on) and the OpenTelemetry pipeline, provided a `LoggerProvider` was configured before this call.
 
@@ -143,14 +143,14 @@ The OpenTelemetry Collector then forwards the records to any compatible backend,
 Each forwarded `LogRecord` becomes an OTEL log record with the following fields populated automatically.
 
 | Field | Description |
-|-------|-------------|
+| --- | --- |
 | Body | Contains the formatted log message. |
 | Severity | Records `severity_text` (`INFO`, `DEBUG`, `ERROR`, and so on) and `severity_number`. |
 | Timestamp | Records the record's emit time. |
 | Trace context | Carries the `trace_id` and `span_id` of the active span when the record was emitted. The values are zero when no span is active. |
 | Code attributes | Include `code.file.path`, `code.function.name`, and `code.line.number` derived from the Python `LogRecord`. |
 
-Log records emitted outside any guardrails request (startup, engine registration, teardown) still flow through, but their `trace_id` / `span_id` are zero because there is no active span.
+Log records emitted outside any guardrails request, such as startup, engine registration, or teardown, still flow through. Their `trace_id` and `span_id` are zero because there is no active span.
 
 ## Considerations
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{ "name": "nemo-guardrails-toolkit", "version": "0.21.0" }
+{ "name": "nemo-guardrails-toolkit", "version": "0.22.0" }

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
     {
         "preferred": true,
+        "version": "0.22.0",
+        "url": "https://docs.nvidia.com/nemo/guardrails/0.22.0/"
+    },
+    {
         "version": "0.21.0",
         "url": "https://docs.nvidia.com/nemo/guardrails/0.21.0/"
     },


### PR DESCRIPTION
## Description

Expands the 0.22.0 release notes with more complete coverage of the release-plan documentation updates, including:

- LangChain decoupling and the new default OpenAI-compatible framework path.
- Improved OpenAI-compatible and Azure OpenAI configuration guidance.
- IORails observability docs for OpenTelemetry logs, traces, metrics, Prometheus setup, and Guardrails entry-point usage.
- Anonymous usage reporting documentation, including privacy boundaries and opt-out controls.
- GLiNER PII NIM docs and notebook updates.
- Public custom LLM extension points and the `nemoguardrails.testing` surface.
- Documentation and behavior fixes for Guardrails Agent Middleware, missing-main-LLM warnings, and the Colang 1.0 Hello World tutorial.

The release-note bullets include cross-references to the relevant updated documentation pages and supporting PR links.

## Related Issue(s)

Release prep for 0.22.0 documentation updates. Relevant doc PR context includes #1784, #1807, #1834, #1845, #1854, #1855, #1856, #1857, #1858, #1864, #1881, #1882, #1891, #1892, #1893, #1894, and #1896.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable. Not applicable, docs-only release-note update.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

## Test Plan

- Docs-only change.
- Checked `docs/about/release-notes.md` with editor diagnostics. Existing release-note heading warnings remain unrelated to this update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v0.22.0 release notes with expanded coverage of key features including optional LangChain integration, improved default OpenAI support with Azure, OpenTelemetry observability guidance, usage reporting documentation, and new testing utilities and extension protocols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->