### PR TITLE
feat(streaming): typed StreamError model for error chunks

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -21,7 +21,6 @@ outside this supported set, the standard LLMRails engine should be used instead.
 """
 
 import asyncio
-import json
 import logging
 import time
 import warnings
@@ -60,6 +59,12 @@ from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
 from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.stream_errors import (
+    StreamError,
+    StreamErrorType,
+    parse_stream_error_chunk,
+    stream_error_to_chunk,
+)
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.tracing.constants import GuardrailsAttributes
 from nemoguardrails.types import LLMModel, LLMResponse
@@ -82,8 +87,10 @@ NONSTREAM_MAX_CONCURRENCY = 256
 # semaphore).
 STREAM_MAX_CONCURRENCY = 256
 
-# Error type used by _generation_task when pushing error JSON into the stream
-_GENERATION_ERROR_TYPE = "generation_error"
+# Error type used by _generation_task when pushing error JSON into the stream.
+# Retained as a module-level constant for backwards compatibility with code that
+# imported it directly; new call sites should reference StreamErrorType.
+_GENERATION_ERROR_TYPE = StreamErrorType.GENERATION_ERROR.value
 
 
 class IORails:
@@ -612,9 +619,7 @@ class IORails:
                 # streaming path.
                 if self._metrics_enabled:
                     record_request_error(e)
-                error_payload = json.dumps(
-                    {"error": {"message": str(e), "type": _GENERATION_ERROR_TYPE, "code": "generation_failed"}}
-                )
+                error_payload = stream_error_to_chunk(StreamError.generation_failed(str(e)))
                 await streaming_handler.push_chunk(error_payload)
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
             finally:
@@ -720,16 +725,15 @@ class IORails:
             user_output_chunks = chunk_batch.user_output_chunks
             bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
 
-            # If the batch contains a generation error from _generation_task,
-            # yield it directly and stop — don't feed error JSON through output rails.
+            # If the batch contains a typed StreamError from _generation_task,
+            # yield it directly and stop. Feeding the error JSON through output
+            # rails would let RollingBuffer concatenate it with neighboring text
+            # and surface it as if the model said it.
             for chunk in user_output_chunks:
-                try:
-                    parsed = json.loads(chunk)
-                    if isinstance(parsed, dict) and parsed.get("error", {}).get("type") == _GENERATION_ERROR_TYPE:
-                        yield chunk
-                        return
-                except (json.JSONDecodeError, TypeError):
-                    pass
+                stream_error = parse_stream_error_chunk(chunk)
+                if stream_error is not None and stream_error.error.type == StreamErrorType.GENERATION_ERROR.value:
+                    yield chunk
+                    return
 
             if stream_first:
                 for chunk in user_output_chunks:
@@ -743,15 +747,12 @@ class IORails:
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                error_data = {
-                    "error": {
-                        "message": f"Blocked by output rails: {output_result.reason}",
-                        "type": "guardrails_violation",
-                        "param": "output_rails",
-                        "code": "content_blocked",
-                    }
-                }
-                yield json.dumps(error_data)
+                yield stream_error_to_chunk(
+                    StreamError.content_blocked(
+                        f"Blocked by output rails: {output_result.reason}",
+                        param="output_rails",
+                    )
+                )
                 return
 
             if not stream_first:

--- a/nemoguardrails/rails/llm/buffer.py
+++ b/nemoguardrails/rails/llm/buffer.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, NamedTuple
 
 from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.stream_errors import parse_stream_error_chunk
 
 __all__ = ["ChunkBatch", "BufferStrategy", "RollingBuffer", "get_buffer_strategy"]
 
@@ -292,7 +293,40 @@ class RollingBuffer(BufferStrategy):
         total_chunks = 0
 
         async for chunk in streaming_handler:
-            buffer.append(chunk["text"] if isinstance(chunk, dict) else chunk)
+            chunk_text = chunk["text"] if isinstance(chunk, dict) else chunk
+
+            # Typed StreamError chunks bypass the rolling buffer entirely:
+            # they are not LLM text and would otherwise pollute the
+            # processing_context fed to output rails (where the error JSON
+            # would either trip the rail or get echoed back to the user).
+            # Yield them in their own batch with an empty processing_context
+            # so the consumer keeps seeing them while the rail check skips.
+            if parse_stream_error_chunk(chunk_text) is not None:
+                # Flush any pending buffered content first so prior text is not
+                # silently dropped when the error arrives mid-stream.
+                if buffer:
+                    remaining = total_chunks - self.total_yielded
+                    pending = buffer[-remaining:] if remaining > 0 else []
+                    if pending:
+                        self.total_yielded += len(pending)
+                        yield ChunkBatch(
+                            processing_context=list(buffer),
+                            user_output_chunks=pending,
+                        )
+                        # Trim the buffer to context size so any post-error
+                        # content (rare) is still scored with prior context.
+                        buffer = buffer[-self.buffer_context_size :]
+
+                # Emit the error chunk on its own with no processing_context;
+                # downstream code uses parse_stream_error_chunk to detect it
+                # and route around the output rail.
+                yield ChunkBatch(
+                    processing_context=[],
+                    user_output_chunks=[chunk_text],
+                )
+                continue
+
+            buffer.append(chunk_text)
             total_chunks += 1
 
             if len(buffer) >= self.buffer_chunk_size:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -101,6 +101,12 @@ from nemoguardrails.rails.llm.utils import (
     get_action_details_from_flow_id,
     get_history_cache_key,
 )
+from nemoguardrails.stream_errors import (
+    StreamError,
+    StreamErrorType,
+    parse_stream_error_chunk,
+    stream_error_to_chunk,
+)
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import (
@@ -932,10 +938,13 @@ class LLMRails:
                 log.error("Error in generate_async: %s", e, exc_info=True)
                 streaming_handler = streaming_handler_var.get()
                 if streaming_handler:
-                    # Push an error chunk instead of None.
-                    error_message = str(e)
-                    error_dict = extract_error_json(error_message)
-                    error_payload: str = json.dumps(error_dict)
+                    # Push a typed error chunk instead of None. ``extract_error_json``
+                    # may yield a partial shape (just ``{"error": {"message": ...}}``)
+                    # for upstream providers; ``StreamError.from_error_dict`` fills in
+                    # the missing type/code with sensible defaults so the on-the-wire
+                    # contract stays the same for all paths.
+                    error_dict = extract_error_json(str(e))
+                    error_payload: str = stream_error_to_chunk(StreamError.from_error_dict(error_dict))
                     await streaming_handler.push_chunk(error_payload)
                     # push a termination signal
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
@@ -1301,12 +1310,12 @@ class LLMRails:
                     state=state,
                 )
             except Exception as e:
-                # If an exception occurs during generation, push it to the streaming handler as a json string
-                # This ensures the streaming pipeline is properly terminated
+                # If an exception occurs during generation, push it to the streaming
+                # handler as a typed StreamError chunk so the buffer-skip path and
+                # downstream consumers can detect it without substring heuristics.
                 log.error(f"Error in generation task: {e}", exc_info=True)
-                error_message = str(e)
-                error_dict = extract_error_json(error_message)
-                error_payload = json.dumps(error_dict)
+                error_dict = extract_error_json(str(e))
+                error_payload = stream_error_to_chunk(StreamError.from_error_dict(error_dict))
                 await streaming_handler.push_chunk(error_payload)
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore
 
@@ -1786,6 +1795,18 @@ class LLMRails:
                     # if it's not JSON, treat it as empty list
                     user_output_chunks = []
 
+            # If the batch contains a typed StreamError emitted by _generation_task
+            # (generation_error), pass it straight through and stop. Without this
+            # skip, RollingBuffer would treat the error JSON as ordinary text and
+            # feed it to the output rails alongside neighboring chunks, which both
+            # leaks the error payload into user-visible context and risks the rail
+            # blocking on its own diagnostic.
+            for chunk in user_output_chunks:
+                stream_error = parse_stream_error_chunk(chunk)
+                if stream_error is not None and stream_error.error.type == StreamErrorType.GENERATION_ERROR.value:
+                    yield chunk
+                    return
+
             if stream_first:
                 # yield the individual chunks directly from the buffer strategy
                 for chunk in user_output_chunks:
@@ -1839,22 +1860,18 @@ class LLMRails:
                             if error_type == "internal_error":
                                 error_message = stop_event.get("error_message", "Unknown error")
                                 reason = f"Internal error in {blocked_flow} rail: {error_message}"
-                                error_code = "rail_execution_failure"
-                                error_type = "internal_error"
+                                stream_error = StreamError.rail_execution_failure(
+                                    reason,
+                                    param=blocked_flow,
+                                )
                             else:
                                 reason = f"Blocked by {blocked_flow} rails."
-                                error_code = "content_blocked"
-                                error_type = "guardrails_violation"
+                                stream_error = StreamError.content_blocked(
+                                    reason,
+                                    param=blocked_flow,
+                                )
 
-                            error_data = {
-                                "error": {
-                                    "message": reason,
-                                    "type": error_type,
-                                    "param": blocked_flow,
-                                    "code": error_code,
-                                }
-                            }
-                            yield json.dumps(error_data)
+                            yield stream_error_to_chunk(stream_error)
                             return
 
                 except Exception as e:
@@ -1888,24 +1905,11 @@ class LLMRails:
                     if is_output_blocked(result, action_func):
                         reason = f"Blocked by {flow_id} rails."
 
-                        # return the error as a plain JSON string (not in SSE format)
-                        # NOTE: When integrating with the OpenAI Python client, the server code should:
-                        # 1. detect this JSON error object in the stream
-                        # 2. terminate the stream
-                        # 3. format the error following OpenAI's SSE format
-                        # the OpenAI client will then properly raise an APIError with this error message
-
-                        error_data = {
-                            "error": {
-                                "message": reason,
-                                "type": "guardrails_violation",
-                                "param": flow_id,
-                                "code": "content_blocked",
-                            }
-                        }
-
-                        # return as plain JSON: the server should detect this JSON and convert it to an HTTP error
-                        yield json.dumps(error_data)
+                        # Yield a typed StreamError as a JSON string. The server
+                        # detects this payload, terminates the stream, and reformats
+                        # it as an SSE error so the OpenAI client raises APIError
+                        # with this message.
+                        yield stream_error_to_chunk(StreamError.content_blocked(reason, param=flow_id))
                         return
 
             if not stream_first:

--- a/nemoguardrails/stream_errors.py
+++ b/nemoguardrails/stream_errors.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed streaming error chunks for guardrails streaming responses.
+
+Before this module existed, IORails and LLMRails each constructed error
+payloads inline with ``json.dumps({"error": {...}})`` and slightly different
+key sets (LLMRails included ``param``, IORails did not; type and code
+strings were free-form). Consumers downstream had no contract to parse
+against, and the same error JSON was indistinguishable from regular LLM
+output so it leaked into the ``RollingBuffer`` and tripped output rails.
+
+The ``StreamError`` model defined here is the single source of truth:
+
+- Both rails engines construct ``StreamError`` instances and serialize via
+  :func:`stream_error_to_chunk` when pushing into a ``StreamingHandler``.
+- :func:`parse_stream_error_chunk` recovers a ``StreamError`` from a chunk
+  string; downstream code (the buffer-skip path and consumer parsers)
+  uses this instead of substring or shape heuristics.
+- :class:`StreamErrorType` and :class:`StreamErrorCode` enums lock down the
+  vocabulary used historically by both engines, so type/code values stop
+  drifting between code sites.
+
+Backwards compatibility: the serialized JSON shape matches what consumers
+already receive (``{"error": {"message": ..., "type": ..., "code": ...,
+"param": ...}}``), so existing OpenAI-style error handling keeps working
+without changes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "StreamError",
+    "StreamErrorCode",
+    "StreamErrorDetails",
+    "StreamErrorType",
+    "parse_stream_error_chunk",
+    "stream_error_to_chunk",
+]
+
+
+class StreamErrorType(str, Enum):
+    """High-level category of a streaming error chunk.
+
+    Values are stable across releases because they appear on the wire to
+    consumers. They mirror the categories the rails engines were already
+    emitting inline.
+    """
+
+    GENERATION_ERROR = "generation_error"
+    GUARDRAILS_VIOLATION = "guardrails_violation"
+    INTERNAL_ERROR = "internal_error"
+
+
+class StreamErrorCode(str, Enum):
+    """Specific machine-readable reason for a streaming error chunk.
+
+    Pairs with :class:`StreamErrorType` to give consumers enough resolution
+    to branch on (e.g. retry on ``generation_failed`` versus surfacing a
+    refusal on ``content_blocked``).
+    """
+
+    GENERATION_FAILED = "generation_failed"
+    CONTENT_BLOCKED = "content_blocked"
+    RAIL_EXECUTION_FAILURE = "rail_execution_failure"
+
+
+class StreamErrorDetails(BaseModel):
+    """Inner payload describing a single streaming error.
+
+    ``type`` and ``code`` are typed as strings rather than the enums above
+    so the model also accepts upstream error shapes (e.g. OpenAI 400
+    payloads passed through :func:`nemoguardrails.utils.extract_error_json`)
+    without raising during construction. Callers within this repo should
+    always use :class:`StreamErrorType` / :class:`StreamErrorCode` values
+    when building a ``StreamError`` so vocabulary stays consistent.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    message: str
+    type: str
+    code: str
+    # `param` carries the flow id when applicable; absent for engine-level
+    # errors like generation failures.
+    param: Optional[str] = None
+
+
+class StreamError(BaseModel):
+    """A typed streaming error chunk.
+
+    The on-the-wire shape is ``{"error": {...}}`` matching the inline
+    ``json.dumps({"error": ...})`` payloads the rails engines used to emit.
+    Construct via the convenience classmethods (:meth:`generation_failed`,
+    :meth:`content_blocked`, :meth:`rail_execution_failure`) when possible
+    so type/code stay aligned with the enums.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    error: StreamErrorDetails = Field(..., description="Structured error payload.")
+
+    def to_chunk(self) -> str:
+        """Serialize to the on-the-wire JSON string used by streaming handlers."""
+        return self.model_dump_json()
+
+    def __str__(self) -> str:
+        # Stringifying a StreamError gives the same JSON string consumers
+        # used to receive from the inline ``json.dumps`` call sites.
+        return self.to_chunk()
+
+    @classmethod
+    def from_error_dict(cls, error_dict: dict) -> "StreamError":
+        """Build a ``StreamError`` from a loose ``{"error": {...}}`` dict.
+
+        Tolerates partial dicts (e.g. ``extract_error_json`` may produce
+        just ``{"error": {"message": ...}}``) by defaulting missing
+        ``type`` and ``code`` to ``internal_error`` / ``generation_failed``
+        respectively; the resulting chunk still carries the original
+        message verbatim.
+        """
+        inner = error_dict.get("error", {}) if isinstance(error_dict, dict) else {}
+        if not isinstance(inner, dict):
+            inner = {}
+
+        message = inner.get("message")
+        if not isinstance(message, str):
+            message = str(message) if message is not None else "Unknown error"
+
+        type_value = inner.get("type") or StreamErrorType.INTERNAL_ERROR.value
+        code_value = inner.get("code") or StreamErrorCode.GENERATION_FAILED.value
+        param_value = inner.get("param") if isinstance(inner.get("param"), str) else None
+
+        details_kwargs = {
+            "message": message,
+            "type": str(type_value),
+            "code": str(code_value),
+            "param": param_value,
+        }
+        # Preserve any unknown keys the upstream provider sent (`extra="allow"`).
+        for key, value in inner.items():
+            if key not in details_kwargs:
+                details_kwargs[key] = value
+
+        return cls(error=StreamErrorDetails(**details_kwargs))
+
+    @classmethod
+    def generation_failed(
+        cls,
+        message: str,
+        *,
+        type_: StreamErrorType = StreamErrorType.GENERATION_ERROR,
+        code: StreamErrorCode = StreamErrorCode.GENERATION_FAILED,
+        param: Optional[str] = None,
+    ) -> "StreamError":
+        """Construct a ``generation_error`` / ``generation_failed`` chunk."""
+        return cls(
+            error=StreamErrorDetails(
+                message=message,
+                type=type_.value,
+                code=code.value,
+                param=param,
+            )
+        )
+
+    @classmethod
+    def content_blocked(cls, message: str, *, param: Optional[str] = None) -> "StreamError":
+        """Construct a ``guardrails_violation`` / ``content_blocked`` chunk."""
+        return cls(
+            error=StreamErrorDetails(
+                message=message,
+                type=StreamErrorType.GUARDRAILS_VIOLATION.value,
+                code=StreamErrorCode.CONTENT_BLOCKED.value,
+                param=param,
+            )
+        )
+
+    @classmethod
+    def rail_execution_failure(cls, message: str, *, param: Optional[str] = None) -> "StreamError":
+        """Construct an ``internal_error`` / ``rail_execution_failure`` chunk."""
+        return cls(
+            error=StreamErrorDetails(
+                message=message,
+                type=StreamErrorType.INTERNAL_ERROR.value,
+                code=StreamErrorCode.RAIL_EXECUTION_FAILURE.value,
+                param=param,
+            )
+        )
+
+
+def stream_error_to_chunk(error: StreamError) -> str:
+    """Serialize a ``StreamError`` to the chunk string that goes on the wire.
+
+    This is the inverse of :func:`parse_stream_error_chunk` and exists so
+    rails engines have a single, named call site to use when bridging
+    typed errors into the existing string-based ``StreamingHandler`` API.
+    """
+    return error.to_chunk()
+
+
+def parse_stream_error_chunk(chunk: object) -> Optional[StreamError]:
+    """Try to recover a ``StreamError`` from a streamed chunk.
+
+    Returns ``None`` when the chunk is not a JSON-encoded ``StreamError``
+    payload, so callers can use this as a typed test (``if parse_... is not
+    None``) to distinguish error chunks from ordinary LLM output. Accepts
+    dicts directly in case a future ``StreamingHandler`` mode forwards
+    structured chunks without serialization.
+    """
+    if isinstance(chunk, StreamError):
+        return chunk
+
+    if isinstance(chunk, dict):
+        payload = chunk
+    elif isinstance(chunk, str):
+        chunk_str = chunk.lstrip()
+        if not chunk_str.startswith("{"):
+            return None
+        try:
+            payload = json.loads(chunk_str)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    else:
+        return None
+
+    if not isinstance(payload, dict) or "error" not in payload:
+        return None
+
+    try:
+        return StreamError.model_validate(payload)
+    except Exception:  # pragma: no cover - defensive
+        return None

--- a/tests/test_stream_errors.py
+++ b/tests/test_stream_errors.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the typed StreamError model and the buffer-skip path."""
+
+import json
+
+import pytest
+
+from nemoguardrails.rails.llm.buffer import RollingBuffer
+from nemoguardrails.stream_errors import (
+    StreamError,
+    StreamErrorCode,
+    StreamErrorDetails,
+    StreamErrorType,
+    parse_stream_error_chunk,
+    stream_error_to_chunk,
+)
+
+
+class TestStreamErrorEnums:
+    """Lock down the on-the-wire vocabulary that downstream consumers rely on."""
+
+    def test_type_values_match_historical_strings(self):
+        # These string values previously appeared as inline literals in both
+        # IORails and LLMRails. They must stay identical so existing consumers
+        # parsing the JSON shape do not break.
+        assert StreamErrorType.GENERATION_ERROR.value == "generation_error"
+        assert StreamErrorType.GUARDRAILS_VIOLATION.value == "guardrails_violation"
+        assert StreamErrorType.INTERNAL_ERROR.value == "internal_error"
+
+    def test_code_values_match_historical_strings(self):
+        assert StreamErrorCode.GENERATION_FAILED.value == "generation_failed"
+        assert StreamErrorCode.CONTENT_BLOCKED.value == "content_blocked"
+        assert StreamErrorCode.RAIL_EXECUTION_FAILURE.value == "rail_execution_failure"
+
+    def test_enums_are_str_subclasses(self):
+        # Enum values are used directly in JSON serialization, so they must
+        # behave like strings (so model_dump_json emits the bare value rather
+        # than an enum repr).
+        assert isinstance(StreamErrorType.GENERATION_ERROR, str)
+        assert isinstance(StreamErrorCode.CONTENT_BLOCKED, str)
+
+
+class TestStreamErrorSerialization:
+    """The serialized shape is the public contract, so pin it explicitly."""
+
+    def test_to_chunk_matches_legacy_shape_with_param(self):
+        err = StreamError.content_blocked("Blocked by foo rails.", param="foo")
+        payload = json.loads(err.to_chunk())
+        assert payload == {
+            "error": {
+                "message": "Blocked by foo rails.",
+                "type": "guardrails_violation",
+                "code": "content_blocked",
+                "param": "foo",
+            }
+        }
+
+    def test_to_chunk_includes_null_param_when_absent(self):
+        err = StreamError.generation_failed("LLM exploded")
+        payload = json.loads(err.to_chunk())
+        # Backwards compatibility: legacy IORails payloads omitted ``param``,
+        # but JSON-with-explicit-null is parse-compatible for OpenAI-style
+        # consumers that .get("param") and tolerate None.
+        assert payload["error"]["message"] == "LLM exploded"
+        assert payload["error"]["type"] == "generation_error"
+        assert payload["error"]["code"] == "generation_failed"
+        assert payload["error"]["param"] is None
+
+    def test_str_equals_to_chunk(self):
+        err = StreamError.rail_execution_failure("Boom", param="rail x")
+        assert str(err) == err.to_chunk()
+
+    def test_stream_error_to_chunk_helper_matches_method(self):
+        err = StreamError.content_blocked("hi")
+        assert stream_error_to_chunk(err) == err.to_chunk()
+
+
+class TestStreamErrorFromErrorDict:
+    """``from_error_dict`` is the bridge from ``extract_error_json`` output."""
+
+    def test_full_dict_round_trips(self):
+        original = {
+            "error": {
+                "message": "boom",
+                "type": "guardrails_violation",
+                "code": "content_blocked",
+                "param": "flow-id",
+            }
+        }
+        err = StreamError.from_error_dict(original)
+        assert json.loads(err.to_chunk()) == original
+
+    def test_partial_dict_fills_defaults(self):
+        # ``extract_error_json`` returns ``{"error": {"message": ...}}`` for
+        # non-JSON upstream messages. The model must accept that shape and
+        # supply sensible default type/code values rather than crashing.
+        err = StreamError.from_error_dict({"error": {"message": "network down"}})
+        payload = json.loads(err.to_chunk())
+        assert payload["error"]["message"] == "network down"
+        assert payload["error"]["type"] == StreamErrorType.INTERNAL_ERROR.value
+        assert payload["error"]["code"] == StreamErrorCode.GENERATION_FAILED.value
+
+    def test_unknown_keys_preserved(self):
+        # OpenAI-style upstream errors sometimes include extra fields like
+        # ``request_id``. ``extra="allow"`` keeps them so downstream consumers
+        # can still see them.
+        original = {
+            "error": {
+                "message": "boom",
+                "type": "internal_error",
+                "code": "generation_failed",
+                "request_id": "req_abc",
+            }
+        }
+        err = StreamError.from_error_dict(original)
+        payload = json.loads(err.to_chunk())
+        assert payload["error"].get("request_id") == "req_abc"
+
+    def test_non_dict_input_yields_unknown_error(self):
+        err = StreamError.from_error_dict({"error": "string-not-dict"})
+        payload = json.loads(err.to_chunk())
+        # Falls back to a sane default rather than raising.
+        assert payload["error"]["message"] == "Unknown error"
+
+    def test_completely_empty_input(self):
+        err = StreamError.from_error_dict({})
+        payload = json.loads(err.to_chunk())
+        assert payload["error"]["message"] == "Unknown error"
+
+
+class TestParseStreamErrorChunk:
+    """Round-trip detection via parse_stream_error_chunk -- this is what the
+    RollingBuffer and consumers use to distinguish error chunks from text.
+    """
+
+    def test_parses_serialized_stream_error(self):
+        original = StreamError.content_blocked("nope", param="rail")
+        recovered = parse_stream_error_chunk(original.to_chunk())
+        assert recovered is not None
+        assert recovered.error.message == "nope"
+        assert recovered.error.code == "content_blocked"
+        assert recovered.error.param == "rail"
+
+    def test_returns_none_for_plain_text(self):
+        assert parse_stream_error_chunk("Hello world") is None
+        assert parse_stream_error_chunk("") is None
+        assert parse_stream_error_chunk(" ") is None
+
+    def test_returns_none_for_non_error_json(self):
+        # A JSON object that happens to start with ``{`` but is not an error
+        # envelope must not be misclassified.
+        assert parse_stream_error_chunk('{"text": "hello"}') is None
+
+    def test_returns_none_for_malformed_json(self):
+        assert parse_stream_error_chunk("{not json") is None
+        assert parse_stream_error_chunk('{"error": ') is None
+
+    def test_accepts_dict_input(self):
+        recovered = parse_stream_error_chunk(
+            {"error": {"message": "x", "type": "internal_error", "code": "generation_failed"}}
+        )
+        assert recovered is not None
+        assert recovered.error.type == "internal_error"
+
+    def test_passthrough_stream_error_instance(self):
+        original = StreamError.generation_failed("x")
+        assert parse_stream_error_chunk(original) is original
+
+    def test_returns_none_for_non_string_non_dict(self):
+        assert parse_stream_error_chunk(42) is None
+        assert parse_stream_error_chunk(None) is None
+        assert parse_stream_error_chunk(["error", "list"]) is None
+
+    def test_leading_whitespace_tolerated(self):
+        chunk = "   " + StreamError.generation_failed("x").to_chunk()
+        assert parse_stream_error_chunk(chunk) is not None
+
+
+class TestRollingBufferSkipsStreamErrors:
+    """Integration: the buffer must keep StreamError chunks out of the
+    processing context so they cannot pollute output rails.
+    """
+
+    @pytest.mark.asyncio
+    async def test_error_chunk_yielded_with_empty_processing_context(self):
+        """A standalone error chunk arrives in its own batch with no context."""
+        error_chunk = stream_error_to_chunk(StreamError.generation_failed("LLM died"))
+
+        async def stream():
+            yield error_chunk
+
+        buf = RollingBuffer(buffer_context_size=2, buffer_chunk_size=5)
+        batches = [b async for b in buf.process_stream(stream())]
+
+        assert len(batches) == 1
+        assert batches[0].user_output_chunks == [error_chunk]
+        # The crucial invariant: error chunks NEVER appear in processing_context
+        # since that is what flows into output rails.
+        assert batches[0].processing_context == []
+
+    @pytest.mark.asyncio
+    async def test_error_chunk_after_content_flushes_pending_text(self):
+        """An error mid-stream still surfaces prior text, but the error is its
+        own batch and the prior text is not concatenated with the error JSON
+        inside ``processing_context``.
+        """
+        error_chunk = stream_error_to_chunk(StreamError.generation_failed("LLM died"))
+
+        async def stream():
+            yield "Hello"
+            yield " "
+            yield "world"
+            yield error_chunk
+
+        buf = RollingBuffer(buffer_context_size=2, buffer_chunk_size=5)
+        batches = [b async for b in buf.process_stream(stream())]
+
+        # At least one batch flushes the prior text, then exactly one batch
+        # carries the error chunk on its own.
+        text_batches = [b for b in batches if b.user_output_chunks and error_chunk not in b.user_output_chunks]
+        error_batches = [b for b in batches if error_chunk in b.user_output_chunks]
+
+        assert error_batches, "expected an error batch"
+        assert len(error_batches) == 1
+        assert error_batches[0].processing_context == []
+
+        flushed_text = "".join(c for batch in text_batches for c in batch.user_output_chunks)
+        assert flushed_text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_regular_chunks_unaffected(self):
+        """Sanity: the new code path does not change behavior for plain text."""
+
+        async def stream():
+            for word in ["Hello", " ", "world", "!"]:
+                yield word
+
+        buf = RollingBuffer(buffer_context_size=2, buffer_chunk_size=5)
+        batches = [b async for b in buf.process_stream(stream())]
+
+        all_user_chunks = [c for batch in batches for c in batch.user_output_chunks]
+        assert "".join(all_user_chunks) == "Hello world!"
+
+        # No batch should have an empty processing_context for plain text.
+        for batch in batches:
+            if batch.user_output_chunks:
+                assert batch.processing_context, "plain-text batches should still carry context"
+
+
+class TestStreamErrorDetailsExtraAllow:
+    """``extra=allow`` keeps unknown error fields rather than raising, which
+    matters when ``extract_error_json`` recovers an OpenAI-style payload.
+    """
+
+    def test_extra_field_round_trip(self):
+        details = StreamErrorDetails(
+            message="m",
+            type="t",
+            code="c",
+            request_id="rid",
+        )
+        assert details.model_dump()["request_id"] == "rid"


### PR DESCRIPTION
Closes #1780.

Streaming errors are currently hand-built JSON strings constructed inline at every emission site. IORails and LLMRails have drifted: LLMRails includes a ``param`` field but IORails does not, type and code values are free-form, and the same payload shape comes through ``extract_error_json`` for upstream provider errors. Worse, because these payloads are plain JSON strings, they are indistinguishable from LLM output and flow into ``RollingBuffer`` where output rails treat them as content.

This change introduces ``nemoguardrails.stream_errors`` with a typed ``StreamError`` Pydantic model, plus ``StreamErrorType`` and ``StreamErrorCode`` enums covering the historical ``generation_error`` / ``guardrails_violation`` / ``internal_error`` vocabulary and ``generation_failed`` / ``content_blocked`` / ``rail_execution_failure`` codes. Both rails engines now build ``StreamError`` instances via classmethods (``StreamError.generation_failed``, ``StreamError.content_blocked``, ``StreamError.rail_execution_failure``) and serialize via ``stream_error_to_chunk`` when pushing into the streaming handler. The serialized shape matches what consumers already see, so OpenAI-style error handling keeps working without changes.

``RollingBuffer`` now uses ``parse_stream_error_chunk`` to detect typed error chunks and yields them in a dedicated batch with an empty ``processing_context``. That keeps the error JSON out of the user-visible text fed to output rails, which previously could either leak the payload back to the user or trip the rail on its own diagnostic. IORails and LLMRails also use ``parse_stream_error_chunk`` to skip generation-error batches before invoking output rails, replacing the substring-based ``parsed.get("error", {}).get("type") == ...`` heuristic with a typed check.

The LLMRails ``stream_async`` exception handler routes ``extract_error_json`` output through ``StreamError.from_error_dict`` so partial upstream shapes (often just ``{"error": {"message": ...}}``) are normalized into the typed contract before hitting the wire. Extra upstream keys like ``request_id`` are preserved via ``extra="allow"``.

Tests cover the enum vocabulary, JSON serialization parity with the legacy inline shape, ``from_error_dict`` round-trips and partial-shape filling, ``parse_stream_error_chunk`` detection across strings, dicts, and malformed inputs, and the buffer-skip behavior including the mid-stream case where prior content must still flush. The full streaming test suite (155 tests across the buffer, handler, internal errors, output rails, parallel rails, IORails streaming, action errors, and langchain streaming) continues to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error detection and reporting during streaming operations.

* **Bug Fixes**
  * Fixed buffering behavior to prevent error messages from being mixed with generated output.
  * Improved handling of generation failures detected mid-stream to ensure proper error propagation.

* **Tests**
  * Added comprehensive test coverage for streaming error handling and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->