### PR TITLE
refactor(llmrails): extract standard generation workflow (6/8)

### DIFF
--- a/nemoguardrails/rails/llm/generation/__init__.py
+++ b/nemoguardrails/rails/llm/generation/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.rails.llm.generation.generation_workflow import generate_standard_async
+
+__all__ = ["generate_standard_async"]

--- a/nemoguardrails/rails/llm/generation/generation_workflow.py
+++ b/nemoguardrails/rails/llm/generation/generation_workflow.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from typing import Any, Optional, Union
+
+from nemoguardrails.actions.llm.utils import get_colang_history
+from nemoguardrails.colang.v2_x.runtime.flows import State
+from nemoguardrails.rails.llm.conversation.conversation_events import (
+    events_for_messages,
+    store_events_history_cache_entry,
+)
+from nemoguardrails.rails.llm.generation.bot_messages import bot_message_from_colang_events
+from nemoguardrails.rails.llm.generation.generation_context import (
+    GenerationRequestContext,
+    start_generation_stats,
+)
+from nemoguardrails.rails.llm.generation.generation_response import (
+    generation_event_metadata,
+    generation_response_from_colang_turn,
+)
+from nemoguardrails.rails.llm.generation.generation_tracing import (
+    export_generation_trace,
+    prepare_generation_tracing,
+    restore_generation_trace_log,
+)
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
+from nemoguardrails.rails.llm.runtime.colang_turns import run_colang_turn
+
+__all__ = ["generate_standard_async"]
+
+log = logging.getLogger("nemoguardrails.rails.llm.llmrails")
+
+
+async def generate_standard_async(
+    rails: Any,
+    *,
+    prompt: Optional[str],
+    messages: list[dict],
+    gen_options: Optional[GenerationOptions],
+    state: Optional[Union[dict, State]],
+    request_context: GenerationRequestContext,
+) -> Union[str, dict, GenerationResponse, tuple[dict, dict]]:
+    rails.explain_info = request_context.explain_info
+
+    t0 = time.time()
+    llm_stats, processing_log = start_generation_stats()
+
+    events = events_for_messages(rails, messages, state)
+
+    turn_result = await run_colang_turn(rails, events, state, processing_log)
+    new_events = turn_result.new_events
+    output_state = turn_result.output_state
+
+    bot_message = bot_message_from_colang_events(rails.config.colang_version, new_events)
+    new_message = bot_message.message
+
+    if rails.config.colang_version == "1.0":
+        events.extend(new_events)
+        events.extend(bot_message.extra_events)
+
+        if state is None:
+            store_events_history_cache_entry(rails.events_history_cache, (messages) + [new_message], events)
+        else:
+            output_state = {"events": events}
+
+    rails.explain_info.colang_history = get_colang_history(events)
+    if rails.verbose:
+        log.info(f"Conversation history so far: \n{rails.explain_info.colang_history}")
+
+    total_time = time.time() - t0
+    log.info("--- :: Total processing took %.2f seconds. LLM Stats: %s" % (total_time, llm_stats))
+
+    await request_context.close_streaming_handler()
+
+    tracing_state = prepare_generation_tracing(
+        tracing_enabled=rails.config.tracing.enabled,
+        gen_options=gen_options,
+    )
+    gen_options = tracing_state.gen_options
+
+    response_event_metadata = generation_event_metadata(new_events)
+    if gen_options:
+        res = generation_response_from_colang_turn(
+            colang_version=rails.config.colang_version,
+            prompt=prompt,
+            new_message=new_message,
+            events=events,
+            new_events=new_events,
+            processing_log=processing_log,
+            gen_options=gen_options,
+            state=state,
+            output_state=output_state,
+            event_metadata=response_event_metadata,
+        )
+
+        if rails.config.tracing.enabled:
+            await export_generation_trace(
+                tracing_config=rails.config.tracing,
+                log_adapters=rails._log_adapters,
+                messages=messages,
+                response=res,
+            )
+            restore_generation_trace_log(
+                response=res,
+                original_log_options=tracing_state.original_log_options,
+            )
+
+        return res
+
+    if response_event_metadata.reasoning_content:
+        thinking_trace = f"<think>{response_event_metadata.reasoning_content}</think>\n"
+        new_message["content"] = thinking_trace + new_message["content"]
+
+    if prompt:
+        return new_message["content"]
+
+    if response_event_metadata.tool_calls:
+        new_message["tool_calls"] = response_event_metadata.tool_calls
+    return new_message

--- a/tests/rails/llm/test_generation_request.py
+++ b/tests/rails/llm/test_generation_request.py
@@ -15,12 +15,17 @@
 
 import pytest
 
+from nemoguardrails.rails.llm import generation as generation_package
 from nemoguardrails.rails.llm.generation import generation_request
 from nemoguardrails.rails.llm.generation.generation_request import (
     normalize_generation_request,
     prepare_generation_request_for_runtime,
 )
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationRailsOptions
+
+
+def test_generation_package_exports():
+    assert generation_package.__all__ == ["generate_standard_async"]
 
 
 def test_generation_request_exports():


### PR DESCRIPTION
## Summary

Adds the standard generation sequence as a focused workflow helper.

## Why

The old `generate_async` path mixed request preparation, event conversion, Colang execution, response assembly, tracing, warning timing, and cleanup. This PR isolates the standard generation sequence before the final `LLMRails` shell wiring.

## What Changed

- Adds `generation_workflow.py`.
- Exports `generate_standard_async` from the generation package.
- Keeps the workflow helper close to the existing generation behavior.

## Review Notes

This PR adds the workflow helper. The final wiring of `LLMRails.generate_async` happens later after streaming and checks are also extracted.

## Stack Position

Part 6 of 8.

- Previous: #1963
- Next: #1965

## Stack Context

This PR is part of an 8-PR stack that decomposes `LLMRails` internals while keeping `LLMRails` as the public compatibility surface.

Please review each PR against its parent branch, not directly against `develop`, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #1959 | `stack/llmrails-01-public-contract-tests` | `develop` |
| 2 | #1960 | `stack/llmrails-02-startup-config-colang` | `stack/llmrails-01-public-contract-tests` |
| 3 | #1961 | `stack/llmrails-03-startup-models-kb-actions` | `stack/llmrails-02-startup-config-colang` |
| 4 | #1962 | `stack/llmrails-04-runtime-conversation` | `stack/llmrails-03-startup-models-kb-actions` |
| 5 | #1963 | `stack/llmrails-05-generation-helpers` | `stack/llmrails-04-runtime-conversation` |
| 6 | #1964 | `stack/llmrails-06-generation-workflow` | `stack/llmrails-05-generation-helpers` |
| 7 | #1965 | `stack/llmrails-07-streaming` | `stack/llmrails-06-generation-workflow` |
| 8 | #1966 | `stack/llmrails-08-checks` | `stack/llmrails-07-streaming` |

## Validation

```text
poetry run pytest tests/rails/llm tests/test_llmrails_check_async.py tests/test_system_message_conversion.py tests/test_token_usage_integration.py -q
poetry run pre-commit run --all-files
```
