### PR TITLE
fix(rails): return copy of action_params from flow lookup — closes #1935

### DIFF
--- a/nemoguardrails/rails/llm/utils.py
+++ b/nemoguardrails/rails/llm/utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import json
 from typing import Any, Dict, List, Tuple, Union
 
@@ -69,6 +70,13 @@ def get_action_details_from_flow_id(
     First, try to find an exact match.
     If not found, then if the provided flow_id starts with one of the special prefixes,
     return the first flow whose id starts with that same prefix.
+
+    Returns a shallow copy of the ``action_params`` dict so callers may
+    safely substitute placeholders in-place (e.g. ``$bot_message`` →
+    actual chunk text) without mutating the parsed flow config, which is
+    shared across streaming chunks and across requests on the same
+    ``LLMRails`` instance. See issue #1935 for the regression this guards
+    against.
     """
 
     candidate_flow = None
@@ -94,6 +102,6 @@ def get_action_details_from_flow_id(
             and "execute" in element["_source_mapping"]["line_text"]
             and "action_name" in element
         ):
-            return element["action_name"], element["action_params"]
+            return element["action_name"], copy.copy(element["action_params"])
 
     raise ValueError(f"No run_action element found for flow_id: {flow_id}")

--- a/tests/test_rails_llm_utils.py
+++ b/tests/test_rails_llm_utils.py
@@ -375,3 +375,30 @@ def test_get_action_details_no_match(dummy_flows):
     with pytest.raises(ValueError) as exc_info:
         get_action_details_from_flow_id("non_existing_flow", dummy_flows)
     assert "No action found for flow_id" in str(exc_info.value)
+
+
+def test_get_action_details_returns_isolated_copy(dummy_flows):
+    """Regression test for #1935.
+
+    The returned ``action_params`` dict must not be the same object as the
+    one stored on the parsed flow config. Otherwise output-rail callers
+    that mutate ``action_params`` in place (e.g. to substitute
+    ``$bot_message`` with the current chunk text) will leak that chunk's
+    value into subsequent chunks and subsequent requests on the same
+    ``LLMRails`` instance.
+    """
+    # First call: simulate the substitution that the streaming output-rail
+    # path performs on the returned dict.
+    _, first_params = get_action_details_from_flow_id("test_flow", dummy_flows)
+    first_params["param1"] = "first chunk text"
+
+    # Second call: should return the original placeholder, NOT the mutation
+    # the first caller performed.
+    _, second_params = get_action_details_from_flow_id("test_flow", dummy_flows)
+    assert second_params == {"param1": "value1"}, (
+        "get_action_details_from_flow_id must return a fresh copy so callers "
+        "cannot mutate the shared flow config (#1935)"
+    )
+
+    # And the two return values must be distinct objects.
+    assert first_params is not second_params


### PR DESCRIPTION
## Summary

`get_action_details_from_flow_id()` returned the original `element[\"action_params\"]` dict from the parsed flow config. The streaming output-rails path then mutated that dict in place to substitute `\$bot_message` / `\$user_message` placeholders with the current chunk text — leaking the first chunk's text into later chunks and into later requests on the same `LLMRails` instance.

This PR makes the function return a shallow `copy.copy()` of the dict so each caller gets an isolated copy it can substitute into without touching the shared flow config.

Closes #1935.

## What changes

### `nemoguardrails/rails/llm/utils.py`

- New `import copy`.
- One-line change at the return: `return element[\"action_name\"], copy.copy(element[\"action_params\"])`.
- Docstring on `get_action_details_from_flow_id` extended with a sentence explaining the copy contract (so a future refactor can't silently remove it).

### `tests/test_rails_llm_utils.py`

- New regression test `test_get_action_details_returns_isolated_copy`:
  - Calls the function twice against the same flow.
  - Mutates the first returned dict (mimicking the streaming substitution).
  - Asserts the second call returns the original placeholder value, not the mutated value.
  - Asserts the two returned dicts are distinct objects.

## Why a shallow copy is sufficient

The `action_params` values used by output-rail substitution are scalar strings like `\"\$bot_message\"`. The mutation pattern at `llmrails.py:1747-1751` does `action_params[key] = bot_response_chunk` — a top-level dict mutation. A shallow copy isolates that mutation; a deep copy would be overkill (and slower per chunk) since no nested mutation occurs in this path.

## Verification

The broader nemoguardrails test suite needs the full conftest/dependency setup (which I can't run cleanly outside the maintainer's dev environment). The regression test logic was verified standalone by extracting the fixed function into an isolated script and running the same assertions — the FAIL → PASS transition reproduces exactly the scenario the issue describes.

## Scope notes

- The mutation pattern at `llmrails.py:1747-1751` is left untouched. With the fix here, the loop mutates a fresh per-chunk dict, so the leak goes away without changing the streaming hot path. Happy to follow up with a defensive `action_params = dict(action_params)` at the top of `_prepare_params` if you prefer belt-and-braces, but it's not required to close #1935.
- Sign-off (DCO) included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where parameter modifications during action processing could unintentionally affect the underlying flow configuration used by subsequent operations.

* **Tests**
  * Added regression test to verify that action parameters remain isolated and independent across multiple invocations, preventing unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->