### PR TITLE
fix: synchronize embedding batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 >
 > The changes related to the Colang language and runtime have moved to [CHANGELOG-Colang](./CHANGELOG-Colang.md) file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- *(embeddings)* Synchronize batched embedding requests to avoid deadlocks ([#1476](https://github.com/NVIDIA-NeMo/Guardrails/issues/1476))
+
 ## [0.21.0] - 2026-03-12
 
 ### 🚀 Features

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -90,6 +90,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         self._req_idx: int = 0
         self._current_batch_finished_event: Optional[asyncio.Event] = None
         self._current_batch_full_event: Optional[asyncio.Event] = None
+        self._current_batch_task: Optional[asyncio.Task] = None
         self._current_batch_submitted: asyncio.Event = asyncio.Event()
         self._batch_lock: asyncio.Lock = asyncio.Lock()
 
@@ -241,7 +242,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
                         self._current_batch_finished_event = asyncio.Event()
                         self._current_batch_full_event = asyncio.Event()
                         self._current_batch_submitted.clear()
-                        asyncio.get_event_loop().create_task(
+                        self._current_batch_task = asyncio.create_task(
                             self._run_batch(
                                 self._current_batch_full_event,
                                 self._current_batch_finished_event,

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -90,6 +90,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         self._current_batch_finished_event: Optional[asyncio.Event] = None
         self._current_batch_full_event: Optional[asyncio.Event] = None
         self._current_batch_submitted: asyncio.Event = asyncio.Event()
+        self._batch_lock: asyncio.Lock = asyncio.Lock()
 
         # Initialize the batching configuration
         self.use_batching = use_batching
@@ -175,7 +176,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
         # If the index is already built, we skip this
         if self._index is None:
-            self._embeddings.extend(await self._get_embeddings([item.text for item in items]))
+            self._embeddings.extend(
+                await self._get_embeddings([item.text for item in items])
+            )
 
             # Update the embedding if it was not computed up to this point
             self._embedding_size = len(self._embeddings[0])
@@ -187,38 +190,37 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._index.add_item(i, self._embeddings[i])
         self._index.build(10)
 
-    async def _run_batch(self):
+    async def _run_batch(
+        self, batch_full_event: asyncio.Event, batch_finished_event: asyncio.Event
+    ):
         """Runs the current batch of embeddings."""
 
         # Wait up to `max_batch_hold` time or until `max_batch_size` is reached.
-        if self._current_batch_full_event is None or self._current_batch_finished_event is None:
-            raise RuntimeError("Batch events not initialized. This should not happen.")
-
         done, pending = await asyncio.wait(
             [
                 asyncio.create_task(asyncio.sleep(self.max_batch_hold)),
-                asyncio.create_task(self._current_batch_full_event.wait()),
+                asyncio.create_task(batch_full_event.wait()),
             ],
             return_when=asyncio.FIRST_COMPLETED,
         )
         for task in pending:
             task.cancel()
 
-        # Reset the batch event
-        batch_event: asyncio.Event = self._current_batch_finished_event
-        self._current_batch_finished_event = None
+        async with self._batch_lock:
+            # Reset the active batch only if it has not already rolled over.
+            if self._current_batch_finished_event is batch_finished_event:
+                self._current_batch_finished_event = None
+                self._current_batch_full_event = None
 
-        # Create the actual batch to be send for computing
-        batch = []
-        batch_ids = list(self._req_queue.keys())
-        for req_id in batch_ids:
-            batch.append(self._req_queue[req_id])
+            # Create the actual batch to be sent for computing.
+            batch_ids = list(self._req_queue.keys())
+            batch = [self._req_queue[req_id] for req_id in batch_ids]
 
-        # Empty the queue up to this point
-        self._req_queue = {}
+            # Empty the queue up to this point.
+            self._req_queue = {}
 
-        # We allow other batches to start
-        self._current_batch_submitted.set()
+            # We allow other batches to start.
+            self._current_batch_submitted.set()
 
         # print(f"Running batch of length {len(batch)}")
 
@@ -228,29 +230,49 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._req_results[batch_ids[i]] = embeddings[i]
 
         # Signal that the batch has finished processing
-        batch_event.set()
+        batch_finished_event.set()
 
     async def _batch_get_embeddings(self, text: str) -> List[float]:
-        # As long as the queue is full, we wait for the next batch
-        while len(self._req_queue) >= self.max_batch_size:
-            await self._current_batch_submitted.wait()
+        while True:
+            async with self._batch_lock:
+                if len(self._req_queue) < self.max_batch_size:
+                    req_id = self._req_idx
+                    self._req_idx += 1
+                    self._req_queue[req_id] = text
 
-        req_id = self._req_idx
-        self._req_idx += 1
-        self._req_queue[req_id] = text
+                    if (
+                        self._current_batch_finished_event is None
+                        or self._current_batch_full_event is None
+                    ):
+                        self._current_batch_finished_event = asyncio.Event()
+                        self._current_batch_full_event = asyncio.Event()
+                        self._current_batch_submitted.clear()
+                        asyncio.ensure_future(
+                            self._run_batch(
+                                self._current_batch_full_event,
+                                self._current_batch_finished_event,
+                            )
+                        )
 
-        if self._current_batch_finished_event is None or self._current_batch_full_event is None:
-            self._current_batch_finished_event = asyncio.Event()
-            self._current_batch_full_event = asyncio.Event()
-            self._current_batch_submitted.clear()
-            asyncio.ensure_future(self._run_batch())
+                    batch_finished_event = self._current_batch_finished_event
+                    batch_full_event = self._current_batch_full_event
+                    if batch_finished_event is None or batch_full_event is None:
+                        raise RuntimeError(
+                            "Batch events not initialized. This should not happen."
+                        )
 
-        # We check if we reached the max batch size
-        if len(self._req_queue) >= self.max_batch_size:
-            self._current_batch_full_event.set()
+                    # We check if we reached the max batch size
+                    if len(self._req_queue) >= self.max_batch_size:
+                        batch_full_event.set()
+
+                    break
+
+                batch_submitted_event = self._current_batch_submitted
+
+            await batch_submitted_event.wait()
 
         # Wait for the batch to finish
-        await self._current_batch_finished_event.wait()
+        await batch_finished_event.wait()
 
         # Remove the result and return it
         result = self._req_results[req_id]
@@ -258,7 +280,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
         return result
 
-    async def search(self, text: str, max_results: int = 20, threshold: Optional[float] = None) -> List[IndexItem]:
+    async def search(
+        self, text: str, max_results: int = 20, threshold: Optional[float] = None
+    ) -> List[IndexItem]:
         """Search the closest `max_results` items.
 
         Args:
@@ -277,7 +301,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             _embedding = (await self._get_embeddings([text]))[0]
 
         if self._index is None:
-            raise ValueError("Index is not built yet. Ensure to call `build` before searching.")
+            raise ValueError(
+                "Index is not built yet. Ensure to call `build` before searching."
+            )
 
         results = self._index.get_nns_by_vector(
             _embedding,
@@ -298,8 +324,14 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         return [self._items[i] for i in filtered_results]
 
     @staticmethod
-    def _filter_results(indices: List[int], distances: List[float], threshold: float) -> List[int]:
+    def _filter_results(
+        indices: List[int], distances: List[float], threshold: float
+    ) -> List[int]:
         if threshold == float("inf"):
             return indices
         else:
-            return [index for index, distance in zip(indices, distances) if (1 - distance / 2) >= threshold]
+            return [
+                index
+                for index, distance in zip(indices, distances)
+                if (1 - distance / 2) >= threshold
+            ]

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -86,6 +86,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         # Data structures for batching embedding requests
         self._req_queue: Dict[int, str] = {}
         self._req_results: Dict[int, List[float]] = {}
+        self._req_errors: Dict[int, BaseException] = {}
         self._req_idx: int = 0
         self._current_batch_finished_event: Optional[asyncio.Event] = None
         self._current_batch_full_event: Optional[asyncio.Event] = None
@@ -176,9 +177,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
         # If the index is already built, we skip this
         if self._index is None:
-            self._embeddings.extend(
-                await self._get_embeddings([item.text for item in items])
-            )
+            self._embeddings.extend(await self._get_embeddings([item.text for item in items]))
 
             # Update the embedding if it was not computed up to this point
             self._embedding_size = len(self._embeddings[0])
@@ -190,9 +189,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._index.add_item(i, self._embeddings[i])
         self._index.build(10)
 
-    async def _run_batch(
-        self, batch_full_event: asyncio.Event, batch_finished_event: asyncio.Event
-    ):
+    async def _run_batch(self, batch_full_event: asyncio.Event, batch_finished_event: asyncio.Event):
         """Runs the current batch of embeddings."""
 
         # Wait up to `max_batch_hold` time or until `max_batch_size` is reached.
@@ -222,15 +219,15 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             # We allow other batches to start.
             self._current_batch_submitted.set()
 
-        # print(f"Running batch of length {len(batch)}")
-
-        # Compute the embeddings
-        embeddings = await self._get_embeddings(batch)
-        for i in range(len(embeddings)):
-            self._req_results[batch_ids[i]] = embeddings[i]
-
-        # Signal that the batch has finished processing
-        batch_finished_event.set()
+        try:
+            embeddings = await self._get_embeddings(batch)
+            for i in range(len(embeddings)):
+                self._req_results[batch_ids[i]] = embeddings[i]
+        except BaseException as exc:
+            for req_id in batch_ids:
+                self._req_errors[req_id] = exc
+        finally:
+            batch_finished_event.set()
 
     async def _batch_get_embeddings(self, text: str) -> List[float]:
         while True:
@@ -240,14 +237,11 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
                     self._req_idx += 1
                     self._req_queue[req_id] = text
 
-                    if (
-                        self._current_batch_finished_event is None
-                        or self._current_batch_full_event is None
-                    ):
+                    if self._current_batch_finished_event is None or self._current_batch_full_event is None:
                         self._current_batch_finished_event = asyncio.Event()
                         self._current_batch_full_event = asyncio.Event()
                         self._current_batch_submitted.clear()
-                        asyncio.ensure_future(
+                        asyncio.get_event_loop().create_task(
                             self._run_batch(
                                 self._current_batch_full_event,
                                 self._current_batch_finished_event,
@@ -257,9 +251,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
                     batch_finished_event = self._current_batch_finished_event
                     batch_full_event = self._current_batch_full_event
                     if batch_finished_event is None or batch_full_event is None:
-                        raise RuntimeError(
-                            "Batch events not initialized. This should not happen."
-                        )
+                        raise RuntimeError("Batch events not initialized. This should not happen.")
 
                     # We check if we reached the max batch size
                     if len(self._req_queue) >= self.max_batch_size:
@@ -274,15 +266,16 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         # Wait for the batch to finish
         await batch_finished_event.wait()
 
+        if req_id in self._req_errors:
+            raise self._req_errors.pop(req_id)
+
         # Remove the result and return it
         result = self._req_results[req_id]
         del self._req_results[req_id]
 
         return result
 
-    async def search(
-        self, text: str, max_results: int = 20, threshold: Optional[float] = None
-    ) -> List[IndexItem]:
+    async def search(self, text: str, max_results: int = 20, threshold: Optional[float] = None) -> List[IndexItem]:
         """Search the closest `max_results` items.
 
         Args:
@@ -301,9 +294,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             _embedding = (await self._get_embeddings([text]))[0]
 
         if self._index is None:
-            raise ValueError(
-                "Index is not built yet. Ensure to call `build` before searching."
-            )
+            raise ValueError("Index is not built yet. Ensure to call `build` before searching.")
 
         results = self._index.get_nns_by_vector(
             _embedding,
@@ -324,14 +315,8 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         return [self._items[i] for i in filtered_results]
 
     @staticmethod
-    def _filter_results(
-        indices: List[int], distances: List[float], threshold: float
-    ) -> List[int]:
+    def _filter_results(indices: List[int], distances: List[float], threshold: float) -> List[int]:
         if threshold == float("inf"):
             return indices
         else:
-            return [
-                index
-                for index, distance in zip(indices, distances)
-                if (1 - distance / 2) >= threshold
-            ]
+            return [index for index, distance in zip(indices, distances) if (1 - distance / 2) >= threshold]

--- a/tests/test_batch_embeddings.py
+++ b/tests/test_batch_embeddings.py
@@ -22,10 +22,37 @@ from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
 from nemoguardrails.embeddings.index import IndexItem
 
 
+class MockEmbeddingModel:
+    async def encode_async(self, texts):
+        await asyncio.sleep(0.01)
+        return [[float(text.split()[-1])] for text in texts]
+
+
+@pytest.mark.asyncio
+async def test_batch_get_embeddings_handles_concurrent_batches():
+    embeddings_index = BasicEmbeddingsIndex(
+        use_batching=True,
+        max_batch_size=2,
+        max_batch_hold=0.01,
+    )
+    embeddings_index._model = MockEmbeddingModel()
+
+    results = await asyncio.wait_for(
+        asyncio.gather(
+            *(embeddings_index._batch_get_embeddings(f"text {i}") for i in range(5))
+        ),
+        timeout=1,
+    )
+
+    assert sorted(result[0] for result in results) == [0, 1, 2, 3, 4]
+
+
 @pytest.mark.skip(reason="Run manually.")
 @pytest.mark.asyncio
 async def test_search_speed():
-    embeddings_index = BasicEmbeddingsIndex(embedding_model="all-MiniLM-L6-v2", embedding_engine="SentenceTransformers")
+    embeddings_index = BasicEmbeddingsIndex(
+        embedding_model="all-MiniLM-L6-v2", embedding_engine="SentenceTransformers"
+    )
 
     # We compute an initial embedding, to warm up the model.
     await embeddings_index._get_embeddings(["warm up"])
@@ -74,7 +101,9 @@ async def test_search_speed():
     t0 = time()
     semaphore = asyncio.Semaphore(concurrency)
     for i in range(requests):
-        task = asyncio.ensure_future(_search(f"This is a long sentence meant to mimic a user request {i}." * 5))
+        task = asyncio.ensure_future(
+            _search(f"This is a long sentence meant to mimic a user request {i}." * 5)
+        )
         tasks.append(task)
 
     await asyncio.gather(*tasks)
@@ -83,5 +112,7 @@ async def test_search_speed():
     print(f"Processing {completed_requests} took {took:0.2f}.")
 
     print(f"Completed {completed_requests} requests in {total_time:.2f} seconds.")
-    print(f"Average latency: {total_time / completed_requests if completed_requests else 0:.2f} seconds.")
+    print(
+        f"Average latency: {total_time / completed_requests if completed_requests else 0:.2f} seconds."
+    )
     print(f"Maximum concurrency: {concurrency}")

--- a/tests/test_batch_embeddings.py
+++ b/tests/test_batch_embeddings.py
@@ -32,6 +32,27 @@ class MockEmbeddingModel:
         return [[float(text.split()[-1])] for text in texts]
 
 
+class FailingEmbeddingModel:
+    async def encode_async(self, texts):
+        raise RuntimeError("embedding model failure")
+
+
+@pytest.mark.asyncio
+async def test_batch_get_embeddings_propagates_model_error():
+    embeddings_index = BasicEmbeddingsIndex(
+        use_batching=True,
+        max_batch_size=2,
+        max_batch_hold=0.01,
+    )
+    embeddings_index._model = FailingEmbeddingModel()
+
+    with pytest.raises(RuntimeError, match="embedding model failure"):
+        await asyncio.wait_for(
+            embeddings_index._batch_get_embeddings("text 0"),
+            timeout=1,
+        )
+
+
 @pytest.mark.asyncio
 async def test_batch_get_embeddings_handles_concurrent_batches():
     mock_model = MockEmbeddingModel()

--- a/tests/test_batch_embeddings.py
+++ b/tests/test_batch_embeddings.py
@@ -23,36 +23,39 @@ from nemoguardrails.embeddings.index import IndexItem
 
 
 class MockEmbeddingModel:
+    def __init__(self):
+        self.call_count = 0
+
     async def encode_async(self, texts):
+        self.call_count += 1
         await asyncio.sleep(0.01)
         return [[float(text.split()[-1])] for text in texts]
 
 
 @pytest.mark.asyncio
 async def test_batch_get_embeddings_handles_concurrent_batches():
+    mock_model = MockEmbeddingModel()
     embeddings_index = BasicEmbeddingsIndex(
         use_batching=True,
         max_batch_size=2,
         max_batch_hold=0.01,
     )
-    embeddings_index._model = MockEmbeddingModel()
+    embeddings_index._model = mock_model
 
     results = await asyncio.wait_for(
-        asyncio.gather(
-            *(embeddings_index._batch_get_embeddings(f"text {i}") for i in range(5))
-        ),
+        asyncio.gather(*(embeddings_index._batch_get_embeddings(f"text {i}") for i in range(5))),
         timeout=1,
     )
 
     assert sorted(result[0] for result in results) == [0, 1, 2, 3, 4]
+    # 5 requests with max_batch_size=2 must produce at least 3 separate batches
+    assert mock_model.call_count >= 3
 
 
 @pytest.mark.skip(reason="Run manually.")
 @pytest.mark.asyncio
 async def test_search_speed():
-    embeddings_index = BasicEmbeddingsIndex(
-        embedding_model="all-MiniLM-L6-v2", embedding_engine="SentenceTransformers"
-    )
+    embeddings_index = BasicEmbeddingsIndex(embedding_model="all-MiniLM-L6-v2", embedding_engine="SentenceTransformers")
 
     # We compute an initial embedding, to warm up the model.
     await embeddings_index._get_embeddings(["warm up"])
@@ -101,9 +104,7 @@ async def test_search_speed():
     t0 = time()
     semaphore = asyncio.Semaphore(concurrency)
     for i in range(requests):
-        task = asyncio.ensure_future(
-            _search(f"This is a long sentence meant to mimic a user request {i}." * 5)
-        )
+        task = asyncio.ensure_future(_search(f"This is a long sentence meant to mimic a user request {i}." * 5))
         tasks.append(task)
 
     await asyncio.gather(*tasks)
@@ -112,7 +113,5 @@ async def test_search_speed():
     print(f"Processing {completed_requests} took {took:0.2f}.")
 
     print(f"Completed {completed_requests} requests in {total_time:.2f} seconds.")
-    print(
-        f"Average latency: {total_time / completed_requests if completed_requests else 0:.2f} seconds."
-    )
+    print(f"Average latency: {total_time / completed_requests if completed_requests else 0:.2f} seconds.")
     print(f"Maximum concurrency: {concurrency}")


### PR DESCRIPTION
## Summary

Fixes #1476.

This updates batched embedding requests so each caller joins a batch while holding a small async lock, captures the finished/full events for that specific batch, and has the batch runner snapshot and clear the queued requests under the same lock. That avoids callers awaiting a later batch event or seeing a partially initialized event pair under concurrent load.

I also added a regression test that runs multiple concurrent batched embedding requests across more than one batch.

## Testing

- python3 -m black nemoguardrails/embeddings/basic.py tests/test_batch_embeddings.py
- .venv/bin/python -m pytest tests/test_batch_embeddings.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization issues in batched embedding requests that could cause deadlocks when processing concurrent requests.

* **Tests**
  * Added comprehensive test coverage for concurrent batch embeddings to verify correct handling of simultaneous requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->