### PR TITLE
fix(llm): share post-processing helpers between streaming and non-streaming llm_call

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -132,30 +132,11 @@ async def _stream_llm_call(
 
             await handler.push_chunk(content, chunk_metadata)
 
-        llm_response_metadata_var.set(accumulated_provider_metadata or None)
-
         await handler.finish()
 
-        llm_call_info = llm_call_info_var.get()
-        if llm_call_info:
-            llm_call_info.completion = handler.completion
-
-        if usage:
-            fake_chunk = LLMResponseChunk(usage=usage)
-            _update_token_stats_from_chunk(fake_chunk)
-
-        if tool_calls:
-            tool_calls_var.set([tc.to_dict() for tc in tool_calls])
-        else:
-            tool_calls_var.set(None)
-
         reasoning_content = "".join(accumulated_reasoning) if accumulated_reasoning else None
-        # TODO: call _extract_and_remove_think_tags on the completed response
-        # to handle models that stream reasoning via <think> tags in content
-        # rather than via delta_reasoning. Pre-existing gap, not introduced here.
-        reasoning_trace_var.set(reasoning_content)
 
-        return LLMResponse(
+        response = LLMResponse(
             content=handler.completion,
             reasoning=reasoning_content,
             tool_calls=tool_calls,
@@ -165,6 +146,18 @@ async def _stream_llm_call(
             usage=usage,
             provider_metadata=accumulated_provider_metadata or None,
         )
+
+        # Apply the same post-processing helpers as the non-streaming path so the
+        # two paths populate context vars, logs, and llm_call_info consistently.
+        # _store_reasoning_traces runs first so any <think>...</think> tags in
+        # response.content are stripped before the completion is logged or stored.
+        _store_reasoning_traces(response)
+        _log_completion(response)
+        _update_token_stats(response)
+        _store_tool_calls(response)
+        _store_response_metadata(response)
+
+        return response
 
     except Exception as e:
         _raise_llm_call_exception(e, model)

--- a/tests/llm/clients/test_stream_llm_call.py
+++ b/tests/llm/clients/test_stream_llm_call.py
@@ -13,10 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 
 from nemoguardrails.actions.llm.utils import _stream_llm_call
-from nemoguardrails.context import llm_response_metadata_var, reasoning_trace_var, tool_calls_var
+from nemoguardrails.context import (
+    llm_call_info_var,
+    llm_response_metadata_var,
+    llm_stats_var,
+    reasoning_trace_var,
+    tool_calls_var,
+)
+from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.logging.stats import LLMStats
 from nemoguardrails.streaming import StreamingHandler
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 
@@ -177,3 +187,95 @@ class TestStreamLlmCallAccumulation:
         await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
 
         assert llm_response_metadata_var.get() is None
+
+
+class TestStreamLlmCallSharedPostProcessing:
+    """Verify the streaming path invokes the same post-processing helpers as the
+    non-streaming path so llm_call_info, completion logging, token stats, and
+    context vars stay consistent across both code paths.
+    """
+
+    @pytest.mark.asyncio
+    async def test_extracts_reasoning_from_think_tags_when_no_delta_reasoning(self):
+        # Models that stream reasoning via <think>...</think> tags in content
+        # (rather than via delta_reasoning) should still have their reasoning
+        # extracted and the visible content cleaned up, matching the
+        # non-streaming behaviour.
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="<think>let me ", model="gpt-4o"),
+                LLMResponseChunk(delta_content="ponder</think>"),
+                LLMResponseChunk(delta_content="42", finish_reason="stop"),
+            ]
+        )
+
+        result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert result.content == "42"
+        assert reasoning_trace_var.get() == "let me ponder"
+
+    @pytest.mark.asyncio
+    async def test_log_completion_populates_llm_call_info_and_logs(self, caplog):
+        info = LLMCallInfo(task="test_task")
+        token = llm_call_info_var.set(info)
+        try:
+            model = _make_chunk_model(
+                [
+                    LLMResponseChunk(delta_content="hello world", finish_reason="stop"),
+                ]
+            )
+
+            with caplog.at_level(logging.INFO, logger="nemoguardrails.actions.llm.utils"):
+                await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+            assert info.completion == "hello world"
+            assert any("Completion" in record.message and "hello world" in record.message for record in caplog.records)
+        finally:
+            llm_call_info_var.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_completion_in_llm_call_info_is_stripped_of_think_tags(self):
+        # llm_call_info.completion should reflect the cleaned content, not the
+        # raw streamed text that still contains <think> tags.
+        info = LLMCallInfo(task="test_task")
+        token = llm_call_info_var.set(info)
+        try:
+            model = _make_chunk_model(
+                [
+                    LLMResponseChunk(delta_content="<think>scratch</think>final", finish_reason="stop"),
+                ]
+            )
+
+            await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+            assert info.completion == "final"
+            assert reasoning_trace_var.get() == "scratch"
+        finally:
+            llm_call_info_var.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_update_token_stats_increments_global_stats(self):
+        info = LLMCallInfo(task="test_task")
+        info_token = llm_call_info_var.set(info)
+        stats = LLMStats()
+        stats_token = llm_stats_var.set(stats)
+        try:
+            model = _make_chunk_model(
+                [
+                    LLMResponseChunk(delta_content="hi", finish_reason="stop"),
+                    LLMResponseChunk(usage=UsageInfo(input_tokens=7, output_tokens=3, total_tokens=10)),
+                ]
+            )
+
+            await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+            assert info.total_tokens == 10
+            assert info.prompt_tokens == 7
+            assert info.completion_tokens == 3
+            stats_dict = stats.get_stats()
+            assert stats_dict["total_tokens"] == 10
+            assert stats_dict["total_prompt_tokens"] == 7
+            assert stats_dict["total_completion_tokens"] == 3
+        finally:
+            llm_call_info_var.reset(info_token)
+            llm_stats_var.reset(stats_token)


### PR DESCRIPTION
The non-streaming branch of `llm_call` runs a small fixed pipeline after the model returns: `_store_reasoning_traces`, `_log_completion`, `_update_token_stats`, `_store_tool_calls`, `_store_response_metadata`. The streaming branch did the same work inline but skipped a few of those helpers, so the two paths could drift. Notably `_log_completion` was never invoked, so the completion log line was missing for streaming, and the `<think>...</think>` fallback inside `_store_reasoning_traces` was never reached, which left hidden reasoning in `llm_call_info.completion` and an unset `reasoning_trace_var` for models that stream reasoning via tags in content rather than via `delta_reasoning`.

The fix builds the `LLMResponse` once streaming finishes and then runs the same five helpers in the same order as the non-streaming path. `_store_reasoning_traces` runs first so any `<think>` tags in `response.content` are stripped before the completion is logged or stored, matching the order already enforced for the non-streaming path. The pre-existing TODO in `_stream_llm_call` about extracting `<think>` tags from the completed response is resolved by this reuse.

I added four tests in `tests/llm/clients/test_stream_llm_call.py` covering reasoning extraction from streamed `<think>` content, `_log_completion` populating `llm_call_info.completion` and emitting the completion log line, the stripped-completion guarantee, and global token stat increments via the shared helper. All 88 existing tests under `tests/test_streaming_*`, `tests/integrations/langchain/test_streaming.py`, and `tests/llm/clients/test_stream_llm_call.py` continue to pass, along with the broader llm/reasoning/tool-call test suites.

Closes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified post-processing logic for streaming and non-streaming LLM calls to ensure consistent behavior across both code paths.

* **Tests**
  * Added comprehensive test coverage for streaming LLM call post-processing, including reasoning extraction, completion logging, and token statistics tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->