### PR TITLE
docs: clarify NGC_API_KEY handling for local GLiNER/PII NIM deployment

### DIFF
--- a/docs/configure-rails/guardrail-catalog/community/gliner.md
+++ b/docs/configure-rails/guardrail-catalog/community/gliner.md
@@ -182,9 +182,9 @@ export NGC_API_KEY="<your-ngc-key>"
 > export NGC_API_KEY="$NVIDIA_API_KEY"
 > ```
 >
-> Alternatively, you can skip the `export` and pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
+> Alternatively, you can pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
 > ```bash
-> docker run ... -e NGC_API_KEY=$NVIDIA_API_KEY ...
+> docker run ... -e NGC_API_KEY="$NVIDIA_API_KEY" ...
 > ```
 
 On a multi-GPU host, pin each container to a distinct GPU with `--gpus '"device=N"'` instead of `--gpus all`. Without an explicit device, both NIMs default to GPU 0 and compete for memory. The examples below assign GLiNER to GPU 0 and Llama to GPU 1; adjust the indices to match your host.

--- a/docs/configure-rails/guardrail-catalog/community/gliner.md
+++ b/docs/configure-rails/guardrail-catalog/community/gliner.md
@@ -175,9 +175,16 @@ Export your NGC Personal API key as `NGC_API_KEY`:
 export NGC_API_KEY="<your-ngc-key>"
 ```
 
-> **Important:** The key must start with `nvapi-`. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) (select at least the **NGC Catalog** service) or at [build.nvidia.com](https://build.nvidia.com) — both portals issue interchangeable `nvapi-` keys. **Legacy NGC keys (older format, not starting with `nvapi-`) will cause the GLiNER container to fail during model-artifact download.** If you already have an `NVIDIA_API_KEY` starting with `nvapi-`, you can reuse it:
+> **Important:** The key must start with `nvapi-`. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) (select at least the **NGC Catalog** service) or at [build.nvidia.com](https://build.nvidia.com) — both portals issue interchangeable `nvapi-` keys. **Legacy NGC keys (older format, not starting with `nvapi-`) will cause the GLiNER container to fail during model-artifact download.**
+>
+> If you already have an `NVIDIA_API_KEY` starting with `nvapi-`, you can reuse it:
 > ```bash
 > export NGC_API_KEY="$NVIDIA_API_KEY"
+> ```
+>
+> Alternatively, you can skip the `export` and pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
+> ```bash
+> docker run ... -e NGC_API_KEY=$NVIDIA_API_KEY ...
 > ```
 
 On a multi-GPU host, pin each container to a distinct GPU with `--gpus '"device=N"'` instead of `--gpus all`. Without an explicit device, both NIMs default to GPU 0 and compete for memory. The examples below assign GLiNER to GPU 0 and Llama to GPU 1; adjust the indices to match your host.

--- a/docs/configure-rails/guardrail-catalog/pii-detection.md
+++ b/docs/configure-rails/guardrail-catalog/pii-detection.md
@@ -103,7 +103,19 @@ rails:
 
 To run both NIMs locally, pull the Docker containers and point each endpoint to localhost. No `api_key_env_var` is needed for local inference.
 
-> **Note:** You still need an `NGC_API_KEY` (starting with `nvapi-`) to pull the Docker images and download model artifacts. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) or [build.nvidia.com](https://build.nvidia.com). Legacy NGC keys (older format) will cause the container to fail during artifact download. See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#start-the-containers) section for full `docker run` instructions.
+> **Important:** You still need an `NGC_API_KEY` (starting with `nvapi-`) to pull the Docker images and download model artifacts. You can generate one at [org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys) or [build.nvidia.com](https://build.nvidia.com). **Legacy NGC keys (older format, not starting with `nvapi-`) will cause the container to fail during artifact download.**
+>
+> If you already have an `NVIDIA_API_KEY` starting with `nvapi-`, you can reuse it:
+> ```bash
+> export NGC_API_KEY="$NVIDIA_API_KEY"
+> ```
+>
+> Alternatively, you can skip the `export` and pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
+> ```bash
+> docker run ... -e NGC_API_KEY=$NVIDIA_API_KEY ...
+> ```
+>
+> See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#start-the-containers) section for full `docker run` instructions.
 
 **PII detection** (update `config/pii_detection/config.yml`):
 

--- a/docs/configure-rails/guardrail-catalog/pii-detection.md
+++ b/docs/configure-rails/guardrail-catalog/pii-detection.md
@@ -110,9 +110,9 @@ To run both NIMs locally, pull the Docker containers and point each endpoint to 
 > export NGC_API_KEY="$NVIDIA_API_KEY"
 > ```
 >
-> Alternatively, you can skip the `export` and pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
+> Alternatively, you can pass the key directly at container runtime — this avoids overwriting any existing `NGC_API_KEY` in your environment:
 > ```bash
-> docker run ... -e NGC_API_KEY=$NVIDIA_API_KEY ...
+> docker run ... -e NGC_API_KEY="$NVIDIA_API_KEY" ...
 > ```
 >
 > See the [GLiNER Integration — Deploy NIMs Locally](community/gliner.md#start-the-containers) section for full `docker run` instructions.


### PR DESCRIPTION
## Description

Restructure the `NGC_API_KEY` callouts in the GLiNER and PII detection guides for readability: split the dense single-paragraph notes into distinct paragraphs, and document two key-handling options — reusing an existing `nvapi-` `NVIDIA_API_KEY` via export, and passing the key directly at container runtime to avoid overwriting an existing `NGC_API_KEY`. Standardize both callouts on the "Important" label.

@alexahaushalter, please review.  

## Related Issue(s)

  - Improves upon the existing fixes to [NGUARD-812](https://jirasw.nvidia.com/browse/NGUARD-812), namely [Commit dd274ef](https://github.com/NVIDIA-NeMo/Guardrails/commit/dd274ef078c351d5c3ba46114dd278736868b78a) (aka [PR 1916](https://github.com/NVIDIA-NeMo/Guardrails/pull/1916))

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable. [NA]
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API key configuration documentation with clearer format requirements, explicit warnings about legacy keys, and multiple methods for passing credentials in local deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Guardrails/pull/1945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->