### PR TITLE
fix(server): honor api_key env vars when overriding main model

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -328,9 +328,7 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
         # set, so a request-side model swap inherits credential resolution
         # (api_key_env_var) and other model-level settings from config.yml.
         api_key_env_var = (
-            main_model.api_key_env_var
-            if main_model.api_key_env_var is not None
-            else existing.api_key_env_var
+            main_model.api_key_env_var if main_model.api_key_env_var is not None else existing.api_key_env_var
         )
         models[main_model_index] = main_model
         models[main_model_index].parameters = parameters

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -309,6 +309,9 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
     """Update the main model in the RailsConfig.
 
     If a model with type="main" exists, it replaces it. Otherwise, adds it.
+    Fields not explicitly set on the override model (such as ``api_key_env_var``)
+    are carried over from the existing entry so request-driven model overrides
+    do not silently drop credential resolution configured in ``config.yml``.
     """
     models = config.models.copy()
     main_model_index = None
@@ -319,9 +322,15 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
             break
 
     if main_model_index is not None:
-        parameters = {**models[main_model_index].parameters, **main_model.parameters}
+        existing = models[main_model_index]
+        parameters = {**existing.parameters, **main_model.parameters}
+        # Preserve fields from the existing entry that the override does not
+        # set, so a request-side model swap inherits credential resolution
+        # (api_key_env_var) and other model-level settings from config.yml.
+        api_key_env_var = main_model.api_key_env_var or existing.api_key_env_var
         models[main_model_index] = main_model
         models[main_model_index].parameters = parameters
+        models[main_model_index].api_key_env_var = api_key_env_var
     else:
         models.append(main_model)
 

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -309,9 +309,10 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
     """Update the main model in the RailsConfig.
 
     If a model with type="main" exists, it replaces it. Otherwise, adds it.
-    Fields not explicitly set on the override model (such as ``api_key_env_var``)
-    are carried over from the existing entry so request-driven model overrides
-    do not silently drop credential resolution configured in ``config.yml``.
+    Only the fields the override model explicitly sets are applied on top of the
+    existing entry. Fields it leaves unset (such as ``api_key_env_var``, ``mode``,
+    and ``cache``) are carried over from ``config.yml`` so request-driven model
+    overrides do not silently drop credential resolution or other model settings.
     """
     models = config.models.copy()
     main_model_index = None
@@ -323,16 +324,17 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
 
     if main_model_index is not None:
         existing = models[main_model_index]
-        parameters = {**existing.parameters, **main_model.parameters}
-        # Preserve fields from the existing entry that the override does not
-        # set, so a request-side model swap inherits credential resolution
-        # (api_key_env_var) and other model-level settings from config.yml.
-        api_key_env_var = (
-            main_model.api_key_env_var if main_model.api_key_env_var is not None else existing.api_key_env_var
-        )
-        models[main_model_index] = main_model
-        models[main_model_index].parameters = parameters
-        models[main_model_index].api_key_env_var = api_key_env_var
+        # Override only the fields the caller actually set on the request model,
+        # starting from the existing entry. This carries over api_key_env_var,
+        # mode, cache, and any future Model field the override leaves unset,
+        # instead of replacing the whole entry and patching fields back by hand
+        # (which silently dropped everything except the few handled explicitly).
+        override = main_model.model_dump(exclude_unset=True)
+        # Merge parameters with override precedence rather than replacing, so a
+        # request-side swap extends the config.yml parameters instead of wiping them.
+        if "parameters" in override:
+            override["parameters"] = {**existing.parameters, **main_model.parameters}
+        models[main_model_index] = existing.model_copy(update=override)
     else:
         models.append(main_model)
 

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -327,7 +327,11 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
         # Preserve fields from the existing entry that the override does not
         # set, so a request-side model swap inherits credential resolution
         # (api_key_env_var) and other model-level settings from config.yml.
-        api_key_env_var = main_model.api_key_env_var or existing.api_key_env_var
+        api_key_env_var = (
+            main_model.api_key_env_var
+            if main_model.api_key_env_var is not None
+            else existing.api_key_env_var
+        )
         models[main_model_index] = main_model
         models[main_model_index].parameters = parameters
         models[main_model_index].api_key_env_var = api_key_env_var

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -953,3 +953,113 @@ def test_list_models_upstream_missing_data_key():
     assert response.status_code == 200
     data = response.json()
     assert data["data"] == []
+
+
+def test_update_models_in_config_preserves_api_key_env_var(monkeypatch):
+    """Regression test for #1895.
+
+    When a request supplies a ``model`` override, ``_update_models_in_config``
+    must preserve ``api_key_env_var`` from the existing main model entry so
+    env-var-based credential resolution configured in ``config.yml`` is not
+    silently dropped when the model name is swapped at request time.
+    """
+    from nemoguardrails import RailsConfig
+    from nemoguardrails.rails.llm.config import Model
+    from nemoguardrails.server.api import _update_models_in_config
+
+    # The RailsConfig validator checks api_key_env_var resolves at construction.
+    monkeypatch.setenv("MY_CUSTOM_KEY", "sk-test-preserved")
+
+    existing = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo",
+        api_key_env_var="MY_CUSTOM_KEY",
+        parameters={"temperature": 0.7},
+    )
+    config = RailsConfig(models=[existing], colang_version="1.0")
+
+    override = Model(
+        type="main",
+        engine="openai",
+        model="gpt-4",
+        parameters={"base_url": "https://api.example.com/v1"},
+    )
+
+    updated = _update_models_in_config(config, override)
+
+    assert len(updated.models) == 1
+    main = updated.models[0]
+    assert main.model == "gpt-4"
+    assert main.engine == "openai"
+    # api_key_env_var carries over from the config entry.
+    assert main.api_key_env_var == "MY_CUSTOM_KEY"
+    # Parameters merge, with the override winning on collisions.
+    assert main.parameters == {"temperature": 0.7, "base_url": "https://api.example.com/v1"}
+
+
+def test_update_models_in_config_override_takes_precedence_for_api_key_env_var(monkeypatch):
+    """An explicit ``api_key_env_var`` on the override wins over the existing entry."""
+    from nemoguardrails import RailsConfig
+    from nemoguardrails.rails.llm.config import Model
+    from nemoguardrails.server.api import _update_models_in_config
+
+    monkeypatch.setenv("OLD_KEY", "sk-old")
+    monkeypatch.setenv("NEW_KEY", "sk-new")
+
+    existing = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo",
+        api_key_env_var="OLD_KEY",
+    )
+    config = RailsConfig(models=[existing], colang_version="1.0")
+
+    override = Model(
+        type="main",
+        engine="openai",
+        model="gpt-4",
+        api_key_env_var="NEW_KEY",
+    )
+
+    updated = _update_models_in_config(config, override)
+
+    assert updated.models[0].api_key_env_var == "NEW_KEY"
+
+
+def test_get_rails_with_model_override_resolves_env_credentials(monkeypatch, tmp_path):
+    """Regression test for #1895.
+
+    With ``OPENAI_API_KEY`` set in the environment and a ``config.yml`` that
+    omits ``api_key_env_var``, the server-path model initialization must
+    still resolve credentials from the env var when a request supplies a
+    ``model`` override. This mirrors the CLI and non-server path behavior.
+    """
+    import asyncio
+
+    config_dir = tmp_path / "general"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text(
+        "colang_version: '1.0'\nmodels:\n  - type: main\n    engine: openai\n    model: gpt-3.5-turbo\n"
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env-1895")
+    monkeypatch.setenv("MAIN_MODEL_ENGINE", "openai")
+    monkeypatch.setenv("MAIN_MODEL_BASE_URL", "https://api.openai.com/v1")
+
+    original_path = api.app.rails_config_path
+    api.app.rails_config_path = str(tmp_path)
+    api.llm_rails_instances.clear()
+
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            llm_rails = loop.run_until_complete(api._get_rails(["general"], model_name="gpt-4"))
+        finally:
+            loop.close()
+
+        client_api_key = getattr(llm_rails.llm._client, "_api_key", None)
+        assert client_api_key == "sk-from-env-1895"
+    finally:
+        api.app.rails_config_path = original_path
+        api.llm_rails_instances.clear()

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -1027,6 +1027,45 @@ def test_update_models_in_config_override_takes_precedence_for_api_key_env_var(m
     assert updated.models[0].api_key_env_var == "NEW_KEY"
 
 
+def test_update_models_in_config_preserves_mode_and_cache(monkeypatch):
+    """A request-side model override must not drop other config.yml model
+    settings it leaves unset, such as ``mode`` and ``cache``.
+
+    Follow-up to #1895: the override now starts from the existing entry and
+    applies only the fields it explicitly sets, so any field added to ``Model``
+    later is preserved without per-field carry-over.
+    """
+    from nemoguardrails import RailsConfig
+    from nemoguardrails.rails.llm.config import Model, ModelCacheConfig
+    from nemoguardrails.server.api import _update_models_in_config
+
+    monkeypatch.setenv("MY_CUSTOM_KEY", "sk-test-preserved")
+
+    existing = Model(
+        type="main",
+        engine="openai",
+        model="gpt-3.5-turbo-instruct",
+        api_key_env_var="MY_CUSTOM_KEY",
+        mode="text",
+        cache=ModelCacheConfig(enabled=True),
+        parameters={"temperature": 0.7},
+    )
+    config = RailsConfig(models=[existing], colang_version="1.0")
+
+    # The override only swaps the model name, leaving mode, cache, credentials,
+    # and existing parameters unset.
+    override = Model(type="main", engine="openai", model="gpt-4")
+
+    updated = _update_models_in_config(config, override)
+
+    main = updated.models[0]
+    assert main.model == "gpt-4"
+    assert main.mode == "text"
+    assert main.cache is not None and main.cache.enabled is True
+    assert main.api_key_env_var == "MY_CUSTOM_KEY"
+    assert main.parameters == {"temperature": 0.7}
+
+
 def test_get_rails_with_model_override_resolves_env_credentials(monkeypatch, tmp_path):
     """Regression test for #1895.
 


### PR DESCRIPTION
Closes #1895.

When a request to `/v1/chat/completions` supplies a `model` field, the server rebuilds the main model entry by constructing a fresh `Model` from the request value plus `MAIN_MODEL_ENGINE` and `MAIN_MODEL_BASE_URL`, then hands it to `_update_models_in_config` to swap into the loaded `RailsConfig`. That swap replaced the existing entry wholesale, so any `api_key_env_var` declared in `config.yml` was silently dropped. The downstream initializer then had no env-var hint and the credential resolution path that the CLI and non-server code uses was never taken, surfacing as an invalid-API-key error from the upstream provider.

This change carries `api_key_env_var` over from the existing main model entry when the override does not set one explicitly, so a `config.yml` that points at a custom environment variable continues to resolve credentials correctly when the model name is swapped at request time. Explicit `api_key_env_var` on the override still takes precedence. Implicit env-var fallback for engines like `openai` continues to work via the default framework, which was already correct on the no-override path.

Added regression coverage on `_update_models_in_config` for both the preserve-from-config and override-wins paths, plus an integration-level test that drives `_get_rails` end to end with `OPENAI_API_KEY` set and a request-side model override, asserting the resolved HTTP client carries the env-derived key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model overrides now preserve existing credential configuration fields when not explicitly set in the override request.
  * Environment-based credential resolution continues to work correctly when applying model overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->