### PR TITLE
fix(actions): handle empty string values in create_event (#1700)

### DIFF
--- a/nemoguardrails/actions/core.py
+++ b/nemoguardrails/actions/core.py
@@ -41,7 +41,7 @@ async def create_event(
 
     # We add basic support for referring variables as values
     for k, v in event_dict.items():
-        if isinstance(v, str) and v[0] == "$":
+        if isinstance(v, str) and v.startswith("$"):
             event_dict[k] = context.get(v[1:], None) if context else None
 
     return ActionResult(events=[event_dict])

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 
+import asyncio
+
 from nemoguardrails.actions.actions import ActionResult, action
+from nemoguardrails.actions.core import create_event
 
 
 def test_action_decorator():
@@ -40,6 +43,29 @@ def test_action_decorator_with_output_mapping():
     assert sample_action.action_meta["output_mapping"] is not None
     assert sample_action.action_meta["output_mapping"]("blocked") is True
     assert sample_action.action_meta["output_mapping"]("not_blocked") is False
+
+
+def test_create_event_accepts_empty_string_values():
+    # #1700: the `$variable` reference check used `v[0] == "$"`, which raised
+    # IndexError on empty string values. Using `startswith("$")` handles them.
+    result = asyncio.run(
+        create_event(event={"_type": "SomeEvent", "param": ""})
+    )
+    assert len(result.events) == 1
+    assert result.events[0]["type"] == "SomeEvent"
+    assert result.events[0]["param"] == ""
+
+
+def test_create_event_still_resolves_dollar_prefixed_references():
+    result = asyncio.run(
+        create_event(
+            event={"_type": "SomeEvent", "param": "$user_name"},
+            context={"user_name": "John"},
+        )
+    )
+    assert len(result.events) == 1
+    assert result.events[0]["type"] == "SomeEvent"
+    assert result.events[0]["param"] == "John"
 
 
 def test_action_result():

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -48,9 +48,7 @@ def test_action_decorator_with_output_mapping():
 def test_create_event_accepts_empty_string_values():
     # #1700: the `$variable` reference check used `v[0] == "$"`, which raised
     # IndexError on empty string values. Using `startswith("$")` handles them.
-    result = asyncio.run(
-        create_event(event={"_type": "SomeEvent", "param": ""})
-    )
+    result = asyncio.run(create_event(event={"_type": "SomeEvent", "param": ""}))
     assert len(result.events) == 1
     assert result.events[0]["type"] == "SomeEvent"
     assert result.events[0]["param"] == ""


### PR DESCRIPTION
Fixes #1700.

`create_event` in `nemoguardrails/actions/core.py` checks `v[0] == "$"` after confirming `v` is a string, to detect `$variable` references that should be looked up in the action context. When `v` is the empty string `""`, this raises `IndexError: string index out of range` because there is no `v[0]`.

The fix replaces `v[0] == "$"` with `v.startswith("$")`, which returns False for the empty string and matches the pattern used elsewhere in the codebase. The behavior for non-empty strings is unchanged.

Reproduction from the issue:

```python
import asyncio
from nemoguardrails.actions.core import create_event

asyncio.run(create_event(event={"_type": "SomeEvent", "param": ""}))
# Before: IndexError: string index out of range
# After:  ActionResult with the event passed through unchanged
```

## Tests

Added two unit tests in `tests/test_actions.py`:
- `test_create_event_accepts_empty_string_values` — fails on the old code, passes after the fix
- `test_create_event_still_resolves_dollar_prefixed_references` — confirms `$user_name` lookup against `context` still works

```
$ pytest tests/test_actions.py -v
tests/test_actions.py::test_action_decorator PASSED
tests/test_actions.py::test_action_decorator_with_output_mapping PASSED
tests/test_actions.py::test_create_event_accepts_empty_string_values PASSED
tests/test_actions.py::test_create_event_still_resolves_dollar_prefixed_references PASSED
tests/test_actions.py::test_action_result PASSED
============================== 5 passed in 0.26s ===============================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of event creation by preventing edge-case errors during parameter processing.

* **Tests**
  * Added test coverage to verify parameter handling reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->