### PR TITLE
test(llmrails): characterize public compatibility behavior (1/8)

### DIFF
--- a/tests/rails/llm/test_llmrails_public_contract.py
+++ b/tests/rails/llm/test_llmrails_public_contract.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from tests.utils import FakeLLMModel
+
+
+def _config() -> RailsConfig:
+    return RailsConfig.from_content(config={"models": []})
+
+
+def test_constructor_keeps_public_state_visible():
+    config = _config()
+    llm = FakeLLMModel(responses=[])
+
+    rails = LLMRails(config=config, llm=llm)
+
+    assert rails.config is config
+    assert rails.llm is llm
+    assert rails.runtime is not None
+    assert rails.llm_generation_actions is not None
+    assert rails.events_history_cache == {}
+    assert rails.explain_info is None
+
+
+def test_update_llm_keeps_runtime_generation_actions_and_public_attr_in_sync():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    new_llm = FakeLLMModel(responses=["updated"])
+
+    rails.update_llm(new_llm)
+
+    assert rails.llm is new_llm
+    assert rails.llm_generation_actions.llm is new_llm
+    assert rails.runtime.registered_action_params["llm"] is new_llm
+
+
+@pytest.mark.asyncio
+async def test_sync_wrappers_raise_when_called_from_async_loop():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+
+    with pytest.raises(RuntimeError, match="sync `generate` inside async code"):
+        rails.generate(prompt="hi")
+
+    with pytest.raises(RuntimeError, match="sync `generate_events` inside async code"):
+        rails.generate_events([])
+
+    with pytest.raises(RuntimeError, match="sync `generate_events` inside async code"):
+        rails.process_events([])
+
+    with pytest.raises(RuntimeError, match="sync `check` inside async code"):
+        rails.check([{"role": "user", "content": "hi"}])
+
+
+def test_getstate_serializes_config_only():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    rails.events_history_cache["cached"] = [{"type": "CachedEvent"}]
+    rails.register_action_param("custom_param", object())
+
+    state = rails.__getstate__()
+
+    assert state == {"config": rails.config}


### PR DESCRIPTION
## Summary

Adds characterization tests for the public `LLMRails` compatibility surface before moving implementation details out of the class.

## Why

The rest of this stack moves constructor, generation, runtime, streaming, and check behavior into focused helpers. This PR pins the public behavior reviewers should expect to remain stable during that decomposition.

## What Changed

- Covers constructor-visible state.
- Covers sync wrapper errors when called from an async loop.
- Covers `update_llm` binding behavior.
- Covers pickle state serialization behavior.

## Review Notes

This PR intentionally does not add new implementation modules. It is the baseline for reviewing the later extraction PRs.

## Stack Position

Part 1 of 8.

- Previous: none, based on `develop`
- Next: #1960

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #1959 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #1960 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #1961 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #1962 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #1963 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #1964 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #1965 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #1966 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
poetry run pre-commit run --all-files
```
