### PR TITLE
refactor(embeddings): replace Annoy with NumPy backend

### DIFF
--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Union, cast
 
-from annoy import AnnoyIndex  # type: ignore
+import numpy as np
 
 from nemoguardrails.embeddings.cache import cache_embeddings
 from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
@@ -31,12 +31,13 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
     """Basic implementation of an embeddings index.
 
     It uses the `sentence-transformers/all-MiniLM-L6-v2` model to compute embeddings.
-    Annoy is employed for efficient nearest-neighbor search.
+    Exact cosine nearest-neighbor search is performed over a NumPy matrix of
+    L2-normalized embeddings, so search results are exact (no approximation).
 
     Attributes:
         embedding_model (str): The model for computing embeddings.
         embedding_engine (str): The engine for computing embeddings.
-        index (AnnoyIndex): The current embedding index.
+        index (np.ndarray): The current embedding index (normalized matrix).
         embedding_size (int): The size of the embeddings.
         cache_config (EmbeddingsCacheConfig): The cache configuration.
         embeddings (List[List[float]]): The computed embeddings.
@@ -50,7 +51,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
         embedding_engine: str = "SentenceTransformers",
         embedding_params: Optional[Dict[str, Any]] = None,
-        index: Optional[AnnoyIndex] = None,
+        index: Optional["np.ndarray"] = None,
         cache_config: Optional[Union[EmbeddingsCacheConfig, Dict[str, Any]]] = None,
         search_threshold: float = float("inf"),
         use_batching: bool = False,
@@ -82,6 +83,8 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         else:
             self._cache_config = cache_config or EmbeddingsCacheConfig()
         self._index = index
+        if index is not None:
+            self._embedding_size = int(index.shape[1])
 
         # Data structures for batching embedding requests
         self._req_queue: Dict[int, str] = {}
@@ -181,11 +184,20 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._embedding_size = len(self._embeddings[0])
 
     async def build(self):
-        """Builds the Annoy index."""
-        self._index = AnnoyIndex(len(self._embeddings[0]), "angular")
-        for i in range(len(self._embeddings)):
-            self._index.add_item(i, self._embeddings[i])
-        self._index.build(10)
+        """Builds the embeddings index.
+
+        Stores an L2-normalized float32 matrix of the computed embeddings. Because
+        rows are normalized, the dot product between a normalized query and a row
+        equals their cosine similarity, which is the score used by `search`.
+        """
+        if not self._embeddings:
+            raise ValueError("No embeddings to build the index from. Add items before calling `build`.")
+        matrix = np.asarray(self._embeddings, dtype=np.float32)
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        # Avoid division by zero for degenerate (all-zero) embeddings.
+        norms[norms == 0] = 1.0
+        self._index = matrix / norms
+        self._embedding_size = int(self._index.shape[1])
 
     async def _run_batch(self):
         """Runs the current batch of embeddings."""
@@ -279,27 +291,49 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         if self._index is None:
             raise ValueError("Index is not built yet. Ensure to call `build` before searching.")
 
-        results = self._index.get_nns_by_vector(
-            _embedding,
-            max_results,
-            include_distances=True,
-        )
+        if self._index.shape[0] == 0:
+            return []
 
-        # In verbose mode, we show detailed info about the scores
+        query = np.asarray(_embedding, dtype=np.float32)
+        query_norm = np.linalg.norm(query)
+        if query_norm > 0:
+            query = query / query_norm
+
+        # Cosine similarity between the normalized query and each normalized row.
+        cosine = self._index @ query
+
+        # Reproduce Annoy's angular-distance score *exactly* so that existing
+        # `search_threshold` / `embeddings_only_similarity_threshold` values keep
+        # their meaning. For normalized vectors Annoy's angular distance is
+        # d = sqrt(2 - 2*cos), and the score was `1 - d/2`. This is a monotonic
+        # function of cosine, so the ranking is identical to (exact) cosine ranking.
+        # `clip` guards against tiny negative values from floating-point error
+        # before the sqrt.
+        distances = np.sqrt(np.clip(2.0 - 2.0 * cosine, 0.0, None))
+        scores = 1.0 - distances / 2.0
+
+        # Select the top `max_results` items, ordered best-first.
+        k = min(max_results, scores.shape[0])
+        top_indices = np.argpartition(-scores, k - 1)[:k]
+        top_indices = top_indices[np.argsort(-scores[top_indices])]
+
+        # In verbose mode, we show detailed info about the scores.
         if threshold != float("inf"):
-            log_items = []
-            for i in range(len(results[0])):
-                score = 1 - results[1][i] / 2
-                log_items.append((score, self._items[results[0][i]].text))
+            log_items = [(float(scores[i]), self._items[i].text) for i in top_indices]
             log.info("Similarity scores :: %s", str(log_items))
-
-        filtered_results = self._filter_results(results[0], results[1], threshold)
-
-        return [self._items[i] for i in filtered_results]
-
-    @staticmethod
-    def _filter_results(indices: List[int], distances: List[float], threshold: float) -> List[int]:
-        if threshold == float("inf"):
-            return indices
+            selected = [int(i) for i in top_indices if scores[i] >= threshold]
         else:
-            return [index for index, distance in zip(indices, distances) if (1 - distance / 2) >= threshold]
+            selected = [int(i) for i in top_indices]
+
+        return [self._items[i] for i in selected]
+
+    def save(self, path: str) -> None:
+        """Persist the built index to disk as a NumPy ``.npy`` file."""
+        if self._index is None:
+            raise ValueError("Index is not built yet. Ensure to call `build` before saving.")
+        np.save(path, self._index)
+
+    def load(self, path: str) -> None:
+        """Restore a previously persisted index from disk."""
+        self._index = np.load(path)
+        self._embedding_size = int(self._index.shape[1])

--- a/nemoguardrails/embeddings/index.py
+++ b/nemoguardrails/embeddings/index.py
@@ -65,3 +65,16 @@ class EmbeddingsIndex:
     async def search(self, text: str, max_results: int, threshold: Optional[float]) -> List[IndexItem]:
         """Searches the index for the closest matches to the provided text."""
         raise NotImplementedError()
+
+    def save(self, path: str) -> None:
+        """Persist the built index to disk.
+
+        Optional. Implemented by backends that support caching the index so it
+        does not have to be rebuilt on every run."""
+        raise NotImplementedError()
+
+    def load(self, path: str) -> None:
+        """Restore a previously persisted index from disk.
+
+        Optional. Counterpart of :meth:`save`."""
+        raise NotImplementedError()

--- a/nemoguardrails/kb/kb.py
+++ b/nemoguardrails/kb/kb.py
@@ -120,17 +120,10 @@ class KnowledgeBase:
         ) + self.config.embedding_search_provider.parameters.get("embedding_model", "")
 
         hash_value = compute_hash(hash_prefix + "".join(all_text_items))
-        cache_file = os.path.join(CACHE_FOLDER, f"{hash_value}.ann")
-        embedding_size_file = os.path.join(CACHE_FOLDER, f"{hash_value}.esize")
+        cache_file = os.path.join(CACHE_FOLDER, f"{hash_value}.npy")
 
         # If we have already computed this before, we use it
-        if (
-            self.config.embedding_search_provider.name == "default"
-            and os.path.exists(cache_file)
-            and os.path.exists(embedding_size_file)
-        ):
-            from annoy import AnnoyIndex
-
+        if self.config.embedding_search_provider.name == "default" and os.path.exists(cache_file):
             from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
 
             log.info(cache_file)
@@ -139,35 +132,26 @@ class KnowledgeBase:
                 self._get_embeddings_search_instance(self.config.embedding_search_provider),
             )
 
-            with open(embedding_size_file, "r") as f:
-                embedding_size = int(f.read())
-
-            ann_index = AnnoyIndex(embedding_size, "angular")
-            ann_index.load(cache_file)
-
-            self.index.embeddings_index = ann_index
-
+            # Restore the persisted index, then attach the item metadata. Since the
+            # index already exists, `add_items` only records the items and does not
+            # recompute embeddings (item order matches the cached matrix rows).
+            self.index.load(cache_file)
             await self.index.add_items(index_items)
         else:
             self.index = self._get_embeddings_search_instance(self.config.embedding_search_provider)
             await self.index.add_items(index_items)
             await self.index.build()
 
-            # For the default Embedding Search provider, which uses annoy, we also
-            # persist the index after it's computed.
+            # For the default Embedding Search provider, we also persist the index
+            # after it's computed so it can be reused on subsequent runs.
             if self.config.embedding_search_provider.name == "default":
                 from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
 
-                # We also save the file for future use
                 os.makedirs(CACHE_FOLDER, exist_ok=True)
                 basic_index = cast(BasicEmbeddingsIndex, self.index)
-                if not basic_index.embeddings_index:
+                if basic_index.embeddings_index is None:
                     raise Exception("Couldn't create basic embeddings index")
-                basic_index.embeddings_index.save(cache_file)
-
-                # And, explicitly save the size as we need it when we reload
-                with open(embedding_size_file, "w") as f:
-                    f.write(str(basic_index.embedding_size))
+                basic_index.save(cache_file)
 
         log.info(f"Building the Knowledge Base index took {time() - t0} seconds.")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -284,17 +284,6 @@ files = [
 ]
 
 [[package]]
-name = "annoy"
-version = "1.17.3"
-description = "Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk."
-optional = false
-python-versions = "*"
-files = [
-    {file = "annoy-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c33a5d4d344c136c84976bfb2825760142a8bb25335165e24e11c9afbfa8c2e9"},
-    {file = "annoy-1.17.3.tar.gz", hash = "sha256:9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15"},
-]
-
-[[package]]
 name = "anyio"
 version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
@@ -8892,4 +8881,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "ab33325bf60f2ea7a23f77124c965569076846b22778236f0a26273e7cdf575d"
+content-hash = "365ce1d8a87dccfdd9a3933201e2fc0e95d034df83a1f7cb56896ee34ff96189"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ nemoguardrails = "nemoguardrails.__main__:app"
 python = ">=3.10,<3.14"
 aiohttp = ">=3.10.11"
 aiohttp-retry = ">=2.9.0"
-annoy = ">=1.17.3"
 dataclasses-json = ">=0.6.7,<0.7.0"
 fastapi = { version = ">=0.103.0", optional = true }
 fastembed = [{ version = ">=0.2.2", python = ">=3.10,<3.14" }]

--- a/tests/test_basic_embeddings_index_numpy.py
+++ b/tests/test_basic_embeddings_index_numpy.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the exact NumPy backend of BasicEmbeddingsIndex.
+
+These exercise the index layer directly with injected embeddings (no embedding
+model), covering: exact cosine ranking, threshold filtering, and save/load
+round-trips.
+"""
+
+import numpy as np
+import pytest
+
+from nemoguardrails.embeddings.basic import BasicEmbeddingsIndex
+from nemoguardrails.embeddings.index import IndexItem
+
+
+def _make_index(embeddings, query_embedding):
+    """Build an index from raw embeddings and stub out the query embedding."""
+    idx = BasicEmbeddingsIndex()
+    idx._items = [IndexItem(text=f"item{i}", meta={"i": i}) for i in range(len(embeddings))]
+    idx._embeddings = [list(map(float, e)) for e in embeddings]
+
+    async def _fake_get_embeddings(texts):
+        return [list(map(float, query_embedding))]
+
+    idx._get_embeddings = _fake_get_embeddings  # type: ignore[assignment]
+    return idx
+
+
+@pytest.mark.asyncio
+async def test_build_normalizes_and_sets_size():
+    idx = _make_index([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]], [1.0, 0.0, 0.0])
+    await idx.build()
+
+    matrix = idx.embeddings_index
+    assert matrix.shape == (2, 3)
+    assert idx.embedding_size == 3
+    # Rows must be unit vectors after build.
+    np.testing.assert_allclose(np.linalg.norm(matrix, axis=1), [1.0, 1.0], atol=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_search_returns_exact_nearest_order():
+    # Query is closest to item0, then item1, then item3.
+    embeddings = [
+        [1.0, 0.0, 0.0],
+        [0.9, 0.1, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.6, 0.6, 0.0],
+    ]
+    idx = _make_index(embeddings, [1.0, 0.05, 0.0])
+    await idx.build()
+
+    results = await idx.search("q", max_results=3)
+    assert [r.text for r in results] == ["item0", "item1", "item3"]
+
+
+@pytest.mark.asyncio
+async def test_threshold_filters_by_annoy_parity_score():
+    embeddings = [
+        [1.0, 0.0, 0.0],  # cos ~1.0 with query
+        [0.0, 1.0, 0.0],  # cos ~0.0 with query
+    ]
+    idx = _make_index(embeddings, [1.0, 0.0, 0.0])
+    await idx.build()
+
+    # High threshold keeps only the near-collinear item.
+    results = await idx.search("q", max_results=5, threshold=0.9)
+    assert [r.text for r in results] == ["item0"]
+
+    # Default (inf) threshold returns everything, best-first.
+    results_all = await idx.search("q", max_results=5)
+    assert {r.text for r in results_all} == {"item0", "item1"}
+
+
+@pytest.mark.asyncio
+async def test_score_matches_annoy_angular_formula_not_raw_cosine():
+    """Lock the scoring contract: score == 1 - sqrt(2 - 2*cos)/2, NOT raw cosine.
+
+    The discriminating item has cosine 0.8 with the query, whose Annoy-parity
+    score is 1 - sqrt(2 - 1.6)/2 = 0.6838. A threshold of 0.70 must EXCLUDE it
+    (raw-cosine scoring, score=0.8, would wrongly include it); 0.68 must keep it.
+    """
+    # Unit vectors: query=[1,0]; item=[0.8, 0.6] -> cosine = 0.8.
+    idx = _make_index([[0.8, 0.6]], [1.0, 0.0])
+    await idx.build()
+
+    parity_score = 1.0 - (2.0 - 2.0 * 0.8) ** 0.5 / 2.0  # ~0.6838
+    assert 0.68 < parity_score < 0.70  # guards the test's own constants
+
+    assert await idx.search("q", max_results=1, threshold=0.70) == []
+    assert len(await idx.search("q", max_results=1, threshold=0.68)) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_caps_at_index_size():
+    idx = _make_index([[1.0, 0.0], [0.0, 1.0]], [1.0, 0.0])
+    await idx.build()
+    results = await idx.search("q", max_results=20)
+    assert len(results) == 2  # never more than the number of items
+
+
+@pytest.mark.asyncio
+async def test_save_load_roundtrip(tmp_path):
+    embeddings = [[1.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.0, 0.0, 1.0]]
+    query = [1.0, 0.05, 0.0]
+    idx = _make_index(embeddings, query)
+    await idx.build()
+    expected = [r.text for r in await idx.search("q", max_results=3)]
+
+    path = str(tmp_path / "index.npy")
+    idx.save(path)
+
+    # Fresh index: load the matrix, attach the same items, search again.
+    reloaded = _make_index(embeddings, query)
+    reloaded._embeddings = []  # ensure search uses the loaded matrix, not rebuilt
+    reloaded.load(path)
+    assert reloaded.embedding_size == 3
+    got = [r.text for r in await reloaded.search("q", max_results=3)]
+    assert got == expected
+
+
+@pytest.mark.asyncio
+async def test_search_before_build_raises():
+    idx = _make_index([[1.0, 0.0]], [1.0, 0.0])
+    with pytest.raises(ValueError):
+        await idx.search("q")
+
+
+@pytest.mark.asyncio
+async def test_build_without_items_raises():
+    idx = BasicEmbeddingsIndex()
+    with pytest.raises(ValueError):
+        await idx.build()


### PR DESCRIPTION
## Summary

Replaces the default Annoy-backed embedding index with exact NumPy search while keeping the existing Annoy angular-distance threshold semantics.

## What Changed

- Stores normalized embeddings in a NumPy matrix for the default index.
- Moves knowledge-base index save/load behind the `EmbeddingsIndex` interface.
- Persists default KB caches as `.npy` files.
- Removes Annoy from the project dependencies and lockfile.
- Adds focused NumPy index tests for ranking, threshold parity, and save/load.

## Stack

Part 1 of 2.

- Base: `develop`
- Head: `drop-annoy-feature`
- Next: https://github.com/Pouyanpi/NeMo-Guardrails/pull/28

## Validation

```text
poetry run pytest tests/test_basic_embeddings_index_numpy.py
8 passed
```
