### PR TITLE
fix(library): `detect_regex_pattern()` crashes with TypeError during output streaming

### DIFF
--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -33,6 +33,7 @@ async def detect_regex_pattern(
     source: str,
     text: str,
     config: RailsConfig,
+    **kwargs,
 ) -> RegexDetectionResult:
     """Checks whether the provided text matches any forbidden regex pattern.
 

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.actions import ActionResult
+from nemoguardrails.library.regex.actions import detect_regex_pattern
 from tests.utils import TestChat
 
 
@@ -646,3 +647,36 @@ def test_regex_detection_retrieval_allows_non_matching():
     # The retrieved chunk does NOT contain "classified" — passes through unchanged.
     chat >> "Hi!"
     chat << "Here is what I found."
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_regex_action_accepts_extra_kwargs():
+    """Regression: detect_regex_pattern must accept the extra kwargs that
+    the action dispatcher injects during output streaming."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  output:
+                    patterns:
+                      - "\\\\bconfidential\\\\b"
+        """,
+        colang_content="",
+    )
+
+    result = await detect_regex_pattern(
+        source="output",
+        text="This is confidential information.",
+        config=config,
+        context={"user_message": "hi"},
+        llm_task_manager=object(),
+        model_name="test-model",
+        llms={"main": object()},
+        llm=object(),
+    )
+
+    assert result["is_match"] is True
+    assert "\\bconfidential\\b" in result["detections"]


### PR DESCRIPTION
## Introduction

This PR attemps to provide a minimal fix for [GH Issue](https://github.com/NVIDIA-NeMo/Guardrails/issues/1931)

## Root cause

When streaming is enabled, output regex rails yields

```bash
ERROR:nemoguardrails.actions.action_dispatcher:detect_regex_pattern() got an unexpected keyword argument 'context'
Traceback (most recent call last):
  File ".../nemoguardrails/actions/action_dispatcher.py", line 213, in execute_action
    result = fn(**params)
             ^^^^^^^^^^^^
TypeError: detect_regex_pattern() got an unexpected keyword argument 'context'
```

The output streaming rail path in `llmrails.py` (`_prepare_params()`, ~line 1753) injects runtime params into the action call:

```python
{
    "context": context,
    "llm_task_manager": self.runtime.llm_task_manager,
    "config": self.config,
    "model_name": model_name,
    "llms": ...,
    "llm": ...,
    **action_params,
}
```

The action dispatcherpasses all params via `fn(**params)` without filtering.

The `detect_regex_pattern` signature (`regex/actions.py:32`) is:

```python
async def detect_regex_pattern(source, text, config) -> RegexDetectionResult:
```

It does not accept `**kwargs`, so the extra injected params cause a `TypeError`.

Compare with `detect_sensitive_data` (`sensitive_data_detection/actions.py`):

```python
async def detect_sensitive_data(source, text, config, **kwargs):
```

## Suggested Fix

Add `**kwargs` to `detect_regex_pattern` to match the established pattern:

```python
async def detect_regex_pattern(
    source: str,
    text: str,
    config: RailsConfig,
    **kwargs,
) -> RegexDetectionResult:
```

## Potential alternative

Later on, we might want to modify `execute_action()` in `action_dispatcher.py` to introspect the action's signature and drop params it doesn't accept, rather than forwarding all of them



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated regex detection action signature to accept additional parameters.

* **Tests**
  * Added regression test validating regex detection functionality with additional dispatcher-injected parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->