### PR TITLE
feat(server): Add tool calling params

### DIFF
--- a/benchmark/mock_llm_server/models.py
+++ b/benchmark/mock_llm_server/models.py
@@ -39,6 +39,9 @@ class ChatCompletionRequest(BaseModel):
     presence_penalty: Optional[float] = Field(0.0, description="Presence penalty", ge=-2.0, le=2.0)
     frequency_penalty: Optional[float] = Field(0.0, description="Frequency penalty", ge=-2.0, le=2.0)
     logit_bias: Optional[dict[str, float]] = Field(None, description="Modify likelihood of specified tokens")
+    tools: Optional[list[dict]] = Field(None, description="Tools parameter.")
+    tool_choice: Optional[str | dict] = Field(None, description="Tool choice parameter.")
+    parallel_tool_calls: Optional[bool] = Field(None, description="Whether to allow parallel tool calls.")
     user: Optional[str] = Field(None, description="Unique identifier representing your end-user")
 
 

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -533,6 +533,17 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             detail="thread_id message-history replay is not supported for Colang 2.0.",
         )
 
+    if (body.tools or body.tool_choice is not None or body.parallel_tool_calls is not None) and (
+        llm_rails.config.passthrough is not True or body.stream
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "The 'tools', 'tool_choice', and 'parallel_tool_calls' parameters are only "
+                "supported for non-streaming requests when the guardrails configuration has 'passthrough: true'."
+            ),
+        )
+
     try:
         messages = body.messages or []
         if body.guardrails.context:

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -28,8 +28,6 @@ from typing import Any, AsyncIterator, Callable, List, Optional, Union
 import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from pydantic import BaseModel, ValidationError
 from starlette.responses import RedirectResponse, StreamingResponse
 
@@ -43,11 +41,15 @@ from nemoguardrails.server.schemas.openai import (
     OpenAIModelsList,
 )
 from nemoguardrails.server.schemas.utils import (
+    bot_message_to_chat_completion,
     create_error_chat_completion,
     extract_bot_message_from_response,
     fetch_models,
     format_streaming_chunk_as_sse,
     generation_response_to_chat_completion,
+    normalize_tool_calls_openai,
+    resolve_tool_calls,
+    warn_if_thread_history_invalid_for_tool_use,
 )
 
 try:
@@ -554,6 +556,7 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             # the string `thread-` to all thread keys.
             datastore_key = "thread-" + body.guardrails.thread_id
             thread_messages = json.loads(await datastore.get(datastore_key) or "[]")
+            warn_if_thread_history_invalid_for_tool_use(thread_messages)
 
             # And prepend them.
             messages = thread_messages + messages
@@ -577,6 +580,12 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             generation_options.llm_params["presence_penalty"] = body.presence_penalty
         if body.frequency_penalty is not None:
             generation_options.llm_params["frequency_penalty"] = body.frequency_penalty
+        if body.tools is not None:
+            generation_options.llm_params["tools"] = body.tools
+        if body.tool_choice is not None:
+            generation_options.llm_params["tool_choice"] = body.tool_choice
+        if body.parallel_tool_calls is not None:
+            generation_options.llm_params["parallel_tool_calls"] = body.parallel_tool_calls
 
         if body.stream:
             # Use stream_async for streaming with output rails support
@@ -603,7 +612,15 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             # If we're using threads, we also need to update the data before returning
             # the message.
             if body.guardrails.thread_id and datastore is not None and datastore_key is not None:
-                await datastore.set(datastore_key, json.dumps(messages + [bot_message]))
+                # If using tool calls, we need to normalize them to OpenAI format before storing.
+                response_tool_calls = res.tool_calls if isinstance(res, GenerationResponse) else None
+                tool_calls_for_storage = resolve_tool_calls(bot_message, response_tool_calls)
+                if tool_calls_for_storage:
+                    normalized = [tc.model_dump() for tc in normalize_tool_calls_openai(tool_calls_for_storage)]
+                    storable_message = {**bot_message, "tool_calls": normalized}
+                else:
+                    storable_message = bot_message
+                await datastore.set(datastore_key, json.dumps(messages + [storable_message]))
 
             # Build the response with OpenAI-compatible format using utility function
             if isinstance(res, GenerationResponse):
@@ -613,23 +630,10 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
                     config_id=config_ids[0] if config_ids else None,
                 )
             else:
-                # For dict responses, convert to basic chat completion
-                return GuardrailsChatCompletion(
-                    id=f"chatcmpl-{uuid.uuid4()}",
-                    object="chat.completion",
-                    created=int(time.time()),
+                return bot_message_to_chat_completion(
+                    bot_message=bot_message,
                     model=body.model,
-                    choices=[
-                        Choice(
-                            index=0,
-                            message=ChatCompletionMessage(
-                                role="assistant",
-                                content=bot_message.get("content", ""),
-                            ),
-                            finish_reason="stop",
-                            logprobs=None,
-                        )
-                    ],
+                    config_id=config_ids[0] if config_ids else None,
                 )
 
     except HTTPException:

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -82,10 +82,6 @@ class OpenAIChatCompletionRequest(BaseModel):
         default=None,
         description="Frequency penalty parameter.",
     )
-    function_call: Optional[dict] = Field(
-        default=None,
-        description="Function call parameter.",
-    )
     logit_bias: Optional[dict] = Field(
         default=None,
         description="Logit bias parameter.",
@@ -93,6 +89,18 @@ class OpenAIChatCompletionRequest(BaseModel):
     logprobs: Optional[bool] = Field(
         default=None,
         description="Log probabilities parameter.",
+    )
+    tools: Optional[list[dict]] = Field(
+        default=None,
+        description="Tools parameter.",
+    )
+    tool_choice: Optional[str | dict] = Field(
+        default=None,
+        description="Tool choice parameter.",
+    )
+    parallel_tool_calls: Optional[bool] = Field(
+        default=None,
+        description="Whether to allow parallel tool calls during tool use.",
     )
 
 

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -26,6 +26,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import httpx
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
 
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.server.schemas.openai import (
@@ -174,6 +178,104 @@ async def fetch_models(
     ]
 
 
+def _parse_tool_call_name_and_arguments(tc: dict) -> tuple[str, str]:
+    if "function" in tc:
+        func = tc.get("function") or {}
+        name = func.get("name", "")
+        arguments = func.get("arguments", {})
+    else:
+        name = tc.get("name", "")
+        arguments = tc.get("args", {})
+
+    if isinstance(arguments, dict):
+        arguments_str = json.dumps(arguments)
+    elif isinstance(arguments, str):
+        arguments_str = arguments
+    else:
+        arguments_str = json.dumps(arguments)
+    return name, arguments_str
+
+
+def _generate_fallback_tool_call_id(tc: dict) -> str:
+    fallback_id = f"call_{uuid.uuid4().hex[:8]}"
+    func_name = tc.get("name") or (tc.get("function") or {}).get("name", "<unknown>")
+    log.warning(
+        "Tool call for function %r is missing an 'id'; generated fallback id %r.",
+        func_name,
+        fallback_id,
+    )
+    return fallback_id
+
+
+def normalize_tool_calls_openai(
+    tool_calls: List[dict],
+) -> List[ChatCompletionMessageToolCall]:
+    """Convert internal tool call dicts to OpenAI function tool call objects."""
+    openai_tool_calls: List[ChatCompletionMessageToolCall] = []
+    for tc in tool_calls:
+        name, arguments_str = _parse_tool_call_name_and_arguments(tc)
+        openai_tool_calls.append(
+            ChatCompletionMessageToolCall(
+                id=tc.get("id") or _generate_fallback_tool_call_id(tc),
+                type="function",
+                function=Function(name=name, arguments=arguments_str),
+            )
+        )
+    return openai_tool_calls
+
+
+def resolve_tool_calls(bot_message: dict, response_tool_calls: Optional[list] = None) -> Optional[List[dict]]:
+    """Collect tool calls from a bot message and/or GenerationResponse.tool_calls."""
+    tool_calls = bot_message.get("tool_calls") or response_tool_calls
+    return tool_calls or None
+
+
+def build_chat_completion_message(
+    bot_message: dict,
+    tool_calls: Optional[List[dict]] = None,
+) -> ChatCompletionMessage:
+    """Build an OpenAI ChatCompletionMessage from an internal bot message dict."""
+    content = bot_message.get("content")
+    if content == "" and tool_calls:
+        content = None
+
+    if not tool_calls:
+        return ChatCompletionMessage(
+            role="assistant",
+            content=content,
+        )
+
+    openai_tool_calls = normalize_tool_calls_openai(tool_calls)
+
+    return ChatCompletionMessage(
+        role="assistant",
+        content=content,
+        tool_calls=openai_tool_calls,  # pyright: ignore[reportArgumentType]
+    )
+
+
+def warn_if_thread_history_invalid_for_tool_use(messages: List[dict]) -> None:
+    """Log when persisted thread history is incompatible with OpenAI tool-calling message ordering."""
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "tool":
+            continue
+        if i == 0 or messages[i - 1].get("role") != "assistant":
+            log.warning(
+                "Thread message history has a tool message without a preceding assistant "
+                "message at index %s. Multi-turn tool use with thread_id is unreliable; "
+                "send the full message list (assistant tool_calls + tool results) in each request.",
+                i,
+            )
+            continue
+        if not messages[i - 1].get("tool_calls"):
+            log.warning(
+                "Thread message history has a tool message after an assistant message "
+                "without tool_calls at index %s. Prior assistant tool_calls may have been "
+                "dropped when the thread was saved; include full history in the request.",
+                i,
+            )
+
+
 def extract_bot_message_from_response(
     response: Union[str, dict, GenerationResponse, Tuple[dict, dict]],
 ) -> Dict[str, Any]:
@@ -194,9 +296,10 @@ def extract_bot_message_from_response(
         bot_message_content = response.response[0]
         # Ensure bot_message is always a dict
         if isinstance(bot_message_content, str):
-            return {"role": "assistant", "content": bot_message_content}
+            bot_message = {"role": "assistant", "content": bot_message_content}
         else:
-            return bot_message_content
+            bot_message = bot_message_content
+        return bot_message
     elif isinstance(response, str):
         # Direct string response
         return {"role": "assistant", "content": response}
@@ -229,6 +332,8 @@ def generation_response_to_chat_completion(
         A GuardrailsChatCompletion instance compatible with OpenAI API format
     """
     bot_message = extract_bot_message_from_response(response)
+    tool_calls = resolve_tool_calls(bot_message, response.tool_calls)
+    finish_reason = "tool_calls" if tool_calls else "stop"
 
     # Convert log to dict if present (for JSON serialization)
     log_dict = None
@@ -255,11 +360,8 @@ def generation_response_to_chat_completion(
         choices=[
             Choice(
                 index=0,
-                message=ChatCompletionMessage(
-                    role="assistant",
-                    content=bot_message.get("content", ""),
-                ),
-                finish_reason="stop",
+                message=build_chat_completion_message(bot_message, tool_calls),
+                finish_reason=finish_reason,
                 logprobs=None,
             )
         ],
@@ -270,6 +372,32 @@ def generation_response_to_chat_completion(
             log=log_dict,
             state=response.state,
         ),
+    )
+
+
+def bot_message_to_chat_completion(
+    bot_message: dict,
+    model: str,
+    config_id: Optional[str] = None,
+) -> GuardrailsChatCompletion:
+    """Convert a bot message dict to an OpenAI-compatible GuardrailsChatCompletion."""
+    tool_calls = resolve_tool_calls(bot_message)
+    finish_reason = "tool_calls" if tool_calls else "stop"
+
+    return GuardrailsChatCompletion(
+        id=f"chatcmpl-{uuid.uuid4()}",
+        object="chat.completion",
+        created=int(time.time()),
+        model=model,
+        choices=[
+            Choice(
+                index=0,
+                message=build_chat_completion_message(bot_message, tool_calls),
+                finish_reason=finish_reason,
+                logprobs=None,
+            )
+        ],
+        guardrails=GuardrailsDataOutput(config_id=config_id) if config_id else None,
     )
 
 
@@ -330,7 +458,6 @@ def format_streaming_chunk(
 
     # Determine the payload format based on chunk type
     if isinstance(chunk, dict):
-        # If chunk is a dict, wrap it in OpenAI chunk format with delta
         return {
             "id": chunk_id,
             "object": "chat.completion.chunk",

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -218,6 +218,145 @@ def test_request_body_messages():
     assert len(request_body.messages) == 1
 
 
+def test_request_body_tools_and_tool_choice():
+    """Test GuardrailsChatCompletionRequest accepts OpenAI tools parameters."""
+    data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "What's the weather?"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "guardrails": {"config_id": "test_config"},
+    }
+    request_body = GuardrailsChatCompletionRequest.model_validate(data)
+    assert len(request_body.tools) == 1
+    assert request_body.tools[0]["function"]["name"] == "get_weather"
+    assert request_body.tool_choice == "auto"
+    assert request_body.parallel_tool_calls is False
+
+
+def test_request_body_messages_with_tool_calls():
+    """Test GuardrailsChatCompletionRequest accepts OpenAI tool call messages."""
+    data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "What's the weather in Boston?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Boston"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc",
+                "content": '{"temp_f": 72}',
+            },
+        ],
+        "guardrails": {"config_id": "test_config"},
+    }
+    request_body = GuardrailsChatCompletionRequest.model_validate(data)
+    assert len(request_body.messages) == 3
+    assert request_body.messages[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert request_body.messages[2]["role"] == "tool"
+
+
+def test_chat_completion_passes_tools_to_llm_params():
+    """Test that tools and tool_choice from the request are forwarded to llm_params."""
+    from nemoguardrails.rails.llm.options import GenerationResponse
+
+    captured_options = {}
+
+    async def mock_generate_async(*, messages, options, state):
+        captured_options["options"] = options
+        return GenerationResponse(response=[{"role": "assistant", "content": "ok"}])
+
+    mock_rails = AsyncMock()
+    mock_rails.generate_async = mock_generate_async
+    mock_rails.config.colang_version = "1.0"
+
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": tools,
+                "tool_choice": "auto",
+                "parallel_tool_calls": False,
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured_options["options"].llm_params["tools"] == tools
+    assert captured_options["options"].llm_params["tool_choice"] == "auto"
+    assert captured_options["options"].llm_params["parallel_tool_calls"] is False
+
+
+def test_chat_completion_returns_tool_calls():
+    """Test that tool calls in the generation response are returned in OpenAI format."""
+    from nemoguardrails.rails.llm.options import GenerationResponse
+
+    tool_calls = [
+        {
+            "name": "get_weather",
+            "args": {"city": "Boston"},
+            "id": "call_123",
+            "type": "tool_call",
+        }
+    ]
+
+    async def mock_generate_async(*, messages, options, state):
+        return GenerationResponse(
+            response=[{"role": "assistant", "content": ""}],
+            tool_calls=tool_calls,
+        )
+
+    mock_rails = AsyncMock()
+    mock_rails.generate_async = mock_generate_async
+    mock_rails.config.colang_version = "1.0"
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Weather in Boston?"}],
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 200
+    res = response.json()
+    assert res["choices"][0]["finish_reason"] == "tool_calls"
+    assert res["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert res["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] == '{"city": "Boston"}'
+
+
 def test_request_body_options():
     """Test GuardrailsChatCompletionRequest options handling."""
     data = {

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -283,7 +283,7 @@ def test_request_body_messages_with_tool_calls():
 
 
 def test_chat_completion_passes_tools_to_llm_params():
-    """Test that tools and tool_choice from the request are forwarded to llm_params."""
+    """Test that tools and tool_choice from the request are forwarded to llm_params in passthrough mode."""
     from nemoguardrails.rails.llm.options import GenerationResponse
 
     captured_options = {}
@@ -295,6 +295,7 @@ def test_chat_completion_passes_tools_to_llm_params():
     mock_rails = AsyncMock()
     mock_rails.generate_async = mock_generate_async
     mock_rails.config.colang_version = "1.0"
+    mock_rails.config.passthrough = True
 
     tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
 
@@ -315,6 +316,74 @@ def test_chat_completion_passes_tools_to_llm_params():
     assert captured_options["options"].llm_params["tools"] == tools
     assert captured_options["options"].llm_params["tool_choice"] == "auto"
     assert captured_options["options"].llm_params["parallel_tool_calls"] is False
+
+
+def test_chat_completion_rejects_tools_for_non_passthrough_config():
+    """Test that tools/tool_choice/parallel_tool_calls are rejected unless passthrough is True."""
+    mock_rails = AsyncMock()
+    mock_rails.config.colang_version = "1.0"
+    mock_rails.config.passthrough = False
+
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": tools,
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert "passthrough" in response.json()["detail"].lower()
+
+
+def test_chat_completion_rejects_tool_choice_without_passthrough():
+    """Test that tool_choice alone is rejected for non-passthrough configs."""
+    mock_rails = AsyncMock()
+    mock_rails.config.colang_version = "1.0"
+    mock_rails.config.passthrough = None
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tool_choice": "auto",
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert "passthrough" in response.json()["detail"].lower()
+
+
+def test_chat_completion_rejects_tools_with_streaming_even_in_passthrough():
+    """Test that tools + stream=True is rejected even when passthrough is True."""
+    mock_rails = AsyncMock()
+    mock_rails.config.colang_version = "1.0"
+    mock_rails.config.passthrough = True
+
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": tools,
+                "stream": True,
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert "passthrough" in response.json()["detail"].lower()
 
 
 def test_chat_completion_returns_tool_calls():

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -34,12 +34,16 @@ from nemoguardrails.server.schemas.utils import (
     PROVIDERS,
     _azure_url,
     _openai_compatible_url,
+    bot_message_to_chat_completion,
     create_error_chat_completion,
     extract_bot_message_from_response,
     fetch_models,
     format_streaming_chunk,
     format_streaming_chunk_as_sse,
     generation_response_to_chat_completion,
+    normalize_tool_calls_openai,
+    resolve_tool_calls,
+    warn_if_thread_history_invalid_for_tool_use,
 )
 
 # ===== Tests for extract_bot_message_from_response =====
@@ -72,6 +76,49 @@ def test_extract_bot_message_from_generation_response_with_dict():
     response = GenerationResponse(response=[bot_msg])
     result = extract_bot_message_from_response(response)
     assert result == {"role": "assistant", "content": "Response from dict"}
+
+
+def test_extract_bot_message_does_not_merge_generation_response_tool_calls():
+    """extract_bot_message_from_response is a pure extractor; it does not merge tool_calls."""
+    tool_calls = [{"name": "get_weather", "args": {"city": "Boston"}, "id": "call_1", "type": "tool_call"}]
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": ""}],
+        tool_calls=tool_calls,
+    )
+    result = extract_bot_message_from_response(response)
+    # tool_calls lives on GenerationResponse, not on the message dict here
+    assert result.get("tool_calls") is None
+
+
+def test_resolve_tool_calls_merges_from_response():
+    """resolve_tool_calls falls back to response_tool_calls when absent on the message."""
+    tool_calls = [{"name": "get_weather", "args": {"city": "Boston"}, "id": "call_1", "type": "tool_call"}]
+    bot_message = {"role": "assistant", "content": ""}
+    result = resolve_tool_calls(bot_message, tool_calls)
+    assert result == tool_calls
+
+
+def test_resolve_tool_calls_prefers_message_tool_calls():
+    """resolve_tool_calls returns message-level tool_calls when present."""
+    message_tool_calls = [{"id": "call_msg", "type": "function", "function": {"name": "a", "arguments": "{}"}}]
+    response_tool_calls = [{"name": "other", "args": {}, "id": "call_res", "type": "tool_call"}]
+    bot_message = {"role": "assistant", "content": "", "tool_calls": message_tool_calls}
+    result = resolve_tool_calls(bot_message, response_tool_calls)
+    assert result == message_tool_calls
+
+
+def test_warn_if_thread_history_invalid_for_tool_use(caplog):
+    """Warn when thread replay would violate OpenAI tool message ordering."""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    warn_if_thread_history_invalid_for_tool_use(
+        [
+            {"role": "assistant", "content": "ok"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+        ]
+    )
+    assert "without tool_calls" in caplog.text
 
 
 def test_extract_bot_message_from_tuple_with_dict():
@@ -121,6 +168,94 @@ def test_generation_response_to_chat_completion_with_empty_content():
     assert result.choices[0].message.content == ""
 
 
+def test_normalize_dict_tool_calls_openai_format():
+    """Test converting nested OpenAI-style tool calls with dict arguments."""
+    tool_calls = [
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "search", "arguments": {"q": "test"}},
+        }
+    ]
+    result = normalize_tool_calls_openai(tool_calls)
+    assert result[0].function.name == "search"
+    assert result[0].function.arguments == '{"q": "test"}'
+
+
+def test_normalize_string_tool_calls_openai_format():
+    """Test converting nested OpenAI-style tool calls with string arguments."""
+    tool_calls = [
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"q": "test"}'},
+        }
+    ]
+    result = normalize_tool_calls_openai(tool_calls)
+    assert result[0].function.name == "search"
+    assert result[0].function.arguments == '{"q": "test"}'
+
+
+def test_normalize_tool_calls_openai_format_with_missing_id(caplog):
+    """Test that a missing id triggers a warning and generates a valid fallback."""
+    import logging
+    import re
+
+    tool_calls = [
+        {
+            "type": "function",
+            "function": {"name": "search", "arguments": {"q": "test"}},
+        }
+    ]
+    caplog.set_level(logging.WARNING)
+    result = normalize_tool_calls_openai(tool_calls)
+    assert re.fullmatch(r"call_[0-9a-f]{8}", result[0].id)
+    assert "missing an 'id'" in caplog.text
+    assert "search" in caplog.text
+
+
+def test_generation_response_to_chat_completion_with_tool_calls():
+    """Test converting GenerationResponse with tool calls."""
+    tool_calls = [
+        {
+            "name": "get_weather",
+            "args": {"city": "Boston"},
+            "id": "call_456",
+            "type": "tool_call",
+        }
+    ]
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": ""}],
+        tool_calls=tool_calls,
+    )
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    assert result.choices[0].finish_reason == "tool_calls"
+    assert result.choices[0].message.content is None
+    assert len(result.choices[0].message.tool_calls) == 1
+    assert result.choices[0].message.tool_calls[0].function.name == "get_weather"
+    assert result.choices[0].message.tool_calls[0].function.arguments == '{"city": "Boston"}'
+
+
+def test_bot_message_to_chat_completion():
+    """Test converting a bot message dict with tool calls."""
+    bot_message = {
+        "role": "assistant",
+        "content": "I'll check that for you.",
+        "tool_calls": [
+            {
+                "id": "call_789",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": {"id": 1}},
+            }
+        ],
+    }
+    result = bot_message_to_chat_completion(bot_message, model="gpt-4o", config_id="cfg")
+    assert result.choices[0].finish_reason == "tool_calls"
+    assert result.choices[0].message.content == "I'll check that for you."
+    assert result.choices[0].message.tool_calls[0].function.arguments == '{"id": 1}'
+    assert result.guardrails.config_id == "cfg"
+
+
 # ===== Tests for create_error_chat_completion =====
 
 
@@ -157,9 +292,6 @@ def test_format_streaming_chunk_with_dict():
     assert result["model"] == "test_model"
     assert result["choices"][0]["delta"] == {"content": "Hello"}
     assert result["choices"][0]["index"] == 0
-    assert result["choices"][0]["finish_reason"] is None
-    assert "id" in result
-    assert "created" in result
 
 
 def test_format_streaming_chunk_with_plain_string():


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Enables tool calls via `v1/chat/completions` endpoint. Currently, NeMo Guardrails is incompatible with applications using tool calls because there was missing API coverage. This PR addresses this bug by adding the following:
* Tool calling params in `OpenAIChatCompletionRequest`
* Normalizes internal/Langchain tool calls to OpenAI format, including streaming chunks

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
#1615 

## Testing 
* Updates `test_schema_utils.py` and `test_api.py` with unit tests

### Unit tests
```
 poetry run pytest -q
................................................ssss........... [  1%]
............................................................... [  2%]
.................s............................................. [  4%]
............................................................... [  5%]
............................................................... [  6%]
............................................................... [  8%]
............................................................... [  9%]
............................................................... [ 11%]
............................................................... [ 12%]
............................................................... [ 13%]
............................................................... [ 15%]
............................................................... [ 16%]
............................................................... [ 18%]
............................................................... [ 19%]
............................................................... [ 20%]
............................................................... [ 22%]
............................................................... [ 23%]
...............................s......ss...................ssss [ 24%]
sss............................................................ [ 26%]
............................................................... [ 27%]
....s.......s.................................................. [ 29%]
............................................................... [ 30%]
............................................................... [ 31%]
............................................................... [ 33%]
.......................................s....................... [ 34%]
............................................................... [ 36%]
............................................................... [ 37%]
............................................................... [ 38%]
............................................................... [ 40%]
........................................................sssssss [ 41%]
s......ssssss..ss.s.............ssssssss....................... [ 42%]
............................................................... [ 44%]
............................................................... [ 45%]
......................................ss....................... [ 47%]
........s...............s.......sssss.......................... [ 48%]
.................................s............................. [ 49%]
............................................................... [ 51%]
............................................................... [ 52%]
......ss........ss...ss........................................ [ 54%]
....s.....................................................s.... [ 55%]
........s...................................................... [ 56%]
............................................................... [ 58%]
............................................................... [ 59%]
............................................................... [ 60%]
............................................................... [ 62%]
...............sssss......ssssssssssssssssss..........sssss.... [ 63%]
............................................................... [ 65%]
.................s...........ss................................ [ 66%]
...................sssssssss.ssssssssss........................ [ 67%]
...............s............................................... [ 69%]
.....s....s.................................................... [ 70%]
....ssssssss.................sss...ss...ss.....sssssssssssss... [ 72%]
............................................................... [ 73%]
............................................................... [ 74%]
.......................s....................................... [ 76%]
............................................................... [ 77%]
........s....................ssssssss.........ss............... [ 78%]
............................................................... [ 80%]
........................................................sssssss [ 81%]
............................................................... [ 83%]
.s............................................................. [ 84%]
............................................................... [ 85%]
............................................................... [ 87%]
............................................................... [ 88%]
............................................................... [ 90%]
............................................................... [ 91%]
............................................................... [ 92%]
............................................................... [ 94%]
.s............................................................. [ 95%]
............................................................... [ 97%]
............................................................... [ 98%]
............................................................... [ 99%]
..........                                                      [100%]
4382 passed, 164 skipped in 127.60s (0:02:07)
```

### Pre-commit 
```
poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```
## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
