### PR TITLE
test(parallel_rails): replace wall-clock assertion with structural overlap check — closes #1953

### DIFF
--- a/tests/test_parallel_rails.py
+++ b/tests/test_parallel_rails.py
@@ -74,22 +74,15 @@ async def test_parallel_rails_success():
     # parallel bucket above 1.5s even when parallelism worked correctly.
     # See issue #1953.
     for rail_type in ("input", "output"):
-        paired_rails = [
-            rail
-            for rail in result.log.activated_rails
-            if f"check blocked {rail_type} terms" in rail.name
-        ]
+        paired_rails = [rail for rail in result.log.activated_rails if f"check blocked {rail_type} terms" in rail.name]
         assert len(paired_rails) == 2, (
-            f"expected 2 paired `check blocked {rail_type} terms` rails, "
-            f"got {len(paired_rails)}"
+            f"expected 2 paired `check blocked {rail_type} terms` rails, got {len(paired_rails)}"
         )
         first, second = sorted(paired_rails, key=lambda r: r.started_at or 0)
         assert first.started_at is not None and first.finished_at is not None, (
             f"{rail_type} rail timing fields not populated: {first}"
         )
-        assert second.started_at is not None, (
-            f"{rail_type} rail timing fields not populated: {second}"
-        )
+        assert second.started_at is not None, f"{rail_type} rail timing fields not populated: {second}"
         assert second.started_at < first.finished_at, (
             f"{rail_type} rails did not run in parallel: "
             f"first  [{first.started_at:.3f}, {first.finished_at:.3f}], "

--- a/tests/test_parallel_rails.py
+++ b/tests/test_parallel_rails.py
@@ -65,12 +65,36 @@ async def test_parallel_rails_success():
     assert result.log.activated_rails[5].name == "check blocked output terms $duration=1.0"
     assert result.log.activated_rails[6].name == "check blocked output terms $duration=1.0"
 
-    # Time should be close to 2 seconds due to parallel processing:
-    # check blocked input terms: 1s
-    # check blocked output terms: 1s
-    assert result.log.stats.input_rails_duration < 1.5 and result.log.stats.output_rails_duration < 1.5, (
-        "Rails processing took too long, parallelization seems to be not working."
-    )
+    # Verify parallelism structurally instead of via a wall-clock threshold.
+    # Each paired `check blocked input/output terms $duration=1.0` rail sleeps
+    # for ~1s; if the two siblings run in parallel, the second one starts
+    # before the first one finishes. This is true regardless of how slow the
+    # CI runner is — the previous `duration < 1.5s` assertion was flaky on
+    # slow runners because event-loop scheduling overhead could push the
+    # parallel bucket above 1.5s even when parallelism worked correctly.
+    # See issue #1953.
+    for rail_type in ("input", "output"):
+        paired_rails = [
+            rail
+            for rail in result.log.activated_rails
+            if f"check blocked {rail_type} terms" in rail.name
+        ]
+        assert len(paired_rails) == 2, (
+            f"expected 2 paired `check blocked {rail_type} terms` rails, "
+            f"got {len(paired_rails)}"
+        )
+        first, second = sorted(paired_rails, key=lambda r: r.started_at or 0)
+        assert first.started_at is not None and first.finished_at is not None, (
+            f"{rail_type} rail timing fields not populated: {first}"
+        )
+        assert second.started_at is not None, (
+            f"{rail_type} rail timing fields not populated: {second}"
+        )
+        assert second.started_at < first.finished_at, (
+            f"{rail_type} rails did not run in parallel: "
+            f"first  [{first.started_at:.3f}, {first.finished_at:.3f}], "
+            f"second started at {second.started_at:.3f}"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1953.

`tests/test_parallel_rails.py::test_parallel_rails_success` previously asserted that the parallel-rails bucket completed in `< 1.5s` wall-clock:

```python
# Time should be close to 2 seconds due to parallel processing:
# check blocked input terms: 1s
# check blocked output terms: 1s
assert result.log.stats.input_rails_duration < 1.5 and result.log.stats.output_rails_duration < 1.5, (
    \"Rails processing took too long, parallelization seems to be not working.\"
)
```

The 1.5s threshold was chosen to split the parallel lower bound (~1.0s, two `asyncio.sleep(1.0)` in flight) from the serial upper bound (~2.0s). On a slow CI runner, event-loop scheduling overhead can push parallel execution above 1.5s, producing a false-positive failure even when parallelism is working correctly. Observed on Ubuntu / Python 3.10 in [#1943's matrix run](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/26667249504).

## Fix

Replace the wall-clock check with a structural overlap check on `ActivatedRail.started_at` / `finished_at`. Two paired rails are running in parallel iff the second rail starts before the first one finishes — true regardless of how slow the runner is.

```python
for rail_type in (\"input\", \"output\"):
    paired_rails = [
        rail
        for rail in result.log.activated_rails
        if f\"check blocked {rail_type} terms\" in rail.name
    ]
    assert len(paired_rails) == 2
    first, second = sorted(paired_rails, key=lambda r: r.started_at or 0)
    assert second.started_at < first.finished_at, ...
```

`ActivatedRail` already exposes `started_at` / `finished_at` / `duration` (`nemoguardrails/rails/llm/options.py`), so no schema changes are needed.

## What's preserved unchanged

- All the prior index-based name assertions on `activated_rails[0..6]`.
- The response-content assertion at the top.
- Every other test in the file — they're behaviour-based (blocked-term detection, stop flag, etc.) and aren't affected by this flake.

## Verification

- `python -m py_compile tests/test_parallel_rails.py` passes locally.
- I haven't run the full pytest matrix from this fork (no LLM credentials configured here), but the logic is straightforward: if parallel runs, sibling rails overlap → assertion holds; if serial regression sneaks in, sibling rails will not overlap → assertion fails (with a clearer error message that includes the actual start/end timestamps).

## DCO

Signed-off-by line is on the commit.

## Notes

- `tests/test_parallel_rails_exceptions.py` uses behaviour-based checks (no wall-clock asserts), so it isn't affected.
- The same `started_at` / `finished_at` structural-overlap pattern could be useful as a helper if more parallel-rail tests get added; happy to factor it into `tests/utils` in a follow-up if you'd like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved parallel execution test reliability by switching from timing-based assertions to structural validation, reducing CI flakiness and ensuring consistent test results across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->