### PR TITLE
fix(colang): guard ' or' line continuation at end of file

### DIFF
--- a/nemoguardrails/colang/v1_0/lang/utils.py
+++ b/nemoguardrails/colang/v1_0/lang/utils.py
@@ -157,7 +157,7 @@ def get_numbered_lines(content: str):
         # but without the indentation.
         # Also, if there's an active "operator" like "or", we also continue to the next line
         text = raw_line
-        while i < len(raw_lines) - 1 and text[-1] == "\\" or text.endswith(" or"):
+        while i < len(raw_lines) - 1 and (text[-1] == "\\" or text.endswith(" or")):
             i += 1
             if text[-1] == "\\":
                 text = text[0:-1]

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemoguardrails.colang.v1_0.lang.utils import split_args
+from nemoguardrails.colang.v1_0.lang.utils import get_numbered_lines, split_args
 
 
 def test_1():
@@ -30,3 +30,18 @@ def test_1():
         "x=[1,2,3]",
         "data = {'name': 'John'}",
     ]
+
+
+def test_get_numbered_lines_or_continuation_at_eof():
+    # A line ending in " or" as the final line must not raise IndexError.
+    # The bounds guard previously only protected the "\\" continuation, so a
+    # dangling " or" at end-of-file indexed past the last line.
+    lines = get_numbered_lines("define flow test\n  user express greeting or")
+    assert lines[-1]["text"] == "user express greeting or"
+
+
+def test_get_numbered_lines_or_continuation_merges():
+    # A valid " or" continuation still merges onto the next line.
+    lines = get_numbered_lines("define flow test\n  a or\n  b")
+    assert [line["text"] for line in lines] == ["define flow test", "a or b"]
+

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -44,4 +44,3 @@ def test_get_numbered_lines_or_continuation_merges():
     # A valid " or" continuation still merges onto the next line.
     lines = get_numbered_lines("define flow test\n  a or\n  b")
     assert [line["text"] for line in lines] == ["define flow test", "a or b"]
-


### PR DESCRIPTION
## Summary

In `get_numbered_lines` (`nemoguardrails/colang/v1_0/lang/utils.py`), the line-continuation loop condition is:

```python
while i < len(raw_lines) - 1 and text[-1] == "\\" or text.endswith(" or"):
```

Because `and` binds tighter than `or`, this evaluates as:

```python
(i < len(raw_lines) - 1 and text[-1] == "\\") or text.endswith(" or")
```

So the bounds check `i < len(raw_lines) - 1` only guards the backslash continuation, **not** the `" or"` continuation. A line ending in `" or"` as the **last line of the file** enters the loop and runs `raw_lines[i]` with `i` past the end, raising `IndexError` instead of parsing cleanly.

Reproducer:
```python
from nemoguardrails.colang.v1_0.lang.parser import parse_colang_file
parse_colang_file("test.co", "define flow test\n  user express greeting or")
# IndexError: list index out of range
```

The backslash sibling is correctly guarded (a `\` at EOF does not crash), which confirms the asymmetry is a bug, not intended.

## Fix

Parenthesize the two continuation conditions so the bounds check guards both:

```python
while i < len(raw_lines) - 1 and (text[-1] == "\\" or text.endswith(" or")):
```

## Tests

Added two regression tests in `tests/test_parser_utils.py`: a `" or"` line at EOF no longer raises (kept as-is), and a valid `" or"` continuation still merges onto the next line.

Verified locally:
```
pytest tests/test_parser_utils.py tests/colang/parser/test_basic.py   # 6 passed
ruff check                                                            # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a parser issue with line continuation handling in CoLang that could cause errors when continuations appear at the end of files.

* **Tests**
  * Added test cases to validate proper handling of line continuations in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->