### PR TITLE
feat(iorails): Telemetry - Content capture

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -255,9 +255,10 @@ class EngineRegistry:
         # chunk when ``stream_options.include_usage=true``.
         captured_usage: Optional["UsageInfo"] = None
         # Accumulate streamed delta_content here when content capture is on;
-        # joined and recorded onto the LLM span at stream end.  Gated on the
-        # flag so the disabled path doesn't pay the list-allocation cost or
-        # carry chunk strings in memory.
+        # joined and recorded onto the LLM span at stream end.  The list is
+        # allocated unconditionally (cost: one empty list per stream); the
+        # per-chunk appends are gated on the flag so the disabled path
+        # doesn't carry chunk strings in memory.
         content_parts: list[str] = []
         duration_ctx = (
             llm_operation_duration(engine.model_name, provider_name, operation_name)
@@ -299,8 +300,12 @@ class EngineRegistry:
             # Reached only on natural exhaustion — consumer cancellation or
             # provider error raises out of the ``with`` blocks above, in
             # which case partial content is intentionally not recorded.
+            # Empty ``content_parts`` -> output_text=None so we don't claim
+            # an empty assistant response (matches iorails.py's request-span
+            # streaming path).
             if self._content_capture_enabled:
-                set_llm_call_content(span, messages, "".join(content_parts))
+                output_text = "".join(content_parts) if content_parts else None
+                set_llm_call_content(span, messages, output_text)
 
         # Reached only on natural exhaustion (not on consumer cancellation
         # or provider error — those raise out of the ``with`` blocks above).

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -32,6 +32,7 @@ from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.telemetry import (
     api_call_span,
     llm_call_span,
+    set_llm_call_content,
 )
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
 from nemoguardrails.tracing.constants import (
@@ -63,6 +64,7 @@ class EngineRegistry:
         rails_config_data: RailsConfigData,
         tracer: Optional["Tracer"] = None,
         metrics_enabled: bool = False,
+        content_capture_enabled: bool = False,
     ) -> None:
         """Build one engine per configured model and API service.
 
@@ -75,11 +77,18 @@ class EngineRegistry:
         chunk-timing metrics).  Defaults to False so callers that don't
         opt in get no metric emissions even if a MeterProvider is
         configured globally.
+
+        When *content_capture_enabled* is True, LLM call spans carry
+        input/output message content per the OTEL GenAI content-capture
+        contract.  Defaults to False; should only be True when
+        ``tracer`` is also set, since capture on a no-op span is wasted
+        work.
         """
         self._engines: dict[str, BaseEngine] = {}
         self._running = False
         self._tracer = tracer
         self._metrics_enabled = metrics_enabled
+        self._content_capture_enabled = content_capture_enabled
 
         for model_config in models:
             engine = ModelEngine(model_config)
@@ -194,9 +203,14 @@ class EngineRegistry:
             if self._metrics_enabled
             else nullcontext()
         )
-        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name):
+        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
             with duration_ctx:
                 result = await engine.chat_completion(messages, **kwargs)
+            # Capture content inside the span context so the helper sees
+            # the live LLM CLIENT span (not None even on the success path)
+            # and the attributes/events land before the span closes.
+            if self._content_capture_enabled:
+                set_llm_call_content(span, messages, result.content)
 
         if self._metrics_enabled:
             record_token_usage(engine.model_name, provider_name, operation_name, result.usage)
@@ -240,12 +254,17 @@ class EngineRegistry:
         # OpenAI-compatible) only populate ``usage`` on the terminal
         # chunk when ``stream_options.include_usage=true``.
         captured_usage: Optional["UsageInfo"] = None
+        # Accumulate streamed delta_content here when content capture is on;
+        # joined and recorded onto the LLM span at stream end.  Gated on the
+        # flag so the disabled path doesn't pay the list-allocation cost or
+        # carry chunk strings in memory.
+        content_parts: list[str] = []
         duration_ctx = (
             llm_operation_duration(engine.model_name, provider_name, operation_name)
             if self._metrics_enabled
             else nullcontext()
         )
-        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name):
+        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
             with duration_ctx:
                 # Gate timing-state setup on ``_metrics_enabled`` so the
                 # cold path skips ``time.monotonic()`` and the per-chunk
@@ -272,7 +291,16 @@ class EngineRegistry:
                             last_chunk_time = now
                         if chunk.usage is not None:
                             captured_usage = chunk.usage
+                    if self._content_capture_enabled and chunk.delta_content:
+                        content_parts.append(chunk.delta_content)
                     yield chunk
+            # Capture accumulated stream content inside the span context so
+            # the helper sees the live LLM CLIENT span before it closes.
+            # Reached only on natural exhaustion — consumer cancellation or
+            # provider error raises out of the ``with`` blocks above, in
+            # which case partial content is intentionally not recorded.
+            if self._content_capture_enabled:
+                set_llm_call_content(span, messages, "".join(content_parts))
 
         # Reached only on natural exhaustion (not on consumer cancellation
         # or provider error — those raise out of the ``with`` blocks above).

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -53,7 +53,7 @@ from nemoguardrails.guardrails.telemetry import (
     record_stream_rejected,
     register_nonstream_saturation_gauges,
     request_metrics,
-    set_llm_call_content,
+    set_request_content,
     set_speculative_span_attrs,
     stream_active_metric,
     traced_request,
@@ -330,7 +330,7 @@ class IORails:
             # Capture content once here at the traced_request boundary so any
             # future early-return added to _do_generate is covered automatically.
             if self._content_capture_enabled:
-                set_llm_call_content(request_span, messages, result.get("content"))
+                set_request_content(request_span, messages, result.get("content"))
             elapsed_ms = (time.monotonic() - t0) * 1000
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             return result
@@ -731,7 +731,7 @@ class IORails:
                                 # falsely claim an "" assistant message was produced.
                                 if self._content_capture_enabled:
                                     output_text = "".join(delivered) if delivered else None
-                                    set_llm_call_content(request_span, messages, output_text)
+                                    set_request_content(request_span, messages, output_text)
                 finally:
                     self._stream_semaphore.release()
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -327,6 +327,10 @@ class IORails:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
                 raise
+            # Capture content once here at the traced_request boundary so any
+            # future early-return added to _do_generate is covered automatically.
+            if self._content_capture_enabled:
+                set_llm_call_content(request_span, messages, result.get("content"))
             elapsed_ms = (time.monotonic() - t0) * 1000
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             return result
@@ -351,8 +355,6 @@ class IORails:
             response = await self._do_generate_sequential(messages, req_id, llm_kwargs)
 
         if response is None:
-            if self._content_capture_enabled:
-                set_llm_call_content(request_span, messages, REFUSAL_MESSAGE)
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         # Log raw content before reasoning extraction and think-token removal
@@ -371,8 +373,6 @@ class IORails:
             log.info("[%s] Output blocked: %s", req_id, output_result.reason)
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.OUTPUT)
-            if self._content_capture_enabled:
-                set_llm_call_content(request_span, messages, REFUSAL_MESSAGE)
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         # TODO: Support returning GenerationResponse `reasoning_content` to match LLMRails
@@ -380,8 +380,6 @@ class IORails:
         if reasoning_content:
             response_text = f"<think>{reasoning_content}</think>\n" + response_text
 
-        if self._content_capture_enabled:
-            set_llm_call_content(request_span, messages, response_text)
         return {"role": "assistant", "content": response_text}
 
     async def _do_generate_sequential(
@@ -701,15 +699,16 @@ class IORails:
                                     async for chunk in base_iterator:
                                         if chunk is not None:
                                             if self._content_capture_enabled:
-                                                # chunk is str by default; dict when
-                                                # include_metadata=True (no output
-                                                # rails streaming in that case, per
-                                                # earlier validation).
+                                                # Plain strings are the normal path.
+                                                # Dicts arrive when include_metadata=True;
+                                                # skip empty-string text fields so
+                                                # metadata-only frames don't pollute
+                                                # the captured output.
                                                 if isinstance(chunk, str):
                                                     delivered.append(chunk)
                                                 elif isinstance(chunk, dict):
                                                     text = chunk.get("text")
-                                                    if isinstance(text, str):
+                                                    if isinstance(text, str) and text:
                                                         delivered.append(text)
                                             yield chunk
                                 finally:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -44,6 +44,7 @@ from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.guardrails.telemetry import (
     are_metrics_enabled,
     get_tracer,
+    is_content_capture_enabled,
     is_tracing_enabled,
     record_nonstream_rejected,
     record_request_blocked,
@@ -52,6 +53,7 @@ from nemoguardrails.guardrails.telemetry import (
     record_stream_rejected,
     register_nonstream_saturation_gauges,
     request_metrics,
+    set_llm_call_content,
     set_speculative_span_attrs,
     stream_active_metric,
     traced_request,
@@ -140,12 +142,17 @@ class IORails:
         self._tracing_enabled = is_tracing_enabled(config.tracing)
         self._tracer = get_tracer() if self._tracing_enabled else None
         self._metrics_enabled = are_metrics_enabled(config.metrics)
+        # Content capture only makes sense when tracing is on — there's no
+        # point recording prompts/responses onto spans that won't be exported.
+        # The flag itself is resolved from config + env var by the helper.
+        self._content_capture_enabled = self._tracing_enabled and is_content_capture_enabled(config.tracing)
 
         self.engine_registry = EngineRegistry(
             config.models,
             config.rails.config,
             tracer=self._tracer,
             metrics_enabled=self._metrics_enabled,
+            content_capture_enabled=self._content_capture_enabled,
         )
         self.rails_manager = RailsManager(
             engine_registry=self.engine_registry,
@@ -155,6 +162,7 @@ class IORails:
             input_parallel=config.rails.input.parallel or False,
             output_parallel=config.rails.output.parallel or False,
             tracer=self._tracer,
+            content_capture_enabled=self._content_capture_enabled,
         )
         self._speculative_generation = config.rails.input.speculative_generation or False
 
@@ -343,6 +351,8 @@ class IORails:
             response = await self._do_generate_sequential(messages, req_id, llm_kwargs)
 
         if response is None:
+            if self._content_capture_enabled:
+                set_llm_call_content(request_span, messages, REFUSAL_MESSAGE)
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         # Log raw content before reasoning extraction and think-token removal
@@ -361,6 +371,8 @@ class IORails:
             log.info("[%s] Output blocked: %s", req_id, output_result.reason)
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.OUTPUT)
+            if self._content_capture_enabled:
+                set_llm_call_content(request_span, messages, REFUSAL_MESSAGE)
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         # TODO: Support returning GenerationResponse `reasoning_content` to match LLMRails
@@ -368,6 +380,8 @@ class IORails:
         if reasoning_content:
             response_text = f"<think>{reasoning_content}</think>\n" + response_text
 
+        if self._content_capture_enabled:
+            set_llm_call_content(request_span, messages, response_text)
         return {"role": "assistant", "content": response_text}
 
     async def _do_generate_sequential(
@@ -661,6 +675,14 @@ class IORails:
                         # spans raised inside _generation_task attach as children.
                         with traced_request(tracer) as (request_span, req_id):
                             t0 = time.monotonic()
+                            # Accumulate chunks the consumer actually receives.
+                            # Declared outside the try so the outer finally can
+                            # always reference it, even if the try body raises
+                            # before any chunk is yielded.  Captured at stream end
+                            # on the request span so we record exactly what reached
+                            # the caller (including any output-rails error JSON
+                            # injected on block).
+                            delivered: list[str] = []
                             try:
                                 log.info("[%s] stream_async called", req_id)
                                 log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
@@ -678,6 +700,17 @@ class IORails:
 
                                     async for chunk in base_iterator:
                                         if chunk is not None:
+                                            if self._content_capture_enabled:
+                                                # chunk is str by default; dict when
+                                                # include_metadata=True (no output
+                                                # rails streaming in that case, per
+                                                # earlier validation).
+                                                if isinstance(chunk, str):
+                                                    delivered.append(chunk)
+                                                elif isinstance(chunk, dict):
+                                                    text = chunk.get("text")
+                                                    if isinstance(text, str):
+                                                        delivered.append(text)
                                             yield chunk
                                 finally:
                                     if not task.done():
@@ -691,6 +724,15 @@ class IORails:
                             finally:
                                 elapsed_ms = (time.monotonic() - t0) * 1000
                                 log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
+                                # Capture input + accumulated output onto the request
+                                # span before it closes.  Always runs (normal exit,
+                                # error, or consumer cancellation) so an errored
+                                # stream still records whatever reached the caller.
+                                # Empty `delivered` -> output_text=None so we don't
+                                # falsely claim an "" assistant message was produced.
+                                if self._content_capture_enabled:
+                                    output_text = "".join(delivered) if delivered else None
+                                    set_llm_call_content(request_span, messages, output_text)
                 finally:
                     self._stream_semaphore.release()
 

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -39,7 +39,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
 )
 from nemoguardrails.guardrails.rail_action import RailAction
-from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span
+from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_name
 
@@ -78,15 +78,23 @@ class RailsManager:
         input_parallel: bool = False,
         output_parallel: bool = False,
         tracer: Optional["Tracer"] = None,
+        content_capture_enabled: bool = False,
     ) -> None:
         """Build RailAction instances for each configured input and output flow.
 
         When *tracer* is provided, rail and action executions produce OTEL
         spans; when ``None`` the span helpers become no-ops.
+
+        When *content_capture_enabled* is True, rail spans carry the
+        rail's input messages (``guardrails.rail.input``) and the block
+        reason (``guardrails.rail.reason``) when the rail rejects the
+        request.  Defaults to False; only meaningful when ``tracer`` is
+        also set.
         """
         self.engine_registry = engine_registry
         self.task_manager = task_manager
         self._tracer = tracer
+        self._content_capture_enabled = content_capture_enabled
 
         self.input_flows: list[str] = list(input_flows)
         self.output_flows: list[str] = list(output_flows)
@@ -159,6 +167,17 @@ class RailsManager:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)
             mark_rail_stop(span, result.is_safe)
+            # Capture rail input + block reason after the action runs.
+            # RailAction.run() catches its own exceptions and returns
+            # RailResult(is_safe=False, reason=...), so this branch is
+            # reached even on action errors and the error reason gets
+            # recorded as the block reason.
+            if self._content_capture_enabled:
+                set_rail_content(
+                    span,
+                    {"messages": messages, "bot_response": bot_response},
+                    reason=result.reason if not result.is_safe else None,
+                )
             return result
 
     async def _run_rails_sequential(

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -448,21 +448,48 @@ def _get_parts_by_role(messages: LLMMessages, role: str, include: bool) -> list[
 
 
 def _system_parts_from_messages(messages: LLMMessages) -> list[dict]:
-    """Return the OTEL GenAI ``parts`` entries for system messages only.
+    """Return the bare OTEL GenAI ``parts`` for system messages only.
 
-    ``gen_ai.system_instructions`` is a flat list of parts (no role
-    wrapping), so this unwraps the role-wrapped form returned by
-    :func:`_get_parts_by_role` down to the bare ``{"type": "text",
-    "content": ...}`` items.
+    Feeds ``gen_ai.system_instructions``, which the spec defines as a flat
+    list of parts with no role wrapper (every entry is implicitly system).
+    Asymmetric with :func:`_non_system_input_messages`, which keeps the role
+    wrapper — the two attributes have different shapes by spec.  Entries
+    missing ``role`` or ``content`` are skipped silently.
+
+    Example::
+
+        >>> _system_parts_from_messages([
+        ...     {"role": "system", "content": "be helpful"},
+        ...     {"role": "user", "content": "hi"},
+        ... ])
+        [{"type": "text", "content": "be helpful"}]
     """
-    return [m["parts"][0] for m in _get_parts_by_role(messages, "system", include=True)]
+    out: list[dict] = []
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role is None or content is None:
+            continue
+        if role == "system":
+            out.append({"type": "text", "content": content})
+    return out
 
 
-def _non_system_messages_to_parts(messages: LLMMessages) -> list[dict]:
-    """Return the OTEL GenAI structured form for non-system messages.
+def _non_system_input_messages(messages: LLMMessages) -> list[dict]:
+    """Return the OTEL GenAI ``gen_ai.input.messages`` form for non-system messages.
 
-    Each non-system message becomes ``{"role": role, "parts": [{"type":
-    "text", "content": content}]}`` to populate ``gen_ai.input.messages``.
+    Each non-system message is role-wrapped as ``{"role": role, "parts":
+    [{"type": "text", "content": content}]}``.  Named for the attribute it
+    populates rather than "parts" because — unlike
+    :func:`_system_parts_from_messages` — it keeps the role wrapper.
+
+    Example::
+
+        >>> _non_system_input_messages([
+        ...     {"role": "system", "content": "be helpful"},
+        ...     {"role": "user", "content": "hi"},
+        ... ])
+        [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
     """
     return _get_parts_by_role(messages, "system", include=False)
 
@@ -484,7 +511,7 @@ def _set_llm_call_content_json(
     if system_parts:
         span.set_attribute(GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS, json.dumps(system_parts))
 
-    non_system = _non_system_messages_to_parts(input_messages)
+    non_system = _non_system_input_messages(input_messages)
     if non_system:
         span.set_attribute(GenAIAttributes.GEN_AI_INPUT_MESSAGES, json.dumps(non_system))
 

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -33,7 +33,6 @@ import time
 import warnings
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
-from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -406,46 +405,18 @@ _LEGACY_EVENT_BY_ROLE = {
 }
 
 
-@cache
 def _use_json_span_format() -> bool:
     """Return True iff OTEL_SEMCONV_STABILITY_OPT_IN selects JSON span attrs.
 
     The env var holds a comma-separated list of opt-in tokens.  When
     ``gen_ai_latest_experimental`` is present, content is emitted as
     JSON-encoded span attributes, otherwise as legacy per-message span events.
-
-    Cached after first call (``functools.cache``) since the env var is
-    process-global and normally set at startup, and this runs on every
-    captured-content span emission.  Tests that mutate the env var must
-    call ``_use_json_span_format.cache_clear()`` to re-read.
+    Read fresh each call so runtime changes to the env var take effect
+    immediately.
     """
     raw_env_value = os.environ.get(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
     tokens = {tok.strip() for tok in raw_env_value.split(",")}
     return OtelContentCapture.STABILITY_OPT_IN_LATEST in tokens
-
-
-def _get_parts_by_role(messages: LLMMessages, role: str, include: bool) -> list[dict]:
-    """Return role-wrapped OTEL GenAI message entries filtered by *role*.
-
-    When *include* is True, returns only messages whose ``role`` field
-    equals *role*; when False, returns only those whose ``role`` differs.
-    Each result is ``{"role": <msg_role>, "parts": [{"type": "text",
-    "content": <content>}]}``.  Entries missing ``role`` or ``content``
-    are skipped silently.
-    """
-    out: list[dict] = []
-    for msg in messages:
-        msg_role = msg.get("role")
-        content = msg.get("content")
-        if msg_role is None or content is None:
-            continue
-        role_matches = msg_role == role
-        if include and not role_matches:
-            continue
-        if not include and role_matches:
-            continue
-        out.append({"role": msg_role, "parts": [{"type": "text", "content": content}]})
-    return out
 
 
 def _system_parts_from_messages(messages: LLMMessages) -> list[dict]:
@@ -492,7 +463,15 @@ def _non_system_input_messages(messages: LLMMessages) -> list[dict]:
         ... ])
         [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
     """
-    return _get_parts_by_role(messages, "system", include=False)
+    out: list[dict] = []
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role is None or content is None:
+            continue
+        if role != "system":
+            out.append({"role": role, "parts": [{"type": "text", "content": content}]})
+    return out
 
 
 def _set_llm_call_content_json(

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -25,7 +25,9 @@ passthrough respectively).  Lower-level helpers like ``request_span`` and
 reachable through ``traced_request`` when a non-``None`` tracer is provided.
 """
 
+import json
 import logging
+import os
 import secrets
 import time
 import warnings
@@ -33,6 +35,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generator,
     Iterable,
@@ -44,6 +47,7 @@ from typing import (
 from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
     REQUEST_ID_HEX_CHARS,
+    LLMMessages,
     RailDirection,
     _set_request_id,
     get_request_id,
@@ -51,10 +55,12 @@ from nemoguardrails.guardrails.guardrails_types import (
     set_new_request_id,
 )
 from nemoguardrails.tracing.constants import (
+    EventNames,
     GenAIAttributes,
     GuardrailsAttributes,
     MetricNames,
     OperationNames,
+    OtelContentCapture,
     SpanNames,
     SystemConstants,
 )
@@ -386,6 +392,193 @@ def set_speculative_span_attrs(
     # span.set_attribute(GuardrailsAttributes.SPECULATIVE_TIME_SAVED_MS, time_saved_ms)
 
 
+# Maps an OpenAI-style ``role`` to the OTEL GenAI legacy event name used
+# when content capture emits per-message span events (i.e. when the
+# stability opt-in does NOT select the new structured attribute form).
+# Roles outside this set (``tool`` etc.) are not yet supported and will
+# be skipped silently rather than crashing the capture path.
+_LEGACY_EVENT_BY_ROLE = {
+    "system": EventNames.GEN_AI_SYSTEM_MESSAGE,
+    "user": EventNames.GEN_AI_USER_MESSAGE,
+    "assistant": EventNames.GEN_AI_ASSISTANT_MESSAGE,
+}
+
+
+def _use_json_span_format() -> bool:
+    """Return True iff OTEL_SEMCONV_STABILITY_OPT_IN selects JSON span attrs.
+
+    The env var holds a comma-separated list of opt-in tokens.  When
+    ``gen_ai_latest_experimental`` is present, content is emitted as
+    JSON-encoded span attributes, otherwise as legacy per-message span events.
+    """
+    raw_env_value = os.environ.get(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
+    tokens = {tok.strip() for tok in raw_env_value.split(",")}
+    return OtelContentCapture.STABILITY_OPT_IN_LATEST in tokens
+
+
+def _get_parts_by_role(messages: LLMMessages, role: str, include: bool) -> list[dict]:
+    """Return role-wrapped OTEL GenAI message entries filtered by *role*.
+
+    When *include* is True, returns only messages whose ``role`` field
+    equals *role*; when False, returns only those whose ``role`` differs.
+    Each result is ``{"role": <msg_role>, "parts": [{"type": "text",
+    "content": <content>}]}``.  Entries missing ``role`` or ``content``
+    are skipped silently.
+    """
+    out: list[dict] = []
+    for msg in messages:
+        msg_role = msg.get("role")
+        content = msg.get("content")
+        if msg_role is None or content is None:
+            continue
+        role_matches = msg_role == role
+        if include and not role_matches:
+            continue
+        if not include and role_matches:
+            continue
+        out.append({"role": msg_role, "parts": [{"type": "text", "content": content}]})
+    return out
+
+
+def _system_parts_from_messages(messages: LLMMessages) -> list[dict]:
+    """Return the OTEL GenAI ``parts`` entries for system messages only.
+
+    ``gen_ai.system_instructions`` is a flat list of parts (no role
+    wrapping), so this unwraps the role-wrapped form returned by
+    :func:`_get_parts_by_role` down to the bare ``{"type": "text",
+    "content": ...}`` items.
+    """
+    return [m["parts"][0] for m in _get_parts_by_role(messages, "system", include=True)]
+
+
+def _non_system_messages_to_parts(messages: LLMMessages) -> list[dict]:
+    """Return the OTEL GenAI structured form for non-system messages.
+
+    Each non-system message becomes ``{"role": role, "parts": [{"type":
+    "text", "content": content}]}`` to populate ``gen_ai.input.messages``.
+    """
+    return _get_parts_by_role(messages, "system", include=False)
+
+
+def _set_llm_call_content_json(
+    span: "Span",
+    input_messages: LLMMessages,
+    output_text: Optional[str],
+) -> None:
+    """JSON-attribute branch of :func:`set_llm_call_content`.
+
+    Sets ``gen_ai.input.messages``, ``gen_ai.output.messages``, and
+    ``gen_ai.system_instructions`` as JSON-encoded span attributes per
+    the latest experimental OTEL GenAI semantic conventions.  Attributes
+    are only set when non-empty so backends can distinguish "no system
+    instructions" from "system instructions == ''".
+    """
+    system_parts = _system_parts_from_messages(input_messages)
+    if system_parts:
+        span.set_attribute(GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS, json.dumps(system_parts))
+
+    non_system = _non_system_messages_to_parts(input_messages)
+    if non_system:
+        span.set_attribute(GenAIAttributes.GEN_AI_INPUT_MESSAGES, json.dumps(non_system))
+
+    if output_text is not None:
+        output_messages = [{"role": "assistant", "parts": [{"type": "text", "content": output_text}]}]
+        span.set_attribute(GenAIAttributes.GEN_AI_OUTPUT_MESSAGES, json.dumps(output_messages))
+
+
+def _set_llm_call_content_events(
+    span: "Span",
+    input_messages: LLMMessages,
+    output_text: Optional[str],
+) -> None:
+    """Legacy-event branch of :func:`set_llm_call_content`.
+
+    Adds one span event per input message (``gen_ai.system.message`` /
+    ``gen_ai.user.message`` / ``gen_ai.assistant.message``) plus a
+    ``gen_ai.choice`` event for the assistant output.  Roles not in
+    :data:`_LEGACY_EVENT_BY_ROLE` (e.g. ``tool``) are skipped — adding
+    tool/function-call events is deferred until IORails supports them.
+    """
+    for msg in input_messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role is None or content is None:
+            continue
+        event_name = _LEGACY_EVENT_BY_ROLE.get(role)
+        if event_name is None:
+            continue
+        span.add_event(event_name, attributes={"role": role, "content": content})
+
+    if output_text is not None:
+        span.add_event(
+            EventNames.GEN_AI_CHOICE,
+            attributes={"index": 0, "message.role": "assistant", "message.content": output_text},
+        )
+
+
+def set_llm_call_content(
+    span: Optional["Span"],
+    input_messages: LLMMessages,
+    output_text: Optional[str] = None,
+) -> None:
+    """Capture input/output messages on a span representing a model interaction.
+
+    Used for both ``gen_ai.*`` CLIENT spans (LLM calls) and the
+    ``guardrails.request`` SERVER span — the OTEL GenAI semconv
+    attribute names apply to any span that represents a model
+    interaction, so reusing the names lets backends correlate the outer
+    guardrails request with the inner LLM call by attribute name alone.
+
+    Dispatches on :func:`_use_json_span_format`:
+
+    * **JSON attrs** (``OTEL_SEMCONV_STABILITY_OPT_IN`` includes
+      ``gen_ai_latest_experimental``): :func:`_set_llm_call_content_json`
+      sets the JSON-encoded ``gen_ai.input.messages``,
+      ``gen_ai.output.messages``, and ``gen_ai.system_instructions``
+      span attributes per the latest experimental OTEL GenAI semantic
+      conventions.
+    * **Legacy events** (default): :func:`_set_llm_call_content_events`
+      adds one span event per input message plus a ``gen_ai.choice``
+      event for the assistant output.
+
+    Safe to call with ``span=None`` (no-op) so callers don't have to
+    branch on whether tracing is enabled.  Caller is responsible for
+    checking the content-capture flag — this helper does NOT re-check
+    :func:`is_content_capture_enabled` so it stays cheap on hot paths.
+    """
+    if span is None:
+        return
+    if _use_json_span_format():
+        _set_llm_call_content_json(span, input_messages, output_text)
+    else:
+        _set_llm_call_content_events(span, input_messages, output_text)
+
+
+def set_rail_content(
+    span: Optional["Span"],
+    rail_input: dict[str, Any],
+    reason: Optional[str] = None,
+) -> None:
+    """Capture rail input + (optionally) block reason on a ``guardrails.rail`` span.
+
+    Sets ``guardrails.rail.input`` to the JSON-encoded *rail_input* dict
+    (typically ``{"messages": [...], "bot_response": ...}``).  When
+    *reason* is non-None, also sets ``guardrails.rail.reason`` — caller
+    passes the human-readable block reason from the failing rail (or
+    ``None`` when the rail passed, in which case only the input
+    attribute is recorded).
+
+    Safe to call with ``span=None`` (no-op).  No GenAI semconv covers
+    rail spans, so these attributes live under the guardrails.* namespace
+    alongside ``rail.type`` / ``rail.name`` / ``rail.stop``.
+    """
+    if span is None:
+        return
+    span.set_attribute(GuardrailsAttributes.RAIL_INPUT, json.dumps(rail_input))
+    if reason is not None:
+        span.set_attribute(GuardrailsAttributes.RAIL_REASON, reason)
+
+
 @contextmanager
 def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
     """Create a live ``guardrails.request`` SERVER span.
@@ -546,6 +739,31 @@ def is_tracing_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
         )
         return False
     return True
+
+
+def is_content_capture_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
+    """Return True when message content should be captured onto spans.
+
+    Resolves in priority order:
+
+    1. ``config.tracing.enable_content_capture`` — when True, capture is on.
+    2. ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` env var —
+       truthy values (``true``, ``1``, case-insensitive) turn capture on.
+       Matches the de-facto standard used by upstream Python GenAI
+       instrumentations, so operators can flip capture across services
+       via one env var without per-service config edits.
+    3. Otherwise False.
+
+    Callers should ALSO require :func:`is_tracing_enabled` before
+    treating capture as active — there is no point capturing content
+    onto spans that won't be exported.  This helper deliberately does
+    not perform that check itself so it stays orthogonal to the
+    tracing-enabled signal (and so tests can exercise each independently).
+    """
+    if config_tracing is not None and getattr(config_tracing, "enable_content_capture", False):
+        return True
+    env_value = os.environ.get(OtelContentCapture.CAPTURE_CONTENT_ENV, "").strip().lower()
+    return env_value in ("true", "1")
 
 
 def are_metrics_enabled(config_metrics: Optional["MetricsConfig"]) -> bool:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -586,8 +586,9 @@ def set_request_content(
     ``guardrails.request.input`` is always a JSON-encoded list of role/content
     message objects matching the caller's input.  ``guardrails.request.output``
     is the plain string that IORails returned (REFUSAL_MESSAGE on block paths,
-    the model's response text on the success path).  ``output_text=None`` is
-    valid when the output is not yet known (input-only capture at span open).
+    the model's response text on the success path).  ``output_text=None``
+    suppresses the output attribute entirely — used by the streaming path when
+    the stream produced no content, so an empty output is not falsely recorded.
 
     Safe to call with ``span=None`` (no-op).
     """

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -396,12 +396,13 @@ def set_speculative_span_attrs(
 # Maps an OpenAI-style ``role`` to the OTEL GenAI legacy event name used
 # when content capture emits per-message span events (i.e. when the
 # stability opt-in does NOT select the new structured attribute form).
-# Roles outside this set (``tool`` etc.) are not yet supported and will
-# be skipped silently rather than crashing the capture path.
+# ``function`` role (OpenAI legacy function-call format) is deliberately
+# excluded — it will need its own decision when function-call support lands.
 _LEGACY_EVENT_BY_ROLE = {
     "system": EventNames.GEN_AI_SYSTEM_MESSAGE,
     "user": EventNames.GEN_AI_USER_MESSAGE,
     "assistant": EventNames.GEN_AI_ASSISTANT_MESSAGE,
+    "tool": EventNames.GEN_AI_TOOL_MESSAGE,
 }
 
 
@@ -528,10 +529,10 @@ def _set_llm_call_content_events(
     """Legacy-event branch of :func:`set_llm_call_content`.
 
     Adds one span event per input message (``gen_ai.system.message`` /
-    ``gen_ai.user.message`` / ``gen_ai.assistant.message``) plus a
-    ``gen_ai.choice`` event for the assistant output.  Roles not in
-    :data:`_LEGACY_EVENT_BY_ROLE` (e.g. ``tool``) are skipped — adding
-    tool/function-call events is deferred until IORails supports them.
+    ``gen_ai.user.message`` / ``gen_ai.assistant.message`` /
+    ``gen_ai.tool.message``) plus a ``gen_ai.choice`` event for the
+    assistant output.  Roles not in :data:`_LEGACY_EVENT_BY_ROLE`
+    (e.g. ``function``) are skipped silently.
     """
     for msg in input_messages:
         role = msg.get("role")

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -589,6 +589,36 @@ def set_llm_call_content(
         _set_llm_call_content_events(span, input_messages, output_text)
 
 
+def set_request_content(
+    span: Optional["Span"],
+    input_messages: LLMMessages,
+    output_text: Optional[str] = None,
+) -> None:
+    """Capture caller-facing input/output on the ``guardrails.request`` SERVER span.
+
+    Uses ``guardrails.request.input`` (JSON-encoded input messages) and
+    ``guardrails.request.output`` (the text actually returned to the caller)
+    rather than the ``gen_ai.*`` attribute names used on LLM CLIENT spans.
+    This distinction matters on block paths: the LLM CLIENT span records the
+    raw model response, while the SERVER span records the refusal message —
+    the same ``gen_ai.output.messages`` name on both spans would carry
+    different values and confuse backends correlating the two.
+
+    ``guardrails.request.input`` is always a JSON-encoded list of role/content
+    message objects matching the caller's input.  ``guardrails.request.output``
+    is the plain string that IORails returned (REFUSAL_MESSAGE on block paths,
+    the model's response text on the success path).  ``output_text=None`` is
+    valid when the output is not yet known (input-only capture at span open).
+
+    Safe to call with ``span=None`` (no-op).
+    """
+    if span is None:
+        return
+    span.set_attribute(GuardrailsAttributes.REQUEST_INPUT, json.dumps(input_messages))
+    if output_text is not None:
+        span.set_attribute(GuardrailsAttributes.REQUEST_OUTPUT, output_text)
+
+
 def set_rail_content(
     span: Optional["Span"],
     rail_input: dict[str, Any],

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -33,6 +33,7 @@ import time
 import warnings
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
+from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -404,12 +405,18 @@ _LEGACY_EVENT_BY_ROLE = {
 }
 
 
+@cache
 def _use_json_span_format() -> bool:
     """Return True iff OTEL_SEMCONV_STABILITY_OPT_IN selects JSON span attrs.
 
     The env var holds a comma-separated list of opt-in tokens.  When
     ``gen_ai_latest_experimental`` is present, content is emitted as
     JSON-encoded span attributes, otherwise as legacy per-message span events.
+
+    Cached after first call (``functools.cache``) since the env var is
+    process-global and normally set at startup, and this runs on every
+    captured-content span emission.  Tests that mutate the env var must
+    call ``_use_json_span_format.cache_clear()`` to re-read.
     """
     raw_env_value = os.environ.get(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
     tokens = {tok.strip() for tok in raw_env_value.split(",")}
@@ -744,15 +751,16 @@ def is_tracing_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
 def is_content_capture_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
     """Return True when message content should be captured onto spans.
 
-    Resolves in priority order:
+    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` is the
+    primary control — when set, it overrides any config-file value so
+    operators have a single OTEL-standard env var that flips capture
+    across all services regardless of what the deployed config says.
+    Recognized values (case-insensitive, surrounding whitespace
+    stripped): ``true`` / ``1`` enable; ``false`` / ``0`` disable; any
+    other value falls through to the config field.
 
-    1. ``config.tracing.enable_content_capture`` — when True, capture is on.
-    2. ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` env var —
-       truthy values (``true``, ``1``, case-insensitive) turn capture on.
-       Matches the de-facto standard used by upstream Python GenAI
-       instrumentations, so operators can flip capture across services
-       via one env var without per-service config edits.
-    3. Otherwise False.
+    When the env var is absent or unrecognized, capture is on iff
+    ``config.tracing.enable_content_capture`` is True.
 
     Callers should ALSO require :func:`is_tracing_enabled` before
     treating capture as active — there is no point capturing content
@@ -760,10 +768,14 @@ def is_content_capture_enabled(config_tracing: Optional["TracingConfig"]) -> boo
     not perform that check itself so it stays orthogonal to the
     tracing-enabled signal (and so tests can exercise each independently).
     """
-    if config_tracing is not None and getattr(config_tracing, "enable_content_capture", False):
-        return True
     env_value = os.environ.get(OtelContentCapture.CAPTURE_CONTENT_ENV, "").strip().lower()
-    return env_value in ("true", "1")
+    if env_value in ("true", "1"):
+        return True
+    if env_value in ("false", "0"):
+        return False
+    if config_tracing is None:
+        return False
+    return getattr(config_tracing, "enable_content_capture", False)
 
 
 def are_metrics_enabled(config_metrics: Optional["MetricsConfig"]) -> bool:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -592,7 +592,15 @@ class TracingConfig(BaseModel):
         default=False,
         description=(
             "Capture prompts and responses (user/assistant/tool message content) in tracing/telemetry events. "
+            "Honored by both the LLMRails and IORails. "
             "Disabled by default for privacy and alignment with OpenTelemetry GenAI semantic conventions. "
+            "As a fallback when this field is unset/false, IORails also honors the "
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable "
+            "Output format on IORails is selected by OTEL_SEMCONV_STABILITY_OPT_IN: when it contains "
+            "'gen_ai_latest_experimental', content is emitted as JSON-encoded span attributes "
+            "(gen_ai.input.messages, gen_ai.output.messages, gen_ai.system_instructions); "
+            "otherwise as legacy per-message span events "
+            "(gen_ai.user.message, gen_ai.assistant.message, gen_ai.system.message, gen_ai.choice). "
             "WARNING: Enabling this may include PII and sensitive data in your telemetry backend."
         ),
     )

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -592,10 +592,11 @@ class TracingConfig(BaseModel):
         default=False,
         description=(
             "Capture prompts and responses (user/assistant/tool message content) in tracing/telemetry events. "
-            "Honored by both the LLMRails and IORails. "
+            "Honored by both LLMRails and IORails. "
             "Disabled by default for privacy and alignment with OpenTelemetry GenAI semantic conventions. "
-            "As a fallback when this field is unset/false, IORails also honors the "
-            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable "
+            "On IORails, the OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable "
+            "overrides this field in both directions: 'true' / '1' force capture on, 'false' / '0' force "
+            "it off, unrecognized values fall through to this field. "
             "Output format on IORails is selected by OTEL_SEMCONV_STABILITY_OPT_IN: when it contains "
             "'gen_ai_latest_experimental', content is emitted as JSON-encoded span attributes "
             "(gen_ai.input.messages, gen_ai.output.messages, gen_ai.system_instructions); "

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -594,7 +594,7 @@ class TracingConfig(BaseModel):
             "Capture prompts and responses (user/assistant/tool message content) in tracing/telemetry events. "
             "Honored by both LLMRails and IORails. "
             "Disabled by default for privacy and alignment with OpenTelemetry GenAI semantic conventions. "
-            "On IORails, the OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable "
+            "On IORails, the OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable. "
             "overrides this field in both directions: 'true' / '1' force capture on, 'false' / '0' force "
             "it off, unrecognized values fall through to this field. "
             "Output format on IORails is selected by OTEL_SEMCONV_STABILITY_OPT_IN: when it contains "

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -592,17 +592,22 @@ class TracingConfig(BaseModel):
         default=False,
         description=(
             "Capture prompts and responses (user/assistant/tool message content) in tracing/telemetry events. "
-            "Honored by both LLMRails and IORails. "
             "Disabled by default for privacy and alignment with OpenTelemetry GenAI semantic conventions. "
-            "On IORails, the OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable. "
-            "overrides this field in both directions: 'true' / '1' force capture on, 'false' / '0' force "
-            "it off, unrecognized values fall through to this field. "
-            "Output format on IORails is selected by OTEL_SEMCONV_STABILITY_OPT_IN: when it contains "
-            "'gen_ai_latest_experimental', content is emitted as JSON-encoded span attributes "
+            "WARNING: Enabling this may include PII and sensitive data in your telemetry backend. "
+            "Behaviour differs by engine. "
+            "For IORails — "
+            "1. OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT environment variable has highest priority: "
+            "'true'/'1' force on, 'false'/'0' force off, for other values this field is used. "
+            "2. OTEL_SEMCONV_STABILITY_OPT_IN selects output format: when the comma-separated token list "
+            "contains 'gen_ai_latest_experimental', content is emitted as JSON-encoded span attributes "
             "(gen_ai.input.messages, gen_ai.output.messages, gen_ai.system_instructions); "
             "otherwise as legacy per-message span events "
             "(gen_ai.user.message, gen_ai.assistant.message, gen_ai.system.message, gen_ai.choice). "
-            "WARNING: Enabling this may include PII and sensitive data in your telemetry backend."
+            "For LLMRails — "
+            "Neither OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT nor OTEL_SEMCONV_STABILITY_OPT_IN "
+            "are consulted; this field is the only control. "
+            "Content is always emitted via the deprecated gen_ai.content.prompt and "
+            "gen_ai.content.completion span events."
         ),
     )
 

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -87,6 +87,26 @@ class SystemConstants:
     UNKNOWN = "unknown"
 
 
+class OtelContentCapture:
+    """OTEL environment-variable names and tokens for content-capture gating.
+
+    Two independent OTEL-standard env vars control content capture:
+
+    * ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` — fallback
+      enable switch when ``config.tracing.enable_content_capture`` is
+      unset/False.  Truthy values (``"true"``, ``"1"``) turn capture on.
+    * ``OTEL_SEMCONV_STABILITY_OPT_IN`` — comma-separated stability
+      opt-in list.  When ``"gen_ai_latest_experimental"`` is present,
+      content is emitted as new-form span attributes
+      (``gen_ai.input.messages`` etc.); otherwise as legacy span events
+      (``gen_ai.user.message`` etc.).
+    """
+
+    CAPTURE_CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+    STABILITY_OPT_IN_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN"
+    STABILITY_OPT_IN_LATEST = "gen_ai_latest_experimental"
+
+
 class GenAIAttributes:
     """GenAI semantic convention attributes following the draft specification.
 
@@ -124,6 +144,14 @@ class GenAIAttributes:
     # metric label values.
     GEN_AI_TOKEN_TYPE = "gen_ai.token.type"
 
+    # New-form content-capture span attributes (opt-in, gated by
+    # OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental).  Values
+    # are JSON-encoded strings.  Default emission uses the legacy event
+    # form (EventNames.GEN_AI_*_MESSAGE / GEN_AI_CHOICE) instead.
+    GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
+    GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
+    GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
+
 
 class CommonAttributes:
     """Common OpenTelemetry attributes used across spans."""
@@ -139,6 +167,14 @@ class GuardrailsAttributes:
     RAIL_NAME = "rail.name"
     RAIL_STOP = "rail.stop"
     RAIL_DECISIONS = "rail.decisions"
+
+    # rail content-capture attributes (opt-in alongside the GenAI
+    # content-capture knob).  No GenAI semconv exists for rail spans,
+    # so these live under the guardrails.* namespace.  RAIL_INPUT is
+    # a JSON-encoded snapshot of the rail's inputs; RAIL_REASON is set
+    # only when the rail blocks.
+    RAIL_INPUT = "guardrails.rail.input"
+    RAIL_REASON = "guardrails.rail.reason"
 
     # action attributes
     ACTION_NAME = "action.name"

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -296,7 +296,7 @@ class EventNames:
     GEN_AI_SYSTEM_MESSAGE = "gen_ai.system.message"
     GEN_AI_USER_MESSAGE = "gen_ai.user.message"
     GEN_AI_ASSISTANT_MESSAGE = "gen_ai.assistant.message"
-    # GEN_AI_TOOL_MESSAGE = "gen_ai.tool.message"
+    GEN_AI_TOOL_MESSAGE = "gen_ai.tool.message"
 
     GEN_AI_CHOICE = "gen_ai.choice"
 

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -176,6 +176,16 @@ class GuardrailsAttributes:
     RAIL_INPUT = "guardrails.rail.input"
     RAIL_REASON = "guardrails.rail.reason"
 
+    # request-level content-capture attributes on the guardrails.request
+    # SERVER span.  These record the caller-facing input and output —
+    # what the caller sent and what was returned — which differs
+    # from gen_ai.input/output.messages on the LLM CLIENT span on block
+    # paths (where the LLM CLIENT span records the raw model response
+    # while the SERVER span records the refusal message).  Using a
+    # distinct attribute namespace avoids conflating the two semantics.
+    REQUEST_INPUT = "guardrails.request.input"
+    REQUEST_OUTPUT = "guardrails.request.output"
+
     # action attributes
     ACTION_NAME = "action.name"
     ACTION_HAS_LLM_CALLS = "action.has_llm_calls"

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -34,7 +34,12 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, Rai
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing import constants as tracing_constants
-from nemoguardrails.tracing.constants import SystemConstants
+from nemoguardrails.tracing.constants import (
+    GenAIAttributes,
+    GuardrailsAttributes,
+    OtelContentCapture,
+    SystemConstants,
+)
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
 from tests.guardrails.async_helpers import saturate_stream_semaphore, wait_for_queue_state
 from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
@@ -1934,3 +1939,349 @@ class TestGenerateAsyncLLMMetrics:
         points = collect_metric_points(metric_reader)
         assert "gen_ai.client.token.usage" not in points
         assert "gen_ai.client.operation.duration" not in points
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_content_envvars(monkeypatch):
+    """Strip OTEL content-capture env vars from each test's environment.
+
+    Without this, an inherited ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
+    or ``OTEL_SEMCONV_STABILITY_OPT_IN`` from CI / dev shell would flip
+    capture on or change format mid-suite and produce flaky assertions.
+    """
+    monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
+    monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
+
+
+def _make_content_capture_config():
+    """``_make_tracing_config()`` with ``enable_content_capture=True`` added."""
+    cfg = _make_tracing_config()
+    cfg["tracing"]["enable_content_capture"] = True
+    return cfg
+
+
+def _make_content_capture_streaming_config():
+    """Input-only streaming config with tracing + content capture enabled."""
+    cfg = copy.deepcopy(_INPUT_ONLY_STREAMING_TRACING_CONFIG)
+    cfg["tracing"]["enable_content_capture"] = True
+    return cfg
+
+
+@pytest_asyncio.fixture
+async def iorails_content_capture(tracer_from_provider):
+    """IORails with tracing + content capture enabled."""
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_make_content_capture_config())
+            iorails = IORails(config)
+        async with iorails:
+            yield iorails
+
+
+@pytest_asyncio.fixture
+async def iorails_streaming_content_capture(tracer_from_provider):
+    """Input-only streaming + tracing + content capture enabled."""
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_make_content_capture_streaming_config())
+            iorails = IORails(config)
+        async with iorails:
+            yield iorails
+
+
+def _request_span(spans):
+    """Return the single guardrails.request SERVER span from a list of spans."""
+    request_spans = [s for s in spans if s.name == "guardrails.request"]
+    assert len(request_spans) == 1
+    return request_spans[0]
+
+
+def _main_llm_span(spans):
+    """Return the CLIENT span for the main LLM call (model name "meta/llama-3.3-70b-instruct")."""
+    candidates = [
+        s
+        for s in spans
+        if s.kind == SpanKind.CLIENT and s.attributes.get("gen_ai.request.model") == "meta/llama-3.3-70b-instruct"
+    ]
+    assert len(candidates) == 1
+    return candidates[0]
+
+
+class TestContentCaptureDisabled:
+    """Default config (tracing on, capture off): spans carry no content attrs/events."""
+
+    @pytest.mark.asyncio
+    async def test_no_content_on_request_span(self, iorails_tracing, exporter):
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+        # No legacy events either
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+
+    @pytest.mark.asyncio
+    async def test_no_content_on_llm_span(self, iorails_tracing, exporter):
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+
+    @pytest.mark.asyncio
+    async def test_no_rail_input_on_rail_spans(self, iorails_tracing, exporter):
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
+        for span in rail_spans:
+            assert GuardrailsAttributes.RAIL_INPUT not in span.attributes
+            assert GuardrailsAttributes.RAIL_REASON not in span.attributes
+
+
+class TestContentCaptureLegacyFormat:
+    """Capture on + opt-in env unset: legacy gen_ai.* events on request + LLM spans."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_events_on_request_span(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture, main_llm_response="Hi back")
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        event_names = [e.name for e in span.events]
+        assert "gen_ai.user.message" in event_names
+        assert "gen_ai.choice" in event_names
+        # No JSON-attr leakage on the events path
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+
+    @pytest.mark.asyncio
+    async def test_user_message_event_carries_content(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        user_events = [e for e in span.events if e.name == "gen_ai.user.message"]
+        assert len(user_events) == 1
+        assert dict(user_events[0].attributes) == {"role": "user", "content": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_choice_event_carries_assistant_output(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        attrs = dict(choice_events[0].attributes)
+        assert attrs["message.role"] == "assistant"
+        assert attrs["message.content"] == "The answer"
+
+    @pytest.mark.asyncio
+    async def test_legacy_events_on_main_llm_span(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        event_names = [e.name for e in span.events]
+        assert "gen_ai.user.message" in event_names
+        assert "gen_ai.choice" in event_names
+
+    @pytest.mark.asyncio
+    async def test_refusal_message_captured_on_blocked_input(self, iorails_content_capture, exporter):
+        """A blocked input still records the REFUSAL_MESSAGE as the assistant output."""
+        _stub_deep_pipeline(iorails_content_capture, input_safe=False)
+
+        result = await iorails_content_capture.generate_async([{"role": "user", "content": "bad"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        span = _request_span(exporter.get_finished_spans())
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+
+
+class TestContentCaptureJsonFormat:
+    """Capture on + OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental: JSON attrs."""
+
+    @pytest.fixture(autouse=True)
+    def _set_stability_opt_in(self, monkeypatch):
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            OtelContentCapture.STABILITY_OPT_IN_LATEST,
+        )
+
+    @pytest.mark.asyncio
+    async def test_json_attrs_on_request_span(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
+        outputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
+
+        assert inputs == [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
+        assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": "The answer"}]}]
+        # No legacy events on the JSON path
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+
+    @pytest.mark.asyncio
+    async def test_system_instructions_split_into_own_attr(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture)
+
+        messages = [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+        ]
+        await iorails_content_capture.generate_async(messages)
+
+        span = _request_span(exporter.get_finished_spans())
+        sysinst = json.loads(span.attributes[GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS])
+        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
+
+        assert sysinst == [{"type": "text", "content": "be helpful"}]
+        # System message must not also appear in input.messages
+        assert [m["role"] for m in inputs] == ["user"]
+
+    @pytest.mark.asyncio
+    async def test_json_attrs_on_main_llm_span(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES in span.attributes
+
+
+class TestContentCaptureEnvVarFallback:
+    """OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT enables capture when config is unset."""
+
+    @pytest.mark.asyncio
+    async def test_env_var_enables_capture_when_config_unset(self, monkeypatch, tracer_from_provider, exporter):
+        """Config without enable_content_capture + env=true → capture is active."""
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "true")
+
+        with patch.object(telemetry, "_tracer", tracer_from_provider):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                # _make_tracing_config has tracing on but enable_content_capture unset
+                config = RailsConfig.from_content(config=_make_tracing_config())
+                iorails = IORails(config)
+            async with iorails:
+                _stub_deep_pipeline(iorails)
+                await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        # Events emitted on the legacy path (no stability opt-in)
+        assert any(e.name == "gen_ai.user.message" for e in span.events)
+
+
+class TestRailContentCapture:
+    """guardrails.rail.input on every rail span; guardrails.rail.reason on blocked rails only."""
+
+    @pytest.mark.asyncio
+    async def test_rail_input_recorded_on_passing_rail(self, iorails_content_capture, exporter):
+        _stub_deep_pipeline(iorails_content_capture)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
+
+        rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
+        assert len(rail_spans) >= 1
+        for span in rail_spans:
+            rail_input = json.loads(span.attributes[GuardrailsAttributes.RAIL_INPUT])
+            assert "messages" in rail_input
+            assert rail_input["messages"] == [{"role": "user", "content": "hi"}]
+            # Passing rails carry no block reason
+            assert GuardrailsAttributes.RAIL_REASON not in span.attributes
+
+    @pytest.mark.asyncio
+    async def test_rail_reason_set_on_blocked_rail_only(self, iorails_content_capture, exporter):
+        """When an input rail blocks, its span gets a reason; later rails never run."""
+        _stub_deep_pipeline(iorails_content_capture, input_safe=False)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "bad"}])
+
+        rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
+        blocked = [s for s in rail_spans if GuardrailsAttributes.RAIL_REASON in s.attributes]
+        # Exactly one rail blocked (sequential mode short-circuits)
+        assert len(blocked) == 1
+        # The blocking rail's reason is a non-empty string
+        assert blocked[0].attributes[GuardrailsAttributes.RAIL_REASON]
+
+
+class TestStreamingContentCapture:
+    """Streamed delta_content accumulates and lands on the request + LLM spans."""
+
+    @pytest.mark.asyncio
+    async def test_output_text_recorded_on_request_span(self, iorails_streaming_content_capture, exporter):
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        delivered = "".join(c for c in chunks if isinstance(c, str))
+        assert delivered  # sanity: stream produced something
+
+        span = _request_span(exporter.get_finished_spans())
+        # Legacy events path (no stability opt-in) — choice event carries output
+        choice = next(e for e in span.events if e.name == "gen_ai.choice")
+        assert dict(choice.attributes)["message.content"] == delivered
+
+    @pytest.mark.asyncio
+    async def test_output_text_recorded_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        delivered = "".join(c for c in chunks if isinstance(c, str))
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        choice = next(e for e in span.events if e.name == "gen_ai.choice")
+        assert dict(choice.attributes)["message.content"] == delivered
+
+    @pytest.mark.asyncio
+    async def test_blocked_input_records_refusal_as_output(self, iorails_streaming_content_capture, exporter):
+        """Input-rail block: REFUSAL_MESSAGE is pushed through the streaming
+        handler, so the consumer receives it and content capture records it
+        as the assistant output on the request span (not empty)."""
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails, input_safe=False)
+
+        [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
+
+        span = _request_span(exporter.get_finished_spans())
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_empty_delivered_records_no_choice_event(self, iorails_streaming_content_capture, exporter):
+        """When the LLM yields zero content chunks, output_text becomes None
+        and no gen_ai.choice event fires.  Guards against an empty-string
+        assistant message getting recorded for a stream that produced nothing."""
+        iorails = iorails_streaming_content_capture
+
+        async def _empty_stream(messages, **kwargs):
+            # An async generator that yields no items at all
+            if False:
+                yield  # pragma: no cover
+
+        _stub_deep_streaming_pipeline(iorails, main_stream=_empty_stream)
+
+        [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        span = _request_span(exporter.get_finished_spans())
+        # No choice event because output_text was None (empty delivered list)
+        assert all(e.name != "gen_ai.choice" for e in span.events)
+        # Input events still fire (input messages were captured)
+        assert any(e.name == "gen_ai.user.message" for e in span.events)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2136,6 +2136,40 @@ class TestContentCaptureLegacyFormat:
         span = _request_span(exporter.get_finished_spans())
         assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
 
+    @pytest.mark.asyncio
+    async def test_llm_and_request_spans_diverge_on_output_block(self, iorails_content_capture, exporter):
+        """On an output block, the LLM CLIENT span and request SERVER span hold different outputs.
+
+        This is the core scenario that motivated separate guardrails.request.*
+        attributes: the LLM span records the RAW model response (what the model
+        produced) while the request span records REFUSAL_MESSAGE (what the caller
+        actually received).  The main LLM call runs for real at the engine level
+        so its CLIENT span is created and captures content; only the output rail
+        is forced to block.
+        """
+        iorails = iorails_content_capture
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        # Mock at the engine level (not engine_registry.model_call) so the real
+        # model_call wrapper runs, creating the LLM CLIENT span + capturing content.
+        iorails.engine_registry._engines["main"].chat_completion = AsyncMock(
+            return_value=LLMResponse(content="raw model answer")
+        )
+        iorails.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="unsafe response")
+        )
+
+        result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        spans = exporter.get_finished_spans()
+        # LLM CLIENT span: the raw model output (legacy gen_ai.choice event)
+        llm_span = _main_llm_span(spans)
+        choice = next(e for e in llm_span.events if e.name == "gen_ai.choice")
+        assert dict(choice.attributes)["message.content"] == "raw model answer"
+        # Request SERVER span: the refusal the caller actually received — divergent
+        req_span = _request_span(spans)
+        assert req_span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
+
 
 class TestContentCaptureJsonFormat:
     """Capture on + OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental: JSON attrs."""

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2113,6 +2113,29 @@ class TestContentCaptureLegacyFormat:
         assert len(choice_events) == 1
         assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
 
+    @pytest.mark.asyncio
+    async def test_refusal_message_captured_on_blocked_output(self, iorails_content_capture, exporter):
+        """A blocked OUTPUT records REFUSAL_MESSAGE as the assistant output too.
+
+        Exercises the second of three return sites in _do_generate (output-rail
+        block path) — distinct from the input-rail block above.  Mocks at the
+        rails_manager level since _stub_deep_pipeline only varies input safety.
+        """
+        iorails = iorails_content_capture
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="bad response"))
+        iorails.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="unsafe response")
+        )
+
+        result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        span = _request_span(exporter.get_finished_spans())
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+
 
 class TestContentCaptureJsonFormat:
     """Capture on + OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental: JSON attrs."""
@@ -2291,8 +2314,77 @@ class TestStreamingContentCapture:
 
         [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
-        span = _request_span(exporter.get_finished_spans())
+        spans = exporter.get_finished_spans()
+        request_span = _request_span(spans)
         # No choice event because output_text was None (empty delivered list)
-        assert all(e.name != "gen_ai.choice" for e in span.events)
+        assert all(e.name != "gen_ai.choice" for e in request_span.events)
         # Input events still fire (input messages were captured)
-        assert any(e.name == "gen_ai.user.message" for e in span.events)
+        assert any(e.name == "gen_ai.user.message" for e in request_span.events)
+
+        # LLM streaming span behaves consistently: empty content_parts ->
+        # output_text=None -> no choice event (matches request span).
+        llm_span = _main_llm_span(spans)
+        assert all(e.name != "gen_ai.choice" for e in llm_span.events)
+
+    @pytest.mark.asyncio
+    async def test_dict_chunks_with_include_metadata_get_captured(self, iorails_streaming_content_capture, exporter):
+        """include_metadata=True streams dict chunks; capture extracts text fields.
+
+        Covers the isinstance(chunk, dict) branch in _wrapped_iterator's
+        accumulator — without this test, that path is unreachable from the
+        rest of the suite (which all use plain-string streaming).
+        """
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}], include_metadata=True)]
+        # Sanity: with include_metadata=True chunks are dicts, not strings
+        assert all(isinstance(c, dict) for c in chunks)
+        expected = "".join(c.get("text", "") for c in chunks if isinstance(c.get("text"), str))
+
+        span = _request_span(exporter.get_finished_spans())
+        choice = next(e for e in span.events if e.name == "gen_ai.choice")
+        assert dict(choice.attributes)["message.content"] == expected
+
+
+class TestStreamingContentCaptureJsonFormat:
+    """Streaming + capture on + OTEL_SEMCONV_STABILITY_OPT_IN: JSON attrs on both spans."""
+
+    @pytest.fixture(autouse=True)
+    def _set_stability_opt_in(self, monkeypatch, _clear_otel_content_envvars):
+        # Same dependency-ordering trick as TestContentCaptureJsonFormat:
+        # force the module-level cleanup BEFORE the class-level setenv so the
+        # cleanup's cache_clear doesn't wipe our opt-in.
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            OtelContentCapture.STABILITY_OPT_IN_LATEST,
+        )
+        telemetry._use_json_span_format.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_json_attrs_on_request_span(self, iorails_streaming_content_capture, exporter):
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        delivered = "".join(c for c in chunks if isinstance(c, str))
+
+        span = _request_span(exporter.get_finished_spans())
+        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
+        outputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
+        assert inputs == [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
+        assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": delivered}]}]
+        # No legacy events leaking onto the JSON path
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+
+    @pytest.mark.asyncio
+    async def test_json_attrs_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):
+        iorails = iorails_streaming_content_capture
+        _stub_deep_streaming_pipeline(iorails)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        delivered = "".join(c for c in chunks if isinstance(c, str))
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        outputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
+        assert outputs[0]["parts"][0]["content"] == delivered

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2011,42 +2011,27 @@ class TestContentCaptureDisabled:
     """Default config (tracing on, capture off): spans carry no content attrs/events."""
 
     @pytest.mark.asyncio
-    async def test_no_content_on_request_span(self, iorails_tracing, exporter):
-        """Capture off → the request span has no content attributes or gen_ai events."""
+    async def test_no_content_on_any_span(self, iorails_tracing, exporter):
+        """Capture off → request, LLM, and rail spans carry no captured content."""
         _stub_deep_pipeline(iorails_tracing)
 
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
 
-        span = _request_span(exporter.get_finished_spans())
-        assert GuardrailsAttributes.REQUEST_INPUT not in span.attributes
-        assert GuardrailsAttributes.REQUEST_OUTPUT not in span.attributes
-        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
-        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
-        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+        spans = exporter.get_finished_spans()
 
-    @pytest.mark.asyncio
-    async def test_no_content_on_llm_span(self, iorails_tracing, exporter):
-        """Capture off → the main LLM span has no content attributes or gen_ai events."""
-        _stub_deep_pipeline(iorails_tracing)
+        request_span = _request_span(spans)
+        assert GuardrailsAttributes.REQUEST_INPUT not in request_span.attributes
+        assert GuardrailsAttributes.REQUEST_OUTPUT not in request_span.attributes
+        assert all(not e.name.startswith("gen_ai.") for e in request_span.events)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        llm_span = _main_llm_span(spans)
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in llm_span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in llm_span.attributes
+        assert all(not e.name.startswith("gen_ai.") for e in llm_span.events)
 
-        span = _main_llm_span(exporter.get_finished_spans())
-        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
-        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
-        assert all(not e.name.startswith("gen_ai.") for e in span.events)
-
-    @pytest.mark.asyncio
-    async def test_no_rail_input_on_rail_spans(self, iorails_tracing, exporter):
-        """Capture off → rail spans carry no rail.input or rail.reason attributes."""
-        _stub_deep_pipeline(iorails_tracing)
-
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
-
-        rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
-        for span in rail_spans:
-            assert GuardrailsAttributes.RAIL_INPUT not in span.attributes
-            assert GuardrailsAttributes.RAIL_REASON not in span.attributes
+        for rail_span in (s for s in spans if s.name == "guardrails.rail"):
+            assert GuardrailsAttributes.RAIL_INPUT not in rail_span.attributes
+            assert GuardrailsAttributes.RAIL_REASON not in rail_span.attributes
 
 
 class TestContentCaptureLegacyFormat:
@@ -2068,7 +2053,11 @@ class TestContentCaptureLegacyFormat:
 
     @pytest.mark.asyncio
     async def test_legacy_events_on_main_llm_span(self, iorails_content_capture, exporter):
-        """The main LLM span carries the legacy gen_ai.* message/choice events."""
+        """The main LLM span carries the legacy gen_ai.* message/choice events.
+
+        Verifies the engine→set_llm_call_content wiring; the exact event
+        attributes are pinned by the unit tests for _set_llm_call_content_events.
+        """
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2077,32 +2066,6 @@ class TestContentCaptureLegacyFormat:
         event_names = [e.name for e in span.events]
         assert "gen_ai.user.message" in event_names
         assert "gen_ai.choice" in event_names
-
-    @pytest.mark.asyncio
-    async def test_llm_span_user_event_carries_content(self, iorails_content_capture, exporter):
-        """The gen_ai.user.message event on the LLM span carries role and content."""
-        _stub_deep_pipeline(iorails_content_capture)
-
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
-
-        span = _main_llm_span(exporter.get_finished_spans())
-        user_events = [e for e in span.events if e.name == "gen_ai.user.message"]
-        assert len(user_events) == 1
-        assert dict(user_events[0].attributes) == {"role": "user", "content": "hello"}
-
-    @pytest.mark.asyncio
-    async def test_llm_span_choice_event_carries_output(self, iorails_content_capture, exporter):
-        """The gen_ai.choice event on the LLM span carries the model's response."""
-        _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
-
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
-
-        span = _main_llm_span(exporter.get_finished_spans())
-        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
-        assert len(choice_events) == 1
-        attrs = dict(choice_events[0].attributes)
-        assert attrs["message.role"] == "assistant"
-        assert attrs["message.content"] == "The answer"
 
     @pytest.mark.asyncio
     async def test_refusal_message_captured_on_blocked_input(self, iorails_content_capture, exporter):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1948,12 +1948,9 @@ def _clear_otel_content_envvars(monkeypatch):
     Without this, an inherited ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
     or ``OTEL_SEMCONV_STABILITY_OPT_IN`` from CI / dev shell would flip
     capture on or change format mid-suite and produce flaky assertions.
-    Also clears the ``_use_json_span_format`` cache so format-switching
-    tests (legacy vs JSON) re-read the env var fresh.
     """
     monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
     monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
-    telemetry._use_json_span_format.cache_clear()
 
 
 def _make_content_capture_config():
@@ -2144,19 +2141,11 @@ class TestContentCaptureJsonFormat:
     """Capture on + OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental: JSON attrs."""
 
     @pytest.fixture(autouse=True)
-    def _set_stability_opt_in(self, monkeypatch, _clear_otel_content_envvars):
-        # Explicit dependency on _clear_otel_content_envvars forces pytest to
-        # run the module-level cleanup (which delenvs both OTEL vars and clears
-        # the _use_json_span_format cache) BEFORE this fixture sets the opt-in.
-        # Without the dependency, the autouse fixture ordering is alphabetical
-        # within the same scope and _clear would run after _set, undoing it.
+    def _set_stability_opt_in(self, monkeypatch):
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             OtelContentCapture.STABILITY_OPT_IN_LATEST,
         )
-        # Cache cleared by _clear_otel_content_envvars above; clear again here
-        # in case any prior in-class fixture warmed it with the wrong value.
-        telemetry._use_json_span_format.cache_clear()
 
     @pytest.mark.asyncio
     async def test_request_span_carries_guardrails_attrs(self, iorails_content_capture, exporter):
@@ -2390,15 +2379,11 @@ class TestStreamingContentCaptureJsonFormat:
     """Streaming + capture on + OTEL_SEMCONV_STABILITY_OPT_IN: JSON attrs on both spans."""
 
     @pytest.fixture(autouse=True)
-    def _set_stability_opt_in(self, monkeypatch, _clear_otel_content_envvars):
-        # Same dependency-ordering trick as TestContentCaptureJsonFormat:
-        # force the module-level cleanup BEFORE the class-level setenv so the
-        # cleanup's cache_clear doesn't wipe our opt-in.
+    def _set_stability_opt_in(self, monkeypatch):
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             OtelContentCapture.STABILITY_OPT_IN_LATEST,
         )
-        telemetry._use_json_span_format.cache_clear()
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_request_span(self, iorails_streaming_content_capture, exporter):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2021,9 +2021,10 @@ class TestContentCaptureDisabled:
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
 
         span = _request_span(exporter.get_finished_spans())
+        assert GuardrailsAttributes.REQUEST_INPUT not in span.attributes
+        assert GuardrailsAttributes.REQUEST_OUTPUT not in span.attributes
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
         assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
-        # No legacy events either
         assert all(not e.name.startswith("gen_ai.") for e in span.events)
 
     @pytest.mark.asyncio
@@ -2052,52 +2053,25 @@ class TestContentCaptureDisabled:
 
 
 class TestContentCaptureLegacyFormat:
-    """Capture on + opt-in env unset: legacy gen_ai.* events on request + LLM spans."""
+    """Capture on + opt-in env unset: guardrails.request.* attrs on request span; gen_ai.* events on LLM span."""
 
     @pytest.mark.asyncio
-    async def test_legacy_events_on_request_span(self, iorails_content_capture, exporter):
-        """Capture on, no opt-in → request span gets gen_ai.* events, no JSON attrs."""
+    async def test_request_span_carries_guardrails_attrs(self, iorails_content_capture, exporter):
+        """Request span carries guardrails.request.input/output attrs, not gen_ai.* events."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="Hi back")
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
 
         span = _request_span(exporter.get_finished_spans())
-        event_names = [e.name for e in span.events]
-        assert "gen_ai.user.message" in event_names
-        assert "gen_ai.choice" in event_names
-        # No JSON-attr leakage on the events path
+        assert json.loads(span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == [{"role": "user", "content": "hello"}]
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == "Hi back"
+        # The request span does not carry gen_ai.* content attrs or events
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
-        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
-
-    @pytest.mark.asyncio
-    async def test_user_message_event_carries_content(self, iorails_content_capture, exporter):
-        """The gen_ai.user.message event carries the user's role and content."""
-        _stub_deep_pipeline(iorails_content_capture)
-
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
-
-        span = _request_span(exporter.get_finished_spans())
-        user_events = [e for e in span.events if e.name == "gen_ai.user.message"]
-        assert len(user_events) == 1
-        assert dict(user_events[0].attributes) == {"role": "user", "content": "hello"}
-
-    @pytest.mark.asyncio
-    async def test_choice_event_carries_assistant_output(self, iorails_content_capture, exporter):
-        """The gen_ai.choice event carries the assistant's response content."""
-        _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
-
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
-
-        span = _request_span(exporter.get_finished_spans())
-        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
-        assert len(choice_events) == 1
-        attrs = dict(choice_events[0].attributes)
-        assert attrs["message.role"] == "assistant"
-        assert attrs["message.content"] == "The answer"
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
 
     @pytest.mark.asyncio
     async def test_legacy_events_on_main_llm_span(self, iorails_content_capture, exporter):
-        """The main LLM span also carries the legacy gen_ai.* message/choice events."""
+        """The main LLM span carries the legacy gen_ai.* message/choice events."""
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2108,25 +2082,49 @@ class TestContentCaptureLegacyFormat:
         assert "gen_ai.choice" in event_names
 
     @pytest.mark.asyncio
+    async def test_llm_span_user_event_carries_content(self, iorails_content_capture, exporter):
+        """The gen_ai.user.message event on the LLM span carries role and content."""
+        _stub_deep_pipeline(iorails_content_capture)
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        user_events = [e for e in span.events if e.name == "gen_ai.user.message"]
+        assert len(user_events) == 1
+        assert dict(user_events[0].attributes) == {"role": "user", "content": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_llm_span_choice_event_carries_output(self, iorails_content_capture, exporter):
+        """The gen_ai.choice event on the LLM span carries the model's response."""
+        _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
+
+        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _main_llm_span(exporter.get_finished_spans())
+        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
+        assert len(choice_events) == 1
+        attrs = dict(choice_events[0].attributes)
+        assert attrs["message.role"] == "assistant"
+        assert attrs["message.content"] == "The answer"
+
+    @pytest.mark.asyncio
     async def test_refusal_message_captured_on_blocked_input(self, iorails_content_capture, exporter):
-        """A blocked input still records the REFUSAL_MESSAGE as the assistant output."""
+        """A blocked input records REFUSAL_MESSAGE as guardrails.request.output."""
         _stub_deep_pipeline(iorails_content_capture, input_safe=False)
 
         result = await iorails_content_capture.generate_async([{"role": "user", "content": "bad"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         span = _request_span(exporter.get_finished_spans())
-        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
-        assert len(choice_events) == 1
-        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
 
     @pytest.mark.asyncio
     async def test_refusal_message_captured_on_blocked_output(self, iorails_content_capture, exporter):
-        """A blocked OUTPUT records REFUSAL_MESSAGE as the assistant output too.
+        """A blocked OUTPUT records REFUSAL_MESSAGE as guardrails.request.output.
 
-        Exercises the second of three return sites in _do_generate (output-rail
-        block path) — distinct from the input-rail block above.  Mocks at the
-        rails_manager level since _stub_deep_pipeline only varies input safety.
+        The LLM CLIENT span still records the raw model response while the
+        request SERVER span records what the caller actually received (REFUSAL) —
+        this is the semantic distinction that motivated the separate attr names.
         """
         iorails = iorails_content_capture
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
@@ -2139,9 +2137,7 @@ class TestContentCaptureLegacyFormat:
         assert result["content"] == REFUSAL_MESSAGE
 
         span = _request_span(exporter.get_finished_spans())
-        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
-        assert len(choice_events) == 1
-        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
 
 
 class TestContentCaptureJsonFormat:
@@ -2163,24 +2159,22 @@ class TestContentCaptureJsonFormat:
         telemetry._use_json_span_format.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_json_attrs_on_request_span(self, iorails_content_capture, exporter):
-        """Opt-in set → request span carries JSON input/output message attrs, no events."""
+    async def test_request_span_carries_guardrails_attrs(self, iorails_content_capture, exporter):
+        """Opt-in set → request span carries guardrails.request.* attrs (plain strings)."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
 
         span = _request_span(exporter.get_finished_spans())
-        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
-        outputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
-
-        assert inputs == [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
-        assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": "The answer"}]}]
-        # No legacy events on the JSON path
+        assert json.loads(span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == [{"role": "user", "content": "hello"}]
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == "The answer"
+        # The request span does not carry gen_ai.* content attrs or events
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
         assert all(not e.name.startswith("gen_ai.") for e in span.events)
 
     @pytest.mark.asyncio
-    async def test_system_instructions_split_into_own_attr(self, iorails_content_capture, exporter):
-        """System messages go to gen_ai.system_instructions, not gen_ai.input.messages."""
+    async def test_system_instructions_on_llm_span(self, iorails_content_capture, exporter):
+        """System messages split to gen_ai.system_instructions on the LLM span."""
         _stub_deep_pipeline(iorails_content_capture)
 
         messages = [
@@ -2189,13 +2183,16 @@ class TestContentCaptureJsonFormat:
         ]
         await iorails_content_capture.generate_async(messages)
 
-        span = _request_span(exporter.get_finished_spans())
-        sysinst = json.loads(span.attributes[GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS])
-        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
+        llm_span = _main_llm_span(exporter.get_finished_spans())
+        sysinst = json.loads(llm_span.attributes[GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS])
+        inputs = json.loads(llm_span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
 
         assert sysinst == [{"type": "text", "content": "be helpful"}]
-        # System message must not also appear in input.messages
         assert [m["role"] for m in inputs] == ["user"]
+
+        # Request span records the full raw input list (no split)
+        req_span = _request_span(exporter.get_finished_spans())
+        assert json.loads(req_span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == messages
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_main_llm_span(self, iorails_content_capture, exporter):
@@ -2227,8 +2224,9 @@ class TestContentCaptureEnvVarFallback:
                 await iorails.generate_async([{"role": "user", "content": "hi"}])
 
         span = _request_span(exporter.get_finished_spans())
-        # Events emitted on the legacy path (no stability opt-in)
-        assert any(e.name == "gen_ai.user.message" for e in span.events)
+        # Request span carries guardrails.request.* attrs
+        assert GuardrailsAttributes.REQUEST_INPUT in span.attributes
+        assert GuardrailsAttributes.REQUEST_OUTPUT in span.attributes
 
     @pytest.mark.asyncio
     async def test_env_var_false_disables_capture_when_config_true(self, monkeypatch, tracer_from_provider, exporter):
@@ -2250,8 +2248,9 @@ class TestContentCaptureEnvVarFallback:
                 await iorails.generate_async([{"role": "user", "content": "hi"}])
 
         span = _request_span(exporter.get_finished_spans())
-        # No content events despite config=True — env=false wins
-        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+        # No content attrs despite config=True — env=false wins
+        assert GuardrailsAttributes.REQUEST_INPUT not in span.attributes
+        assert GuardrailsAttributes.REQUEST_OUTPUT not in span.attributes
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
 
 
@@ -2303,9 +2302,8 @@ class TestStreamingContentCapture:
         assert delivered  # sanity: stream produced something
 
         span = _request_span(exporter.get_finished_spans())
-        # Legacy events path (no stability opt-in) — choice event carries output
-        choice = next(e for e in span.events if e.name == "gen_ai.choice")
-        assert dict(choice.attributes)["message.content"] == delivered
+        # Request span: guardrails.request.* attrs carry the delivered text
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == delivered
 
     @pytest.mark.asyncio
     async def test_output_text_recorded_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):
@@ -2331,19 +2329,17 @@ class TestStreamingContentCapture:
         [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
 
         span = _request_span(exporter.get_finished_spans())
-        choice_events = [e for e in span.events if e.name == "gen_ai.choice"]
-        assert len(choice_events) == 1
-        assert dict(choice_events[0].attributes)["message.content"] == REFUSAL_MESSAGE
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
 
     @pytest.mark.asyncio
-    async def test_empty_delivered_records_no_choice_event(self, iorails_streaming_content_capture, exporter):
-        """When the LLM yields zero content chunks, output_text becomes None
-        and no gen_ai.choice event fires.  Guards against an empty-string
-        assistant message getting recorded for a stream that produced nothing."""
+    async def test_empty_delivered_records_no_output_attr(self, iorails_streaming_content_capture, exporter):
+        """When the LLM yields zero content chunks, guardrails.request.output is absent.
+
+        Guards against an empty-string output being recorded when the stream
+        produced nothing — None output_text means no attribute is set."""
         iorails = iorails_streaming_content_capture
 
         async def _empty_stream(messages, **kwargs):
-            # An async generator that yields no items at all
             if False:
                 yield  # pragma: no cover
 
@@ -2353,13 +2349,11 @@ class TestStreamingContentCapture:
 
         spans = exporter.get_finished_spans()
         request_span = _request_span(spans)
-        # No choice event because output_text was None (empty delivered list)
-        assert all(e.name != "gen_ai.choice" for e in request_span.events)
-        # Input events still fire (input messages were captured)
-        assert any(e.name == "gen_ai.user.message" for e in request_span.events)
+        # Input is captured; output is absent (empty delivered)
+        assert GuardrailsAttributes.REQUEST_INPUT in request_span.attributes
+        assert GuardrailsAttributes.REQUEST_OUTPUT not in request_span.attributes
 
-        # LLM streaming span behaves consistently: empty content_parts ->
-        # output_text=None -> no choice event (matches request span).
+        # LLM span also has no output — empty content_parts → None
         llm_span = _main_llm_span(spans)
         assert all(e.name != "gen_ai.choice" for e in llm_span.events)
 
@@ -2389,8 +2383,7 @@ class TestStreamingContentCapture:
         expected = "Hello world"
 
         span = _request_span(exporter.get_finished_spans())
-        choice = next(e for e in span.events if e.name == "gen_ai.choice")
-        assert dict(choice.attributes)["message.content"] == expected
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == expected
 
 
 class TestStreamingContentCaptureJsonFormat:
@@ -2417,12 +2410,10 @@ class TestStreamingContentCaptureJsonFormat:
         delivered = "".join(c for c in chunks if isinstance(c, str))
 
         span = _request_span(exporter.get_finished_spans())
-        inputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
-        outputs = json.loads(span.attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
-        assert inputs == [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
-        assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": delivered}]}]
-        # No legacy events leaking onto the JSON path
-        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+        # Request span: guardrails.request.* plain-string attrs regardless of opt-in format
+        assert json.loads(span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == [{"role": "user", "content": "hi"}]
+        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == delivered
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2365,19 +2365,28 @@ class TestStreamingContentCapture:
 
     @pytest.mark.asyncio
     async def test_dict_chunks_with_include_metadata_get_captured(self, iorails_streaming_content_capture, exporter):
-        """include_metadata=True streams dict chunks; capture extracts text fields.
+        """include_metadata=True streams dict chunks; capture extracts non-empty text fields.
 
         Covers the isinstance(chunk, dict) branch in _wrapped_iterator's
-        accumulator — without this test, that path is unreachable from the
-        rest of the suite (which all use plain-string streaming).
+        accumulator.  Also verifies that dict chunks with an empty-string
+        ``text`` field (metadata-only frames) are excluded from the captured
+        output — they must not contribute empty strings to the join and must
+        not cause a spurious empty assistant output where None is correct.
         """
         iorails = iorails_streaming_content_capture
-        _stub_deep_streaming_pipeline(iorails)
+
+        async def _stream_with_empty_frame(messages, **kwargs):
+            """Inject an empty-text metadata frame between real content chunks."""
+            yield LLMResponseChunk(delta_content="Hello")
+            yield LLMResponseChunk(delta_content="")  # empty delta — metadata frame
+            yield LLMResponseChunk(delta_content=" world")
+
+        _stub_deep_streaming_pipeline(iorails, main_stream=_stream_with_empty_frame)
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}], include_metadata=True)]
-        # Sanity: with include_metadata=True chunks are dicts, not strings
         assert all(isinstance(c, dict) for c in chunks)
-        expected = "".join(c.get("text", "") for c in chunks if isinstance(c.get("text"), str))
+        # Expected: only the non-empty text parts joined; empty delta excluded
+        expected = "Hello world"
 
         span = _request_span(exporter.get_finished_spans())
         choice = next(e for e in span.events if e.name == "gen_ai.choice")

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1948,9 +1948,12 @@ def _clear_otel_content_envvars(monkeypatch):
     Without this, an inherited ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
     or ``OTEL_SEMCONV_STABILITY_OPT_IN`` from CI / dev shell would flip
     capture on or change format mid-suite and produce flaky assertions.
+    Also clears the ``_use_json_span_format`` cache so format-switching
+    tests (legacy vs JSON) re-read the env var fresh.
     """
     monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
     monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
+    telemetry._use_json_span_format.cache_clear()
 
 
 def _make_content_capture_config():
@@ -2115,11 +2118,19 @@ class TestContentCaptureJsonFormat:
     """Capture on + OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental: JSON attrs."""
 
     @pytest.fixture(autouse=True)
-    def _set_stability_opt_in(self, monkeypatch):
+    def _set_stability_opt_in(self, monkeypatch, _clear_otel_content_envvars):
+        # Explicit dependency on _clear_otel_content_envvars forces pytest to
+        # run the module-level cleanup (which delenvs both OTEL vars and clears
+        # the _use_json_span_format cache) BEFORE this fixture sets the opt-in.
+        # Without the dependency, the autouse fixture ordering is alphabetical
+        # within the same scope and _clear would run after _set, undoing it.
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             OtelContentCapture.STABILITY_OPT_IN_LATEST,
         )
+        # Cache cleared by _clear_otel_content_envvars above; clear again here
+        # in case any prior in-class fixture warmed it with the wrong value.
+        telemetry._use_json_span_format.cache_clear()
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_request_span(self, iorails_content_capture, exporter):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -2015,6 +2015,7 @@ class TestContentCaptureDisabled:
 
     @pytest.mark.asyncio
     async def test_no_content_on_request_span(self, iorails_tracing, exporter):
+        """Capture off → the request span has no content attributes or gen_ai events."""
         _stub_deep_pipeline(iorails_tracing)
 
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
@@ -2027,6 +2028,7 @@ class TestContentCaptureDisabled:
 
     @pytest.mark.asyncio
     async def test_no_content_on_llm_span(self, iorails_tracing, exporter):
+        """Capture off → the main LLM span has no content attributes or gen_ai events."""
         _stub_deep_pipeline(iorails_tracing)
 
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
@@ -2038,6 +2040,7 @@ class TestContentCaptureDisabled:
 
     @pytest.mark.asyncio
     async def test_no_rail_input_on_rail_spans(self, iorails_tracing, exporter):
+        """Capture off → rail spans carry no rail.input or rail.reason attributes."""
         _stub_deep_pipeline(iorails_tracing)
 
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
@@ -2053,6 +2056,7 @@ class TestContentCaptureLegacyFormat:
 
     @pytest.mark.asyncio
     async def test_legacy_events_on_request_span(self, iorails_content_capture, exporter):
+        """Capture on, no opt-in → request span gets gen_ai.* events, no JSON attrs."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="Hi back")
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2067,6 +2071,7 @@ class TestContentCaptureLegacyFormat:
 
     @pytest.mark.asyncio
     async def test_user_message_event_carries_content(self, iorails_content_capture, exporter):
+        """The gen_ai.user.message event carries the user's role and content."""
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2078,6 +2083,7 @@ class TestContentCaptureLegacyFormat:
 
     @pytest.mark.asyncio
     async def test_choice_event_carries_assistant_output(self, iorails_content_capture, exporter):
+        """The gen_ai.choice event carries the assistant's response content."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
@@ -2091,6 +2097,7 @@ class TestContentCaptureLegacyFormat:
 
     @pytest.mark.asyncio
     async def test_legacy_events_on_main_llm_span(self, iorails_content_capture, exporter):
+        """The main LLM span also carries the legacy gen_ai.* message/choice events."""
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2157,6 +2164,7 @@ class TestContentCaptureJsonFormat:
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_request_span(self, iorails_content_capture, exporter):
+        """Opt-in set → request span carries JSON input/output message attrs, no events."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2172,6 +2180,7 @@ class TestContentCaptureJsonFormat:
 
     @pytest.mark.asyncio
     async def test_system_instructions_split_into_own_attr(self, iorails_content_capture, exporter):
+        """System messages go to gen_ai.system_instructions, not gen_ai.input.messages."""
         _stub_deep_pipeline(iorails_content_capture)
 
         messages = [
@@ -2190,6 +2199,7 @@ class TestContentCaptureJsonFormat:
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_main_llm_span(self, iorails_content_capture, exporter):
+        """Opt-in set → the main LLM span carries JSON input/output message attrs."""
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
@@ -2220,12 +2230,37 @@ class TestContentCaptureEnvVarFallback:
         # Events emitted on the legacy path (no stability opt-in)
         assert any(e.name == "gen_ai.user.message" for e in span.events)
 
+    @pytest.mark.asyncio
+    async def test_env_var_false_disables_capture_when_config_true(self, monkeypatch, tracer_from_provider, exporter):
+        """config enable_content_capture=True + env=false → capture inactive.
+
+        End-to-end counterpart to the unit-level
+        test_env_var_falsy_disables_capture_even_when_config_true: confirms
+        the env-var-wins semantic holds through the full IORails pipeline,
+        not just the is_content_capture_enabled helper in isolation."""
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "false")
+
+        with patch.object(telemetry, "_tracer", tracer_from_provider):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                # _make_content_capture_config sets enable_content_capture=True
+                config = RailsConfig.from_content(config=_make_content_capture_config())
+                iorails = IORails(config)
+            async with iorails:
+                _stub_deep_pipeline(iorails)
+                await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        span = _request_span(exporter.get_finished_spans())
+        # No content events despite config=True — env=false wins
+        assert all(not e.name.startswith("gen_ai.") for e in span.events)
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+
 
 class TestRailContentCapture:
     """guardrails.rail.input on every rail span; guardrails.rail.reason on blocked rails only."""
 
     @pytest.mark.asyncio
     async def test_rail_input_recorded_on_passing_rail(self, iorails_content_capture, exporter):
+        """Every rail span records its rail.input; passing rails carry no rail.reason."""
         _stub_deep_pipeline(iorails_content_capture)
 
         await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
@@ -2259,6 +2294,7 @@ class TestStreamingContentCapture:
 
     @pytest.mark.asyncio
     async def test_output_text_recorded_on_request_span(self, iorails_streaming_content_capture, exporter):
+        """Streamed chunks accumulate and the joined text lands on the request span."""
         iorails = iorails_streaming_content_capture
         _stub_deep_streaming_pipeline(iorails)
 
@@ -2273,6 +2309,7 @@ class TestStreamingContentCapture:
 
     @pytest.mark.asyncio
     async def test_output_text_recorded_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):
+        """Streamed chunks accumulate and the joined text lands on the LLM span too."""
         iorails = iorails_streaming_content_capture
         _stub_deep_streaming_pipeline(iorails)
 
@@ -2363,6 +2400,7 @@ class TestStreamingContentCaptureJsonFormat:
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_request_span(self, iorails_streaming_content_capture, exporter):
+        """Streaming + opt-in → request span carries JSON input/output attrs, no events."""
         iorails = iorails_streaming_content_capture
         _stub_deep_streaming_pipeline(iorails)
 
@@ -2379,6 +2417,7 @@ class TestStreamingContentCaptureJsonFormat:
 
     @pytest.mark.asyncio
     async def test_json_attrs_on_streaming_llm_span(self, iorails_streaming_content_capture, exporter):
+        """Streaming + opt-in → the LLM span's JSON output.messages holds the joined stream."""
         iorails = iorails_streaming_content_capture
         _stub_deep_streaming_pipeline(iorails)
 

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for content-capture helpers in nemoguardrails.guardrails.telemetry.
+
+Covers the helpers introduced for OTEL GenAI content capture:
+``is_content_capture_enabled``, ``_use_json_span_format``,
+``_get_parts_by_role``, ``_system_parts_from_messages``,
+``_non_system_messages_to_parts``, the two ``_set_llm_call_content_*``
+branches, the ``set_llm_call_content`` dispatcher, and ``set_rail_content``.
+"""
+
+import json
+from typing import Optional
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from nemoguardrails.guardrails.telemetry import (
+    _get_parts_by_role,
+    _non_system_messages_to_parts,
+    _set_llm_call_content_events,
+    _set_llm_call_content_json,
+    _system_parts_from_messages,
+    _use_json_span_format,
+    is_content_capture_enabled,
+    set_llm_call_content,
+    set_rail_content,
+)
+from nemoguardrails.rails.llm.config import TracingConfig
+from nemoguardrails.tracing.constants import (
+    EventNames,
+    GenAIAttributes,
+    GuardrailsAttributes,
+    OtelContentCapture,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_envvars(monkeypatch):
+    """Strip any inherited OTEL env vars so each test starts from a clean slate.
+
+    The CI/dev shell may have ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
+    or ``OTEL_SEMCONV_STABILITY_OPT_IN`` set; without this, tests asserting
+    "False" / "events branch" would be flaky depending on the runner's env.
+    """
+    monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
+    monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
+
+
+@pytest.fixture
+def finished_span():
+    """Factory that runs a callback inside a real span and returns the finished span.
+
+    Uses an in-memory SDK exporter so tests can assert on real OTEL
+    attributes and events instead of mocking ``span.set_attribute`` /
+    ``span.add_event``.  Each invocation creates and tears down its own
+    provider so tests stay isolated.
+    """
+
+    def _run(callback):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span") as span:
+            callback(span)
+        provider.shutdown()
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        return spans[0]
+
+    return _run
+
+
+def _config_with_capture(value: Optional[bool]) -> TracingConfig:
+    """Build a ``TracingConfig`` with the given ``enable_content_capture`` flag.
+
+    ``value=None`` returns a default-constructed ``TracingConfig`` (where
+    ``enable_content_capture`` defaults to False on the Pydantic model).
+    Using the real model rather than a stand-in keeps the tests honest
+    against the production type, including the default value contract.
+    """
+    if value is None:
+        return TracingConfig()
+    return TracingConfig(enable_content_capture=value)
+
+
+class TestIsContentCaptureEnabled:
+    """Resolution of the content-capture flag: config field wins, env var as fallback."""
+
+    def test_returns_false_when_config_none_and_env_unset(self):
+        assert is_content_capture_enabled(None) is False
+
+    def test_returns_true_when_config_flag_set(self):
+        assert is_content_capture_enabled(_config_with_capture(True)) is True
+
+    def test_returns_false_when_config_flag_false_and_env_unset(self):
+        assert is_content_capture_enabled(_config_with_capture(False)) is False
+
+    def test_returns_false_for_default_tracing_config_and_env_unset(self):
+        # Default TracingConfig() has enable_content_capture=False by spec
+        assert is_content_capture_enabled(_config_with_capture(None)) is False
+
+    @pytest.mark.parametrize("env_value", ["true", "True", "TRUE", "1"])
+    def test_env_var_truthy_values_enable_capture(self, monkeypatch, env_value):
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
+        assert is_content_capture_enabled(None) is True
+
+    @pytest.mark.parametrize("env_value", ["false", "0", "yes", "no", "", "  "])
+    def test_env_var_other_values_do_not_enable_capture(self, monkeypatch, env_value):
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
+        assert is_content_capture_enabled(None) is False
+
+    def test_env_var_takes_effect_when_config_unset(self, monkeypatch):
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "true")
+        assert is_content_capture_enabled(_config_with_capture(False)) is True
+
+    def test_config_true_overrides_env_unset(self):
+        assert is_content_capture_enabled(_config_with_capture(True)) is True
+
+    def test_env_value_with_surrounding_whitespace(self, monkeypatch):
+        # Leading/trailing whitespace gets stripped (.strip() in the helper)
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  true  ")
+        assert is_content_capture_enabled(None) is True
+
+
+class TestUseJsonSpanFormat:
+    """Parsing of OTEL_SEMCONV_STABILITY_OPT_IN to select JSON attrs vs legacy events."""
+
+    def test_returns_false_when_env_unset(self):
+        assert _use_json_span_format() is False
+
+    def test_returns_true_when_opt_in_token_present(self, monkeypatch):
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            OtelContentCapture.STABILITY_OPT_IN_LATEST,
+        )
+        assert _use_json_span_format() is True
+
+    def test_returns_true_when_token_in_csv_list(self, monkeypatch):
+        # Real usage: opt-in env is a comma-separated set of tokens
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            f"http,{OtelContentCapture.STABILITY_OPT_IN_LATEST},db",
+        )
+        assert _use_json_span_format() is True
+
+    def test_strips_token_whitespace(self, monkeypatch):
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            f"http,  {OtelContentCapture.STABILITY_OPT_IN_LATEST}  ,db",
+        )
+        assert _use_json_span_format() is True
+
+    def test_returns_false_for_unrelated_token(self, monkeypatch):
+        monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "gen_ai_legacy")
+        assert _use_json_span_format() is False
+
+    def test_returns_false_for_empty_string(self, monkeypatch):
+        monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
+        assert _use_json_span_format() is False
+
+
+_MIXED_MESSAGES = [
+    {"role": "system", "content": "you are helpful"},
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi there"},
+    {"role": "user", "content": "ok"},
+]
+
+
+class TestGetPartsByRole:
+    """Role-filtered walker that powers the two specialised parts helpers."""
+
+    def test_include_true_returns_matching_role(self):
+        result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=True)
+        assert result == [{"role": "system", "parts": [{"type": "text", "content": "you are helpful"}]}]
+
+    def test_include_false_returns_non_matching_roles(self):
+        result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=False)
+        roles = [entry["role"] for entry in result]
+        assert roles == ["user", "assistant", "user"]
+
+    def test_empty_messages_returns_empty(self):
+        assert _get_parts_by_role([], "system", include=True) == []
+
+    def test_skips_entries_missing_role(self):
+        messages = [{"content": "no role"}, {"role": "user", "content": "ok"}]
+        result = _get_parts_by_role(messages, "user", include=True)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_skips_entries_missing_content(self):
+        messages = [{"role": "user"}, {"role": "user", "content": "ok"}]
+        result = _get_parts_by_role(messages, "user", include=True)
+        assert len(result) == 1
+        assert result[0]["parts"][0]["content"] == "ok"
+
+    def test_no_matches_returns_empty(self):
+        result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=True)
+        assert result == []
+
+    def test_all_match_when_excluded_role_absent(self):
+        # When excluding a role that's not present, every valid entry comes through
+        result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=False)
+        assert len(result) == len(_MIXED_MESSAGES)
+
+
+class TestSystemPartsFromMessages:
+    """Flat-parts extraction of system messages for gen_ai.system_instructions."""
+
+    def test_returns_flat_parts_for_system_only(self):
+        # gen_ai.system_instructions is a flat list of {type,content} parts
+        # — no role wrapping, even though the underlying walker produces it
+        result = _system_parts_from_messages(_MIXED_MESSAGES)
+        assert result == [{"type": "text", "content": "you are helpful"}]
+
+    def test_empty_when_no_system_messages(self):
+        messages = [{"role": "user", "content": "hi"}]
+        assert _system_parts_from_messages(messages) == []
+
+    def test_multiple_system_messages_preserves_order(self):
+        messages = [
+            {"role": "system", "content": "first"},
+            {"role": "user", "content": "ignored"},
+            {"role": "system", "content": "second"},
+        ]
+        result = _system_parts_from_messages(messages)
+        assert [p["content"] for p in result] == ["first", "second"]
+
+
+class TestNonSystemMessagesToParts:
+    """Role-wrapped extraction of non-system messages for gen_ai.input.messages."""
+
+    def test_returns_role_wrapped_non_system(self):
+        result = _non_system_messages_to_parts(_MIXED_MESSAGES)
+        assert result == [
+            {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
+            {"role": "assistant", "parts": [{"type": "text", "content": "hi there"}]},
+            {"role": "user", "parts": [{"type": "text", "content": "ok"}]},
+        ]
+
+    def test_empty_when_only_system_messages(self):
+        messages = [{"role": "system", "content": "x"}]
+        assert _non_system_messages_to_parts(messages) == []
+
+
+class TestSetLlmCallContentJsonBranch:
+    """Direct tests for the JSON-attributes branch helper."""
+
+    def test_sets_all_three_attributes_when_data_present(self, finished_span):
+        span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, "the answer"))
+        attrs = span.attributes
+
+        sysinst = json.loads(attrs[GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS])
+        assert sysinst == [{"type": "text", "content": "you are helpful"}]
+
+        inputs = json.loads(attrs[GenAIAttributes.GEN_AI_INPUT_MESSAGES])
+        assert [m["role"] for m in inputs] == ["user", "assistant", "user"]
+
+        outputs = json.loads(attrs[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES])
+        assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": "the answer"}]}]
+
+    def test_omits_system_instructions_when_no_system_message(self, finished_span):
+        # Distinguishing "no system instructions" from "empty system instructions"
+        # is part of the contract — backends should not see an empty JSON array
+        messages = [{"role": "user", "content": "hi"}]
+        span = finished_span(lambda s: _set_llm_call_content_json(s, messages, "hello"))
+        assert GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS not in span.attributes
+
+    def test_omits_input_messages_when_only_system(self, finished_span):
+        messages = [{"role": "system", "content": "be brief"}]
+        span = finished_span(lambda s: _set_llm_call_content_json(s, messages, "x"))
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS in span.attributes
+
+    def test_omits_output_messages_when_output_text_is_none(self, finished_span):
+        span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, None))
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
+
+    def test_emits_no_legacy_events(self, finished_span):
+        span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, "out"))
+        # Cross-branch hygiene: JSON-attr path must never add events
+        assert span.events == ()
+
+
+class TestSetLlmCallContentEventsBranch:
+    """Direct tests for the legacy-events branch helper."""
+
+    def test_emits_one_event_per_supported_role(self, finished_span):
+        span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "the answer"))
+        event_names = [e.name for e in span.events]
+        # 3 input events (1 system + 2 user + 1 assistant = 4) + 1 choice
+        assert event_names == [
+            EventNames.GEN_AI_SYSTEM_MESSAGE,
+            EventNames.GEN_AI_USER_MESSAGE,
+            EventNames.GEN_AI_ASSISTANT_MESSAGE,
+            EventNames.GEN_AI_USER_MESSAGE,
+            EventNames.GEN_AI_CHOICE,
+        ]
+
+    def test_event_attributes_carry_role_and_content(self, finished_span):
+        messages = [{"role": "user", "content": "hello"}]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, "hi"))
+        user_event = next(e for e in span.events if e.name == EventNames.GEN_AI_USER_MESSAGE)
+        assert dict(user_event.attributes) == {"role": "user", "content": "hello"}
+
+    def test_choice_event_carries_assistant_output(self, finished_span):
+        messages = [{"role": "user", "content": "hello"}]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, "the answer"))
+        choice = next(e for e in span.events if e.name == EventNames.GEN_AI_CHOICE)
+        assert dict(choice.attributes) == {
+            "index": 0,
+            "message.role": "assistant",
+            "message.content": "the answer",
+        }
+
+    def test_no_choice_event_when_output_text_none(self, finished_span):
+        messages = [{"role": "user", "content": "hello"}]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
+        assert all(e.name != EventNames.GEN_AI_CHOICE for e in span.events)
+
+    def test_skips_unsupported_roles_silently(self, finished_span):
+        # IORails doesn't yet emit tool/function events; unknown roles must
+        # be dropped rather than crashing the capture path
+        messages = [
+            {"role": "user", "content": "u"},
+            {"role": "tool", "content": "should be skipped"},
+            {"role": "assistant", "content": "a"},
+        ]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
+        names = [e.name for e in span.events]
+        assert EventNames.GEN_AI_USER_MESSAGE in names
+        assert EventNames.GEN_AI_ASSISTANT_MESSAGE in names
+        # No event was raised for the tool role
+        assert len(span.events) == 2
+
+    def test_sets_no_json_attributes(self, finished_span):
+        # Cross-branch hygiene: events path must never set the JSON attrs
+        span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "out"))
+        attrs = span.attributes
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in attrs
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in attrs
+        assert GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS not in attrs
+
+
+class TestSetLlmCallContentDispatch:
+    """End-to-end tests for the dispatcher choosing JSON vs events."""
+
+    def test_uses_events_branch_when_opt_in_unset(self, finished_span):
+        span = finished_span(lambda s: set_llm_call_content(s, _MIXED_MESSAGES, "out"))
+        assert len(span.events) > 0
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+
+    def test_uses_json_branch_when_opt_in_set(self, monkeypatch, finished_span):
+        monkeypatch.setenv(
+            OtelContentCapture.STABILITY_OPT_IN_ENV,
+            OtelContentCapture.STABILITY_OPT_IN_LATEST,
+        )
+        span = finished_span(lambda s: set_llm_call_content(s, _MIXED_MESSAGES, "out"))
+        assert span.events == ()
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
+
+    def test_none_span_is_noop(self):
+        # No exception even though we pass None for the span and structured input
+        set_llm_call_content(None, _MIXED_MESSAGES, "out")
+
+
+class TestSetRailContent:
+    """guardrails.rail.input and guardrails.rail.reason attribute capture on rail spans."""
+
+    def test_sets_only_input_when_reason_is_none(self, finished_span):
+        rail_input = {"messages": [{"role": "user", "content": "hi"}], "bot_response": None}
+        span = finished_span(lambda s: set_rail_content(s, rail_input))
+        attrs = span.attributes
+        assert json.loads(attrs[GuardrailsAttributes.RAIL_INPUT]) == rail_input
+        assert GuardrailsAttributes.RAIL_REASON not in attrs
+
+    def test_sets_input_and_reason_when_reason_provided(self, finished_span):
+        rail_input = {"messages": [{"role": "user", "content": "hi"}], "bot_response": "out"}
+        span = finished_span(lambda s: set_rail_content(s, rail_input, reason="unsafe topic"))
+        attrs = span.attributes
+        assert json.loads(attrs[GuardrailsAttributes.RAIL_INPUT]) == rail_input
+        assert attrs[GuardrailsAttributes.RAIL_REASON] == "unsafe topic"
+
+    def test_none_span_is_noop(self):
+        # No exception even when we pass real input and reason
+        set_rail_content(None, {"messages": []}, reason="should not raise")

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -57,9 +57,13 @@ def _clear_otel_envvars(monkeypatch):
     The CI/dev shell may have ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
     or ``OTEL_SEMCONV_STABILITY_OPT_IN`` set; without this, tests asserting
     "False" / "events branch" would be flaky depending on the runner's env.
+    Also clears the ``_use_json_span_format`` cache so each test re-reads
+    the stability opt-in env var fresh — without this, the first test's
+    value would stick across the whole module.
     """
     monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
     monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
+    _use_json_span_format.cache_clear()
 
 
 @pytest.fixture
@@ -126,7 +130,7 @@ class TestIsContentCaptureEnabled:
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(None) is False
 
-    def test_env_var_takes_effect_when_config_unset(self, monkeypatch):
+    def test_env_var_takes_effect_when_config_is_false(self, monkeypatch):
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "true")
         assert is_content_capture_enabled(_config_with_capture(False)) is True
 
@@ -137,6 +141,27 @@ class TestIsContentCaptureEnabled:
         # Leading/trailing whitespace gets stripped (.strip() in the helper)
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  true  ")
         assert is_content_capture_enabled(None) is True
+
+    @pytest.mark.parametrize("env_value", ["false", "False", "FALSE", "0"])
+    def test_env_var_falsy_disables_capture_even_when_config_true(self, monkeypatch, env_value):
+        # Env-var-wins semantic: explicit env=false/0 overrides config=True.
+        # Operators can disable content capture across services via the
+        # OTEL-standard env var even if the deployed config has it enabled.
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
+        assert is_content_capture_enabled(_config_with_capture(True)) is False
+
+    def test_env_var_falsy_with_whitespace_disables_capture(self, monkeypatch):
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  FALSE  ")
+        assert is_content_capture_enabled(_config_with_capture(True)) is False
+
+    @pytest.mark.parametrize("env_value", ["yes", "no", "maybe"])
+    def test_unrecognized_env_value_falls_through_to_config(self, monkeypatch, env_value):
+        # Unrecognized env values are neither enable nor disable signals —
+        # they fall through to the config field.  Avoids accidentally
+        # disabling capture if someone types "off" / "yes" / etc.
+        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
+        assert is_content_capture_enabled(_config_with_capture(True)) is True
+        assert is_content_capture_enabled(_config_with_capture(False)) is False
 
 
 class TestUseJsonSpanFormat:

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails.telemetry import (
     is_content_capture_enabled,
     set_llm_call_content,
     set_rail_content,
+    set_request_content,
 )
 from nemoguardrails.rails.llm.config import TracingConfig
 from nemoguardrails.tracing.constants import (
@@ -265,6 +266,16 @@ class TestNonSystemInputMessages:
         messages = [{"role": "system", "content": "x"}]
         assert _non_system_input_messages(messages) == []
 
+    def test_skips_entries_missing_role_or_content(self):
+        """Malformed non-system entries missing role or content are skipped silently."""
+        messages = [
+            {"content": "no role"},
+            {"role": "user"},
+            {"role": "user", "content": "valid"},
+        ]
+        result = _non_system_input_messages(messages)
+        assert result == [{"role": "user", "parts": [{"type": "text", "content": "valid"}]}]
+
 
 class TestSetLlmCallContentJsonBranch:
     """Direct tests for the JSON-attributes branch helper."""
@@ -452,3 +463,35 @@ class TestSetRailContent:
     def test_none_span_is_noop(self):
         """Passing span=None is a no-op and raises nothing."""
         set_rail_content(None, {"messages": []}, reason="should not raise")
+
+
+class TestSetRequestContent:
+    """guardrails.request.input / guardrails.request.output capture on the SERVER span."""
+
+    def test_sets_input_and_output(self, finished_span):
+        """Both attrs are set: input as JSON messages, output as the returned string."""
+        messages = [{"role": "user", "content": "hi"}]
+        span = finished_span(lambda s: set_request_content(s, messages, "the answer"))
+        attrs = span.attributes
+        assert json.loads(attrs[GuardrailsAttributes.REQUEST_INPUT]) == messages
+        assert attrs[GuardrailsAttributes.REQUEST_OUTPUT] == "the answer"
+
+    def test_omits_output_when_output_text_none(self, finished_span):
+        """output_text=None → only request.input is set, request.output is absent."""
+        messages = [{"role": "user", "content": "hi"}]
+        span = finished_span(lambda s: set_request_content(s, messages, None))
+        attrs = span.attributes
+        assert GuardrailsAttributes.REQUEST_INPUT in attrs
+        assert GuardrailsAttributes.REQUEST_OUTPUT not in attrs
+
+    def test_uses_guardrails_attrs_not_genai(self, finished_span):
+        """Request capture uses guardrails.* attrs, never the gen_ai.* names or events."""
+        messages = [{"role": "user", "content": "hi"}]
+        span = finished_span(lambda s: set_request_content(s, messages, "out"))
+        assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
+        assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+        assert span.events == ()
+
+    def test_none_span_is_noop(self):
+        """Passing span=None is a no-op and raises nothing."""
+        set_request_content(None, [{"role": "user", "content": "hi"}], "out")

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -367,7 +367,7 @@ class TestSetLlmCallContentEventsBranch:
         """Each supported-role message becomes one event, plus a final choice event."""
         span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "the answer"))
         event_names = [e.name for e in span.events]
-        # 3 input events (1 system + 2 user + 1 assistant = 4) + 1 choice
+        # 4 input events (1 system + 1 assistant + 2 user) + 1 choice
         assert event_names == [
             EventNames.GEN_AI_SYSTEM_MESSAGE,
             EventNames.GEN_AI_USER_MESSAGE,
@@ -400,22 +400,32 @@ class TestSetLlmCallContentEventsBranch:
         span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
         assert all(e.name != EventNames.GEN_AI_CHOICE for e in span.events)
 
-    def test_skips_unsupported_roles_silently(self, finished_span):
-        """Roles without a legacy event mapping (e.g. tool) are dropped, not errored.
-
-        IORails doesn't yet emit tool/function events; unknown roles must
-        be dropped rather than crashing the capture path.
-        """
+    def test_tool_role_produces_tool_message_event(self, finished_span):
+        """tool role maps to gen_ai.tool.message — forward-compatible for tool calling."""
         messages = [
             {"role": "user", "content": "u"},
-            {"role": "tool", "content": "should be skipped"},
+            {"role": "tool", "content": "tool result"},
+            {"role": "assistant", "content": "a"},
+        ]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
+        names = [e.name for e in span.events]
+        assert EventNames.GEN_AI_USER_MESSAGE in names
+        assert EventNames.GEN_AI_TOOL_MESSAGE in names
+        assert EventNames.GEN_AI_ASSISTANT_MESSAGE in names
+        assert len(span.events) == 3
+
+    def test_skips_unsupported_roles_silently(self, finished_span):
+        """Roles without a legacy event mapping (e.g. function) are dropped, not errored."""
+        messages = [
+            {"role": "user", "content": "u"},
+            {"role": "function", "content": "should be skipped"},
             {"role": "assistant", "content": "a"},
         ]
         span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
         names = [e.name for e in span.events]
         assert EventNames.GEN_AI_USER_MESSAGE in names
         assert EventNames.GEN_AI_ASSISTANT_MESSAGE in names
-        # No event was raised for the tool role
+        # function role has no mapping — dropped silently
         assert len(span.events) == 2
 
     def test_skips_messages_missing_role_or_content(self, finished_span):

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -17,7 +17,7 @@
 
 Covers the helpers introduced for OTEL GenAI content capture:
 ``is_content_capture_enabled``, ``_use_json_span_format``,
-``_get_parts_by_role``, ``_system_parts_from_messages``,
+``_system_parts_from_messages``,
 ``_non_system_input_messages``, the two ``_set_llm_call_content_*``
 branches, the ``set_llm_call_content`` dispatcher, and ``set_rail_content``.
 """
@@ -31,7 +31,6 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.guardrails.telemetry import (
-    _get_parts_by_role,
     _non_system_input_messages,
     _set_llm_call_content_events,
     _set_llm_call_content_json,
@@ -57,13 +56,9 @@ def _clear_otel_envvars(monkeypatch):
     The CI/dev shell may have ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``
     or ``OTEL_SEMCONV_STABILITY_OPT_IN`` set; without this, tests asserting
     "False" / "events branch" would be flaky depending on the runner's env.
-    Also clears the ``_use_json_span_format`` cache so each test re-reads
-    the stability opt-in env var fresh — without this, the first test's
-    value would stick across the whole module.
     """
     monkeypatch.delenv(OtelContentCapture.CAPTURE_CONTENT_ENV, raising=False)
     monkeypatch.delenv(OtelContentCapture.STABILITY_OPT_IN_ENV, raising=False)
-    _use_json_span_format.cache_clear()
 
 
 @pytest.fixture
@@ -216,49 +211,6 @@ _MIXED_MESSAGES = [
     {"role": "assistant", "content": "hi there"},
     {"role": "user", "content": "ok"},
 ]
-
-
-class TestGetPartsByRole:
-    """Role-filtered walker that powers the two specialised parts helpers."""
-
-    def test_include_true_returns_matching_role(self):
-        """include=True keeps only messages whose role equals the target role."""
-        result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=True)
-        assert result == [{"role": "system", "parts": [{"type": "text", "content": "you are helpful"}]}]
-
-    def test_include_false_returns_non_matching_roles(self):
-        """include=False keeps every message whose role differs from the target."""
-        result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=False)
-        roles = [entry["role"] for entry in result]
-        assert roles == ["user", "assistant", "user"]
-
-    def test_empty_messages_returns_empty(self):
-        """An empty message list yields an empty result."""
-        assert _get_parts_by_role([], "system", include=True) == []
-
-    def test_skips_entries_missing_role(self):
-        """Messages without a ``role`` field are skipped silently."""
-        messages = [{"content": "no role"}, {"role": "user", "content": "ok"}]
-        result = _get_parts_by_role(messages, "user", include=True)
-        assert len(result) == 1
-        assert result[0]["role"] == "user"
-
-    def test_skips_entries_missing_content(self):
-        """Messages without a ``content`` field are skipped silently."""
-        messages = [{"role": "user"}, {"role": "user", "content": "ok"}]
-        result = _get_parts_by_role(messages, "user", include=True)
-        assert len(result) == 1
-        assert result[0]["parts"][0]["content"] == "ok"
-
-    def test_no_matches_returns_empty(self):
-        """include=True with a role absent from the messages yields an empty result."""
-        result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=True)
-        assert result == []
-
-    def test_all_match_when_excluded_role_absent(self):
-        """include=False excluding an absent role returns every valid entry."""
-        result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=False)
-        assert len(result) == len(_MIXED_MESSAGES)
 
 
 class TestSystemPartsFromMessages:

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -103,62 +103,38 @@ def _config_with_capture(value: Optional[bool]) -> TracingConfig:
 class TestIsContentCaptureEnabled:
     """Resolution of the content-capture flag: env var wins, config field as fallback."""
 
-    def test_returns_false_when_config_none_and_env_unset(self):
-        """No config and no env var → capture off."""
-        assert is_content_capture_enabled(None) is False
+    @pytest.mark.parametrize(
+        "config_tracing, expected",
+        [
+            (None, False),  # no config object
+            (TracingConfig(), False),  # default → enable_content_capture False
+            (_config_with_capture(False), False),
+            (_config_with_capture(True), True),
+        ],
+    )
+    def test_config_decides_when_env_unset(self, config_tracing, expected):
+        """With no env var, the config field (default False) decides."""
+        assert is_content_capture_enabled(config_tracing) is expected
 
-    def test_returns_true_when_config_flag_set(self):
-        """Config enable_content_capture=True with no env var → capture on."""
-        assert is_content_capture_enabled(_config_with_capture(True)) is True
-
-    def test_returns_false_when_config_flag_false_and_env_unset(self):
-        """Config enable_content_capture=False with no env var → capture off."""
-        assert is_content_capture_enabled(_config_with_capture(False)) is False
-
-    def test_returns_false_for_default_tracing_config_and_env_unset(self):
-        """Default TracingConfig() has enable_content_capture=False by spec → capture off."""
-        assert is_content_capture_enabled(_config_with_capture(None)) is False
-
-    @pytest.mark.parametrize("env_value", ["true", "True", "TRUE", "1"])
-    def test_env_var_truthy_values_enable_capture(self, monkeypatch, env_value):
-        """Truthy env-var values (case-insensitive 'true' / '1') force capture on."""
+    @pytest.mark.parametrize("config_flag", [None, True, False])
+    @pytest.mark.parametrize("env_value", ["true", "True", "TRUE", "1", "  true  "])
+    def test_env_truthy_forces_on(self, monkeypatch, env_value, config_flag):
+        """Truthy env (case-insensitive, whitespace-stripped) forces capture on regardless of config."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
-        assert is_content_capture_enabled(None) is True
+        config = None if config_flag is None else _config_with_capture(config_flag)
+        assert is_content_capture_enabled(config) is True
 
-    @pytest.mark.parametrize("env_value", ["false", "0", "yes", "no", "", "  "])
-    def test_env_var_other_values_do_not_enable_capture(self, monkeypatch, env_value):
-        """Falsy and unrecognized env values do not enable capture when config is unset."""
+    @pytest.mark.parametrize("config_flag", [None, True, False])
+    @pytest.mark.parametrize("env_value", ["false", "False", "FALSE", "0", "  FALSE  "])
+    def test_env_falsy_forces_off(self, monkeypatch, env_value, config_flag):
+        """Falsy env (case-insensitive, whitespace-stripped) forces capture off regardless of config."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
-        assert is_content_capture_enabled(None) is False
+        config = None if config_flag is None else _config_with_capture(config_flag)
+        assert is_content_capture_enabled(config) is False
 
-    def test_env_var_takes_effect_when_config_is_false(self, monkeypatch):
-        """env=true overrides an explicit config=False (env-var-wins semantic)."""
-        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "true")
-        assert is_content_capture_enabled(_config_with_capture(False)) is True
-
-    def test_config_true_overrides_env_unset(self):
-        """Config=True with no env var → capture on (config is the fallback signal)."""
-        assert is_content_capture_enabled(_config_with_capture(True)) is True
-
-    def test_env_value_with_surrounding_whitespace(self, monkeypatch):
-        """Leading/trailing whitespace on the env value is stripped before matching."""
-        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  true  ")
-        assert is_content_capture_enabled(None) is True
-
-    @pytest.mark.parametrize("env_value", ["false", "False", "FALSE", "0"])
-    def test_env_var_falsy_disables_capture_even_when_config_true(self, monkeypatch, env_value):
-        """Explicit env=false/0 overrides config=True so operators can disable capture fleet-wide."""
-        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
-        assert is_content_capture_enabled(_config_with_capture(True)) is False
-
-    def test_env_var_falsy_with_whitespace_disables_capture(self, monkeypatch):
-        """A falsy env value with surrounding whitespace still overrides config=True."""
-        monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  FALSE  ")
-        assert is_content_capture_enabled(_config_with_capture(True)) is False
-
-    @pytest.mark.parametrize("env_value", ["yes", "no", "maybe"])
-    def test_unrecognized_env_value_falls_through_to_config(self, monkeypatch, env_value):
-        """Unrecognized env values are neither enable nor disable signals — config decides."""
+    @pytest.mark.parametrize("env_value", ["yes", "no", "maybe", ""])
+    def test_unrecognized_env_falls_through_to_config(self, monkeypatch, env_value):
+        """Unrecognized/empty env values are ignored; the config field decides."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(_config_with_capture(True)) is True
         assert is_content_capture_enabled(_config_with_capture(False)) is False
@@ -167,43 +143,24 @@ class TestIsContentCaptureEnabled:
 class TestUseJsonSpanFormat:
     """Parsing of OTEL_SEMCONV_STABILITY_OPT_IN to select JSON attrs vs legacy events."""
 
-    def test_returns_false_when_env_unset(self):
-        """No stability opt-in → legacy-event format (False)."""
+    def test_false_when_env_unset(self):
+        """No stability opt-in set → legacy-event format (False)."""
         assert _use_json_span_format() is False
 
-    def test_returns_true_when_opt_in_token_present(self, monkeypatch):
-        """The exact opt-in token alone selects JSON-attribute format."""
-        monkeypatch.setenv(
-            OtelContentCapture.STABILITY_OPT_IN_ENV,
-            OtelContentCapture.STABILITY_OPT_IN_LATEST,
-        )
-        assert _use_json_span_format() is True
-
-    def test_returns_true_when_token_in_csv_list(self, monkeypatch):
-        """The opt-in token is recognized within a comma-separated token list."""
-        monkeypatch.setenv(
-            OtelContentCapture.STABILITY_OPT_IN_ENV,
-            f"http,{OtelContentCapture.STABILITY_OPT_IN_LATEST},db",
-        )
-        assert _use_json_span_format() is True
-
-    def test_strips_token_whitespace(self, monkeypatch):
-        """Whitespace around individual CSV tokens is stripped before matching."""
-        monkeypatch.setenv(
-            OtelContentCapture.STABILITY_OPT_IN_ENV,
-            f"http,  {OtelContentCapture.STABILITY_OPT_IN_LATEST}  ,db",
-        )
-        assert _use_json_span_format() is True
-
-    def test_returns_false_for_unrelated_token(self, monkeypatch):
-        """A different opt-in token does not select JSON format."""
-        monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "gen_ai_legacy")
-        assert _use_json_span_format() is False
-
-    def test_returns_false_for_empty_string(self, monkeypatch):
-        """An empty opt-in value selects legacy-event format (False)."""
-        monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
-        assert _use_json_span_format() is False
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            (OtelContentCapture.STABILITY_OPT_IN_LATEST, True),  # exact token
+            (f"http,{OtelContentCapture.STABILITY_OPT_IN_LATEST},db", True),  # token within CSV list
+            (f"http,  {OtelContentCapture.STABILITY_OPT_IN_LATEST}  ,db", True),  # CSV token w/ whitespace
+            ("gen_ai_legacy", False),  # unrelated token
+            ("", False),  # empty value
+        ],
+    )
+    def test_format_selection(self, monkeypatch, env_value, expected):
+        """gen_ai_latest_experimental anywhere in the comma-separated token list selects JSON attrs."""
+        monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, env_value)
+        assert _use_json_span_format() is expected
 
 
 _MIXED_MESSAGES = [

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -284,6 +284,17 @@ class TestSystemPartsFromMessages:
         result = _system_parts_from_messages(messages)
         assert [p["content"] for p in result] == ["first", "second"]
 
+    def test_skips_entries_missing_role_or_content(self):
+        """Malformed entries missing role or content are skipped without crashing."""
+        messages = [
+            {"content": "no role"},
+            {"role": "system"},
+            {"role": "system", "content": "valid"},
+        ]
+        result = _system_parts_from_messages(messages)
+        # Only the well-formed system message survives
+        assert result == [{"type": "text", "content": "valid"}]
+
 
 class TestNonSystemInputMessages:
     """Role-wrapped extraction of non-system messages for gen_ai.input.messages."""

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -18,7 +18,7 @@
 Covers the helpers introduced for OTEL GenAI content capture:
 ``is_content_capture_enabled``, ``_use_json_span_format``,
 ``_get_parts_by_role``, ``_system_parts_from_messages``,
-``_non_system_messages_to_parts``, the two ``_set_llm_call_content_*``
+``_non_system_input_messages``, the two ``_set_llm_call_content_*``
 branches, the ``set_llm_call_content`` dispatcher, and ``set_rail_content``.
 """
 
@@ -32,7 +32,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from nemoguardrails.guardrails.telemetry import (
     _get_parts_by_role,
-    _non_system_messages_to_parts,
+    _non_system_input_messages,
     _set_llm_call_content_events,
     _set_llm_call_content_json,
     _system_parts_from_messages,
@@ -105,60 +105,64 @@ def _config_with_capture(value: Optional[bool]) -> TracingConfig:
 
 
 class TestIsContentCaptureEnabled:
-    """Resolution of the content-capture flag: config field wins, env var as fallback."""
+    """Resolution of the content-capture flag: env var wins, config field as fallback."""
 
     def test_returns_false_when_config_none_and_env_unset(self):
+        """No config and no env var → capture off."""
         assert is_content_capture_enabled(None) is False
 
     def test_returns_true_when_config_flag_set(self):
+        """Config enable_content_capture=True with no env var → capture on."""
         assert is_content_capture_enabled(_config_with_capture(True)) is True
 
     def test_returns_false_when_config_flag_false_and_env_unset(self):
+        """Config enable_content_capture=False with no env var → capture off."""
         assert is_content_capture_enabled(_config_with_capture(False)) is False
 
     def test_returns_false_for_default_tracing_config_and_env_unset(self):
-        # Default TracingConfig() has enable_content_capture=False by spec
+        """Default TracingConfig() has enable_content_capture=False by spec → capture off."""
         assert is_content_capture_enabled(_config_with_capture(None)) is False
 
     @pytest.mark.parametrize("env_value", ["true", "True", "TRUE", "1"])
     def test_env_var_truthy_values_enable_capture(self, monkeypatch, env_value):
+        """Truthy env-var values (case-insensitive 'true' / '1') force capture on."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(None) is True
 
     @pytest.mark.parametrize("env_value", ["false", "0", "yes", "no", "", "  "])
     def test_env_var_other_values_do_not_enable_capture(self, monkeypatch, env_value):
+        """Falsy and unrecognized env values do not enable capture when config is unset."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(None) is False
 
     def test_env_var_takes_effect_when_config_is_false(self, monkeypatch):
+        """env=true overrides an explicit config=False (env-var-wins semantic)."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "true")
         assert is_content_capture_enabled(_config_with_capture(False)) is True
 
     def test_config_true_overrides_env_unset(self):
+        """Config=True with no env var → capture on (config is the fallback signal)."""
         assert is_content_capture_enabled(_config_with_capture(True)) is True
 
     def test_env_value_with_surrounding_whitespace(self, monkeypatch):
-        # Leading/trailing whitespace gets stripped (.strip() in the helper)
+        """Leading/trailing whitespace on the env value is stripped before matching."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  true  ")
         assert is_content_capture_enabled(None) is True
 
     @pytest.mark.parametrize("env_value", ["false", "False", "FALSE", "0"])
     def test_env_var_falsy_disables_capture_even_when_config_true(self, monkeypatch, env_value):
-        # Env-var-wins semantic: explicit env=false/0 overrides config=True.
-        # Operators can disable content capture across services via the
-        # OTEL-standard env var even if the deployed config has it enabled.
+        """Explicit env=false/0 overrides config=True so operators can disable capture fleet-wide."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(_config_with_capture(True)) is False
 
     def test_env_var_falsy_with_whitespace_disables_capture(self, monkeypatch):
+        """A falsy env value with surrounding whitespace still overrides config=True."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, "  FALSE  ")
         assert is_content_capture_enabled(_config_with_capture(True)) is False
 
     @pytest.mark.parametrize("env_value", ["yes", "no", "maybe"])
     def test_unrecognized_env_value_falls_through_to_config(self, monkeypatch, env_value):
-        # Unrecognized env values are neither enable nor disable signals —
-        # they fall through to the config field.  Avoids accidentally
-        # disabling capture if someone types "off" / "yes" / etc.
+        """Unrecognized env values are neither enable nor disable signals — config decides."""
         monkeypatch.setenv(OtelContentCapture.CAPTURE_CONTENT_ENV, env_value)
         assert is_content_capture_enabled(_config_with_capture(True)) is True
         assert is_content_capture_enabled(_config_with_capture(False)) is False
@@ -168,9 +172,11 @@ class TestUseJsonSpanFormat:
     """Parsing of OTEL_SEMCONV_STABILITY_OPT_IN to select JSON attrs vs legacy events."""
 
     def test_returns_false_when_env_unset(self):
+        """No stability opt-in → legacy-event format (False)."""
         assert _use_json_span_format() is False
 
     def test_returns_true_when_opt_in_token_present(self, monkeypatch):
+        """The exact opt-in token alone selects JSON-attribute format."""
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             OtelContentCapture.STABILITY_OPT_IN_LATEST,
@@ -178,7 +184,7 @@ class TestUseJsonSpanFormat:
         assert _use_json_span_format() is True
 
     def test_returns_true_when_token_in_csv_list(self, monkeypatch):
-        # Real usage: opt-in env is a comma-separated set of tokens
+        """The opt-in token is recognized within a comma-separated token list."""
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             f"http,{OtelContentCapture.STABILITY_OPT_IN_LATEST},db",
@@ -186,6 +192,7 @@ class TestUseJsonSpanFormat:
         assert _use_json_span_format() is True
 
     def test_strips_token_whitespace(self, monkeypatch):
+        """Whitespace around individual CSV tokens is stripped before matching."""
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             f"http,  {OtelContentCapture.STABILITY_OPT_IN_LATEST}  ,db",
@@ -193,10 +200,12 @@ class TestUseJsonSpanFormat:
         assert _use_json_span_format() is True
 
     def test_returns_false_for_unrelated_token(self, monkeypatch):
+        """A different opt-in token does not select JSON format."""
         monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "gen_ai_legacy")
         assert _use_json_span_format() is False
 
     def test_returns_false_for_empty_string(self, monkeypatch):
+        """An empty opt-in value selects legacy-event format (False)."""
         monkeypatch.setenv(OtelContentCapture.STABILITY_OPT_IN_ENV, "")
         assert _use_json_span_format() is False
 
@@ -213,35 +222,41 @@ class TestGetPartsByRole:
     """Role-filtered walker that powers the two specialised parts helpers."""
 
     def test_include_true_returns_matching_role(self):
+        """include=True keeps only messages whose role equals the target role."""
         result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=True)
         assert result == [{"role": "system", "parts": [{"type": "text", "content": "you are helpful"}]}]
 
     def test_include_false_returns_non_matching_roles(self):
+        """include=False keeps every message whose role differs from the target."""
         result = _get_parts_by_role(_MIXED_MESSAGES, "system", include=False)
         roles = [entry["role"] for entry in result]
         assert roles == ["user", "assistant", "user"]
 
     def test_empty_messages_returns_empty(self):
+        """An empty message list yields an empty result."""
         assert _get_parts_by_role([], "system", include=True) == []
 
     def test_skips_entries_missing_role(self):
+        """Messages without a ``role`` field are skipped silently."""
         messages = [{"content": "no role"}, {"role": "user", "content": "ok"}]
         result = _get_parts_by_role(messages, "user", include=True)
         assert len(result) == 1
         assert result[0]["role"] == "user"
 
     def test_skips_entries_missing_content(self):
+        """Messages without a ``content`` field are skipped silently."""
         messages = [{"role": "user"}, {"role": "user", "content": "ok"}]
         result = _get_parts_by_role(messages, "user", include=True)
         assert len(result) == 1
         assert result[0]["parts"][0]["content"] == "ok"
 
     def test_no_matches_returns_empty(self):
+        """include=True with a role absent from the messages yields an empty result."""
         result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=True)
         assert result == []
 
     def test_all_match_when_excluded_role_absent(self):
-        # When excluding a role that's not present, every valid entry comes through
+        """include=False excluding an absent role returns every valid entry."""
         result = _get_parts_by_role(_MIXED_MESSAGES, "tool", include=False)
         assert len(result) == len(_MIXED_MESSAGES)
 
@@ -250,16 +265,17 @@ class TestSystemPartsFromMessages:
     """Flat-parts extraction of system messages for gen_ai.system_instructions."""
 
     def test_returns_flat_parts_for_system_only(self):
-        # gen_ai.system_instructions is a flat list of {type,content} parts
-        # — no role wrapping, even though the underlying walker produces it
+        """System messages are returned as bare {type,content} parts, no role wrapper."""
         result = _system_parts_from_messages(_MIXED_MESSAGES)
         assert result == [{"type": "text", "content": "you are helpful"}]
 
     def test_empty_when_no_system_messages(self):
+        """No system message → empty parts list."""
         messages = [{"role": "user", "content": "hi"}]
         assert _system_parts_from_messages(messages) == []
 
     def test_multiple_system_messages_preserves_order(self):
+        """Multiple system messages are returned in their original order."""
         messages = [
             {"role": "system", "content": "first"},
             {"role": "user", "content": "ignored"},
@@ -269,11 +285,12 @@ class TestSystemPartsFromMessages:
         assert [p["content"] for p in result] == ["first", "second"]
 
 
-class TestNonSystemMessagesToParts:
+class TestNonSystemInputMessages:
     """Role-wrapped extraction of non-system messages for gen_ai.input.messages."""
 
     def test_returns_role_wrapped_non_system(self):
-        result = _non_system_messages_to_parts(_MIXED_MESSAGES)
+        """Non-system messages are returned role-wrapped with a single text part each."""
+        result = _non_system_input_messages(_MIXED_MESSAGES)
         assert result == [
             {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
             {"role": "assistant", "parts": [{"type": "text", "content": "hi there"}]},
@@ -281,14 +298,16 @@ class TestNonSystemMessagesToParts:
         ]
 
     def test_empty_when_only_system_messages(self):
+        """A messages list of only system entries yields an empty result."""
         messages = [{"role": "system", "content": "x"}]
-        assert _non_system_messages_to_parts(messages) == []
+        assert _non_system_input_messages(messages) == []
 
 
 class TestSetLlmCallContentJsonBranch:
     """Direct tests for the JSON-attributes branch helper."""
 
     def test_sets_all_three_attributes_when_data_present(self, finished_span):
+        """System/input/output content all land on their respective JSON span attributes."""
         span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, "the answer"))
         attrs = span.attributes
 
@@ -302,26 +321,31 @@ class TestSetLlmCallContentJsonBranch:
         assert outputs == [{"role": "assistant", "parts": [{"type": "text", "content": "the answer"}]}]
 
     def test_omits_system_instructions_when_no_system_message(self, finished_span):
-        # Distinguishing "no system instructions" from "empty system instructions"
-        # is part of the contract — backends should not see an empty JSON array
+        """No system message → the system_instructions attribute is omitted, not set empty.
+
+        Distinguishing "no system instructions" from "empty system instructions"
+        is part of the contract — backends should not see an empty JSON array.
+        """
         messages = [{"role": "user", "content": "hi"}]
         span = finished_span(lambda s: _set_llm_call_content_json(s, messages, "hello"))
         assert GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS not in span.attributes
 
     def test_omits_input_messages_when_only_system(self, finished_span):
+        """Only a system message → input.messages omitted, system_instructions set."""
         messages = [{"role": "system", "content": "be brief"}]
         span = finished_span(lambda s: _set_llm_call_content_json(s, messages, "x"))
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
         assert GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS in span.attributes
 
     def test_omits_output_messages_when_output_text_is_none(self, finished_span):
+        """output_text=None → output.messages omitted while input.messages is still set."""
         span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, None))
         assert GenAIAttributes.GEN_AI_OUTPUT_MESSAGES not in span.attributes
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
 
     def test_emits_no_legacy_events(self, finished_span):
+        """Cross-branch hygiene: the JSON-attr path must never add span events."""
         span = finished_span(lambda s: _set_llm_call_content_json(s, _MIXED_MESSAGES, "out"))
-        # Cross-branch hygiene: JSON-attr path must never add events
         assert span.events == ()
 
 
@@ -329,6 +353,7 @@ class TestSetLlmCallContentEventsBranch:
     """Direct tests for the legacy-events branch helper."""
 
     def test_emits_one_event_per_supported_role(self, finished_span):
+        """Each supported-role message becomes one event, plus a final choice event."""
         span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "the answer"))
         event_names = [e.name for e in span.events]
         # 3 input events (1 system + 2 user + 1 assistant = 4) + 1 choice
@@ -341,12 +366,14 @@ class TestSetLlmCallContentEventsBranch:
         ]
 
     def test_event_attributes_carry_role_and_content(self, finished_span):
+        """A message event carries the message's role and content as attributes."""
         messages = [{"role": "user", "content": "hello"}]
         span = finished_span(lambda s: _set_llm_call_content_events(s, messages, "hi"))
         user_event = next(e for e in span.events if e.name == EventNames.GEN_AI_USER_MESSAGE)
         assert dict(user_event.attributes) == {"role": "user", "content": "hello"}
 
     def test_choice_event_carries_assistant_output(self, finished_span):
+        """The choice event carries the assistant output text and index 0."""
         messages = [{"role": "user", "content": "hello"}]
         span = finished_span(lambda s: _set_llm_call_content_events(s, messages, "the answer"))
         choice = next(e for e in span.events if e.name == EventNames.GEN_AI_CHOICE)
@@ -357,13 +384,17 @@ class TestSetLlmCallContentEventsBranch:
         }
 
     def test_no_choice_event_when_output_text_none(self, finished_span):
+        """output_text=None → no choice event is emitted."""
         messages = [{"role": "user", "content": "hello"}]
         span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
         assert all(e.name != EventNames.GEN_AI_CHOICE for e in span.events)
 
     def test_skips_unsupported_roles_silently(self, finished_span):
-        # IORails doesn't yet emit tool/function events; unknown roles must
-        # be dropped rather than crashing the capture path
+        """Roles without a legacy event mapping (e.g. tool) are dropped, not errored.
+
+        IORails doesn't yet emit tool/function events; unknown roles must
+        be dropped rather than crashing the capture path.
+        """
         messages = [
             {"role": "user", "content": "u"},
             {"role": "tool", "content": "should be skipped"},
@@ -377,8 +408,11 @@ class TestSetLlmCallContentEventsBranch:
         assert len(span.events) == 2
 
     def test_skips_messages_missing_role_or_content(self, finished_span):
-        # Defensive guard for malformed input — LLMMessage is typed dict[str,
-        # str], so missing fields are not normal but the helper must not crash.
+        """Malformed messages missing role or content are skipped without crashing.
+
+        LLMMessage is typed dict[str, str], so missing fields are not normal
+        but the helper must still not crash on them.
+        """
         messages = [
             {"content": "no role"},
             {"role": "user"},
@@ -391,7 +425,7 @@ class TestSetLlmCallContentEventsBranch:
         assert dict(span.events[0].attributes)["content"] == "valid"
 
     def test_sets_no_json_attributes(self, finished_span):
-        # Cross-branch hygiene: events path must never set the JSON attrs
+        """Cross-branch hygiene: the events path must never set the JSON attrs."""
         span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "out"))
         attrs = span.attributes
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in attrs
@@ -403,11 +437,13 @@ class TestSetLlmCallContentDispatch:
     """End-to-end tests for the dispatcher choosing JSON vs events."""
 
     def test_uses_events_branch_when_opt_in_unset(self, finished_span):
+        """No stability opt-in → dispatcher emits legacy events, no JSON attrs."""
         span = finished_span(lambda s: set_llm_call_content(s, _MIXED_MESSAGES, "out"))
         assert len(span.events) > 0
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES not in span.attributes
 
     def test_uses_json_branch_when_opt_in_set(self, monkeypatch, finished_span):
+        """Stability opt-in set → dispatcher emits JSON attrs, no legacy events."""
         monkeypatch.setenv(
             OtelContentCapture.STABILITY_OPT_IN_ENV,
             OtelContentCapture.STABILITY_OPT_IN_LATEST,
@@ -417,7 +453,7 @@ class TestSetLlmCallContentDispatch:
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
 
     def test_none_span_is_noop(self):
-        # No exception even though we pass None for the span and structured input
+        """Passing span=None is a no-op and raises nothing."""
         set_llm_call_content(None, _MIXED_MESSAGES, "out")
 
 
@@ -425,6 +461,7 @@ class TestSetRailContent:
     """guardrails.rail.input and guardrails.rail.reason attribute capture on rail spans."""
 
     def test_sets_only_input_when_reason_is_none(self, finished_span):
+        """reason=None → only the rail.input attribute is set, no rail.reason."""
         rail_input = {"messages": [{"role": "user", "content": "hi"}], "bot_response": None}
         span = finished_span(lambda s: set_rail_content(s, rail_input))
         attrs = span.attributes
@@ -432,6 +469,7 @@ class TestSetRailContent:
         assert GuardrailsAttributes.RAIL_REASON not in attrs
 
     def test_sets_input_and_reason_when_reason_provided(self, finished_span):
+        """A non-None reason sets both rail.input and rail.reason."""
         rail_input = {"messages": [{"role": "user", "content": "hi"}], "bot_response": "out"}
         span = finished_span(lambda s: set_rail_content(s, rail_input, reason="unsafe topic"))
         attrs = span.attributes
@@ -439,5 +477,5 @@ class TestSetRailContent:
         assert attrs[GuardrailsAttributes.RAIL_REASON] == "unsafe topic"
 
     def test_none_span_is_noop(self):
-        # No exception even when we pass real input and reason
+        """Passing span=None is a no-op and raises nothing."""
         set_rail_content(None, {"messages": []}, reason="should not raise")

--- a/tests/guardrails/test_telemetry_content_capture.py
+++ b/tests/guardrails/test_telemetry_content_capture.py
@@ -376,6 +376,20 @@ class TestSetLlmCallContentEventsBranch:
         # No event was raised for the tool role
         assert len(span.events) == 2
 
+    def test_skips_messages_missing_role_or_content(self, finished_span):
+        # Defensive guard for malformed input — LLMMessage is typed dict[str,
+        # str], so missing fields are not normal but the helper must not crash.
+        messages = [
+            {"content": "no role"},
+            {"role": "user"},
+            {"role": "user", "content": "valid"},
+        ]
+        span = finished_span(lambda s: _set_llm_call_content_events(s, messages, None))
+        # Only the valid message produces an event
+        assert len(span.events) == 1
+        assert span.events[0].name == EventNames.GEN_AI_USER_MESSAGE
+        assert dict(span.events[0].attributes)["content"] == "valid"
+
     def test_sets_no_json_attributes(self, finished_span):
         # Cross-branch hygiene: events path must never set the JSON attrs
         span = finished_span(lambda s: _set_llm_call_content_events(s, _MIXED_MESSAGES, "out"))


### PR DESCRIPTION
## Description

Adds opt-in OTEL GenAI content capture to the IORails engine so operators can see real prompts and responses on traces alongside the metadata already emitted. The config works as below:

* `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable overrides all other configuration, allowing a deployment to ensure content-capture is enabled or disabled.
* If `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` isn't set, the existing `config.tracing.enable_content_capture` field takes effect.
* `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` selects the latest JSON span attributes (gen_ai.input.messages, gen_ai.output.messages, gen_ai.system_instructions), while the default emits the legacy per-message span events. 

Content lands on the request SERVER span, every LLM CLIENT span (main plus per-rail-action calls), and rail spans (guardrails.rail.input + guardrails.rail.reason on blocks); streaming accumulates delivered chunks and records the joined text at stream end so the captured output matches exactly what reached the caller. Comes with unit tests for the new telemetry helpers and integration tests against the full IORails pipeline.

## Related Issue(s)

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
................................................ssss................................................................ [  2%]
...........................s........................................................................................ [  4%]
.................................................................................................................... [  7%]
.................................................................................................................... [  9%]
.................................................................................................................... [ 12%]
.................................................................................................................... [ 14%]
.................................................................................................................... [ 17%]
.................................................................................................................... [ 19%]
.................................................................................................................... [ 22%]
.................................................................................................................... [ 24%]
............s......ss...................sssssss..................................................................... [ 27%]
..........................................................s.......s................................................. [ 29%]
.................................................................................................................... [ 32%]
.................................................................................................................s.. [ 34%]
.................................................................................................................... [ 37%]
.................................................................................................................... [ 39%]
.................................................................................................ssssssss......sssss [ 41%]
s..ss.s.............ssssssss........................................................................................ [ 44%]
...................................................................................................ss............... [ 46%]
............s...............s.......sssss.......................................................s................... [ 49%]
.................................................................................................................... [ 51%]
..........................ss........ss...ss............................................s............................ [ 54%]
.........................s............s............................................................................. [ 56%]
.................................................................................................................... [ 59%]
.................................................................................................................... [ 61%]
............sssss......ssssssssssssssssss..........sssss............................................................ [ 64%]
........................s...........ss...................................................sssssssss.ssssssssss....... [ 66%]
.................................................................................................................... [ 69%]
.........s....................................................s....s................................................ [ 71%]
........ssssssss.................sss...ss...ss.....sssssssssssss.................................................... [ 74%]
....................................................................................................s............... [ 76%]
...............................................................................................s.................... [ 78%]
ssssssss.........ss................................................................................................. [ 81%]
.....................................sssssss................................................................s....... [ 83%]
.................................................................................................................... [ 86%]
.................................................................................................................... [ 88%]
.................................................................................................................... [ 91%]
.................................................................................................................... [ 93%]
................................s................................................................................... [ 96%]
.................................................................................................................... [ 98%]
.............................................................                                                        [100%]
4537 passed, 164 skipped in 117.71s (0:01:57)
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-06-02 15:08:26 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-02 15:08:26 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-06-02 15:08:26 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-06-02 15:08:26 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-02 15:08:26 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-06-02 15:08:29 INFO: [f9aba0f0c8d87e6e] generate_async called
2026-06-02 15:08:29 INFO: [f9aba0f0c8d87e6e] Running input rails
2026-06-02 15:08:29 INFO: [f9aba0f0c8d87e6e] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-02 15:08:29 INFO: [f9aba0f0c8d87e6e] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-06-02 15:08:30 INFO: [f9aba0f0c8d87e6e] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-02 15:08:30 INFO: [f9aba0f0c8d87e6e] Calling main LLM
2026-06-02 15:08:30 INFO: [f9aba0f0c8d87e6e] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-02 15:08:31 INFO: [f9aba0f0c8d87e6e] Running output rails
2026-06-02 15:08:31 INFO: [f9aba0f0c8d87e6e] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-02 15:08:31 INFO: [f9aba0f0c8d87e6e] generate_async completed time=2208.9ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] generate_async called
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] Running input rails
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] Input flow content safety check input $model=content_safety blocked
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] Input blocked: Safety categories: JSON parsing failed
2026-06-02 15:08:36 INFO: [1bf2dc351985339f] generate_async completed time=193.2ms
I'm sorry, I can't respond to that.
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry GenAI content capture for LLM requests and guardrail activity, including optional capture of inputs, outputs, and rail reasons.
  * Supports legacy event format and JSON span-attribute format, with streaming-aware capture matching consumer-visible output.

* **Documentation**
  * Clarified tracing config docs about content-capture defaults and environment-variable fallback.

* **Tests**
  * Added comprehensive tests covering content-capture formats, streaming behavior, and rail capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->