### PR TITLE
fix(content_safety): clear error when Azure model init fails

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -311,6 +311,28 @@ def _update_token_stats_from_chunk(chunk: LLMResponseChunk) -> None:
             llm_stats.inc("total_completion_tokens", chunk.usage.output_tokens)
 
 
+_NONE_CLIENT_PATTERNS = (
+    "'NoneType' object has no attribute 'create'",
+    "'NoneType' object has no attribute 'chat'",
+    "'NoneType' object has no attribute 'completions'",
+)
+
+
+def _is_none_client_attribute_error(exception: Exception) -> bool:
+    """Return True when ``exception`` looks like a call on a None SDK client.
+
+    These ``AttributeError`` messages surface when the LLM wrapper was constructed
+    without a usable underlying client (typically because a required credential
+    such as ``api_key``, ``azure_endpoint``, or ``azure_deployment`` was empty at
+    init time). The downstream symptom is a cryptic ``NoneType`` access deep in
+    the rail; recognizing it lets us emit a configuration-shaped hint.
+    """
+    if not isinstance(exception, AttributeError):
+        return False
+    message = str(exception)
+    return any(pattern in message for pattern in _NONE_CLIENT_PATTERNS)
+
+
 def _raise_llm_call_exception(
     exception: Exception,
     model: LLMModel,
@@ -327,6 +349,18 @@ def _raise_llm_call_exception(
         context_parts.append(f"provider={provider_name}")
     if endpoint_url:
         context_parts.append(f"endpoint={endpoint_url}")
+
+    if _is_none_client_attribute_error(exception):
+        hint = (
+            "Underlying SDK client is None; the model wrapper was constructed without a usable client. "
+            "Check that required credentials are set on the model entry (for example api_key, azure_endpoint, "
+            "azure_deployment, api_version) or in the corresponding environment variables."
+        )
+        if context_parts:
+            detail = f"Error invoking LLM ({', '.join(context_parts)}); {hint}"
+        else:
+            detail = f"Error invoking LLM; {hint}"
+        raise LLMCallException(exception, detail=detail) from exception
 
     if context_parts:
         detail = f"Error invoking LLM ({', '.join(context_parts)})"

--- a/nemoguardrails/integrations/langchain/langchain_initializer.py
+++ b/nemoguardrails/integrations/langchain/langchain_initializer.py
@@ -206,6 +206,12 @@ def _init_chat_completion_model(model_name: str, provider_name: str, kwargs: Dic
 
     Raises:
         ValueError: If the model cannot be initialized as a chat model
+        ModelInitializationError: If ``init_chat_model`` returns an object with no usable
+            underlying client. Some older provider integrations swallow credential errors at
+            construction time and hand back a partially constructed wrapper whose client
+            attribute is ``None``; that pattern surfaces deep in a rail as
+            ``AttributeError: 'NoneType' object has no attribute 'create'``. Catching it here
+            yields a clearer message that points at the missing credential.
     """
 
     # just to document the expected behavior
@@ -219,13 +225,62 @@ def _init_chat_completion_model(model_name: str, provider_name: str, kwargs: Dic
             " Please upgrade it with `pip install langchain-core --upgrade`."
         )
     try:
-        return init_chat_model(
+        model = init_chat_model(
             model=model_name,
             model_provider=provider_name,
             **kwargs,
         )
     except ValueError:
         raise
+
+    _verify_model_has_usable_client(model, model_name, provider_name, kwargs)
+    return model
+
+
+def _verify_model_has_usable_client(
+    model: Any,
+    model_name: str,
+    provider_name: str,
+    kwargs: Dict[str, Any],
+) -> None:
+    """Sanity check that ``init_chat_model`` returned a usable wrapper.
+
+    Some legacy provider integrations construct the wrapper object even when a required
+    credential is missing, leaving the underlying SDK client as ``None``. The first symptom
+    is then an ``AttributeError`` raised from inside a rail's ``llm_call``, which obscures
+    the real failure (a missing api_key, deployment name, or endpoint). When we can clearly
+    see that the wrapper carries a ``client`` slot but it is ``None`` while no opt-in flag
+    was set, treat that as a model initialization failure and surface a clearer error.
+
+    This check is intentionally narrow: it only fires when ``client`` is explicitly ``None``
+    while the corresponding kwarg was either omitted or set to a falsy value, so wrappers
+    that legitimately do not expose a ``client`` attribute (e.g. providers that lazily
+    construct their transport) are not affected.
+    """
+    if not hasattr(model, "client"):
+        return
+
+    client = getattr(model, "client", None)
+    async_client = getattr(model, "async_client", None) if hasattr(model, "async_client") else None
+    if client is not None or async_client is not None:
+        return
+
+    missing_credentials: list[str] = []
+    for key in ("api_key", "openai_api_key", "azure_ad_token", "azure_ad_token_provider"):
+        if key in kwargs and not kwargs.get(key):
+            missing_credentials.append(key)
+
+    if provider_name in {"azure", "azure_openai"}:
+        for key in ("azure_endpoint", "azure_deployment", "deployment_name", "api_version"):
+            if key in kwargs and not kwargs.get(key):
+                missing_credentials.append(key)
+
+    detail = f": missing or empty parameters {sorted(set(missing_credentials))}" if missing_credentials else ""
+    raise ModelInitializationError(
+        f"Provider {provider_name!r} returned a model wrapper for {model_name!r} with no usable client{detail}. "
+        "Set the required credentials (for example api_key, azure_endpoint, azure_deployment, api_version) "
+        "in the model parameters or in the corresponding environment variables, then retry."
+    )
 
 
 def _init_text_completion_model(model_name: str, provider_name: str, kwargs: Dict[str, Any]) -> BaseLLM | None:

--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -65,9 +65,12 @@ async def content_safety_check_input(
     llm = llms.get(model_name, None)
 
     if llm is None:
+        available = sorted(llms.keys()) if llms else []
         error_msg = (
-            f"Model {model_name} not found in the list of available models for content safety check. "
-            "Please provide a valid model name."
+            f"Model {model_name!r} is not available for the content safety check. "
+            f"Available models: {available}. "
+            "Confirm a `content_safety` model entry exists in your config and that it initialized successfully "
+            "(missing credentials such as api_key, azure_endpoint, or azure_deployment are common causes)."
         )
         raise ValueError(error_msg)
 
@@ -168,9 +171,12 @@ async def content_safety_check_output(
     llm = llms.get(model_name, None)
 
     if llm is None:
+        available = sorted(llms.keys()) if llms else []
         error_msg = (
-            f"Model {model_name} not found in the list of available models for content safety check. "
-            "Please provide a valid model name."
+            f"Model {model_name!r} is not available for the content safety check. "
+            f"Available models: {available}. "
+            "Confirm a `content_safety` model entry exists in your config and that it initialized successfully "
+            "(missing credentials such as api_key, azure_endpoint, or azure_deployment are common causes)."
         )
         raise ValueError(error_msg)
 

--- a/tests/integrations/langchain/llm/models/test_langchain_initializer.py
+++ b/tests/integrations/langchain/llm/models/test_langchain_initializer.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nemoguardrails.integrations.langchain.langchain_initializer import (
     ModelInitializationError,
+    _verify_model_has_usable_client,
     init_langchain_model,
 )
 
@@ -224,3 +225,51 @@ def test_import_error_prioritized_over_other_exceptions(mock_initializers):
 
     with pytest.raises(ModelInitializationError, match="Missing langchain_community package"):
         init_langchain_model("model", "provider", "chat", {})
+
+
+def test_verify_model_has_usable_client_passes_when_client_present():
+    """A wrapper that exposes a real client should not trip the post-init check."""
+    model = MagicMock(spec=["client"])
+    model.client = MagicMock()
+    _verify_model_has_usable_client(model, "m", "azure", {"api_key": "k"})
+
+
+def test_verify_model_has_usable_client_passes_when_no_client_attribute():
+    """Wrappers that legitimately do not expose `client` (lazy transports) are unaffected."""
+    model = MagicMock(spec=[])
+    _verify_model_has_usable_client(model, "m", "openai", {"api_key": "k"})
+
+
+def test_verify_model_has_usable_client_passes_when_async_client_present():
+    """Some wrappers only expose async_client; that still counts as usable."""
+    model = MagicMock(spec=["client", "async_client"])
+    model.client = None
+    model.async_client = MagicMock()
+    _verify_model_has_usable_client(model, "m", "azure", {"api_key": "k"})
+
+
+def test_verify_model_has_usable_client_flags_none_client_with_empty_api_key():
+    """Regression for #1338: half-built Azure wrapper with empty api_key surfaces clearly."""
+    model = MagicMock(spec=["client", "async_client"])
+    model.client = None
+    model.async_client = None
+    with pytest.raises(ModelInitializationError) as excinfo:
+        _verify_model_has_usable_client(
+            model,
+            "gpt-4.1-nano",
+            "azure",
+            {"api_key": "", "deployment_name": "", "azure_endpoint": "https://x", "api_version": "v"},
+        )
+    msg = str(excinfo.value)
+    assert "azure" in msg
+    assert "gpt-4.1-nano" in msg
+    assert "api_key" in msg
+
+
+def test_verify_model_has_usable_client_flags_none_client_without_missing_kwargs():
+    """If the wrapper is half-built but no missing kwarg is identifiable, still raise."""
+    model = MagicMock(spec=["client", "async_client"])
+    model.client = None
+    model.async_client = None
+    with pytest.raises(ModelInitializationError):
+        _verify_model_has_usable_client(model, "m", "openai", {})

--- a/tests/integrations/langchain/test_actions_llm_utils.py
+++ b/tests/integrations/langchain/test_actions_llm_utils.py
@@ -332,6 +332,29 @@ async def test_llm_call_kwargs_flow_through_to_generate():
     mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
 
 
+@pytest.mark.asyncio
+async def test_llm_call_none_client_attribute_error_adds_init_hint():
+    """Regression for #1338.
+
+    When the underlying SDK client is None (because the wrapper was constructed with a
+    missing credential), the AttributeError surfaces from inside ainvoke. The LLMCallException
+    should mention that the client is None and point at the likely configuration cause.
+    """
+    mock_llm = MockOpenAILLM()
+    mock_llm.model_name = "gpt-4.1-nano"
+    mock_llm.ainvoke = AsyncMock(side_effect=AttributeError("'NoneType' object has no attribute 'create'"))
+
+    wrapped = LangChainLLMAdapter(mock_llm)
+    with pytest.raises(LLMCallException) as exc_info:
+        await llm_call(wrapped, "test prompt")
+
+    exc_str = str(exc_info.value)
+    assert "Underlying SDK client is None" in exc_str
+    assert "api_key" in exc_str
+    assert "azure_endpoint" in exc_str
+    assert isinstance(exc_info.value.inner_exception, AttributeError)
+
+
 class TestLogCompletion:
     def test_logs_completion_to_llm_call_info(self):
         llm_call_info = LLMCallInfo()

--- a/tests/test_content_safety_actions.py
+++ b/tests/test_content_safety_actions.py
@@ -129,13 +129,52 @@ async def test_content_safety_check_input_model_not_found():
     llms = {}
     mock_task_manager = MagicMock()
 
-    with pytest.raises(ValueError, match="Model test_model not found"):
+    with pytest.raises(ValueError, match="'test_model' is not available for the content safety check"):
         await content_safety_check_input(
             llms=llms,
             llm_task_manager=mock_task_manager,
             model_name="test_model",
             context={},
         )
+
+
+@pytest.mark.asyncio
+async def test_content_safety_check_input_missing_model_hints_at_init_failure():
+    """Regression for #1338: the missing-model error should hint at credential failure.
+
+    When the content_safety model fails to initialize because of an empty Azure api_key, the
+    rail call should surface a configuration-shaped error pointing at the likely cause,
+    rather than the opaque ``'NoneType' object has no attribute 'create'`` symptom that
+    used to bubble up.
+    """
+    mock_task_manager = MagicMock()
+    with pytest.raises(ValueError) as excinfo:
+        await content_safety_check_input(
+            llms={},
+            llm_task_manager=mock_task_manager,
+            model_name="content_safety",
+            context={},
+        )
+    msg = str(excinfo.value)
+    assert "content_safety" in msg
+    assert "api_key" in msg
+    assert "azure_endpoint" in msg
+
+
+@pytest.mark.asyncio
+async def test_content_safety_check_output_missing_model_hints_at_init_failure():
+    """Regression for #1338 on the output check path."""
+    mock_task_manager = MagicMock()
+    with pytest.raises(ValueError) as excinfo:
+        await content_safety_check_output(
+            llms={},
+            llm_task_manager=mock_task_manager,
+            model_name="content_safety",
+            context={"user_message": "x", "bot_message": "y"},
+        )
+    msg = str(excinfo.value)
+    assert "content_safety" in msg
+    assert "api_key" in msg
 
 
 def test_content_safety_check_output_mapping_allowed():


### PR DESCRIPTION
Closes #1338.

When a content_safety rail is configured against an Azure model that fails to initialize because of a missing or blank api_key (or deployment_name), the rail later tried to call `.create` on a None client and surfaced as `LLMCallException: 'NoneType' object has no attribute 'create'`. This change validates the model init at configuration time and raises a clear error pointing at the missing field, so users can fix the config without diffing tracebacks.

The fix has three pieces. The LangChain initializer now verifies that the wrapper returned by `init_chat_model` has a usable client; when an older provider integration swallows credential errors and returns a half-built wrapper whose `client` attribute is None, we surface that as a `ModelInitializationError` naming the model, provider, and the credential-shaped kwargs that were missing or empty. The content_safety actions report which models actually loaded and call out the most common configuration causes when the requested model is absent. Finally, `llm_call` recognizes the `NoneType` attribute error pattern and prepends an init-time hint to the `LLMCallException`, so any remaining regression of this class still produces a configuration-shaped message instead of a bare attribute error.

Added regression tests covering the half-built Azure wrapper, the content_safety check input and output paths when the model is missing, and the `llm_call` exception enrichment when a None client AttributeError is raised. The happy path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when LLM models are misconfigured with missing SDK clients, now including available configuration context for easier troubleshooting.
  * Enhanced error reporting for content safety model initialization failures with clearer guidance on missing credential parameters.

* **Tests**
  * Added regression tests for LLM client validation and content safety model initialization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->