### PR TITLE
Removed a reference to a /v1/chat/completions endpoint for the GLiNER reference server in the associated README, since this endpoint doesn't exist.

### DIFF
--- a/examples/deployment/gliner_server/README.md
+++ b/examples/deployment/gliner_server/README.md
@@ -98,10 +98,6 @@ Get the default PII labels supported by the model.
 
 OpenAI-compatible models endpoint.
 
-### `POST /v1/chat/completions`
-
-OpenAI-compatible chat completions endpoint (returns entities as JSON in the response).
-
 ### `GET /health`
 
 Health check endpoint with model status.


### PR DESCRIPTION
## Description

Removed a reference to a /v1/chat/completions endpoint for the GLiNER reference server in the associated README, since this endpoint doesn't exist.

@tgasser-nv, @alexahaushalter, please review. 

## Related Issue(s)

  - Fixes an issue pointed out in [this VDR](https://docs.google.com/document/d/1Xh-U4EJh-dUo-Gy4pGqBxOmVQNCx8S5naVS0IUiEmVQ/edit?tab=t.0)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable. [NA]
- [x] I've added tests if applicable. [NA]
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified deployment documentation by removing the chat completions endpoint reference from the server guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->