### PR TITLE
docs: clarify NGC_API_KEY requirements for local GLiNER NIM deployment

### DIFF
--- a/docs/configure-rails/guardrail-catalog/community/gliner.md
+++ b/docs/configure-rails/guardrail-catalog/community/gliner.md
@@ -169,11 +169,16 @@ The Llama NIM auto-selects the optimal TensorRT-LLM profile (FP16 or INT8) based
 
 ### Start the Containers
 
-Export your NGC Personal API key as `NGC_API_KEY` (this is a different key from the `NVIDIA_API_KEY` set in *Prerequisites* — they authenticate against different services even though both are issued by NVIDIA):
+Export your NGC Personal API key as `NGC_API_KEY`:
 
 ```bash
 export NGC_API_KEY="<your-ngc-key>"
 ```
+
+> **Important:** The key must start with `nvapi-`. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) (select at least the **NGC Catalog** service) or at [build.nvidia.com](https://build.nvidia.com) — both portals issue interchangeable `nvapi-` keys. **Legacy NGC keys (older format, not starting with `nvapi-`) will cause the GLiNER container to fail during model-artifact download.** If you already have an `NVIDIA_API_KEY` starting with `nvapi-`, you can reuse it:
+> ```bash
+> export NGC_API_KEY="$NVIDIA_API_KEY"
+> ```
 
 On a multi-GPU host, pin each container to a distinct GPU with `--gpus '"device=N"'` instead of `--gpus all`. Without an explicit device, both NIMs default to GPU 0 and compete for memory. The examples below assign GLiNER to GPU 0 and Llama to GPU 1; adjust the indices to match your host.
 

--- a/docs/configure-rails/guardrail-catalog/pii-detection.md
+++ b/docs/configure-rails/guardrail-catalog/pii-detection.md
@@ -103,6 +103,8 @@ rails:
 
 To run both NIMs locally, pull the Docker containers and point each endpoint to localhost. No `api_key_env_var` is needed for local inference.
 
+> **Note:** You still need an `NGC_API_KEY` (starting with `nvapi-`) to pull the Docker images and download model artifacts. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) or [build.nvidia.com](https://build.nvidia.com). Legacy NGC keys (older format) will cause the container to fail during artifact download. See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#deploy-nims-locally) section for full `docker run` instructions.
+
 **PII detection** (update `config/pii_detection/config.yml`):
 
 ```yaml

--- a/docs/configure-rails/guardrail-catalog/pii-detection.md
+++ b/docs/configure-rails/guardrail-catalog/pii-detection.md
@@ -103,7 +103,7 @@ rails:
 
 To run both NIMs locally, pull the Docker containers and point each endpoint to localhost. No `api_key_env_var` is needed for local inference.
 
-> **Note:** You still need an `NGC_API_KEY` (starting with `nvapi-`) to pull the Docker images and download model artifacts. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) or [build.nvidia.com](https://build.nvidia.com). Legacy NGC keys (older format) will cause the container to fail during artifact download. See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#deploy-nims-locally) section for full `docker run` instructions.
+> **Note:** You still need an `NGC_API_KEY` (starting with `nvapi-`) to pull the Docker images and download model artifacts. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) or [build.nvidia.com](https://build.nvidia.com). Legacy NGC keys (older format) will cause the container to fail during artifact download. See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#start-the-containers) section for full `docker run` instructions.
 
 **PII detection** (update `config/pii_detection/config.yml`):
 


### PR DESCRIPTION
## Description

Legacy NGC API keys (older format, not starting with `nvapi-`) silently fail during model-artifact download when running the GLiNER NIM container locally. The container starts but cannot fetch the model weights, with no clear error message pointing to the key format as the cause.

Add a callout to gliner.md (Deploy NIMs Locally > Start the Containers) documenting that NGC_API_KEY must start with `nvapi-`, that keys from either org.ngc.nvidia.com or build.nvidia.com work (verified on both portals), and that an existing NVIDIA_API_KEY can be reused via
`export NGC_API_KEY="$NVIDIA_API_KEY"`.

Add a cross-referencing note to pii-detection.md (Locally Hosted NIMs) with the same legacy-key warning and a link to the gliner.md section for full Docker instructions.

Also removes the misleading parenthetical claiming NGC_API_KEY and NVIDIA_API_KEY "authenticate against different services" — both portals now issue interchangeable `nvapi-` keys.

@alexahaushalter, please review. 

## Related Issue(s)

  - Fixes an issue in [this VDR](https://docs.google.com/document/d/1Xh-U4EJh-dUo-Gy4pGqBxOmVQNCx8S5naVS0IUiEmVQ/edit?tab=t.0): [Local GLiNER NIM fails during artifact download](https://docs.google.com/document/d/1Xh-U4EJh-dUo-Gy4pGqBxOmVQNCx8S5naVS0IUiEmVQ/edit?tab=t.0#heading=h.fp2bfa6cju12)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable. [NA]
- [x] I've added tests if applicable. [NA]
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified NGC API key requirements and format specifications for local NIM deployment.
  * Updated deployment guidance to explicitly specify NGC API key prerequisites for Docker images and model artifacts.
  * Added compatibility notes regarding legacy keys and improved cross-references between related documentation sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->