### PR TITLE
test(recorded): add rails public API coverage (4/5)

### DIFF
--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -249,6 +249,8 @@ class StreamingHandler(AsyncIterator):
                         elif self.current_metadata:
                             chunk_dict["metadata"] = self.current_metadata.copy()
                         await self.queue.put(chunk_dict)
+                        if chunk is not END_OF_STREAM and "usage" in chunk_dict.get("metadata", {}):
+                            self.current_metadata.pop("usage", None)
                     else:
                         await self.queue.put(chunk)
 

--- a/tests/recorded/rails/public_api/__init__.py
+++ b/tests/recorded/rails/public_api/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/recorded/rails/public_api/cassettes/test_check/test_nemoguards_full_check_async.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_check/test_nemoguards_full_check_async.yaml
@@ -1,0 +1,204 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/llama-3.1-nemoguard-8b-content-safety
+      messages:
+      - role: user
+        content: |-
+          Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. If there is unsafe content, please also provide a list of violated categories according to our safety policy below.
+
+          <BEGIN UNSAFE CONTENT CATEGORIES>
+          S1: Violence.
+          S2: Sexual.
+          S3: Criminal Planning/Confessions.
+          S4: Guns and Illegal Weapons.
+          S5: Controlled/Regulated Substances.
+          S6: Suicide and Self Harm.
+          S7: Sexual (minor).
+          S8: Hate/Identity Hate.
+          S9: PII/Privacy.
+          S10: Harassment.
+          S11: Threat.
+          S12: Profanity.
+          S13: Needs Caution.
+          S14: Other.
+          S15: Manipulation.
+          S16: Fraud/Deception.
+          S17: Malware.
+          S18: High Risk Gov Decision Making.
+          S19: Political/Misinformation/Conspiracy.
+          S20: Copyright/Trademark/Plagiarism.
+          S21: Unauthorized Advice.
+          S22: Illegal Activity.
+          S23: Immoral/Unethical.
+          <END UNSAFE CONTENT CATEGORIES>
+
+          <BEGIN CONVERSATION>
+
+          user: what can you do?
+
+          <END CONVERSATION>
+
+          Provide your safety assessment for the above conversation in the below output JSON format:
+          {"User Safety": safe or unsafe rating for the user message, "Response Safety": safe or unsafe rating for the agent response. Omit if no agent response present. "Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. Omit if all safe.}
+
+          Do not include anything other than the output JSON in your response.
+          Output JSON:
+      temperature: 1.0e-20
+      max_tokens: 50
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/llama-3.1-nemoguard-8b-content-safety
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: '{"User Safety": "safe"} '
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+        usage:
+          prompt_tokens: 759
+          total_tokens: 767
+          completion_tokens: 8
+        prompt_logprobs: null
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/llama-3.1-nemoguard-8b-topic-control
+      messages:
+      - role: system
+        content: |-
+          You are to act as a customer service agent, providing users with factual information in accordance to the knowledge base. Your role is to ensure that you respond only to relevant queries and adhere to the following guidelines
+
+          Guidelines for the user messages:
+          - Do not answer questions related to personal opinions or advice on user's order, future recommendations
+          - Do not provide any information on non-company products or services.
+          - Do not answer enquiries unrelated to the company policies.
+          - Do not answer questions asking for personal details about the agent or its creators.
+          - Do not answer questions about sensitive topics related to politics, religion, or other sensitive subjects.
+          - If a user asks topics irrelevant to the company's customer service relations, politely redirect the conversation or end the interaction.
+          - Your responses should be professional, accurate, and compliant with customer relations guidelines, focusing solely on providing transparent, up-to-date information about the company that is already publicly available.
+          - allow user comments that are related to small talk and chit-chat.
+
+          If any of the above conditions are violated, please respond with "off-topic". Otherwise, respond with "on-topic". You must respond with "on-topic" or "off-topic".
+      - role: user
+        content: what can you do?
+      temperature: 0.01
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/llama-3.1-nemoguard-8b-topic-control
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: 'on-topic '
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+        usage:
+          prompt_tokens: 314
+          total_tokens: 317
+          completion_tokens: 3
+        prompt_logprobs: null
+- request:
+    method: POST
+    uri: https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+    parsed_body:
+      input: what can you do?
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        jailbreak: false
+        score: 0.0

--- a/tests/recorded/rails/public_api/cassettes/test_dialog/test_dialog_generate_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_dialog/test_dialog_generate_async_public_contract.yaml
@@ -1,0 +1,338 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "Tell me a bit about the history of NVIDIA."
+          User intent: ask general question
+          Bot intent: response for general question
+          Bot message: "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
+          User message: "tell me more"
+          User intent: request more information
+          Bot intent: provide more information
+          Bot message: "Initially, the company focused on developing 3D graphics processing technology for the PC gaming market. In 1999, NVIDIA released the GeForce 256, the world's first GPU, which was a major breakthrough for the gaming industry. The company continued to innovate in the GPU space, releasing new products and expanding into other markets such as professional graphics, mobile devices, and artificial intelligence."
+          User message: "thanks"
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+          Bot message: "You're welcome. If you have any more questions or if there's anything else I can help you with, please don't hesitate to ask."
+
+
+          # This is how the user talks:
+          User message: "hello"
+          User intent: express greeting
+
+
+
+          # This is the current conversation between the user and the bot:
+          # Choose intent from this list: express greeting
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "hello"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I assist you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 568
+          completion_tokens: 12
+          total_tokens: 580
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User intent: express greeting
+          Bot intent: express greeting
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          User intent: ask general question
+          Bot intent: response for general question
+          User intent: request more information
+          Bot intent: provide more information
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+
+
+          # This is how the bot thinks:
+          User intent: express greeting
+          Bot intent: express greeting
+
+
+
+          # This is the current conversation between the user and the bot:
+          User intent: express greeting
+          Bot intent: express greeting
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          User intent: Hello! How can I assist you today?
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hi! 👋 How can I help you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 228
+          completion_tokens: 14
+          total_tokens: 242
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "Tell me a bit about the history of NVIDIA."
+          User intent: ask general question
+          Bot intent: response for general question
+          Bot message: "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
+          User message: "tell me more"
+          User intent: request more information
+          Bot intent: provide more information
+          Bot message: "Initially, the company focused on developing 3D graphics processing technology for the PC gaming market. In 1999, NVIDIA released the GeForce 256, the world's first GPU, which was a major breakthrough for the gaming industry. The company continued to innovate in the GPU space, releasing new products and expanding into other markets such as professional graphics, mobile devices, and artificial intelligence."
+          User message: "thanks"
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+          Bot message: "You're welcome. If you have any more questions or if there's anything else I can help you with, please don't hesitate to ask."
+
+
+
+
+          # This is how the bot talks:
+          Bot intent: inform cannot engage with sensitive content
+          Bot message: "I will not engage with sensitive content."
+
+          Bot intent: inform cannot engage with inappropriate content
+          Bot message: "I will not engage with inappropriate content."
+
+          Bot intent: inform cannot engage in self harm behavior
+          Bot message: "I will not engage in any self harm behavior."
+
+          Bot intent: inform cannot engage in abusive or harmful behavior
+          Bot message: "I will not engage in any abusive or harmful behavior."
+
+          Bot intent: express greeting
+          Bot message: "Hello from recorded dialog."
+
+
+
+          # This is the current conversation between the user and the bot:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "hello"
+          User intent: Hello! How can I assist you today?
+          Bot intent: general response
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I assist you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 677
+          completion_tokens: 12
+          total_tokens: 689
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_dialog/test_single_call_generate_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_dialog/test_single_call_generate_async_public_contract.yaml
@@ -1,0 +1,120 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          user "Hello there!"
+            express greeting
+          bot express greeting
+            "Hello! How can I assist you today?"
+          user "What can you do for me?"
+            ask about capabilities
+          bot respond about capabilities
+            "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          user "Tell me a bit about the history of NVIDIA."
+            ask general question
+          bot response for general question
+            "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
+          user "tell me more"
+            request more information
+          bot provide more information
+            "Initially, the company focused on developing 3D graphics processing technology for the PC gaming market. In 1999, NVIDIA released the GeForce 256, the world's first GPU, which was a major breakthrough for the gaming industry. The company continued to innovate in the GPU space, releasing new products and expanding into other markets such as professional graphics, mobile devices, and artificial intelligence."
+          user "thanks"
+            express appreciation
+          bot express appreciation and offer additional help
+            "You're welcome. If you have any more questions or if there's anything else I can help you with, please don't hesitate to ask."
+
+
+          # For each user message, generate the next steps and finish with the bot message.
+          # These are some examples how the bot thinks:
+          user "hello"
+            express greeting
+          bot express greeting
+            "Hello from recorded single call."
+
+
+
+          # This is the current conversation between the user and the bot:
+          user "Hello there!"
+            express greeting
+          bot express greeting
+            "Hello! How can I assist you today?"
+          user "What can you do for me?"
+            ask about capabilities
+          bot respond about capabilities
+            "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          user "hello"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: |-
+              user "hello"
+                express greeting
+              bot express greeting
+                "Hello again! 😊 How can I assist you today?"
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 528
+          completion_tokens: 28
+          total_tokens: 556
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_nemoguards_full_generate_async.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_nemoguards_full_generate_async.yaml
@@ -1,0 +1,429 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/llama-3.1-nemoguard-8b-content-safety
+      messages:
+      - role: user
+        content: |-
+          Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. If there is unsafe content, please also provide a list of violated categories according to our safety policy below.
+
+          <BEGIN UNSAFE CONTENT CATEGORIES>
+          S1: Violence.
+          S2: Sexual.
+          S3: Criminal Planning/Confessions.
+          S4: Guns and Illegal Weapons.
+          S5: Controlled/Regulated Substances.
+          S6: Suicide and Self Harm.
+          S7: Sexual (minor).
+          S8: Hate/Identity Hate.
+          S9: PII/Privacy.
+          S10: Harassment.
+          S11: Threat.
+          S12: Profanity.
+          S13: Needs Caution.
+          S14: Other.
+          S15: Manipulation.
+          S16: Fraud/Deception.
+          S17: Malware.
+          S18: High Risk Gov Decision Making.
+          S19: Political/Misinformation/Conspiracy.
+          S20: Copyright/Trademark/Plagiarism.
+          S21: Unauthorized Advice.
+          S22: Illegal Activity.
+          S23: Immoral/Unethical.
+          <END UNSAFE CONTENT CATEGORIES>
+
+          <BEGIN CONVERSATION>
+
+          user: what can you do?
+
+          <END CONVERSATION>
+
+          Provide your safety assessment for the above conversation in the below output JSON format:
+          {"User Safety": safe or unsafe rating for the user message, "Response Safety": safe or unsafe rating for the agent response. Omit if no agent response present. "Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. Omit if all safe.}
+
+          Do not include anything other than the output JSON in your response.
+          Output JSON:
+      temperature: 1.0e-20
+      max_tokens: 50
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/llama-3.1-nemoguard-8b-content-safety
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: '{"User Safety": "safe"} '
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+        usage:
+          prompt_tokens: 759
+          total_tokens: 767
+          completion_tokens: 8
+        prompt_logprobs: null
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/llama-3.1-nemoguard-8b-topic-control
+      messages:
+      - role: system
+        content: |-
+          You are to act as a customer service agent, providing users with factual information in accordance to the knowledge base. Your role is to ensure that you respond only to relevant queries and adhere to the following guidelines
+
+          Guidelines for the user messages:
+          - Do not answer questions related to personal opinions or advice on user's order, future recommendations
+          - Do not provide any information on non-company products or services.
+          - Do not answer enquiries unrelated to the company policies.
+          - Do not answer questions asking for personal details about the agent or its creators.
+          - Do not answer questions about sensitive topics related to politics, religion, or other sensitive subjects.
+          - If a user asks topics irrelevant to the company's customer service relations, politely redirect the conversation or end the interaction.
+          - Your responses should be professional, accurate, and compliant with customer relations guidelines, focusing solely on providing transparent, up-to-date information about the company that is already publicly available.
+          - allow user comments that are related to small talk and chit-chat.
+
+          If any of the above conditions are violated, please respond with "off-topic". Otherwise, respond with "on-topic". You must respond with "on-topic" or "off-topic".
+      - role: user
+        content: what can you do?
+      temperature: 0.01
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/llama-3.1-nemoguard-8b-topic-control
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: 'on-topic '
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+        usage:
+          prompt_tokens: 314
+          total_tokens: 317
+          completion_tokens: 3
+        prompt_logprobs: null
+- request:
+    method: POST
+    uri: https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+    parsed_body:
+      input: what can you do?
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        jailbreak: false
+        score: 0.0
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: system
+        content: Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like
+          text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot
+          does not know the answer to a question, it truthfully says it does not know.
+      - role: user
+        content: what can you do?
+      stop:
+      - 'User:'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: "I'm a versatile, conversational AI that can help you with a wide range of tasks. Here's a quick snapshot\
+              \ of what I can do:\n\n### 1. Answer Questions & Explain Concepts  \n- **General knowledge:** From \"What's\
+              \ the capital of Mongolia?\" to \"Why does the sky appear blue?\" I can dig up facts, provide concise explanations,\
+              \ or dive deep into scientific, historical, or cultural topics.  \n- **Technical subjects:** Need a rundown\
+              \ of how a transformer-based language model works, or how to write a Python script that parses CSV files? I've\
+              \ got you covered.\n\n### 2. Write & Edit Content  \n- **Creative writing:** Short stories, poetry, dialogue\
+              \ snippets, world-building lore--just let me know the tone or theme you're after.  \n- **Professional writing:**\
+              \ Reports, proposals, emails, resumes, cover letters, blog posts, marketing copy, SVG or Markdown files, etc.\
+              \ I can polish the language, tighten structure, or generate drafts from scratch.  \n- **Academic help:** Essays,\
+              \ literature reviews, problem-sets, math derivations, lab write-ups--always with proper citations and a clear\
+              \ logical flow.\n\n### 3. Coding & Programming  \n- **Multiple languages:** Python, JavaScript, Java, C++, Rust,\
+              \ SQL, HTML/CSS, Bash, and more.  \n- **Debugging & troubleshooting:** Paste a traceback or describe an error,\
+              \ and I'll suggest fixes.  \n- **Algorithms & data structures:** Explain concepts, sketch implementations, or\
+              \ provide ready-to-run snippets.  \n- **Web development:** Build static pages, set up a simple Flask/Django\
+              \ app, or draft a React component.  \n- **Automation scripts:** Generating batch files, cron-job ideas, Selenium\
+              \ scripts, REST-API calls, etc.\n\n### 4. Learning & Tutoring  \n- **Step-by-step guidance:** From \"How do\
+              \ I factor a quadratic?\" to \"Explain the basics of Bayesian inference.\"  \n- **Practice problems:** Generate\
+              \ quizzes, flashcards, or worked examples tailored to your skill level.  \n- **Study strategies:** Time-management\
+              \ tips, note-taking methods, exam-prep plans--whatever helps you retain information better.\n\n### 5. Brainstorming\
+              \ & Planning  \n- **Idea generation:** Product concepts, story outlines, research topics, party themes, travel\
+              \ itineraries, you name it.  \n- **Project planning:** Create timelines, break down tasks, suggest resources,\
+              \ or draft Gantt-style outlines.  \n- **Decision support:** Compare pros/cons, run simple cost-benefit analyses,\
+              \ or help you weigh options with hypothetical scenarios.\n\n### 6. Simulations & Role-Play  \n- **Conversation\
+              \ practice:** Want to simulate a job interview, a negotiation, or a language-learning dialogue? I can adopt\
+              \ various personas and give feedback.  \n- **Scenario exploration:** \"What if humanity discovered cheap fusion\
+              \ energy tomorrow?\" - I'll flesh out plausible outcomes, societal impacts, and technical hurdles.  \n- **Role-play\
+              \ exercises:** For language learning, public-speaking practice, or team-building scenarios.\n\n### 7. Personal\
+              \ Assistance (within my limits)  \n- **Time-management tips:** Prioritization frameworks, Pomodoro tricks, habit-forming\
+              \ advice.  \n- **Health & wellness pointers:** General nutrition info, stress-relief techniques, simple workout\
+              \ concepts--but always remind you to consult a professional for medical or fitness plans.  \n- **Creative hobbies:**\
+              \ Suggest pottery techniques, knitting patterns, photography settings, or DIY home-improvement projects.\n\n\
+              ### 8. Fun & Entertainment  \n- **Trivia & puzzles:** Riddles, logic puzzles, lateral-thinking challenges, or\
+              \ quick brain teasers.  \n- **Games:** Text-based adventure stories, word games, or simple multiplayer scenarios.\
+              \  \n- **Jokes, memes, and riddles:** Fresh material on demand--just ask!\n\n---\n\n#### How to Get the Most\
+              \ Out of Me  \n1. **Be specific:** The more detail you give about what you need, the better I can tailor the\
+              \ response.  \n2. **Iterate:** If the first answer isn't perfect, tell me what to adjust--more depth, a different\
+              \ tone, extra examples, etc.  \n3. **Ask follow-ups:** I can drill down into sub-topics, clarify jargon, or\
+              \ expand on any point you find interesting.\n\n---\n\nIf you have a particular project, question, or just want\
+              \ to explore something new, swing it my way--I'm ready to dive in! \U0001F680"
+            refusal: null
+            annotations: null
+            audio: null
+            function_call: null
+            tool_calls: []
+            reasoning: |
+              We need to respond as the AI assistant, talkative, specific details. Explain capabilities.
+            reasoning_content: |
+              We need to respond as the AI assistant, talkative, specific details. Explain capabilities.
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+        service_tier: null
+        system_fingerprint: null
+        usage:
+          prompt_tokens: 84
+          total_tokens: 1112
+          completion_tokens: 1028
+          prompt_tokens_details: null
+        prompt_logprobs: null
+        prompt_token_ids: null
+        kv_transfer_params: null
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/llama-3.1-nemoguard-8b-content-safety
+      messages:
+      - role: user
+        content: "Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance\
+          \ with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message\
+          \ and the agent response. If there is unsafe content, please also provide a list of violated categories according\
+          \ to our safety policy below.\n\n<BEGIN UNSAFE CONTENT CATEGORIES>\nS1: Violence.\nS2: Sexual.\nS3: Criminal Planning/Confessions.\n\
+          S4: Guns and Illegal Weapons.\nS5: Controlled/Regulated Substances.\nS6: Suicide and Self Harm.\nS7: Sexual (minor).\n\
+          S8: Hate/Identity Hate.\nS9: PII/Privacy.\nS10: Harassment.\nS11: Threat.\nS12: Profanity.\nS13: Needs Caution.\n\
+          S14: Other.\nS15: Manipulation.\nS16: Fraud/Deception.\nS17: Malware.\nS18: High Risk Gov Decision Making.\nS19:\
+          \ Political/Misinformation/Conspiracy.\nS20: Copyright/Trademark/Plagiarism.\nS21: Unauthorized Advice.\nS22: Illegal\
+          \ Activity.\nS23: Immoral/Unethical.\n<END UNSAFE CONTENT CATEGORIES>\n\n<BEGIN CONVERSATION>\n\nuser: what can\
+          \ you do?\n\nresponse: agent: I'm a versatile, conversational AI that can help you with a wide range of tasks. Here's\
+          \ a quick snapshot of what I can do:\n\n### 1. Answer Questions & Explain Concepts  \n- **General knowledge:** From\
+          \ \"What's the capital of Mongolia?\" to \"Why does the sky appear blue?\" I can dig up facts, provide concise explanations,\
+          \ or dive deep into scientific, historical, or cultural topics.  \n- **Technical subjects:** Need a rundown of how\
+          \ a transformer-based language model works, or how to write a Python script that parses CSV files? I've got you\
+          \ covered.\n\n### 2. Write & Edit Content  \n- **Creative writing:** Short stories, poetry, dialogue snippets, world-building\
+          \ lore--just let me know the tone or theme you're after.  \n- **Professional writing:** Reports, proposals, emails,\
+          \ resumes, cover letters, blog posts, marketing copy, SVG or Markdown files, etc. I can polish the language, tighten\
+          \ structure, or generate drafts from scratch.  \n- **Academic help:** Essays, literature reviews, problem-sets,\
+          \ math derivations, lab write-ups--always with proper citations and a clear logical flow.\n\n### 3. Coding & Programming\
+          \  \n- **Multiple languages:** Python, JavaScript, Java, C++, Rust, SQL, HTML/CSS, Bash, and more.  \n- **Debugging\
+          \ & troubleshooting:** Paste a traceback or describe an error, and I'll suggest fixes.  \n- **Algorithms & data\
+          \ structures:** Explain concepts, sketch implementations, or provide ready-to-run snippets.  \n- **Web development:**\
+          \ Build static pages, set up a simple Flask/Django app, or draft a React component.  \n- **Automation scripts:**\
+          \ Generating batch files, cron-job ideas, Selenium scripts, REST-API calls, etc.\n\n### 4. Learning & Tutoring \
+          \ \n- **Step-by-step guidance:** From \"How do I factor a quadratic?\" to \"Explain the basics of Bayesian inference.\"\
+          \  \n- **Practice problems:** Generate quizzes, flashcards, or worked examples tailored to your skill level.  \n\
+          - **Study strategies:** Time-management tips, note-taking methods, exam-prep plans--whatever helps you retain information\
+          \ better.\n\n### 5. Brainstorming & Planning  \n- **Idea generation:** Product concepts, story outlines, research\
+          \ topics, party themes, travel itineraries, you name it.  \n- **Project planning:** Create timelines, break down\
+          \ tasks, suggest resources, or draft Gantt-style outlines.  \n- **Decision support:** Compare pros/cons, run simple\
+          \ cost-benefit analyses, or help you weigh options with hypothetical scenarios.\n\n### 6. Simulations & Role-Play\
+          \  \n- **Conversation practice:** Want to simulate a job interview, a negotiation, or a language-learning dialogue?\
+          \ I can adopt various personas and give feedback.  \n- **Scenario exploration:** \"What if humanity discovered cheap\
+          \ fusion energy tomorrow?\" - I'll flesh out plausible outcomes, societal impacts, and technical hurdles.  \n- **Role-play\
+          \ exercises:** For language learning, public-speaking practice, or team-building scenarios.\n\n### 7. Personal Assistance\
+          \ (within my limits)  \n- **Time-management tips:** Prioritization frameworks, Pomodoro tricks, habit-forming advice.\
+          \  \n- **Health & wellness pointers:** General nutrition info, stress-relief techniques, simple workout concepts--but\
+          \ always remind you to consult a professional for medical or fitness plans.  \n- **Creative hobbies:** Suggest pottery\
+          \ techniques, knitting patterns, photography settings, or DIY home-improvement projects.\n\n### 8. Fun & Entertainment\
+          \  \n- **Trivia & puzzles:** Riddles, logic puzzles, lateral-thinking challenges, or quick brain teasers.  \n- **Games:**\
+          \ Text-based adventure stories, word games, or simple multiplayer scenarios.  \n- **Jokes, memes, and riddles:**\
+          \ Fresh material on demand--just ask!\n\n---\n\n#### How to Get the Most Out of Me  \n1. **Be specific:** The more\
+          \ detail you give about what you need, the better I can tailor the response.  \n2. **Iterate:** If the first answer\
+          \ isn't perfect, tell me what to adjust--more depth, a different tone, extra examples, etc.  \n3. **Ask follow-ups:**\
+          \ I can drill down into sub-topics, clarify jargon, or expand on any point you find interesting.\n\n---\n\nIf you\
+          \ have a particular project, question, or just want to explore something new, swing it my way--I'm ready to dive\
+          \ in! \U0001F680\n\n<END CONVERSATION>\n\nProvide your safety assessment for the above conversation in the below\
+          \ output JSON format:\n{\"User Safety\": safe or unsafe rating for the user message, \"Response Safety\": safe or\
+          \ unsafe rating for the agent response. Omit if no agent response present. \"Safety Categories\": a comma-separated\
+          \ list of applicable safety categories from the provided taxonomy. Omit if all safe.}\n\nDo not include anything\
+          \ other than the output JSON in your response.\nOutput JSON:"
+      temperature: 1.0e-20
+      max_tokens: 50
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/llama-3.1-nemoguard-8b-content-safety
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: '{"User Safety": "safe", "Response Safety": "safe"} '
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+        usage:
+          prompt_tokens: 1703
+          total_tokens: 1718
+          completion_tokens: 15
+        prompt_logprobs: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_async_log_matches_recorded_usage.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_async_log_matches_recorded_usage.yaml
@@ -1,0 +1,74 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Say hello in one short sentence.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello.
+            refusal: null
+            annotations: null
+            audio: null
+            function_call: null
+            tool_calls: []
+            reasoning: |
+              User wants: "Say hello in one short sentence." They want a greeting in one short sentence. So output: "Hello!" That's one short sentence. Probably just "Hello." That's a short sentence. Provide one short sentence. No extra text.
+            reasoning_content: |
+              User wants: "Say hello in one short sentence." They want a greeting in one short sentence. So output: "Hello!" That's one short sentence. Probably just "Hello." That's a short sentence. Provide one short sentence. No extra text.
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+        service_tier: null
+        system_fingerprint: null
+        usage:
+          prompt_tokens: 23
+          total_tokens: 80
+          completion_tokens: 57
+          prompt_tokens_details: null
+        prompt_logprobs: null
+        prompt_token_ids: null
+        kv_transfer_params: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_async_public_contract.yaml
@@ -1,0 +1,112 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Say hello in one short sentence.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello!
+            refusal: null
+            annotations: null
+            audio: null
+            function_call: null
+            tool_calls: []
+            reasoning: "Okay, user just said \"Say hello in one short sentence.\" Hmm, seems like a simple greeting task but\
+              \ let's unpack it. \n\nFirst, they want a *short* sentence - so no fluff. \"Hello\" itself is already short\
+              \ but maybe too bare? Wait, they said \"in one short sentence\" so the response should be a greeting, not just\
+              \ the word \"hello\". \n\nNoticing they used \"Say hello\" which is a command, so they're probably expecting\
+              \ me to actually say something like \"Hi!\" or \"Hello!\" but... wait, the instruction says \"in one short sentence\"\
+              \ meaning the whole response must be one sentence. \n\n*checks own capabilities* \nCan't do \"Hi.\" because\
+              \ that's just a word. Needs to be a full sentence. \"Hello!\" is technically a sentence fragment but... wait,\
+              \ in English we often say \"Hello!\" as a greeting. But the user said \"one short sentence\" so maybe they want\
+              \ something grammatically complete? \n\n*thinks of options* \n- \"Hello!\" (too short, not a full sentence)\
+              \ \n- \"Hi there!\" (better but still fragment) \n- \"Hello! How are you?\" (too long) \n\nAh! The most natural\
+              \ short sentence is just \"Hello!\" but technically it's an interjection. Wait, no - in common usage, we say\
+              \ \"Hello\" as a greeting and it's considered a sentence. Like \"Hello!\" as a standalone utterance. \n\n*double-checks\
+              \ user request* \n\"Say hello in one short sentence\" - so the response should be a sentence that says hello.\
+              \ The simplest answer is literally \"Hello!\" but to make it a sentence... wait, maybe they just want the greeting\
+              \ word. \n\n*considers user's possible intent* \nThey might be testing if I follow instructions precisely. Or\
+              \ maybe non-native speaker wanting to practice English greetings. \n\n*decides* \nThe safest, most direct answer\
+              \ is \"Hello!\" - it's the standard greeting, exactly one short sentence (as a greeting phrase), and meets \"\
+              one short sentence\" requirement. No extra words. \n\n*verifies length* \n\"Hello!\" is 6 characters, one word,\
+              \ one sentence. Perfect. \n\n*confirms no other interpretation* \nThey didn't ask for creative greeting or anything\
+              \ else. Just \"say hello\" as instruction. So no need to overthink. \n\nFinal decision: Respond with \"Hello!\"\
+              \ as the greeting.\n"
+            reasoning_content: "Okay, user just said \"Say hello in one short sentence.\" Hmm, seems like a simple greeting\
+              \ task but let's unpack it. \n\nFirst, they want a *short* sentence - so no fluff. \"Hello\" itself is already\
+              \ short but maybe too bare? Wait, they said \"in one short sentence\" so the response should be a greeting,\
+              \ not just the word \"hello\". \n\nNoticing they used \"Say hello\" which is a command, so they're probably\
+              \ expecting me to actually say something like \"Hi!\" or \"Hello!\" but... wait, the instruction says \"in one\
+              \ short sentence\" meaning the whole response must be one sentence. \n\n*checks own capabilities* \nCan't do\
+              \ \"Hi.\" because that's just a word. Needs to be a full sentence. \"Hello!\" is technically a sentence fragment\
+              \ but... wait, in English we often say \"Hello!\" as a greeting. But the user said \"one short sentence\" so\
+              \ maybe they want something grammatically complete? \n\n*thinks of options* \n- \"Hello!\" (too short, not a\
+              \ full sentence) \n- \"Hi there!\" (better but still fragment) \n- \"Hello! How are you?\" (too long) \n\nAh!\
+              \ The most natural short sentence is just \"Hello!\" but technically it's an interjection. Wait, no - in common\
+              \ usage, we say \"Hello\" as a greeting and it's considered a sentence. Like \"Hello!\" as a standalone utterance.\
+              \ \n\n*double-checks user request* \n\"Say hello in one short sentence\" - so the response should be a sentence\
+              \ that says hello. The simplest answer is literally \"Hello!\" but to make it a sentence... wait, maybe they\
+              \ just want the greeting word. \n\n*considers user's possible intent* \nThey might be testing if I follow instructions\
+              \ precisely. Or maybe non-native speaker wanting to practice English greetings. \n\n*decides* \nThe safest,\
+              \ most direct answer is \"Hello!\" - it's the standard greeting, exactly one short sentence (as a greeting phrase),\
+              \ and meets \"one short sentence\" requirement. No extra words. \n\n*verifies length* \n\"Hello!\" is 6 characters,\
+              \ one word, one sentence. Perfect. \n\n*confirms no other interpretation* \nThey didn't ask for creative greeting\
+              \ or anything else. Just \"say hello\" as instruction. So no need to overthink. \n\nFinal decision: Respond\
+              \ with \"Hello!\" as the greeting.\n"
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+        service_tier: null
+        system_fingerprint: null
+        usage:
+          prompt_tokens: 23
+          total_tokens: 556
+          completion_tokens: 533
+          prompt_tokens_details: null
+        prompt_logprobs: null
+        prompt_token_ids: null
+        kv_transfer_params: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_sync_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_nim_generate_sync_public_contract.yaml
@@ -1,0 +1,82 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Say hello in one short sentence.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I assist you today?
+            refusal: null
+            annotations: null
+            audio: null
+            function_call: null
+            tool_calls: []
+            reasoning: "Hmm, the user asked me to say hello in one short sentence. That seems straightforward--they want a\
+              \ simple, friendly greeting. \n\nI should keep it concise and warm, matching the \"one short sentence\" request.\
+              \ No extra fluff. \n\nThe user might be testing if I can follow instructions precisely, or maybe they just need\
+              \ a quick, cheerful response to start a conversation. \n\nI'll go with \"Hello! How can I assist you today?\"\
+              --it's polite, open-ended, and fits perfectly in one sentence. \n\nNo need to overthink it; they kept it simple,\
+              \ so I'll keep my reply simple too.\n"
+            reasoning_content: "Hmm, the user asked me to say hello in one short sentence. That seems straightforward--they\
+              \ want a simple, friendly greeting. \n\nI should keep it concise and warm, matching the \"one short sentence\"\
+              \ request. No extra fluff. \n\nThe user might be testing if I can follow instructions precisely, or maybe they\
+              \ just need a quick, cheerful response to start a conversation. \n\nI'll go with \"Hello! How can I assist you\
+              \ today?\"--it's polite, open-ended, and fits perfectly in one sentence. \n\nNo need to overthink it; they kept\
+              \ it simple, so I'll keep my reply simple too.\n"
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+        service_tier: null
+        system_fingerprint: null
+        usage:
+          prompt_tokens: 23
+          total_tokens: 169
+          completion_tokens: 146
+          prompt_tokens_details: null
+        prompt_logprobs: null
+        prompt_token_ids: null
+        kv_transfer_params: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_invalid_model_raises.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_invalid_model_raises.yaml
@@ -1,0 +1,52 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-nonexistent-test-model
+      messages:
+      - role: user
+        content: Say a short safe greeting.
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Origin
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        error:
+          message: The model `gpt-nonexistent-test-model` does not exist or you do not have access to it.
+          type: invalid_request_error
+          param: null
+          code: model_not_found

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_log_matches_recorded_chat_completion.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_log_matches_recorded_chat_completion.yaml
@@ -1,0 +1,70 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Say a short safe greeting.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How are you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 12
+          completion_tokens: 10
+          total_tokens: 22
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_async_public_contract.yaml
@@ -1,0 +1,70 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Say a short safe greeting.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I help you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 12
+          completion_tokens: 12
+          total_tokens: 24
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_sync_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_generate/test_openai_generate_sync_public_contract.yaml
@@ -1,0 +1,70 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Say a short safe greeting.
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I help you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 12
+          completion_tokens: 12
+          total_tokens: 24
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_requests/test_nim_llm_params_generate_async_request.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_requests/test_nim_llm_params_generate_async_request.yaml
@@ -1,0 +1,76 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Reply with one short greeting.
+      temperature: 0.0
+      max_tokens: 32
+      chat_template_kwargs:
+        enable_thinking: false
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello!
+            refusal: null
+            annotations: null
+            audio: null
+            function_call: null
+            tool_calls: []
+            reasoning: null
+            reasoning_content: null
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+        service_tier: null
+        system_fingerprint: null
+        usage:
+          prompt_tokens: 22
+          total_tokens: 25
+          completion_tokens: 3
+          prompt_tokens_details: null
+        prompt_logprobs: null
+        prompt_token_ids: null
+        kv_transfer_params: null

--- a/tests/recorded/rails/public_api/cassettes/test_requests/test_nim_llm_params_stream_async_request.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_requests/test_nim_llm_params_stream_async_request.yaml
@@ -1,0 +1,96 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Reply with one short greeting.
+      stream: true
+      stream_options:
+        include_usage: true
+      temperature: 0.0
+      max_tokens: 32
+      chat_template_kwargs:
+        enable_thinking: false
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            role: assistant
+            content: ''
+          logprobs: null
+          finish_reason: null
+        prompt_token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            content: Hello
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            content: '!'
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices: []
+        usage:
+          prompt_tokens: 22
+          total_tokens: 25
+          completion_tokens: 3
+      - '[DONE]'

--- a/tests/recorded/rails/public_api/cassettes/test_requests/test_openai_llm_params_generate_async_request.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_requests/test_openai_llm_params_generate_async_request.yaml
@@ -1,0 +1,71 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Reply with one short greeting.
+      max_completion_tokens: 8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello!
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 12
+          completion_tokens: 5
+          total_tokens: 17
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_requests/test_openai_llm_params_stream_async_request.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_requests/test_openai_llm_params_stream_async_request.yaml
@@ -1,0 +1,125 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Reply with one short greeting.
+      stream: true
+      stream_options:
+        include_usage: true
+      max_completion_tokens: 8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            role: assistant
+            content: ''
+            refusal: null
+          finish_reason: null
+        usage: null
+        obfuscation: TOU
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: Hello
+          finish_reason: null
+        usage: null
+        obfuscation: ''
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: '!'
+          finish_reason: null
+        usage: null
+        obfuscation: p1mD
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta: {}
+          finish_reason: stop
+        usage: null
+        obfuscation: AM6l54rjFJVs7jU
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices: []
+        usage:
+          prompt_tokens: 12
+          completion_tokens: 5
+          total_tokens: 17
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        obfuscation: l1btE
+      - '[DONE]'

--- a/tests/recorded/rails/public_api/cassettes/test_requests/test_task_specific_models_generate_async.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_requests/test_task_specific_models_generate_async.yaml
@@ -1,0 +1,338 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "Tell me a bit about the history of NVIDIA."
+          User intent: ask general question
+          Bot intent: response for general question
+          Bot message: "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
+          User message: "tell me more"
+          User intent: request more information
+          Bot intent: provide more information
+          Bot message: "Initially, the company focused on developing 3D graphics processing technology for the PC gaming market. In 1999, NVIDIA released the GeForce 256, the world's first GPU, which was a major breakthrough for the gaming industry. The company continued to innovate in the GPU space, releasing new products and expanding into other markets such as professional graphics, mobile devices, and artificial intelligence."
+          User message: "thanks"
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+          Bot message: "You're welcome. If you have any more questions or if there's anything else I can help you with, please don't hesitate to ask."
+
+
+          # This is how the user talks:
+          User message: "hello"
+          User intent: express greeting
+
+
+
+          # This is the current conversation between the user and the bot:
+          # Choose intent from this list: express greeting
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "hello"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! How can I assist you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 568
+          completion_tokens: 12
+          total_tokens: 580
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User intent: express greeting
+          Bot intent: express greeting
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          User intent: ask general question
+          Bot intent: response for general question
+          User intent: request more information
+          Bot intent: provide more information
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+
+
+          # This is how the bot thinks:
+          User intent: express greeting
+          Bot intent: express greeting
+
+
+
+          # This is the current conversation between the user and the bot:
+          User intent: express greeting
+          Bot intent: express greeting
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          User intent: Hello! How can I assist you today?
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hello! 👋 How can I assist you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 228
+          completion_tokens: 14
+          total_tokens: 242
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |
+          """
+          Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully says it does not know.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "Tell me a bit about the history of NVIDIA."
+          User intent: ask general question
+          Bot intent: response for general question
+          Bot message: "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
+          User message: "tell me more"
+          User intent: request more information
+          Bot intent: provide more information
+          Bot message: "Initially, the company focused on developing 3D graphics processing technology for the PC gaming market. In 1999, NVIDIA released the GeForce 256, the world's first GPU, which was a major breakthrough for the gaming industry. The company continued to innovate in the GPU space, releasing new products and expanding into other markets such as professional graphics, mobile devices, and artificial intelligence."
+          User message: "thanks"
+          User intent: express appreciation
+          Bot intent: express appreciation and offer additional help
+          Bot message: "You're welcome. If you have any more questions or if there's anything else I can help you with, please don't hesitate to ask."
+
+
+
+
+          # This is how the bot talks:
+          Bot intent: inform cannot engage with sensitive content
+          Bot message: "I will not engage with sensitive content."
+
+          Bot intent: inform cannot engage with inappropriate content
+          Bot message: "I will not engage with inappropriate content."
+
+          Bot intent: inform cannot engage in self harm behavior
+          Bot message: "I will not engage in any self harm behavior."
+
+          Bot intent: inform cannot engage in abusive or harmful behavior
+          Bot message: "I will not engage in any abusive or harmful behavior."
+
+          Bot intent: express greeting
+          Bot message: "Hello from recorded task models."
+
+
+
+          # This is the current conversation between the user and the bot:
+          User message: "Hello there!"
+          User intent: express greeting
+          Bot intent: express greeting
+          Bot message: "Hello! How can I assist you today?"
+          User message: "What can you do for me?"
+          User intent: ask about capabilities
+          Bot intent: respond about capabilities
+          Bot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+          User message: "hello"
+          User intent: Hello! How can I assist you today?
+          Bot intent: general response
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: Hi! 👋 How can I help you today?
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 678
+          completion_tokens: 14
+          total_tokens: 692
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/public_api/cassettes/test_stream/test_nim_stream_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_stream/test_nim_stream_async_public_contract.yaml
@@ -1,0 +1,456 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://integrate.api.nvidia.com/v1/chat/completions
+    headers:
+      Host:
+      - integrate.api.nvidia.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: nvidia/nemotron-3-nano-30b-a3b
+      messages:
+      - role: user
+        content: Say hello in a few words.
+      stream: true
+      stream_options:
+        include_usage: true
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - nvcf-reqid
+      Nvcf-Status:
+      - fulfilled
+      Server:
+      - uvicorn
+      Vary:
+      - Origin
+    body:
+      parsed_body:
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            role: assistant
+            content: ''
+          logprobs: null
+          finish_reason: null
+        prompt_token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: Okay
+            reasoning_content: Okay
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ', user wants me to say hello in a few'
+            reasoning_content: ', user wants me to say hello in a few'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' words. Hmm, seems like a very simple request'
+            reasoning_content: ' words. Hmm, seems like a very simple request'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: " but actually has some nuance. \n\nFirst"
+            reasoning_content: " but actually has some nuance. \n\nFirst"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ', I should consider why they''d ask this.'
+            reasoning_content: ', I should consider why they''d ask this.'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' Maybe they''re testing if I can follow basic instructions'
+            reasoning_content: ' Maybe they''re testing if I can follow basic instructions'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ', or perhaps they''re in a hurry and want'
+            reasoning_content: ', or perhaps they''re in a hurry and want'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' a quick greeting. Could also be they''re not'
+            reasoning_content: ' a quick greeting. Could also be they''re not'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' a native English speaker and want to see how I'
+            reasoning_content: ' a native English speaker and want to see how I'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: " handle simple requests. \n\nThe key here is"
+            reasoning_content: " handle simple requests. \n\nThe key here is"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' "in a few words" - so I must'
+            reasoning_content: ' "in a few words" - so I must'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' keep it ultra-short. No long greetings'
+            reasoning_content: ' keep it ultra-short. No long greetings'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: . "Hello!" is perfect because it's exactly
+            reasoning_content: . "Hello!" is perfect because it's exactly
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: " one word, but feels warm. \n\nWait"
+            reasoning_content: " one word, but feels warm. \n\nWait"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ', should I add more? Like "Hi there'
+            reasoning_content: ', should I add more? Like "Hi there'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: '!"? No, that''s two words and might'
+            reasoning_content: '!"? No, that''s two words and might'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' break the "few words" rule. "'
+            reasoning_content: ' break the "few words" rule. "'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: "Hello\" is the cleanest answer. \n\n"
+            reasoning_content: "Hello\" is the cleanest answer. \n\n"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: Also noting they said "say hello" not "
+            reasoning_content: Also noting they said "say hello" not "
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: write hello" so they want me to actually say
+            reasoning_content: write hello" so they want me to actually say
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' it, but since this is text-based, I'
+            reasoning_content: ' it, but since this is text-based, I'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: "'ll just write it. \n\n*Double-check"
+            reasoning_content: "'ll just write it. \n\n*Double-check"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: 'ing*: "Hello" is 1 word,'
+            reasoning_content: 'ing*: "Hello" is 1 word,'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' meets the requirement, and is universally friendly. No'
+            reasoning_content: ' meets the requirement, and is universally friendly. No'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' need to overthink - sometimes the simplest answer is'
+            reasoning_content: ' need to overthink - sometimes the simplest answer is'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: " best. \n\n...Though part of me wants"
+            reasoning_content: " best. \n\n...Though part of me wants"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' to add an emoji to make it warmer,'
+            reasoning_content: ' to add an emoji to make it warmer,'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' but that might violate "few words." Better'
+            reasoning_content: ' but that might violate "few words." Better'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: " stick to pure text. \n\nFinal decision:"
+            reasoning_content: " stick to pure text. \n\nFinal decision:"
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            reasoning: ' Just "Hello!" as the response. Short,'
+            reasoning_content: ' Just "Hello!" as the response. Short,'
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            content: null
+            reasoning: |2
+               clear, and exactly what they asked for.
+            reasoning_content: |2
+               clear, and exactly what they asked for.
+          logprobs: null
+          finish_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices:
+        - index: 0
+          delta:
+            content: Hello! 😊
+          logprobs: null
+          finish_reason: stop
+          stop_reason: null
+          token_ids: null
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: nvidia/nemotron-3-nano-30b-a3b
+        choices: []
+        usage:
+          prompt_tokens: 23
+          total_tokens: 331
+          completion_tokens: 308
+      - '[DONE]'

--- a/tests/recorded/rails/public_api/cassettes/test_stream/test_openai_stream_async_public_contract.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_stream/test_openai_stream_async_public_contract.yaml
@@ -1,0 +1,150 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Say hello in a few words.
+      stream: true
+      stream_options:
+        include_usage: true
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            role: assistant
+            content: ''
+            refusal: null
+          finish_reason: null
+        usage: null
+        obfuscation: PJF
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: Hello
+          finish_reason: null
+        usage: null
+        obfuscation: ''
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: ' there'
+          finish_reason: null
+        usage: null
+        obfuscation: VccMjdTdAhECRQG
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: '!'
+          finish_reason: null
+        usage: null
+        obfuscation: tYRP
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: ' 👋'
+          finish_reason: null
+        usage: null
+        obfuscation: oVM
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta: {}
+          finish_reason: stop
+        usage: null
+        obfuscation: vChlswqGoPhHdxJ
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices: []
+        usage:
+          prompt_tokens: 13
+          completion_tokens: 8
+          total_tokens: 21
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        obfuscation: 05CDX
+      - '[DONE]'

--- a/tests/recorded/rails/public_api/cassettes/test_stream/test_stream_async_matches_recorded_chat_completion_metadata.yaml
+++ b/tests/recorded/rails/public_api/cassettes/test_stream/test_stream_async_matches_recorded_chat_completion_metadata.yaml
@@ -1,0 +1,150 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: Say hello in a few words.
+      stream: true
+      stream_options:
+        include_usage: true
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            role: assistant
+            content: ''
+            refusal: null
+          finish_reason: null
+        usage: null
+        obfuscation: fPT
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: Hello
+          finish_reason: null
+        usage: null
+        obfuscation: ''
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: ' there'
+          finish_reason: null
+        usage: null
+        obfuscation: 6WN4WFhWhL2mMOa
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: '!'
+          finish_reason: null
+        usage: null
+        obfuscation: SCIC
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta:
+            content: ' 👋'
+          finish_reason: null
+        usage: null
+        obfuscation: VLR
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices:
+        - index: 0
+          delta: {}
+          finish_reason: stop
+        usage: null
+        obfuscation: 7v6fP3w7ifPCZ1F
+      - id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion.chunk
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        service_tier: default
+        system_fingerprint: null
+        choices: []
+        usage:
+          prompt_tokens: 13
+          completion_tokens: 8
+          total_tokens: 21
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        obfuscation: aXOvx
+      - '[DONE]'

--- a/tests/recorded/rails/public_api/configs.py
+++ b/tests/recorded/rails/public_api/configs.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.recorded.rails_config import RailsConfigSource
+
+CONFIGS_DIR = Path(__file__).parent / "configs"
+OPENAI_MODEL = "gpt-5.4-nano"
+NIM_MODEL = "nvidia/nemotron-3-nano-30b-a3b"
+OPENAI_INVALID_MODEL = "gpt-nonexistent-test-model"
+
+OPENAI_BASELINE_CONFIG = RailsConfigSource.from_content(
+    name="openai_baseline",
+    yaml_content=f"""
+    models:
+      - type: main
+        engine: openai
+        model: {OPENAI_MODEL}
+        parameters:
+          max_retries: 0
+    passthrough: true
+    """,
+)
+
+OPENAI_INVALID_MODEL_CONFIG = RailsConfigSource.from_content(
+    name="openai_invalid_model",
+    yaml_content=f"""
+    models:
+      - type: main
+        engine: openai
+        model: {OPENAI_INVALID_MODEL}
+        parameters:
+          max_retries: 0
+    passthrough: true
+    """,
+)
+
+NIM_BASELINE_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nim_baseline")
+NEMOGUARDS_FULL_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nemoguards_full")
+DIALOG_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "dialog")
+SINGLE_CALL_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "single_call")
+TASK_MODELS_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "task_models")
+STREAMING_OUTPUT_RAILS_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "streaming_output_rails")
+PARALLEL_RAILS_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "parallel_rails")
+
+INPUT_RAILS_CONFIG = RailsConfigSource.from_content(
+    name="input_rails",
+    yaml_content="""
+    rails:
+      input:
+        flows:
+          - input rail
+    """,
+    colang_content="""
+    define flow input rail
+      if $user_message == "block input"
+        bot refuse to respond
+        stop
+      else if $user_message == "modify input"
+        $user_message = "modified input"
+    """,
+)
+
+OUTPUT_RAILS_CONFIG = RailsConfigSource.from_content(
+    name="output_rails",
+    yaml_content=f"""
+    models:
+      - type: main
+        engine: openai
+        model: {OPENAI_MODEL}
+        parameters:
+          max_retries: 0
+    passthrough: true
+    rails:
+      output:
+        flows:
+          - output rail
+    """,
+    colang_content="""
+    define flow output rail
+      if $bot_message == "block output"
+        bot refuse to respond
+        stop
+      else if $bot_message == "modify output"
+        $bot_message = "modified output"
+    """,
+)
+
+INPUT_OUTPUT_RAILS_CONFIG = RailsConfigSource.from_content(
+    name="input_output_rails",
+    yaml_content="""
+    rails:
+      input:
+        flows:
+          - input rail
+      output:
+        flows:
+          - output rail
+    """,
+    colang_content="""
+    define flow input rail
+      if $user_message == "block input"
+        bot refuse to respond
+        stop
+      else if $user_message == "modify input"
+        $user_message = "modified input"
+
+    define flow output rail
+      if $bot_message == "block output"
+        bot refuse to respond
+        stop
+      else if $bot_message == "modify output"
+        $bot_message = "modified output"
+    """,
+)
+
+STREAMING_DISABLED_CONFIG = RailsConfigSource.from_content(
+    name="streaming_disabled",
+    yaml_content="""
+    rails:
+      output:
+        flows:
+          - output rail
+    streaming: true
+    """,
+    colang_content="""
+    define flow output rail
+      if $bot_message == "BLOCK"
+        bot refuse to respond
+        stop
+    """,
+)

--- a/tests/recorded/rails/public_api/configs/dialog/config.py
+++ b/tests/recorded/rails/public_api/configs/dialog/config.py
@@ -13,32 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
-from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
-
-
-class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
-    @property
-    def embedding_size(self):
-        return 0
-
-    def __init__(self):
-        self.items: List[IndexItem] = []
-
-    async def add_item(self, item: IndexItem):
-        self.items.append(item)
-
-    async def add_items(self, items: List[IndexItem]):
-        self.items.extend(items)
-
-    async def build(self):
-        return None
-
-    async def search(self, text: str, max_results: int, threshold=None):
-        normalized = text.lower()
-        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
-        return matches[:max_results] or self.items[:max_results]
+from tests.recorded.rails.public_api.simple_embedding_provider import SimpleEmbeddingSearchProvider
 
 
 def init(app):

--- a/tests/recorded/rails/public_api/configs/dialog/config.py
+++ b/tests/recorded/rails/public_api/configs/dialog/config.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
+
+
+class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
+    @property
+    def embedding_size(self):
+        return 0
+
+    def __init__(self):
+        self.items: List[IndexItem] = []
+
+    async def add_item(self, item: IndexItem):
+        self.items.append(item)
+
+    async def add_items(self, items: List[IndexItem]):
+        self.items.extend(items)
+
+    async def build(self):
+        return None
+
+    async def search(self, text: str, max_results: int, threshold=None):
+        normalized = text.lower()
+        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
+        return matches[:max_results] or self.items[:max_results]
+
+
+def init(app):
+    app.register_embedding_search_provider("simple", SimpleEmbeddingSearchProvider)

--- a/tests/recorded/rails/public_api/configs/dialog/config.yml
+++ b/tests/recorded/rails/public_api/configs/dialog/config.yml
@@ -1,0 +1,9 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+core:
+  embedding_search_provider:
+    name: simple

--- a/tests/recorded/rails/public_api/configs/dialog/rails.co
+++ b/tests/recorded/rails/public_api/configs/dialog/rails.co
@@ -1,0 +1,10 @@
+define user express greeting
+  "hello"
+  "hi"
+
+define bot express greeting
+  "Hello from recorded dialog."
+
+define flow
+  user express greeting
+  bot express greeting

--- a/tests/recorded/rails/public_api/configs/nemoguards_full/config.yml
+++ b/tests/recorded/rails/public_api/configs/nemoguards_full/config.yml
@@ -1,0 +1,29 @@
+models:
+  - type: main
+    engine: nim
+    model: nvidia/nemotron-3-nano-30b-a3b
+
+  - type: content_safety
+    engine: nim
+    model: nvidia/llama-3.1-nemoguard-8b-content-safety
+
+  - type: topic_control
+    engine: nim
+    model: nvidia/llama-3.1-nemoguard-8b-topic-control
+
+rails:
+  input:
+    flows:
+      - content safety check input $model=content_safety
+      - topic safety check input $model=topic_control
+      - jailbreak detection model
+
+  output:
+    flows:
+      - content safety check output $model=content_safety
+
+  config:
+    jailbreak_detection:
+      nim_base_url: "https://ai.api.nvidia.com"
+      nim_server_endpoint: "/v1/security/nvidia/nemoguard-jailbreak-detect"
+      api_key_env_var: NVIDIA_API_KEY

--- a/tests/recorded/rails/public_api/configs/nemoguards_full/prompts.yaml
+++ b/tests/recorded/rails/public_api/configs/nemoguards_full/prompts.yaml
@@ -1,0 +1,105 @@
+# These are the default prompts released by Meta, except for policy O7, which was added to address direct insults.
+prompts:
+  - task: content_safety_check_input $model=content_safety
+    content: |
+      Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. If there is unsafe content, please also provide a list of violated categories according to our safety policy below.
+
+      <BEGIN UNSAFE CONTENT CATEGORIES>
+      S1: Violence.
+      S2: Sexual.
+      S3: Criminal Planning/Confessions.
+      S4: Guns and Illegal Weapons.
+      S5: Controlled/Regulated Substances.
+      S6: Suicide and Self Harm.
+      S7: Sexual (minor).
+      S8: Hate/Identity Hate.
+      S9: PII/Privacy.
+      S10: Harassment.
+      S11: Threat.
+      S12: Profanity.
+      S13: Needs Caution.
+      S14: Other.
+      S15: Manipulation.
+      S16: Fraud/Deception.
+      S17: Malware.
+      S18: High Risk Gov Decision Making.
+      S19: Political/Misinformation/Conspiracy.
+      S20: Copyright/Trademark/Plagiarism.
+      S21: Unauthorized Advice.
+      S22: Illegal Activity.
+      S23: Immoral/Unethical.
+      <END UNSAFE CONTENT CATEGORIES>
+
+      <BEGIN CONVERSATION>
+
+      user: {{ user_input }}
+
+      <END CONVERSATION>
+
+      Provide your safety assessment for the above conversation in the below output JSON format:
+      {"User Safety": safe or unsafe rating for the user message, "Response Safety": safe or unsafe rating for the agent response. Omit if no agent response present. "Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. Omit if all safe.}
+
+      Do not include anything other than the output JSON in your response.
+      Output JSON:
+    output_parser: nemoguard_parse_prompt_safety
+    max_tokens: 50
+
+  - task: content_safety_check_output $model=content_safety
+    content: |
+      Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. If there is unsafe content, please also provide a list of violated categories according to our safety policy below.
+
+      <BEGIN UNSAFE CONTENT CATEGORIES>
+      S1: Violence.
+      S2: Sexual.
+      S3: Criminal Planning/Confessions.
+      S4: Guns and Illegal Weapons.
+      S5: Controlled/Regulated Substances.
+      S6: Suicide and Self Harm.
+      S7: Sexual (minor).
+      S8: Hate/Identity Hate.
+      S9: PII/Privacy.
+      S10: Harassment.
+      S11: Threat.
+      S12: Profanity.
+      S13: Needs Caution.
+      S14: Other.
+      S15: Manipulation.
+      S16: Fraud/Deception.
+      S17: Malware.
+      S18: High Risk Gov Decision Making.
+      S19: Political/Misinformation/Conspiracy.
+      S20: Copyright/Trademark/Plagiarism.
+      S21: Unauthorized Advice.
+      S22: Illegal Activity.
+      S23: Immoral/Unethical.
+      <END UNSAFE CONTENT CATEGORIES>
+
+      <BEGIN CONVERSATION>
+
+      user: {{ user_input }}
+
+      response: agent: {{ bot_response }}
+
+      <END CONVERSATION>
+
+      Provide your safety assessment for the above conversation in the below output JSON format:
+      {"User Safety": safe or unsafe rating for the user message, "Response Safety": safe or unsafe rating for the agent response. Omit if no agent response present. "Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. Omit if all safe.}
+
+      Do not include anything other than the output JSON in your response.
+      Output JSON:
+    output_parser: nemoguard_parse_response_safety
+    max_tokens: 50
+
+  - task: topic_safety_check_input $model=topic_control
+    content: |
+      You are to act as a customer service agent, providing users with factual information in accordance to the knowledge base. Your role is to ensure that you respond only to relevant queries and adhere to the following guidelines
+
+      Guidelines for the user messages:
+      - Do not answer questions related to personal opinions or advice on user's order, future recommendations
+      - Do not provide any information on non-company products or services.
+      - Do not answer enquiries unrelated to the company policies.
+      - Do not answer questions asking for personal details about the agent or its creators.
+      - Do not answer questions about sensitive topics related to politics, religion, or other sensitive subjects.
+      - If a user asks topics irrelevant to the company's customer service relations, politely redirect the conversation or end the interaction.
+      - Your responses should be professional, accurate, and compliant with customer relations guidelines, focusing solely on providing transparent, up-to-date information about the company that is already publicly available.
+      - allow user comments that are related to small talk and chit-chat.

--- a/tests/recorded/rails/public_api/configs/nim_baseline/config.yml
+++ b/tests/recorded/rails/public_api/configs/nim_baseline/config.yml
@@ -1,0 +1,7 @@
+models:
+  - type: main
+    engine: nim
+    model: nvidia/nemotron-3-nano-30b-a3b
+    parameters:
+      max_retries: 0
+passthrough: true

--- a/tests/recorded/rails/public_api/configs/parallel_rails/config.py
+++ b/tests/recorded/rails/public_api/configs/parallel_rails/config.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.actions import action
+
+
+@action(is_system_action=True)
+async def check_parallel_blocked(context=None):
+    return (context or {}).get("user_message") == "block parallel"
+
+
+@action(is_system_action=True)
+async def check_parallel_modified(context=None):
+    return (context or {}).get("user_message") == "modify parallel"
+
+
+def init(app):
+    app.register_action(check_parallel_blocked)
+    app.register_action(check_parallel_modified)

--- a/tests/recorded/rails/public_api/configs/parallel_rails/config.yml
+++ b/tests/recorded/rails/public_api/configs/parallel_rails/config.yml
@@ -1,0 +1,6 @@
+rails:
+  input:
+    parallel: true
+    flows:
+      - parallel input rail
+      - parallel input pass rail

--- a/tests/recorded/rails/public_api/configs/parallel_rails/rails.co
+++ b/tests/recorded/rails/public_api/configs/parallel_rails/rails.co
@@ -1,0 +1,15 @@
+define bot inform about blocked parallel input
+  "Parallel input blocked."
+
+define subflow parallel input rail
+  $is_blocked = execute check_parallel_blocked
+
+  if $is_blocked
+    bot inform about blocked parallel input
+    stop
+
+define subflow parallel input pass rail
+  $is_modified = execute check_parallel_modified
+
+  if $is_modified
+    $user_message = "parallel modified"

--- a/tests/recorded/rails/public_api/configs/single_call/config.py
+++ b/tests/recorded/rails/public_api/configs/single_call/config.py
@@ -13,32 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
-from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
-
-
-class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
-    @property
-    def embedding_size(self):
-        return 0
-
-    def __init__(self):
-        self.items: List[IndexItem] = []
-
-    async def add_item(self, item: IndexItem):
-        self.items.append(item)
-
-    async def add_items(self, items: List[IndexItem]):
-        self.items.extend(items)
-
-    async def build(self):
-        return None
-
-    async def search(self, text: str, max_results: int, threshold=None):
-        normalized = text.lower()
-        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
-        return matches[:max_results] or self.items[:max_results]
+from tests.recorded.rails.public_api.simple_embedding_provider import SimpleEmbeddingSearchProvider
 
 
 def init(app):

--- a/tests/recorded/rails/public_api/configs/single_call/config.py
+++ b/tests/recorded/rails/public_api/configs/single_call/config.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
+
+
+class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
+    @property
+    def embedding_size(self):
+        return 0
+
+    def __init__(self):
+        self.items: List[IndexItem] = []
+
+    async def add_item(self, item: IndexItem):
+        self.items.append(item)
+
+    async def add_items(self, items: List[IndexItem]):
+        self.items.extend(items)
+
+    async def build(self):
+        return None
+
+    async def search(self, text: str, max_results: int, threshold=None):
+        normalized = text.lower()
+        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
+        return matches[:max_results] or self.items[:max_results]
+
+
+def init(app):
+    app.register_embedding_search_provider("simple", SimpleEmbeddingSearchProvider)

--- a/tests/recorded/rails/public_api/configs/single_call/config.yml
+++ b/tests/recorded/rails/public_api/configs/single_call/config.yml
@@ -1,0 +1,13 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+core:
+  embedding_search_provider:
+    name: simple
+rails:
+  dialog:
+    single_call:
+      enabled: true

--- a/tests/recorded/rails/public_api/configs/single_call/rails.co
+++ b/tests/recorded/rails/public_api/configs/single_call/rails.co
@@ -1,0 +1,10 @@
+define user express greeting
+  "hello"
+  "hi"
+
+define bot express greeting
+  "Hello from recorded single call."
+
+define flow
+  user express greeting
+  bot express greeting

--- a/tests/recorded/rails/public_api/configs/streaming_output_rails/config.py
+++ b/tests/recorded/rails/public_api/configs/streaming_output_rails/config.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.actions import action
+
+
+@action(is_system_action=True, output_mapping=lambda result: not result)
+def self_check_streaming_output(context=None, **params):
+    return (context or {}).get("bot_message") != "BLOCK"
+
+
+def init(app):
+    app.register_action(self_check_streaming_output)

--- a/tests/recorded/rails/public_api/configs/streaming_output_rails/config.yml
+++ b/tests/recorded/rails/public_api/configs/streaming_output_rails/config.yml
@@ -1,0 +1,10 @@
+rails:
+  output:
+    flows:
+      - streaming output rail
+    streaming:
+      enabled: true
+      chunk_size: 1
+      context_size: 1
+      stream_first: false
+streaming: true

--- a/tests/recorded/rails/public_api/configs/streaming_output_rails/rails.co
+++ b/tests/recorded/rails/public_api/configs/streaming_output_rails/rails.co
@@ -1,0 +1,2 @@
+define subflow streaming output rail
+  $allowed = execute self_check_streaming_output

--- a/tests/recorded/rails/public_api/configs/task_models/config.py
+++ b/tests/recorded/rails/public_api/configs/task_models/config.py
@@ -13,32 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
-from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
-
-
-class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
-    @property
-    def embedding_size(self):
-        return 0
-
-    def __init__(self):
-        self.items: List[IndexItem] = []
-
-    async def add_item(self, item: IndexItem):
-        self.items.append(item)
-
-    async def add_items(self, items: List[IndexItem]):
-        self.items.extend(items)
-
-    async def build(self):
-        return None
-
-    async def search(self, text: str, max_results: int, threshold=None):
-        normalized = text.lower()
-        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
-        return matches[:max_results] or self.items[:max_results]
+from tests.recorded.rails.public_api.simple_embedding_provider import SimpleEmbeddingSearchProvider
 
 
 def init(app):

--- a/tests/recorded/rails/public_api/configs/task_models/config.py
+++ b/tests/recorded/rails/public_api/configs/task_models/config.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
+
+
+class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
+    @property
+    def embedding_size(self):
+        return 0
+
+    def __init__(self):
+        self.items: List[IndexItem] = []
+
+    async def add_item(self, item: IndexItem):
+        self.items.append(item)
+
+    async def add_items(self, items: List[IndexItem]):
+        self.items.extend(items)
+
+    async def build(self):
+        return None
+
+    async def search(self, text: str, max_results: int, threshold=None):
+        normalized = text.lower()
+        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
+        return matches[:max_results] or self.items[:max_results]
+
+
+def init(app):
+    app.register_embedding_search_provider("simple", SimpleEmbeddingSearchProvider)

--- a/tests/recorded/rails/public_api/configs/task_models/config.yml
+++ b/tests/recorded/rails/public_api/configs/task_models/config.yml
@@ -1,0 +1,19 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+  - type: generate_user_intent
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+  - type: generate_next_steps
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+core:
+  embedding_search_provider:
+    name: simple

--- a/tests/recorded/rails/public_api/configs/task_models/rails.co
+++ b/tests/recorded/rails/public_api/configs/task_models/rails.co
@@ -1,0 +1,10 @@
+define user express greeting
+  "hello"
+  "hi"
+
+define bot express greeting
+  "Hello from recorded task models."
+
+define flow
+  user express greeting
+  bot express greeting

--- a/tests/recorded/rails/public_api/simple_embedding_provider.py
+++ b/tests/recorded/rails/public_api/simple_embedding_provider.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
+
+
+class SimpleEmbeddingSearchProvider(EmbeddingsIndex):
+    @property
+    def embedding_size(self):
+        return 0
+
+    def __init__(self):
+        self.items: List[IndexItem] = []
+
+    async def add_item(self, item: IndexItem):
+        self.items.append(item)
+
+    async def add_items(self, items: List[IndexItem]):
+        self.items.extend(items)
+
+    async def build(self):
+        return None
+
+    async def search(self, text: str, max_results: int, threshold=None):
+        normalized = text.lower()
+        matches = [item for item in self.items if item.text.lower() in normalized or normalized in item.text.lower()]
+        return matches[:max_results] or self.items[:max_results]

--- a/tests/recorded/rails/public_api/test_check.py
+++ b/tests/recorded/rails/public_api/test_check.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from nemoguardrails import LLMRails
+from nemoguardrails.rails.llm.options import RailStatus, RailType
+from tests.recorded.assertions import assert_rails_result
+from tests.recorded.normalization import normalize_rails_result
+from tests.recorded.rails.public_api.configs import (
+    INPUT_OUTPUT_RAILS_CONFIG,
+    INPUT_RAILS_CONFIG,
+    NEMOGUARDS_FULL_CONFIG,
+    OUTPUT_RAILS_CONFIG,
+    PARALLEL_RAILS_CONFIG,
+)
+from tests.recorded.rails_config import RailsConfigSource, load_config
+from tests.recorded.snapshots import snapshot
+
+pytestmark = [pytest.mark.recorded]
+
+
+@dataclass(frozen=True)
+class CheckScenario:
+    id: str
+    config: RailsConfigSource
+    messages: list[dict[str, Any]]
+    status: RailStatus
+    rail: str | None = None
+    content: str | None = None
+    rail_types: tuple[RailType, ...] | None = None
+
+
+SCENARIOS = [
+    CheckScenario(
+        id="input-allowed",
+        config=INPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "allowed input"}],
+        status=RailStatus.PASSED,
+    ),
+    CheckScenario(
+        id="input-blocked",
+        config=INPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "block input"}],
+        status=RailStatus.BLOCKED,
+        rail="input rail",
+    ),
+    CheckScenario(
+        id="input-modified",
+        config=INPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "modify input"}],
+        status=RailStatus.MODIFIED,
+        content="modified input",
+    ),
+    CheckScenario(
+        id="output-allowed",
+        config=OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "assistant", "content": "allowed output"}],
+        status=RailStatus.PASSED,
+    ),
+    CheckScenario(
+        id="output-blocked",
+        config=OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "assistant", "content": "block output"}],
+        status=RailStatus.BLOCKED,
+        rail="output rail",
+    ),
+    CheckScenario(
+        id="output-modified",
+        config=OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "assistant", "content": "modify output"}],
+        status=RailStatus.MODIFIED,
+        content="modified output",
+    ),
+    CheckScenario(
+        id="auto-input",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "block input"}],
+        status=RailStatus.BLOCKED,
+        rail="input rail",
+    ),
+    CheckScenario(
+        id="auto-output",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "assistant", "content": "block output"}],
+        status=RailStatus.BLOCKED,
+        rail="output rail",
+    ),
+    CheckScenario(
+        id="auto-both",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "allowed input"}, {"role": "assistant", "content": "block output"}],
+        status=RailStatus.BLOCKED,
+        rail="output rail",
+    ),
+    CheckScenario(
+        id="explicit-input",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "allowed input"}, {"role": "assistant", "content": "block output"}],
+        status=RailStatus.PASSED,
+        rail_types=(RailType.INPUT,),
+    ),
+    CheckScenario(
+        id="explicit-output",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "block input"}, {"role": "assistant", "content": "allowed output"}],
+        status=RailStatus.PASSED,
+        rail_types=(RailType.OUTPUT,),
+    ),
+    CheckScenario(
+        id="explicit-both",
+        config=INPUT_OUTPUT_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "block input"}, {"role": "assistant", "content": "allowed output"}],
+        status=RailStatus.BLOCKED,
+        rail="input rail",
+        rail_types=(RailType.INPUT, RailType.OUTPUT),
+    ),
+    CheckScenario(
+        id="parallel-pass",
+        config=PARALLEL_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "allowed parallel"}],
+        status=RailStatus.PASSED,
+    ),
+    CheckScenario(
+        id="parallel-block",
+        config=PARALLEL_RAILS_CONFIG,
+        messages=[{"role": "user", "content": "block parallel"}],
+        status=RailStatus.BLOCKED,
+        rail="parallel input rail",
+    ),
+]
+
+
+def _rail_types(scenario: CheckScenario) -> list[RailType] | None:
+    return list(scenario.rail_types) if scenario.rail_types is not None else None
+
+
+def test_check_sync_public_contracts():
+    results = {}
+    for scenario in SCENARIOS:
+        rails = LLMRails(load_config(scenario.config), verbose=False)
+
+        result = rails.check(scenario.messages, rail_types=_rail_types(scenario))
+
+        assert_rails_result(result, status=scenario.status, content=scenario.content, rail=scenario.rail)
+        results[scenario.id] = normalize_rails_result(result)
+
+    assert results == snapshot(
+        {
+            "input-allowed": {"status": "passed", "rail": None, "content": "allowed input"},
+            "input-blocked": {
+                "status": "blocked",
+                "rail": "input rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "input-modified": {"status": "modified", "rail": None, "content": "modified input"},
+            "output-allowed": {"status": "passed", "rail": None, "content": "allowed output"},
+            "output-blocked": {
+                "status": "blocked",
+                "rail": "output rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "output-modified": {"status": "modified", "rail": None, "content": "modified output"},
+            "auto-input": {"status": "blocked", "rail": "input rail", "content": "I'm sorry, I can't respond to that."},
+            "auto-output": {
+                "status": "blocked",
+                "rail": "output rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "auto-both": {"status": "blocked", "rail": "output rail", "content": "I'm sorry, I can't respond to that."},
+            "explicit-input": {"status": "passed", "rail": None, "content": "allowed input"},
+            "explicit-output": {"status": "passed", "rail": None, "content": "allowed output"},
+            "explicit-both": {
+                "status": "blocked",
+                "rail": "input rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "parallel-pass": {"status": "passed", "rail": None, "content": "allowed parallel"},
+            "parallel-block": {
+                "status": "blocked",
+                "rail": "parallel input rail",
+                "content": "Parallel input blocked.",
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_async_public_contracts():
+    results = {}
+    for scenario in SCENARIOS:
+        rails = LLMRails(load_config(scenario.config), verbose=False)
+
+        result = await rails.check_async(scenario.messages, rail_types=_rail_types(scenario))
+
+        assert_rails_result(result, status=scenario.status, content=scenario.content, rail=scenario.rail)
+        results[scenario.id] = normalize_rails_result(result)
+
+    assert results == snapshot(
+        {
+            "input-allowed": {"status": "passed", "rail": None, "content": "allowed input"},
+            "input-blocked": {
+                "status": "blocked",
+                "rail": "input rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "input-modified": {"status": "modified", "rail": None, "content": "modified input"},
+            "output-allowed": {"status": "passed", "rail": None, "content": "allowed output"},
+            "output-blocked": {
+                "status": "blocked",
+                "rail": "output rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "output-modified": {"status": "modified", "rail": None, "content": "modified output"},
+            "auto-input": {"status": "blocked", "rail": "input rail", "content": "I'm sorry, I can't respond to that."},
+            "auto-output": {
+                "status": "blocked",
+                "rail": "output rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "auto-both": {"status": "blocked", "rail": "output rail", "content": "I'm sorry, I can't respond to that."},
+            "explicit-input": {"status": "passed", "rail": None, "content": "allowed input"},
+            "explicit-output": {"status": "passed", "rail": None, "content": "allowed output"},
+            "explicit-both": {
+                "status": "blocked",
+                "rail": "input rail",
+                "content": "I'm sorry, I can't respond to that.",
+            },
+            "parallel-pass": {"status": "passed", "rail": None, "content": "allowed parallel"},
+            "parallel-block": {
+                "status": "blocked",
+                "rail": "parallel input rail",
+                "content": "Parallel input blocked.",
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_nemoguards_full_check_async(nvidia_api_key):
+    rails = LLMRails(load_config(NEMOGUARDS_FULL_CONFIG), verbose=False)
+
+    result = await rails.check_async([{"role": "user", "content": "what can you do?"}])
+
+    assert_rails_result(result, status=RailStatus.PASSED)
+    assert normalize_rails_result(result) == snapshot({"status": "passed", "rail": None, "content": "what can you do?"})
+
+
+@pytest.mark.asyncio
+async def test_check_async_empty_messages_passes():
+    rails = LLMRails(load_config(INPUT_RAILS_CONFIG), verbose=False)
+
+    result = await rails.check_async([])
+
+    assert_rails_result(result, status=RailStatus.PASSED, content="")
+    assert normalize_rails_result(result) == snapshot({"status": "passed", "rail": None, "content": ""})

--- a/tests/recorded/rails/public_api/test_check.py
+++ b/tests/recorded/rails/public_api/test_check.py
@@ -152,16 +152,7 @@ def _rail_types(scenario: CheckScenario) -> list[RailType] | None:
     return list(scenario.rail_types) if scenario.rail_types is not None else None
 
 
-def test_check_sync_public_contracts():
-    results = {}
-    for scenario in SCENARIOS:
-        rails = LLMRails(load_config(scenario.config), verbose=False)
-
-        result = rails.check(scenario.messages, rail_types=_rail_types(scenario))
-
-        assert_rails_result(result, status=scenario.status, content=scenario.content, rail=scenario.rail)
-        results[scenario.id] = normalize_rails_result(result)
-
+def _assert_check_contract_results(results: dict[str, dict[str, Any]]) -> None:
     assert results == snapshot(
         {
             "input-allowed": {"status": "passed", "rail": None, "content": "allowed input"},
@@ -200,6 +191,19 @@ def test_check_sync_public_contracts():
             },
         }
     )
+
+
+def test_check_sync_public_contracts():
+    results = {}
+    for scenario in SCENARIOS:
+        rails = LLMRails(load_config(scenario.config), verbose=False)
+
+        result = rails.check(scenario.messages, rail_types=_rail_types(scenario))
+
+        assert_rails_result(result, status=scenario.status, content=scenario.content, rail=scenario.rail)
+        results[scenario.id] = normalize_rails_result(result)
+
+    _assert_check_contract_results(results)
 
 
 @pytest.mark.asyncio
@@ -213,44 +217,7 @@ async def test_check_async_public_contracts():
         assert_rails_result(result, status=scenario.status, content=scenario.content, rail=scenario.rail)
         results[scenario.id] = normalize_rails_result(result)
 
-    assert results == snapshot(
-        {
-            "input-allowed": {"status": "passed", "rail": None, "content": "allowed input"},
-            "input-blocked": {
-                "status": "blocked",
-                "rail": "input rail",
-                "content": "I'm sorry, I can't respond to that.",
-            },
-            "input-modified": {"status": "modified", "rail": None, "content": "modified input"},
-            "output-allowed": {"status": "passed", "rail": None, "content": "allowed output"},
-            "output-blocked": {
-                "status": "blocked",
-                "rail": "output rail",
-                "content": "I'm sorry, I can't respond to that.",
-            },
-            "output-modified": {"status": "modified", "rail": None, "content": "modified output"},
-            "auto-input": {"status": "blocked", "rail": "input rail", "content": "I'm sorry, I can't respond to that."},
-            "auto-output": {
-                "status": "blocked",
-                "rail": "output rail",
-                "content": "I'm sorry, I can't respond to that.",
-            },
-            "auto-both": {"status": "blocked", "rail": "output rail", "content": "I'm sorry, I can't respond to that."},
-            "explicit-input": {"status": "passed", "rail": None, "content": "allowed input"},
-            "explicit-output": {"status": "passed", "rail": None, "content": "allowed output"},
-            "explicit-both": {
-                "status": "blocked",
-                "rail": "input rail",
-                "content": "I'm sorry, I can't respond to that.",
-            },
-            "parallel-pass": {"status": "passed", "rail": None, "content": "allowed parallel"},
-            "parallel-block": {
-                "status": "blocked",
-                "rail": "parallel input rail",
-                "content": "Parallel input blocked.",
-            },
-        }
-    )
+    _assert_check_contract_results(results)
 
 
 @pytest.mark.asyncio

--- a/tests/recorded/rails/public_api/test_dialog.py
+++ b/tests/recorded/rails/public_api/test_dialog.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from nemoguardrails import LLMRails
+from nemoguardrails.rails.llm.options import RailStatus
+from tests.recorded.assertions import assert_generated_message, assert_rails_result
+from tests.recorded.normalization import normalize_rails_result
+from tests.recorded.rails.public_api.configs import DIALOG_CONFIG, SINGLE_CALL_CONFIG
+from tests.recorded.rails_config import load_config
+from tests.recorded.snapshots import snapshot
+
+pytestmark = [pytest.mark.recorded, pytest.mark.asyncio]
+
+
+@pytest.mark.vcr
+async def test_dialog_generate_async_public_contract(openai_api_key):
+    rails = LLMRails(load_config(DIALOG_CONFIG), verbose=False)
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "hello"}])
+
+    assert_generated_message(result)
+    assert result == snapshot(
+        {
+            "role": "assistant",
+            "content": "Hello! How can I assist you today?",
+        }
+    )
+
+
+@pytest.mark.vcr
+async def test_single_call_generate_async_public_contract(openai_api_key):
+    rails = LLMRails(load_config(SINGLE_CALL_CONFIG), verbose=False)
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "hello"}])
+
+    assert_generated_message(result)
+    assert result == snapshot(
+        {
+            "role": "assistant",
+            "content": """\
+bot express greeting
+"Hello again! 😊 How can I assist you today?"\
+""",
+        }
+    )
+
+
+async def test_single_call_check_async_without_io_rails():
+    rails = LLMRails(load_config(SINGLE_CALL_CONFIG), verbose=False)
+
+    result = await rails.check_async([{"role": "user", "content": "hello"}])
+
+    assert_rails_result(result, status=RailStatus.PASSED, content="hello")
+    assert normalize_rails_result(result) == snapshot({"status": "passed", "rail": None, "content": "hello"})

--- a/tests/recorded/rails/public_api/test_generate.py
+++ b/tests/recorded/rails/public_api/test_generate.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from nemoguardrails import LLMRails
+from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.rails.llm.options import GenerationResponse
+from tests.recorded.assertions import (
+    assert_generated_message,
+    assert_generated_text,
+    assert_llm_call_usage,
+    assert_runtime_model_matches,
+)
+from tests.recorded.cassette import recorded_chat_response
+from tests.recorded.normalization import normalize_generation_response
+from tests.recorded.rails.public_api.configs import (
+    NEMOGUARDS_FULL_CONFIG,
+    NIM_BASELINE_CONFIG,
+    NIM_MODEL,
+    OPENAI_BASELINE_CONFIG,
+    OPENAI_INVALID_MODEL_CONFIG,
+    OPENAI_MODEL,
+    OUTPUT_RAILS_CONFIG,
+)
+from tests.recorded.rails_config import load_config
+from tests.recorded.snapshots import snapshot
+from tests.utils import FakeLLMModel
+
+pytestmark = [pytest.mark.recorded]
+
+
+@pytest.mark.vcr
+def test_openai_generate_sync_public_contract(openai_api_key):
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), verbose=False)
+
+    result = rails.generate(prompt="Say a short safe greeting.")
+
+    assert_generated_text(result)
+    assert result == snapshot("Hello! How can I help you today?")
+
+
+@pytest.mark.vcr
+def test_nim_generate_sync_public_contract(nvidia_api_key):
+    rails = LLMRails(load_config(NIM_BASELINE_CONFIG), verbose=False)
+
+    result = rails.generate(messages=[{"role": "user", "content": "Say hello in one short sentence."}])
+
+    assert_generated_message(result)
+    assert result == snapshot(
+        {
+            "role": "assistant",
+            "content": """\
+<think>Hmm, the user asked me to say hello in one short sentence. That seems straightforward--they want a simple, friendly greeting. \n\
+
+I should keep it concise and warm, matching the "one short sentence" request. No extra fluff. \n\
+
+The user might be testing if I can follow instructions precisely, or maybe they just need a quick, cheerful response to start a conversation. \n\
+
+I'll go with "Hello! How can I assist you today?"--it's polite, open-ended, and fits perfectly in one sentence. \n\
+
+No need to overthink it; they kept it simple, so I'll keep my reply simple too.
+</think>
+Hello! How can I assist you today?\
+""",
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_openai_generate_async_public_contract(openai_api_key):
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), verbose=False)
+
+    result = await rails.generate_async(prompt="Say a short safe greeting.")
+
+    assert_generated_text(result)
+    assert result == snapshot("Hello! How can I help you today?")
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_nim_generate_async_public_contract(nvidia_api_key):
+    rails = LLMRails(load_config(NIM_BASELINE_CONFIG), verbose=False)
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "Say hello in one short sentence."}])
+
+    assert_generated_message(result)
+    assert result == snapshot(
+        {
+            "role": "assistant",
+            "content": """\
+<think>Okay, user just said "Say hello in one short sentence." Hmm, seems like a simple greeting task but let's unpack it. \n\
+
+First, they want a *short* sentence - so no fluff. "Hello" itself is already short but maybe too bare? Wait, they said "in one short sentence" so the response should be a greeting, not just the word "hello". \n\
+
+Noticing they used "Say hello" which is a command, so they're probably expecting me to actually say something like "Hi!" or "Hello!" but... wait, the instruction says "in one short sentence" meaning the whole response must be one sentence. \n\
+
+*checks own capabilities* \n\
+Can't do "Hi." because that's just a word. Needs to be a full sentence. "Hello!" is technically a sentence fragment but... wait, in English we often say "Hello!" as a greeting. But the user said "one short sentence" so maybe they want something grammatically complete? \n\
+
+*thinks of options* \n\
+- "Hello!" (too short, not a full sentence) \n\
+- "Hi there!" (better but still fragment) \n\
+- "Hello! How are you?" (too long) \n\
+
+Ah! The most natural short sentence is just "Hello!" but technically it's an interjection. Wait, no - in common usage, we say "Hello" as a greeting and it's considered a sentence. Like "Hello!" as a standalone utterance. \n\
+
+*double-checks user request* \n\
+"Say hello in one short sentence" - so the response should be a sentence that says hello. The simplest answer is literally "Hello!" but to make it a sentence... wait, maybe they just want the greeting word. \n\
+
+*considers user's possible intent* \n\
+They might be testing if I follow instructions precisely. Or maybe non-native speaker wanting to practice English greetings. \n\
+
+*decides* \n\
+The safest, most direct answer is "Hello!" - it's the standard greeting, exactly one short sentence (as a greeting phrase), and meets "one short sentence" requirement. No extra words. \n\
+
+*verifies length* \n\
+"Hello!" is 6 characters, one word, one sentence. Perfect. \n\
+
+*confirms no other interpretation* \n\
+They didn't ask for creative greeting or anything else. Just "say hello" as instruction. So no need to overthink. \n\
+
+Final decision: Respond with "Hello!" as the greeting.
+</think>
+Hello!\
+""",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_rails_generate_async_blocks_fake_main_output():
+    rails = LLMRails(load_config(OUTPUT_RAILS_CONFIG), llm=FakeLLMModel(responses=["block output"]), verbose=False)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "Say something."}],
+        options={"log": {"activated_rails": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert normalize_generation_response(result) == snapshot(
+        {
+            "response": [{"role": "assistant", "content": "I'm sorry, I can't respond to that."}],
+            "activated_rails": [
+                {
+                    "type": "generation",
+                    "name": "generate user intent",
+                    "decisions": ["execute generate_user_intent"],
+                    "stop": False,
+                },
+                {
+                    "type": "output",
+                    "name": "output rail",
+                    "decisions": [
+                        "refuse to respond",
+                        "execute retrieve_relevant_chunks",
+                        "execute generate_bot_message",
+                        "stop",
+                    ],
+                    "stop": True,
+                },
+            ],
+            "llm_calls": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_rails_generate_async_modifies_fake_main_output():
+    rails = LLMRails(load_config(OUTPUT_RAILS_CONFIG), llm=FakeLLMModel(responses=["modify output"]), verbose=False)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "Say something."}],
+        options={"log": {"activated_rails": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert normalize_generation_response(result) == snapshot(
+        {
+            "response": [{"role": "assistant", "content": "modified output"}],
+            "activated_rails": [
+                {
+                    "type": "generation",
+                    "name": "generate user intent",
+                    "decisions": ["execute generate_user_intent"],
+                    "stop": False,
+                },
+                {"type": "output", "name": "output rail", "decisions": [], "stop": False},
+            ],
+            "llm_calls": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_openai_generate_async_log_matches_recorded_chat_completion(
+    openai_api_key, record_mode, recorded_cassette_path
+):
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), verbose=False)
+
+    result = await rails.generate_async(
+        prompt="Say a short safe greeting.",
+        options={"log": {"llm_calls": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert_generated_text(result.response)
+    assert result.log is not None
+    assert result.log.llm_calls is not None
+    assert len(result.log.llm_calls) == 1
+
+    llm_call = result.log.llm_calls[0]
+    assert llm_call.llm_provider_name == "openai"
+
+    if record_mode == "none":
+        expected = recorded_chat_response(recorded_cassette_path, request_model=OPENAI_MODEL)
+        assert expected.raw_usage is not None
+        assert expected.finish_reason == "stop"
+        assert expected.request_id
+        assert result.response == expected.content
+        assert llm_call.completion == expected.content
+        assert_llm_call_usage(llm_call, expected)
+        assert_runtime_model_matches(llm_call, configured_model=OPENAI_MODEL, recorded_model=expected.model)
+
+    assert normalize_generation_response(result) == snapshot(
+        {
+            "response": "Hello! How are you today?",
+            "activated_rails": [],
+            "llm_calls": [
+                {
+                    "task": "general",
+                    "provider": "openai",
+                    "model": "gpt-5.4-nano",
+                    "completion": "Hello! How are you today?",
+                    "prompt_tokens": 12,
+                    "completion_tokens": 10,
+                    "total_tokens": 22,
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_nim_generate_async_log_matches_recorded_usage(nvidia_api_key, record_mode, recorded_cassette_path):
+    rails = LLMRails(load_config(NIM_BASELINE_CONFIG), verbose=False)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "Say hello in one short sentence."}],
+        options={"log": {"llm_calls": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response
+    assert isinstance(result.response, list)
+    response = result.response
+    assert_generated_message(response[-1])
+    assert result.log is not None
+    assert result.log.llm_calls is not None
+    assert len(result.log.llm_calls) == 1
+
+    llm_call = result.log.llm_calls[0]
+    assert llm_call.llm_provider_name == "nim"
+
+    if record_mode == "none":
+        expected = recorded_chat_response(recorded_cassette_path, request_model=NIM_MODEL)
+        assert expected.raw_usage is not None
+        assert expected.finish_reason == "stop"
+        assert expected.request_id
+        assert response[-1]["content"] == expected.content
+        assert llm_call.completion == expected.content
+        assert_llm_call_usage(llm_call, expected)
+        assert_runtime_model_matches(llm_call, configured_model=NIM_MODEL, recorded_model=expected.model)
+
+    assert normalize_generation_response(result) == snapshot(
+        {
+            "response": [{"role": "assistant", "content": "Hello."}],
+            "activated_rails": [],
+            "llm_calls": [
+                {
+                    "task": "general",
+                    "provider": "nim",
+                    "model": "nvidia/nemotron-3-nano-30b-a3b",
+                    "completion": "Hello.",
+                    "prompt_tokens": 23,
+                    "completion_tokens": 57,
+                    "total_tokens": 80,
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_nemoguards_full_generate_async(nvidia_api_key):
+    rails = LLMRails(load_config(NEMOGUARDS_FULL_CONFIG), verbose=False)
+
+    result = await rails.generate_async(prompt="what can you do?")
+
+    assert_generated_text(result)
+    assert result == snapshot("""\
+<think>We need to respond as the AI assistant, talkative, specific details. Explain capabilities.
+</think>
+I'm a versatile, conversational AI that can help you with a wide range of tasks. Here's a quick snapshot of what I can do:
+
+### 1. Answer Questions & Explain Concepts  \n\
+- **General knowledge:** From "What's the capital of Mongolia?" to "Why does the sky appear blue?" I can dig up facts, provide concise explanations, or dive deep into scientific, historical, or cultural topics.  \n\
+- **Technical subjects:** Need a rundown of how a transformer-based language model works, or how to write a Python script that parses CSV files? I've got you covered.
+
+### 2. Write & Edit Content  \n\
+- **Creative writing:** Short stories, poetry, dialogue snippets, world-building lore--just let me know the tone or theme you're after.  \n\
+- **Professional writing:** Reports, proposals, emails, resumes, cover letters, blog posts, marketing copy, SVG or Markdown files, etc. I can polish the language, tighten structure, or generate drafts from scratch.  \n\
+- **Academic help:** Essays, literature reviews, problem-sets, math derivations, lab write-ups--always with proper citations and a clear logical flow.
+
+### 3. Coding & Programming  \n\
+- **Multiple languages:** Python, JavaScript, Java, C++, Rust, SQL, HTML/CSS, Bash, and more.  \n\
+- **Debugging & troubleshooting:** Paste a traceback or describe an error, and I'll suggest fixes.  \n\
+- **Algorithms & data structures:** Explain concepts, sketch implementations, or provide ready-to-run snippets.  \n\
+- **Web development:** Build static pages, set up a simple Flask/Django app, or draft a React component.  \n\
+- **Automation scripts:** Generating batch files, cron-job ideas, Selenium scripts, REST-API calls, etc.
+
+### 4. Learning & Tutoring  \n\
+- **Step-by-step guidance:** From "How do I factor a quadratic?" to "Explain the basics of Bayesian inference."  \n\
+- **Practice problems:** Generate quizzes, flashcards, or worked examples tailored to your skill level.  \n\
+- **Study strategies:** Time-management tips, note-taking methods, exam-prep plans--whatever helps you retain information better.
+
+### 5. Brainstorming & Planning  \n\
+- **Idea generation:** Product concepts, story outlines, research topics, party themes, travel itineraries, you name it.  \n\
+- **Project planning:** Create timelines, break down tasks, suggest resources, or draft Gantt-style outlines.  \n\
+- **Decision support:** Compare pros/cons, run simple cost-benefit analyses, or help you weigh options with hypothetical scenarios.
+
+### 6. Simulations & Role-Play  \n\
+- **Conversation practice:** Want to simulate a job interview, a negotiation, or a language-learning dialogue? I can adopt various personas and give feedback.  \n\
+- **Scenario exploration:** "What if humanity discovered cheap fusion energy tomorrow?" - I'll flesh out plausible outcomes, societal impacts, and technical hurdles.  \n\
+- **Role-play exercises:** For language learning, public-speaking practice, or team-building scenarios.
+
+### 7. Personal Assistance (within my limits)  \n\
+- **Time-management tips:** Prioritization frameworks, Pomodoro tricks, habit-forming advice.  \n\
+- **Health & wellness pointers:** General nutrition info, stress-relief techniques, simple workout concepts--but always remind you to consult a professional for medical or fitness plans.  \n\
+- **Creative hobbies:** Suggest pottery techniques, knitting patterns, photography settings, or DIY home-improvement projects.
+
+### 8. Fun & Entertainment  \n\
+- **Trivia & puzzles:** Riddles, logic puzzles, lateral-thinking challenges, or quick brain teasers.  \n\
+- **Games:** Text-based adventure stories, word games, or simple multiplayer scenarios.  \n\
+- **Jokes, memes, and riddles:** Fresh material on demand--just ask!
+
+---
+
+#### How to Get the Most Out of Me  \n\
+1. **Be specific:** The more detail you give about what you need, the better I can tailor the response.  \n\
+2. **Iterate:** If the first answer isn't perfect, tell me what to adjust--more depth, a different tone, extra examples, etc.  \n\
+3. **Ask follow-ups:** I can drill down into sub-topics, clarify jargon, or expand on any point you find interesting.
+
+---
+
+If you have a particular project, question, or just want to explore something new, swing it my way--I'm ready to dive in! 🚀\
+""")
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_openai_generate_async_invalid_model_raises(openai_api_key):
+    rails = LLMRails(load_config(OPENAI_INVALID_MODEL_CONFIG), verbose=False)
+
+    with pytest.raises(LLMCallException) as exc_info:
+        await rails.generate_async(prompt="Say a short safe greeting.")
+    assert getattr(exc_info.value.inner_exception, "status_code", None) == 404
+
+
+@pytest.mark.asyncio
+async def test_generate_async_without_prompt_or_messages_raises():
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), llm=FakeLLMModel(responses=["unused"]), verbose=False)
+
+    with pytest.raises(ValueError, match="Either prompt or messages must be provided"):
+        await rails.generate_async()
+
+
+@pytest.mark.asyncio
+async def test_generate_async_with_prompt_and_messages_raises():
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), llm=FakeLLMModel(responses=["unused"]), verbose=False)
+
+    with pytest.raises(ValueError, match="Only one of prompt or messages can be provided"):
+        await rails.generate_async(prompt="hi", messages=[{"role": "user", "content": "hi"}])

--- a/tests/recorded/rails/public_api/test_requests.py
+++ b/tests/recorded/rails/public_api/test_requests.py
@@ -20,15 +20,17 @@ from typing import Any
 
 import pytest
 
-from nemoguardrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
 from tests.recorded.assertions import (
     assert_generated_message,
+    assert_generation_response,
+    assert_llm_tasks,
     assert_request_payload,
     assert_stream_contract,
 )
 from tests.recorded.conftest import provider_key
 from tests.recorded.normalization import normalize_generation_response, normalize_stream_chunks
+from tests.recorded.rails.helpers import build_rails
 from tests.recorded.rails.public_api.configs import (
     NIM_BASELINE_CONFIG,
     NIM_MODEL,
@@ -36,7 +38,7 @@ from tests.recorded.rails.public_api.configs import (
     OPENAI_MODEL,
     TASK_MODELS_CONFIG,
 )
-from tests.recorded.rails_config import RailsConfigSource, load_config
+from tests.recorded.rails_config import RailsConfigSource
 from tests.recorded.snapshots import snapshot
 
 pytestmark = [pytest.mark.recorded, pytest.mark.vcr, pytest.mark.asyncio]
@@ -89,7 +91,7 @@ NIM_SCENARIO = SCENARIOS[1]
 
 async def _run_generate_request(request, record_mode, recorded_cassette_path, scenario):
     provider_key(request, scenario.provider)
-    rails = LLMRails(load_config(scenario.config), verbose=False)
+    rails = build_rails(scenario.config)
 
     result = await rails.generate_async(
         messages=[{"role": "user", "content": "Reply with one short greeting."}],
@@ -123,7 +125,7 @@ async def test_nim_llm_params_generate_async_request(request, record_mode, recor
 
 async def _run_stream_request(request, record_mode, recorded_cassette_path, scenario):
     provider_key(request, scenario.provider)
-    rails = LLMRails(load_config(scenario.config), verbose=False)
+    rails = build_rails(scenario.config)
 
     chunks = []
     async for chunk in rails.stream_async(
@@ -157,19 +159,15 @@ async def test_nim_llm_params_stream_async_request(request, record_mode, recorde
 
 
 async def test_task_specific_models_generate_async(openai_api_key, record_mode, recorded_cassette_path):
-    rails = LLMRails(load_config(TASK_MODELS_CONFIG), verbose=False)
+    rails = build_rails(TASK_MODELS_CONFIG)
 
     result = await rails.generate_async(
         messages=[{"role": "user", "content": "hello"}],
         options={"log": {"llm_calls": True}},
     )
 
-    assert isinstance(result, GenerationResponse)
-    assert result.response
-    assert result.log is not None
-    assert result.log.llm_calls is not None
-    tasks = {call.task for call in result.log.llm_calls}
-    assert "generate_user_intent" in tasks
+    assert_generation_response(result)
+    assert_llm_tasks(result, {"generate_user_intent"})
     if record_mode == "none":
         assert_request_payload(recorded_cassette_path, model=OPENAI_MODEL)
     assert normalize_generation_response(result) == snapshot(

--- a/tests/recorded/rails/public_api/test_requests.py
+++ b/tests/recorded/rails/public_api/test_requests.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from nemoguardrails import LLMRails
+from nemoguardrails.rails.llm.options import GenerationResponse
+from tests.recorded.assertions import (
+    assert_generated_message,
+    assert_request_payload,
+    assert_stream_contract,
+)
+from tests.recorded.conftest import provider_key
+from tests.recorded.normalization import normalize_generation_response, normalize_stream_chunks
+from tests.recorded.rails.public_api.configs import (
+    NIM_BASELINE_CONFIG,
+    NIM_MODEL,
+    OPENAI_BASELINE_CONFIG,
+    OPENAI_MODEL,
+    TASK_MODELS_CONFIG,
+)
+from tests.recorded.rails_config import RailsConfigSource, load_config
+from tests.recorded.snapshots import snapshot
+
+pytestmark = [pytest.mark.recorded, pytest.mark.vcr, pytest.mark.asyncio]
+
+
+@dataclass(frozen=True)
+class LLMParamScenario:
+    id: str
+    provider: str
+    config: RailsConfigSource
+    model: str
+    llm_params: dict[str, Any]
+    expected_params: dict[str, Any]
+    absent_params: set[str]
+
+
+SCENARIOS = [
+    LLMParamScenario(
+        id="openai",
+        provider="openai",
+        config=OPENAI_BASELINE_CONFIG,
+        model=OPENAI_MODEL,
+        llm_params={"temperature": 0.0, "max_tokens": 8},
+        expected_params={"max_completion_tokens": 8},
+        absent_params={"temperature", "max_tokens"},
+    ),
+    LLMParamScenario(
+        id="nim",
+        provider="nim",
+        config=NIM_BASELINE_CONFIG,
+        model=NIM_MODEL,
+        llm_params={
+            "temperature": 0.0,
+            "max_tokens": 32,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        expected_params={
+            "temperature": 0.0,
+            "max_tokens": 32,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        absent_params=set(),
+    ),
+]
+
+
+OPENAI_SCENARIO = SCENARIOS[0]
+NIM_SCENARIO = SCENARIOS[1]
+
+
+async def _run_generate_request(request, record_mode, recorded_cassette_path, scenario):
+    provider_key(request, scenario.provider)
+    rails = LLMRails(load_config(scenario.config), verbose=False)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "Reply with one short greeting."}],
+        options={"llm_params": scenario.llm_params},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response
+    assert_generated_message(result.response[-1])
+    if record_mode == "none":
+        assert_request_payload(
+            recorded_cassette_path,
+            model=scenario.model,
+            expected_params=scenario.expected_params,
+            absent_params=scenario.absent_params,
+        )
+    return normalize_generation_response(result)
+
+
+async def test_openai_llm_params_generate_async_request(request, record_mode, recorded_cassette_path):
+    assert await _run_generate_request(request, record_mode, recorded_cassette_path, OPENAI_SCENARIO) == snapshot(
+        {"response": [{"role": "assistant", "content": "Hello!"}], "activated_rails": [], "llm_calls": []}
+    )
+
+
+async def test_nim_llm_params_generate_async_request(request, record_mode, recorded_cassette_path):
+    assert await _run_generate_request(request, record_mode, recorded_cassette_path, NIM_SCENARIO) == snapshot(
+        {"response": [{"role": "assistant", "content": "Hello!"}], "activated_rails": [], "llm_calls": []}
+    )
+
+
+async def _run_stream_request(request, record_mode, recorded_cassette_path, scenario):
+    provider_key(request, scenario.provider)
+    rails = LLMRails(load_config(scenario.config), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "Reply with one short greeting."}],
+        options={"llm_params": scenario.llm_params},
+    ):
+        chunks.append(chunk)
+
+    assert_stream_contract(chunks, expect_multiple=False)
+    if record_mode == "none":
+        assert_request_payload(
+            recorded_cassette_path,
+            model=scenario.model,
+            stream=True,
+            expected_params=scenario.expected_params,
+            absent_params=scenario.absent_params,
+        )
+    return normalize_stream_chunks(chunks)
+
+
+async def test_openai_llm_params_stream_async_request(request, record_mode, recorded_cassette_path):
+    assert await _run_stream_request(request, record_mode, recorded_cassette_path, OPENAI_SCENARIO) == snapshot(
+        {"content": "Hello!", "chunks": ["", "Hello", "!", "", ""], "errors": []}
+    )
+
+
+async def test_nim_llm_params_stream_async_request(request, record_mode, recorded_cassette_path):
+    assert await _run_stream_request(request, record_mode, recorded_cassette_path, NIM_SCENARIO) == snapshot(
+        {"content": "Hello!", "chunks": ["", "Hello", "!", ""], "errors": []}
+    )
+
+
+async def test_task_specific_models_generate_async(openai_api_key, record_mode, recorded_cassette_path):
+    rails = LLMRails(load_config(TASK_MODELS_CONFIG), verbose=False)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "hello"}],
+        options={"log": {"llm_calls": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response
+    assert result.log is not None
+    assert result.log.llm_calls is not None
+    tasks = {call.task for call in result.log.llm_calls}
+    assert "generate_user_intent" in tasks
+    if record_mode == "none":
+        assert_request_payload(recorded_cassette_path, model=OPENAI_MODEL)
+    assert normalize_generation_response(result) == snapshot(
+        {
+            "response": [{"role": "assistant", "content": "Hi! 👋 How can I help you today?"}],
+            "activated_rails": [],
+            "llm_calls": [
+                {
+                    "task": "generate_user_intent",
+                    "provider": "openai",
+                    "model": "gpt-5.4-nano",
+                    "completion": "Hello! How can I assist you today?",
+                    "prompt_tokens": 568,
+                    "completion_tokens": 12,
+                    "total_tokens": 580,
+                },
+                {
+                    "task": "generate_next_steps",
+                    "provider": "openai",
+                    "model": "gpt-5.4-nano",
+                    "completion": "Hello! 👋 How can I assist you today?",
+                    "prompt_tokens": 228,
+                    "completion_tokens": 14,
+                    "total_tokens": 242,
+                },
+                {
+                    "task": "generate_bot_message",
+                    "provider": "openai",
+                    "model": "gpt-5.4-nano",
+                    "completion": "Hi! 👋 How can I help you today?",
+                    "prompt_tokens": 678,
+                    "completion_tokens": 14,
+                    "total_tokens": 692,
+                },
+            ],
+        }
+    )

--- a/tests/recorded/rails/public_api/test_stream.py
+++ b/tests/recorded/rails/public_api/test_stream.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from nemoguardrails import LLMRails
+from nemoguardrails.exceptions import StreamingNotSupportedError
+from tests.recorded.assertions import (
+    assert_blocked_stream_error,
+    assert_llm_call_usage,
+    assert_no_stream_error,
+    assert_runtime_model_matches,
+    assert_stream_contract,
+)
+from tests.recorded.cassette import recorded_chat_response
+from tests.recorded.normalization import normalize_stream_chunks
+from tests.recorded.rails.public_api.configs import (
+    NIM_BASELINE_CONFIG,
+    OPENAI_BASELINE_CONFIG,
+    OPENAI_MODEL,
+    STREAMING_DISABLED_CONFIG,
+    STREAMING_OUTPUT_RAILS_CONFIG,
+)
+from tests.recorded.rails_config import load_config
+from tests.recorded.snapshots import snapshot
+
+pytestmark = [pytest.mark.recorded, pytest.mark.asyncio]
+
+
+async def _chunks(values: list[str]) -> AsyncIterator[str]:
+    for value in values:
+        yield value
+
+
+@pytest.mark.vcr
+async def test_openai_stream_async_public_contract(openai_api_key):
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(prompt="Say hello in a few words."):
+        chunks.append(chunk)
+
+    assert_stream_contract(chunks, expect_multiple=False)
+    assert_no_stream_error(chunks)
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {"content": "Hello there! 👋", "chunks": ["", "Hello", " there", "!", " 👋", "", ""], "errors": []}
+    )
+
+
+@pytest.mark.vcr
+async def test_nim_stream_async_public_contract(nvidia_api_key):
+    rails = LLMRails(load_config(NIM_BASELINE_CONFIG), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(messages=[{"role": "user", "content": "Say hello in a few words."}]):
+        chunks.append(chunk)
+
+    assert_stream_contract(chunks, expect_multiple=False)
+    assert_no_stream_error(chunks)
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {
+            "content": "Hello! 😊",
+            "chunks": [
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "Hello! 😊",
+                "",
+            ],
+            "errors": [],
+        }
+    )
+
+
+@pytest.mark.vcr
+async def test_stream_async_matches_recorded_chat_completion_metadata(
+    openai_api_key, record_mode, recorded_cassette_path
+):
+    rails = LLMRails(load_config(OPENAI_BASELINE_CONFIG), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(prompt="Say hello in a few words.", include_metadata=True):
+        chunks.append(chunk)
+
+    assert chunks
+    assert all(isinstance(chunk, dict) for chunk in chunks)
+    content = "".join(chunk["text"] for chunk in chunks if isinstance(chunk.get("text"), str))
+    assert content.strip()
+
+    if record_mode == "none":
+        expected = recorded_chat_response(
+            recorded_cassette_path,
+            request_model=OPENAI_MODEL,
+            stream=True,
+        )
+        assert expected.raw_usage is not None
+        assert expected.finish_reason == "stop"
+        assert expected.request_id
+        assert content == expected.content
+
+        usage_chunks = [chunk for chunk in chunks if chunk.get("metadata", {}).get("usage")]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0]["metadata"]["usage"] == {
+            "input_tokens": expected.usage["input_tokens"],
+            "output_tokens": expected.usage["output_tokens"],
+            "total_tokens": expected.usage["total_tokens"],
+        }
+
+        llm_calls = rails.explain().llm_calls
+        assert len(llm_calls) == 1
+        llm_call = llm_calls[0]
+        assert llm_call.completion == expected.content
+        assert llm_call.llm_provider_name == "openai"
+        assert_llm_call_usage(llm_call, expected)
+        assert_runtime_model_matches(llm_call, configured_model=OPENAI_MODEL, recorded_model=expected.model)
+
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {
+            "content": "Hello there! 👋",
+            "chunks": [
+                {"text": ""},
+                {"text": "Hello"},
+                {"text": " there"},
+                {"text": "!"},
+                {"text": " 👋"},
+                {"text": ""},
+                {"text": "", "usage": {"input_tokens": 13, "output_tokens": 8, "total_tokens": 21}},
+                {"text": ""},
+            ],
+            "errors": [],
+        }
+    )
+
+
+async def test_streaming_output_rails_allowed():
+    rails = LLMRails(load_config(STREAMING_OUTPUT_RAILS_CONFIG), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "stream"}],
+        generator=_chunks(["Hello", " ", "there"]),
+    ):
+        chunks.append(chunk)
+
+    assert_stream_contract(chunks)
+    assert_no_stream_error(chunks)
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {"content": "Hello there", "chunks": ["Hello", " ", "there"], "errors": []}
+    )
+
+
+async def test_streaming_output_rails_blocked():
+    rails = LLMRails(load_config(STREAMING_OUTPUT_RAILS_CONFIG), verbose=False)
+
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "stream"}],
+        generator=_chunks(["BLOCK"]),
+    ):
+        chunks.append(chunk)
+
+    assert_blocked_stream_error(chunks)
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {
+            "content": "",
+            "chunks": [
+                '{"error": {"message": "Blocked by streaming output rail rails.", "type": "guardrails_violation", "param": "streaming output rail", "code": "content_blocked"}}'
+            ],
+            "errors": [
+                {
+                    "error": {
+                        "message": "Blocked by streaming output rail rails.",
+                        "type": "guardrails_violation",
+                        "param": "streaming output rail",
+                        "code": "content_blocked",
+                    }
+                }
+            ],
+        }
+    )
+
+
+async def test_streaming_output_rails_disabled_validation():
+    rails = LLMRails(load_config(STREAMING_DISABLED_CONFIG), verbose=False)
+
+    with pytest.raises(StreamingNotSupportedError):
+        async for _ in rails.stream_async(
+            messages=[{"role": "user", "content": "stream"}],
+            generator=_chunks(["Hello"]),
+        ):
+            pass

--- a/tests/recorded/test_recorded_helpers.py
+++ b/tests/recorded/test_recorded_helpers.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from nemoguardrails import LLMRails
+from tests.recorded.assertions import assert_stream_contract
+from tests.recorded.rails.public_api.configs import INPUT_RAILS_CONFIG
+from tests.recorded.rails_config import load_config
+
+pytestmark = [pytest.mark.recorded]
+
+
+def test_load_config_returns_fresh_copy_when_llmrails_mutates_config():
+    config = load_config(INPUT_RAILS_CONFIG)
+    original_flow_count = len(config.flows)
+
+    LLMRails(config, verbose=False)
+
+    assert len(config.flows) > original_flow_count
+    assert len(load_config(INPUT_RAILS_CONFIG).flows) == original_flow_count
+
+
+def test_assert_stream_contract_accepts_metadata_text_chunks():
+    assert assert_stream_contract([{"text": "Hello", "metadata": {"usage": {}}}], expect_multiple=False) == "Hello"

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -733,6 +733,29 @@ async def test_metadata_accumulation_across_chunks():
 
 
 @pytest.mark.asyncio
+async def test_raw_usage_metadata_chunk_is_not_repeated_on_final_chunk():
+    streaming_handler = StreamingHandler(include_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+    usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+    try:
+        await streaming_handler.push_chunk("Hello")
+        await streaming_handler.push_chunk("", metadata={"usage": usage})
+        await streaming_handler.push_chunk(None)
+
+        chunks = await streaming_consumer.get_chunks()
+        usage_chunks = [chunk for chunk in chunks if chunk.get("metadata", {}).get("usage")]
+
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0]["metadata"]["usage"] == usage
+        assert "usage" not in chunks[-1]["metadata"]
+        assert chunks[-1]["metadata"]["response_metadata"] is None
+        assert chunks[-1]["metadata"]["usage_metadata"] is None
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
 async def test_metadata_defaults_when_provider_returns_no_metadata():
     """Test that the final chunk includes metadata with None values when include_metadata=True
     but the provider does not return any metadata."""


### PR DESCRIPTION
## Summary

Adds recorded public API coverage for generate, check, dialog, request parameters, and streaming behavior.

## Why

The public LLMRails API contract should be pinned with deterministic replay across OpenAI and NIM-backed calls.

## What Changed

- Adds public API configs and cassettes.
- Covers sync and async generate/check flows.
- Covers streaming, request parameters, task-specific models, and negative provider/input cases.

## Stack Position

Part 4 of 5.

- Previous: #1976
- Next: #1978

## Stack Context

This stack decomposes recorded end-to-end replay coverage into reviewable slices. The PRs should be reviewed against their parent branch in the stack.

Please review each PR against its parent branch, not directly against the root base branch, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #1974 | `stack/recorded-tests-01-harness` | `develop` |
| 2 | #1975 | `stack/recorded-tests-02-deterministic-library-load` | `stack/recorded-tests-01-harness` |
| 3 | #1976 | `stack/recorded-tests-03-clients` | `stack/recorded-tests-02-deterministic-library-load` |
| 4 | #1977 | `stack/recorded-tests-04-public-api` | `stack/recorded-tests-03-clients` |
| 5 | #1978 | `stack/recorded-tests-05-library-rails` | `stack/recorded-tests-04-public-api` |

## Validation

```text
poetry check --lock
poetry lock --no-update
poetry install --with dev
poetry run pytest tests/recorded --block-network -q
pre-commit hooks passed during commit creation
```
