### PR TITLE
fix: add missing f-string prefixes in log/progress messages

### DIFF
--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -581,7 +581,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
         # Use action specific llm if registered else fallback to main llm
         generation_llm: Optional[LLMModel] = llm if llm else self.llm
-        log.info("Generating flow for name: {name}")
+        log.info(f"Generating flow for name: {name}")
 
         if not self.instruction_flows_index:
             raise RuntimeError("No instruction flows index has been created.")

--- a/nemoguardrails/eval/check.py
+++ b/nemoguardrails/eval/check.py
@@ -287,7 +287,7 @@ class LLMJudgeComplianceChecker:
                     self.print_prompt(prompt)
                     self.print_completion(result)
 
-                self.progress.print("[{progress_idx}] [red]Invalid LLM response. Ignoring.[/]")
+                self.progress.print(f"[{progress_idx}] [red]Invalid LLM response. Ignoring.[/]")
             else:
                 reason = match.group(1)
                 compliance = match.group(2)


### PR DESCRIPTION
## Summary

Two strings contain `{placeholders}` but are missing the `f` prefix, so they emit the literal placeholder text instead of the interpolated value.

### 1. `nemoguardrails/eval/check.py:290`
```diff
-                self.progress.print("[{progress_idx}] [red]Invalid LLM response. Ignoring.[/]")
+                self.progress.print(f"[{progress_idx}] [red]Invalid LLM response. Ignoring.[/]")
```
Every other `progress.print` / `print_progress_detail` call in the same `check_interaction` method is f-prefixed (lines 209, 261, 313, …). This one is the lone omission, so it prints the literal `[{progress_idx}]` instead of the interaction index.

### 2. `nemoguardrails/actions/v2_x/generation.py:584`
```diff
-        log.info("Generating flow for name: {name}")
+        log.info(f"Generating flow for name: {name}")
```
`name` is the function parameter and is used correctly as `f"flow {name}"` five lines below (line 589). Without the prefix the log line emits the literal `{name}`.

Both placeholders are in-scope locals. Pure one-character fixes, no behavior change beyond the messages now showing the intended values. `ruff`, `ruff format`, and the end-of-file/license pre-commit hooks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log message formatting issues in generation workflows where placeholder variables were incorrectly displaying as literal text instead of actual values. Corrected progress and error message formatting in compliance evaluation checks to ensure proper variable interpolation. Users now receive clear and accurate information about processing progress and errors encountered during evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->