### PR TITLE
docs: update README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ To the best of our knowledge, the NeMo Guardrails library is the only guardrails
 ## Learn More
 
 - [Documentation](https://docs.nvidia.com/nemo/guardrails)
-- [Getting Started Guide](https://docs.nvidia.com/nemo/guardrails/getting-started)
+- [Getting Started Guide](https://docs.nvidia.com/nemo/guardrails/latest/quick-start.html)
 - [Examples](./examples)
 - [Troubleshooting](https://docs.nvidia.com/nemo/guardrails/latest/troubleshooting.html)
 - [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/latest/resources/security/guidelines.html)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can use programmable guardrails in different types of use cases:
 
 ### Usage
 
-To add programmable guardrails to your application you can use the Python API or a guardrails server (see the [Server Guide](https://docs.nvidia.com/nemo/guardrails/user-guides/server-guide.html) for more details). Using the Python API is similar to using the LLM directly. Calling the guardrails layer instead of the LLM requires only minimal changes to the code base, and it involves two simple steps:
+To add programmable guardrails to your application you can use the Python API or a guardrails server (see the [Guardrails API Server Guide](https://docs.nvidia.com/nemo/guardrails/latest/run-rails/using-fastapi-server/index.html) for more details). Using the Python API is similar to using the LLM directly. Calling the guardrails layer instead of the LLM requires only minimal changes to the code base, and it involves two simple steps:
 
 1. Loading a guardrails configuration and creating an `LLMRails` instance.
 2. Making the calls to the LLM using the `generate`/`generate_async` methods.
@@ -111,7 +111,7 @@ The NeMo Guardrails library is an async-first toolkit as the core mechanics are 
 
 ### Supported LLMs
 
-You can use NeMo Guardrails with multiple LLMs like OpenAI GPT-3.5, GPT-4, LLaMa-2, Falcon, Vicuna, or Mosaic. For more details, check out the [Supported LLM Models](https://docs.nvidia.com/nemo/guardrails/user-guides/configuration-guide.html#supported-llm-models) section in the Configuration Guide.
+You can use NeMo Guardrails with multiple LLMs like OpenAI GPT-3.5, GPT-4, LLaMa-2, Falcon, Vicuna, or Mosaic. For more details, check out the [Supported LLMs](https://docs.nvidia.com/nemo/guardrails/latest/about/supported-llms.html) page.
 
 ### Types of Guardrails
 
@@ -123,7 +123,7 @@ The NeMo Guardrails library supports five main types of guardrails:
 
 1. **Input rails**: applied to the input from the user; an input rail can reject the input, stopping any additional processing, or alter the input (e.g., to mask potentially sensitive data, to rephrase).
 
-2. **Dialog rails**: influence how the LLM is prompted; dialog rails operate on canonical form messages for details see [Colang Guide](https://docs.nvidia.com/nemo/guardrails/user-guides/colang-language-syntax-guide.html)) and determine if an action should be executed, if the LLM should be invoked to generate the next step or a response, if a predefined response should be used instead, etc.
+2. **Dialog rails**: influence how the LLM is prompted; dialog rails operate on canonical form messages (for details see the [Colang 1.0 Guide](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/colang/colang-1/colang-language-syntax-guide.html)) and determine if an action should be executed, if the LLM should be invoked to generate the next step or a response, if a predefined response should be used instead, etc.
 
 3. **Retrieval rails**: applied to the retrieved chunks in the case of a RAG (Retrieval Augmented Generation) scenario; a retrieval rail can reject a chunk, preventing it from being used to prompt the LLM, or alter the relevant chunks (e.g., to mask potentially sensitive data).
 
@@ -147,7 +147,7 @@ The standard structure for a guardrails configuration folder looks like this:
 │   ├── ...
 ```
 
-The `config.yml` contains all the general configuration options, such as LLM models, active rails, and custom configuration data". The `config.py` file contains any custom initialization code and the `actions.py` contains any custom python actions. For a complete overview, see the [Configuration Guide](https://docs.nvidia.com/nemo/guardrails/user-guides/configuration-guide.html).
+The `config.yml` contains all the general configuration options, such as LLM models, active rails, and custom configuration data. The `config.py` file contains any custom initialization code and the `actions.py` contains any custom python actions. For a complete overview, see [Configure Guardrails](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/index.html).
 
 Below is an example `config.yml`:
 
@@ -219,19 +219,19 @@ To configure and implement various types of guardrails, this toolkit introduces 
 Two versions of Colang, 1.0 and 2.0, are supported and Colang 1.0 is the default.
 ```
 
-For a brief introduction to the Colang 1.0 syntax, see the [Colang 1.0 Language Syntax Guide](https://docs.nvidia.com/nemo/guardrails/user-guides/colang-language-syntax-guide.html).
+For a brief introduction to the Colang 1.0 syntax, see the [Colang 1.0 Language Syntax Guide](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/colang/colang-1/colang-language-syntax-guide.html).
 
-To get started with Colang 2.0, see the [Colang 2.0 Documentation](https://docs.nvidia.com/nemo/guardrails/colang-2/overview.html).
+To get started with Colang 2.0, see the [Colang 2.0 Documentation](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/colang/colang-2/index.html).
 
 ### Guardrails Library
 
-NeMo Guardrails comes with a set of [built-in guardrails](https://docs.nvidia.com/nemo/guardrails/user-guides/guardrails-library.html).
+NeMo Guardrails comes with a set of [built-in guardrails](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/guardrail-catalog/index.html).
 
 ```{note}
 The built-in guardrails may or may not be suitable for a given production use case. As always, developers should work with their internal application team to ensure guardrails meets requirements for the relevant industry and use case and address unforeseen product misuse.
 ```
 
-The library includes guardrails for LLM self-checking (input/output moderation, fact-checking, hallucination detection), NVIDIA safety models (content safety, topic safety), jailbreak and injection detection, and integrations with community models and third-party APIs. For the complete list, see the [Guardrails Library documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/guardrails-library.html).
+The library includes guardrails for LLM self-checking (input/output moderation, fact-checking, hallucination detection), NVIDIA safety models (content safety, topic safety), jailbreak and injection detection, and integrations with community models and third-party APIs. For the complete list, see the [Guardrail Catalog](https://docs.nvidia.com/nemo/guardrails/latest/configure-rails/guardrail-catalog/index.html).
 
 ## CLI
 
@@ -280,11 +280,11 @@ Sample output:
 
 #### Docker
 
-To start a guardrails server, you can also use a Docker container. The NeMo Guardrails library provides a [Dockerfile](./Dockerfile) that you can use to build a `nemoguardrails` image. For further information, see the [using Docker](https://docs.nvidia.com/nemo/guardrails/user-guides/advanced/using-docker.html) section.
+To start a guardrails server, you can also use a Docker container. The NeMo Guardrails library provides a [Dockerfile](./Dockerfile) that you can use to build a `nemoguardrails` image. For further information, see the [Using Docker](https://docs.nvidia.com/nemo/guardrails/latest/deployment/using-docker.html) section.
 
 ## Integration with LangChain (Optional)
 
-LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Then install the LangChain packages your configuration requires. After you enable the integration, you can wrap a guardrails configuration around a LangChain chain (or any `Runnable`), and you can call a LangChain chain from within a guardrails configuration. For more information, refer to the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/user-guides/langchain/langchain-integration.html).
+LangChain integration is opt-in. To enable it, set the `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` environment variable or call `set_default_framework("langchain")`. Then install the LangChain packages your configuration requires. After you enable the integration, you can wrap a guardrails configuration around a LangChain chain (or any `Runnable`), and you can call a LangChain chain from within a guardrails configuration. For more information, refer to the [LangChain Integration Documentation](https://docs.nvidia.com/nemo/guardrails/latest/integration/langchain/langchain-integration.html).
 
 ## Evaluation
 
@@ -306,8 +306,8 @@ To the best of our knowledge, the NeMo Guardrails library is the only guardrails
 - [Documentation](https://docs.nvidia.com/nemo/guardrails)
 - [Getting Started Guide](https://docs.nvidia.com/nemo/guardrails/getting-started)
 - [Examples](./examples)
-- [FAQs](https://docs.nvidia.com/nemo/guardrails/faqs.html)
-- [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/security/guidelines.html)
+- [Troubleshooting](https://docs.nvidia.com/nemo/guardrails/latest/troubleshooting.html)
+- [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/latest/resources/security/guidelines.html)
 
 ## Telemetry and Privacy
 


### PR DESCRIPTION
## Description

Updates README documentation links to point to the current published NeMo Guardrails documentation pages under the `/latest/` docs path.

This refreshes stale links for:
- Guardrails API server docs
- Supported LLMs
- Colang 1.0 and 2.0 docs
- Configure Guardrails
- Guardrail Catalog
- Docker deployment
- LangChain integration
- Troubleshooting
- Security Guidelines

Also fixes a small README typo in the configuration description.

## Related Issue(s)

N/A

## Validation

Verified all updated README documentation links with HTTP checks. Each updated docs URL returned `200`.

No code changes were made; tests are not applicable for this docs-only README update.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with refreshed links to latest NeMo Guardrails documentation
  * Aligned terminology and references with current documentation standards
  * Updated links for supported LLMs, configuration guides, Colang syntax, Docker, LangChain integration, troubleshooting, and security guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->