### PR TITLE
fix(library): `detect_regex_pattern()` matches during output streaming but does not block

### DIFF
--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -28,7 +28,12 @@ class RegexDetectionResult(TypedDict):
     detections: List[str]
 
 
-@action(is_system_action=True)
+def _regex_blocked_mapping(result: dict) -> bool:
+    """Return True (blocked) when a regex match was found."""
+    return result.get("is_match", False)
+
+
+@action(is_system_action=True, output_mapping=_regex_blocked_mapping)
 async def detect_regex_pattern(
     source: str,
     text: str,

--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -28,7 +28,7 @@ class RegexDetectionResult(TypedDict):
     detections: List[str]
 
 
-def _regex_blocked_mapping(result: dict) -> bool:
+def _regex_blocked_mapping(result: RegexDetectionResult) -> bool:
     """Return True (blocked) when a regex match was found."""
     return result.get("is_match", False)
 

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -680,3 +680,27 @@ async def test_regex_action_accepts_extra_kwargs():
 
     assert result["is_match"] is True
     assert "\\bconfidential\\b" in result["detections"]
+
+
+@pytest.mark.unit
+def test_regex_output_mapping_blocks_on_match():
+    """The output_mapping on detect_regex_pattern must return True (blocked)
+    when is_match is True, so the streaming output rail framework blocks content."""
+    from nemoguardrails.actions.output_mapping import is_output_blocked
+    from nemoguardrails.library.regex.actions import RegexDetectionResult
+
+    matched = RegexDetectionResult(is_match=True, text="fight club", detections=["\\bfight\\s+club\\b"])
+    no_match = RegexDetectionResult(is_match=False, text="hello", detections=[])
+
+    assert is_output_blocked(matched, detect_regex_pattern) is True
+    assert is_output_blocked(no_match, detect_regex_pattern) is False
+
+
+@pytest.mark.unit
+def test_regex_output_mapping_is_registered():
+    """detect_regex_pattern must have an output_mapping in its action_meta."""
+    meta = getattr(detect_regex_pattern, "action_meta", {})
+    assert meta.get("output_mapping") is not None, (
+        "detect_regex_pattern is missing output_mapping — streaming output rails "
+        "will silently pass matched content through (see #1932 follow-up)"
+    )

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -702,5 +702,5 @@ def test_regex_output_mapping_is_registered():
     meta = getattr(detect_regex_pattern, "action_meta", {})
     assert meta.get("output_mapping") is not None, (
         "detect_regex_pattern is missing output_mapping — streaming output rails "
-        "will silently pass matched content through (see #1932 follow-up)"
+        "will silently pass matched content through (see #1936 follow-up)"
     )


### PR DESCRIPTION
## Introduction

This PR attempts to provide a minimal fix for this [GH issue](https://github.com/NVIDIA-NeMo/Guardrails/issues/1936) 

## Root cause

The built-in `detect_regex_pattern` action correctly detects forbidden regex patterns during streaming output rail execution (logs confirm the match), but the streaming framework does not block the content. The matched output is streamed to the client as if no violation occurred.

In the server logs, we would see

```bash
INFO:nemoguardrails.actions.action_dispatcher:Executing registered action: detect_regex_pattern
INFO:nemoguardrails.library.regex.actions:Regex pattern matched: \bfight\s+club\b
```

The pattern matches — but the response is **not blocked**. The full LLM output streams to the client.

When the regex pattern matches in a streaming output chunk, the stream should be terminated and a guardrails violation error should be returned:

```json
{"error": {"message": "Blocked by regex check output rails.", "type": "guardrails_violation", "param": "regex check output", "code": "content_blocked"}}
```

What seems to happen is: 

- is_output_blocked looks for an output_mapping function attached to the action's metadata. If none is found, it falls back to default_output_mapping
- detect_regex_pattern returns a RegexDetectionResult (a TypedDict / dict)
- Since a dict is not bool and not int/float, default_output_mapping returns False — meaning "not blocked" — regardless of what is_match says.


Closes #1936
## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
