### PR TITLE
fix(embeddings): EmbeddingsCache.from_dict drops store_config on round-trip

### DIFF
--- a/nemoguardrails/embeddings/cache.py
+++ b/nemoguardrails/embeddings/cache.py
@@ -231,7 +231,11 @@ class EmbeddingsCache:
         store_config: dict = store_config_raw if isinstance(store_config_raw, dict) else {}
         cache_store = CacheStore.from_name(d.get("store"))(**store_config)
 
-        return cls(key_generator=key_generator, cache_store=cache_store)
+        return cls(
+            key_generator=key_generator,
+            cache_store=cache_store,
+            store_config=store_config,
+        )
 
     @classmethod
     def from_config(cls, config: EmbeddingsCacheConfig):

--- a/tests/test_cache_embeddings.py
+++ b/tests/test_cache_embeddings.py
@@ -322,3 +322,24 @@ async def test_in_memory_cache_stores_multiple_texts():
     assert index.compute_count == 2, (
         f"Expected underlying function to be called for 2 texts total, but was called {index.compute_count} times"
     )
+
+
+def test_from_config_roundtrips_store_config():
+    """from_config -> get_config must preserve a non-empty store_config.
+
+    Regression test: EmbeddingsCache.from_dict built the cache store from
+    store_config but never forwarded store_config to the constructor, so
+    get_config() reported an empty store_config and the configured store
+    location (e.g. a custom filesystem cache_dir) was silently dropped on a
+    config round-trip.
+    """
+    cfg = EmbeddingsCacheConfig(
+        enabled=True,
+        key_generator="md5",
+        store="filesystem",
+        store_config={"cache_dir": "/tmp/myembcache"},
+    )
+
+    cache = EmbeddingsCache.from_config(cfg)
+
+    assert cache.get_config().store_config == cfg.store_config

--- a/tests/test_cache_embeddings.py
+++ b/tests/test_cache_embeddings.py
@@ -324,7 +324,7 @@ async def test_in_memory_cache_stores_multiple_texts():
     )
 
 
-def test_from_config_roundtrips_store_config():
+def test_from_config_roundtrips_store_config(tmp_path):
     """from_config -> get_config must preserve a non-empty store_config.
 
     Regression test: EmbeddingsCache.from_dict built the cache store from
@@ -333,11 +333,11 @@ def test_from_config_roundtrips_store_config():
     location (e.g. a custom filesystem cache_dir) was silently dropped on a
     config round-trip.
     """
+    cache_dir = str(tmp_path / "myembcache")
     cfg = EmbeddingsCacheConfig(
-        enabled=True,
         key_generator="md5",
         store="filesystem",
-        store_config={"cache_dir": "/tmp/myembcache"},
+        store_config={"cache_dir": cache_dir},
     )
 
     cache = EmbeddingsCache.from_config(cfg)


### PR DESCRIPTION
## Problem

`EmbeddingsCache.__init__` accepts a `store_config` argument and reports it back via `get_config()`:

```python
def __init__(self, key_generator, cache_store, store_config: Optional[dict] = None):
    ...
    self._store_config = store_config or {}

def get_config(self):
    return EmbeddingsCacheConfig(..., store_config=self._store_config)
```

But `from_dict()` built the cache store from `store_config` and then **forgot to forward `store_config` to the constructor**:

```python
store_config = ...
cache_store = CacheStore.from_name(d.get("store"))(**store_config)
return cls(key_generator=key_generator, cache_store=cache_store)   # store_config not passed
```

So `self._store_config` defaulted to `{}`, and `from_config(cfg).get_config()` did **not** equal `cfg` whenever `store_config` was non-empty. A configured store location — a custom filesystem `cache_dir`, or redis `host`/`port`/`db` — was silently dropped on a config round-trip and fell back to the default `.cache/embeddings`.

## Fix

Forward `store_config` to the constructor in `from_dict`.

## Verification

```
before:  pytest tests/test_cache_embeddings.py::test_from_config_roundtrips_store_config
         AssertionError: assert {} == {'cache_dir': '/tmp/myembcache'}
after :  19 passed, 1 skipped   (full tests/test_cache_embeddings.py)
```

Added `test_from_config_roundtrips_store_config` asserting `from_config(cfg).get_config().store_config == cfg.store_config`. `ruff check` and `ruff format --check` pass on both changed files (pre-commit ruff v0.14.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where embeddings cache configuration wasn't properly preserved when creating instances from configuration, ensuring configured values are retained and accessible.

* **Tests**
  * Added regression test to verify cache configuration is correctly preserved through the create-and-retrieve cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->