### PR TITLE
fix(iorails): Make OTEL recording best-effort

### DIFF
--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -31,7 +31,7 @@ import os
 import secrets
 import time
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -348,12 +348,20 @@ def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
     (per OTEL GenAI conditional-required convention).  Safe to call with
     ``None`` (no-op).  Use from every span helper's ``except`` block and
     from callers that swallow exceptions before they can propagate.
+
+    Best-effort: any failure while annotating the span (e.g. a broken
+    exporter or SDK) is swallowed so it can never mask the original
+    exception the caller is about to re-raise — notably ``CancelledError``
+    / ``GeneratorExit`` on a cancelled stream.  Only ``Exception`` is
+    suppressed, so a ``BaseException`` raised *inside* the SDK still
+    propagates.
     """
     if span is None:
         return
-    span.set_attribute("error.type", type(exc).__name__)
-    span.record_exception(exc)
-    span.set_status(StatusCode.ERROR, str(exc))
+    with suppress(Exception):
+        span.set_attribute("error.type", type(exc).__name__)
+        span.record_exception(exc)
+        span.set_status(StatusCode.ERROR, str(exc))
 
 
 def mark_rail_stop(span: Optional["Span"], is_safe: bool) -> None:
@@ -901,11 +909,14 @@ def record_request_error(exc: BaseException) -> None:
     requests, not just those whose exceptions bubble up.
 
     No-op when the OTEL API is unavailable or instruments cannot be created.
+    Best-effort: a failure inside the meter SDK is swallowed so it can never
+    mask the original exception the caller is about to re-raise.
     """
     instruments = _ensure_request_instruments()
     if instruments is None:
         return
-    instruments.errors.add(1, attributes={"error.type": type(exc).__name__})
+    with suppress(Exception):
+        instruments.errors.add(1, attributes={"error.type": type(exc).__name__})
 
 
 def record_stream_rejected() -> None:
@@ -984,9 +995,15 @@ def request_metrics() -> Generator[None, None, None]:
         record_request_error(exc)
         raise
     finally:
-        instruments.requests_active.add(-1)
+        # Best-effort emission: a broken meter SDK must never mask the
+        # original exception propagating through ``finally``.  Guard each
+        # emit independently so a failure in one still attempts the other —
+        # the active-counter decrement must run to avoid leaking the gauge.
+        with suppress(Exception):
+            instruments.requests_active.add(-1)
         duration_s = time.monotonic() - t0
-        instruments.duration.record(duration_s)
+        with suppress(Exception):
+            instruments.duration.record(duration_s)
 
 
 @contextmanager

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -25,7 +25,7 @@ to satisfy the OTEL GenAI semantic conventions.
 """
 
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional
 
@@ -550,7 +550,10 @@ def llm_operation_duration(
     finally:
         elapsed = time.monotonic() - t0
         attrs = base if exc_type is None else {**base, "error.type": exc_type}
-        instruments.operation_duration.record(elapsed, attributes=attrs)
+        # Best-effort emission: a broken meter SDK must never mask the
+        # original exception propagating through ``finally``.
+        with suppress(Exception):
+            instruments.operation_duration.record(elapsed, attributes=attrs)
 
 
 def record_time_to_first_chunk(

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -254,6 +254,31 @@ class TestRecordSpanError:
         assert len(exc_events) == 1
         assert exc_events[0].attributes["exception.type"] == "ValueError"
 
+    def test_swallows_sdk_failure(self):
+        """A broken span/exporter that raises while being annotated must not
+        propagate — ``record_span_error`` is best-effort so the span helpers
+        can call it from an ``except`` branch handling a cancellation without
+        the telemetry failure masking the original exception (NGUARD-810).
+        """
+        broken_span = MagicMock()
+        broken_span.set_attribute.side_effect = RuntimeError("exporter down")
+        broken_span.record_exception.side_effect = RuntimeError("exporter down")
+        broken_span.set_status.side_effect = RuntimeError("exporter down")
+
+        # Must return cleanly, not raise.
+        record_span_error(broken_span, ValueError("orig"))
+
+    def test_does_not_swallow_base_exception_from_sdk(self):
+        """Only ``Exception`` is suppressed.  A ``BaseException`` raised by the
+        SDK (e.g. a cancellation delivered while the call is in flight) must
+        still propagate rather than be silently dropped.
+        """
+        broken_span = MagicMock()
+        broken_span.set_attribute.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            record_span_error(broken_span, ValueError("orig"))
+
 
 class TestMarkRailStop:
     """``mark_rail_stop`` encapsulates the None-span + rail-safe conditional."""

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -258,7 +258,7 @@ class TestRecordSpanError:
         """A broken span/exporter that raises while being annotated must not
         propagate — ``record_span_error`` is best-effort so the span helpers
         can call it from an ``except`` branch handling a cancellation without
-        the telemetry failure masking the original exception (NGUARD-810).
+        the telemetry failure masking the original exception.
         """
         broken_span = MagicMock()
         broken_span.set_attribute.side_effect = RuntimeError("exporter down")

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -17,7 +17,7 @@
 
 import asyncio
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
@@ -356,6 +356,36 @@ class TestLLMOperationDuration:
                 pass  # must not raise
 
 
+class TestLLMOperationDurationBestEffort:
+    """The ``finally`` emission must be best-effort: a meter SDK that raises
+    while recording the duration must never mask the original exception, nor
+    turn a successful call into a failure (NGUARD-810)."""
+
+    def test_finally_record_failure_does_not_mask_original_exception(self):
+        broken = Mock()
+        broken.operation_duration.record.side_effect = RuntimeError("meter SDK down")
+
+        with patch.object(tracing_constants, "_ensure_llm_instruments", return_value=broken):
+            # The original CancelledError must propagate, NOT the meter's
+            # RuntimeError raised from ``finally``.
+            with pytest.raises(asyncio.CancelledError):
+                with llm_operation_duration("model-x", "openai", "chat"):
+                    raise asyncio.CancelledError()
+
+        broken.operation_duration.record.assert_called_once()
+
+    def test_finally_record_failure_swallowed_on_success_path(self):
+        broken = Mock()
+        broken.operation_duration.record.side_effect = RuntimeError("meter SDK down")
+
+        with patch.object(tracing_constants, "_ensure_llm_instruments", return_value=broken):
+            # A broken meter must not turn a successful block into a failure.
+            with llm_operation_duration("model-x", "openai", "chat"):
+                pass
+
+        broken.operation_duration.record.assert_called_once()
+
+
 class TestRecordTimeToFirstChunk:
     """``record_time_to_first_chunk`` records a single observation onto
     ``gen_ai.client.operation.time_to_first_chunk`` with the standard
@@ -538,6 +568,58 @@ class TestRequestMetrics:
             # Just verify no crash; there's no reader to check against.
 
 
+class TestRequestMetricsBestEffort:
+    """The ``finally`` emissions must be best-effort: a meter SDK that raises
+    while decrementing the active gauge or recording duration must never mask
+    the original exception, nor turn a successful request into a failure.
+    Each emit is guarded independently so a failure in one still attempts the
+    other — the active-gauge decrement must run to avoid leaking the gauge
+    (NGUARD-810)."""
+
+    @staticmethod
+    def _broken_instruments():
+        """A RequestInstruments-shaped mock whose ``finally`` emits both fail.
+
+        ``requests_active.add`` succeeds on the ``+1`` entry bump (so the
+        scope is entered normally) but fails on the ``-1`` finally decrement,
+        and ``duration.record`` always fails.
+        """
+        broken = Mock()
+
+        def _add(delta, *args, **kwargs):
+            if delta < 0:
+                raise RuntimeError("meter SDK down")
+
+        broken.requests_active.add.side_effect = _add
+        broken.duration.record.side_effect = RuntimeError("meter SDK down")
+        return broken
+
+    def test_finally_emit_failure_does_not_mask_original_exception(self):
+        broken = self._broken_instruments()
+
+        with patch.object(telemetry, "_ensure_request_instruments", return_value=broken):
+            # The original CancelledError must propagate, NOT a RuntimeError
+            # from either failing ``finally`` emit.
+            with pytest.raises(asyncio.CancelledError):
+                with request_metrics():
+                    raise asyncio.CancelledError()
+
+        # Both finally emits were attempted despite the first one failing.
+        broken.requests_active.add.assert_any_call(-1)
+        broken.duration.record.assert_called_once()
+
+    def test_finally_emit_failure_swallowed_on_success_path(self):
+        broken = self._broken_instruments()
+
+        with patch.object(telemetry, "_ensure_request_instruments", return_value=broken):
+            # A broken meter must not turn a successful request into a failure.
+            with request_metrics():
+                pass
+
+        broken.requests_active.add.assert_any_call(-1)
+        broken.duration.record.assert_called_once()
+
+
 class TestTracedRequestMetrics:
     """``traced_request(tracer, metrics_enabled)`` gates the two signals
     independently.  All four combinations exercised here.
@@ -647,6 +729,32 @@ class TestRecordRequestError:
             telemetry._request_instruments = None
             # Must not raise; must not crash on attribute access.
             record_request_error(ValueError("boom"))
+
+    def test_swallows_sdk_failure(self):
+        """A meter SDK that raises while bumping the errors counter must not
+        propagate — ``record_request_error`` is best-effort so it can be
+        called from an ``except`` branch handling a cancellation without
+        masking it (NGUARD-810).
+        """
+        broken = Mock()
+        broken.errors.add.side_effect = RuntimeError("meter SDK down")
+
+        with patch.object(telemetry, "_ensure_request_instruments", return_value=broken):
+            # Must return cleanly, not raise.
+            record_request_error(ValueError("orig"))
+
+        broken.errors.add.assert_called_once()
+
+    def test_does_not_swallow_base_exception_from_sdk(self):
+        """Only ``Exception`` is suppressed.  A ``BaseException`` raised by the
+        meter SDK must still propagate rather than be silently dropped.
+        """
+        broken = Mock()
+        broken.errors.add.side_effect = KeyboardInterrupt()
+
+        with patch.object(telemetry, "_ensure_request_instruments", return_value=broken):
+            with pytest.raises(KeyboardInterrupt):
+                record_request_error(ValueError("orig"))
 
 
 class TestRecordRequestBlocked:

--- a/tests/guardrails/test_telemetry_metrics.py
+++ b/tests/guardrails/test_telemetry_metrics.py
@@ -316,7 +316,7 @@ class TestLLMOperationDuration:
         a ``BaseException`` subclass — inside the context manager.  The
         duration record must still carry ``error.type=CancelledError``
         so dashboards can distinguish cancelled streams from successful
-        ones (NGUARD-776 plan #6).
+        ones.
         """
         with pytest.raises(asyncio.CancelledError):
             with llm_operation_duration("model-x", "openai", "chat"):
@@ -359,7 +359,7 @@ class TestLLMOperationDuration:
 class TestLLMOperationDurationBestEffort:
     """The ``finally`` emission must be best-effort: a meter SDK that raises
     while recording the duration must never mask the original exception, nor
-    turn a successful call into a failure (NGUARD-810)."""
+    turn a successful call into a failure"""
 
     def test_finally_record_failure_does_not_mask_original_exception(self):
         broken = Mock()
@@ -574,7 +574,7 @@ class TestRequestMetricsBestEffort:
     the original exception, nor turn a successful request into a failure.
     Each emit is guarded independently so a failure in one still attempts the
     other — the active-gauge decrement must run to avoid leaking the gauge
-    (NGUARD-810)."""
+    """
 
     @staticmethod
     def _broken_instruments():
@@ -734,7 +734,7 @@ class TestRecordRequestError:
         """A meter SDK that raises while bumping the errors counter must not
         propagate — ``record_request_error`` is best-effort so it can be
         called from an ``except`` branch handling a cancellation without
-        masking it (NGUARD-810).
+        masking it.
         """
         broken = Mock()
         broken.errors.add.side_effect = RuntimeError("meter SDK down")


### PR DESCRIPTION
## Description

Follow-up hardening for the non-blocking review comment on #1897 ([thread](https://github.com/NVIDIA-NeMo/Guardrails/pull/1897#discussion_r3263948921)).

#1897 widened `except Exception` → `except BaseException` in seven OTEL context managers so that consumer-cancelled streams (`asyncio.CancelledError` / `GeneratorExit`, both `BaseException` subclasses) get their spans/metrics tagged with `error.type` before re-raising.

That widening introduced a second-order risk: now that these blocks run a telemetry call *while handling a cancellation*, if that telemetry call itself raises (broken exporter, misconfigured/over-quota meter, SDK bug) the new
exception **masks** the original `CancelledError` / `GeneratorExit` — turning a cancellation into an unrelated error and changing control flow. In `request_metrics` a raising `finally` emit could additionally skip the `guardrails.requests.active` decrement and leak that gauge.

This PR makes telemetry emission **best-effort** so it can never mask the original exception or alter control flow:

- `record_span_error` (`nemoguardrails/guardrails/telemetry.py`) — span annotation wrapped in `contextlib.suppress(Exception)`. One change covers all five span context managers (`request_span`, `rail_span`, `action_span`, `llm_call_span`, `api_call_span`), whose `except BaseException … raise` blocks are untouched, plus any other callers.
- `record_request_error` — the errors-counter emit wrapped in `suppress(Exception)`.
- `request_metrics` `finally` — the active-gauge decrement and duration record are guarded **independently**, so a failing duration record still leaves the `requests.active` decrement attempted (no gauge leak).
- `llm_operation_duration` (`nemoguardrails/tracing/constants.py`) — the   `gen_ai.client.operation.duration` record wrapped in `suppress(Exception)`.

Design notes:

- The guard lives **inside the helpers**, not duplicated at each call site, and it protects every caller (including the swallow-before-propagate callers noted in the `record_span_error` docstring), not just these blocks.
- Only `Exception` is suppressed, **not** `BaseException`: a cancellation delivered *while an SDK call is in flight* must still propagate, never be silently dropped.
- The `raise` in each `except BaseException` block is unchanged, so cancel semantics are preserved.

## Related Issue(s)

- Addresses NGUARD-810 (non-blocking feedback from #1897).

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q

................................................ssss................................................................. [  2%]
..........................s.......................................................................................... [  4%]
..................................................................................................................... [  7%]
..................................................................................................................... [  9%]
..................................................................................................................... [ 12%]
..................................................................................................................... [ 14%]
..................................................................................................................... [ 17%]
..................................................................................................................... [ 19%]
..................................................................................................................... [ 22%]
..................................................................................................................... [ 24%]
...........................................................s......ss...................sssssss....................... [ 26%]
........................................................................................................s.......s.... [ 29%]
..................................................................................................................... [ 31%]
..................................................................................................................... [ 34%]
........................................s............................................................................ [ 36%]
..................................................................................................................... [ 39%]
..................................................................................................................... [ 41%]
.....................ssssssss......ssssss..ss.s.............ssssssss................................................. [ 44%]
..................................................................................................................... [ 46%]
.....................ss...........................s...............s.......sssss...................................... [ 49%]
.................s................................................................................................... [ 51%]
..............................................................ss........ss...ss...................................... [ 53%]
.....................s.....................................................s............s............................ [ 56%]
..................................................................................................................... [ 58%]
..................................................................................................................... [ 61%]
...........................................................sssss......ssssssssssssssssss..........sssss.............. [ 63%]
......................................................................s...........ss................................. [ 66%]
..................sssssssss.ssssssssss............................................................................... [ 68%]
.....................................................s....................................................s....s..... [ 71%]
...................................................ssssssss.................sss...ss...ss.....sssssssssssss.......... [ 73%]
..................................................................................................................... [ 75%]
.........................s........................................................................................... [ 78%]
...................s....................ssssssss.........ss.......................................................... [ 80%]
............................................................................sssssss.................................. [ 83%]
..............................s...................................................................................... [ 85%]
..................................................................................................................... [ 88%]
..................................................................................................................... [ 90%]
..................................................................................................................... [ 93%]
...................................................................s................................................. [ 95%]
..................................................................................................................... [ 98%]
..............................................................................................                        [100%]
4610 passed, 164 skipped in 103.79s (0:01:43)
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-06-05 13:25:27 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-05 13:25:27 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-06-05 13:25:27 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-06-05 13:25:27 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-05 13:25:27 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-06-05 13:25:31 INFO: [79115332afbd79ed] generate_async called
2026-06-05 13:25:31 INFO: [79115332afbd79ed] Running input rails
2026-06-05 13:25:31 INFO: [79115332afbd79ed] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-05 13:25:32 INFO: [79115332afbd79ed] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-06-05 13:25:34 INFO: [79115332afbd79ed] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-05 13:25:36 INFO: [79115332afbd79ed] Calling main LLM
2026-06-05 13:25:36 INFO: [79115332afbd79ed] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-05 13:25:39 INFO: [79115332afbd79ed] Running output rails
2026-06-05 13:25:39 INFO: [79115332afbd79ed] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-05 13:25:39 INFO: [79115332afbd79ed] generate_async completed time=7878.4ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-06-05 13:25:44 INFO: [a199df2cf9641634] generate_async called
2026-06-05 13:25:44 INFO: [a199df2cf9641634] Running input rails
2026-06-05 13:25:44 INFO: [a199df2cf9641634] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-05 13:25:44 INFO: [a199df2cf9641634] Input flow content safety check input $model=content_safety blocked
2026-06-05 13:25:44 INFO: [a199df2cf9641634] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-06-05 13:25:44 INFO: [a199df2cf9641634] generate_async completed time=784.2ms
I'm sorry, I can't respond to that.

```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in telemetry operations so OpenTelemetry SDK failures no longer mask or interrupt application exceptions.
  * Enhanced metrics recording to prevent SDK errors from interfering with core operations.
  * Strengthened span error annotation to gracefully handle SDK-level failures.

* **Tests**
  * Added test coverage for telemetry error handling in edge cases.
  * Added tests validating resilience when OpenTelemetry SDK components fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->