### PR TITLE
fix(llmrails): normalize OpenAI multi-part content to string before rail evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 >
 > The changes related to the Colang language and runtime have moved to [CHANGELOG-Colang](./CHANGELOG-Colang.md) file.
 
-## [Unreleased]
-
-### 🐛 Bug Fixes
-
-- *(llmrails)* Normalize OpenAI multi-part content lists to plain strings before rail evaluation, fixing garbled self-check prompts and TypeError crash in `get_colang_history` ([#1741](https://github.com/NVIDIA-NeMo/Guardrails/issues/1741))
-
 ## [0.22.0] - 2026-05-22
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 >
 > The changes related to the Colang language and runtime have moved to [CHANGELOG-Colang](./CHANGELOG-Colang.md) file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- *(llmrails)* Normalize OpenAI multi-part content lists to plain strings before rail evaluation, fixing garbled self-check prompts and TypeError crash in `get_colang_history` ([#1741](https://github.com/NVIDIA-NeMo/Guardrails/issues/1741))
+
 ## [0.22.0] - 2026-05-22
 
 ### 🚀 Features

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -100,6 +100,7 @@ from nemoguardrails.rails.llm.options import (
 )
 from nemoguardrails.rails.llm.utils import (
     get_action_details_from_flow_id,
+    get_content_text,
     get_history_cache_key,
 )
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
@@ -769,10 +770,11 @@ class LLMRails(BaseGuardrails):
             for idx in range(p, len(messages)):
                 msg = messages[idx]
                 if msg["role"] == "user":
+                    user_text = get_content_text(msg["content"])
                     events.append(
                         {
                             "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
+                            "final_transcript": user_text,
                         }
                     )
 
@@ -781,7 +783,7 @@ class LLMRails(BaseGuardrails):
                         events.append(
                             {
                                 "type": "UserMessage",
-                                "text": msg["content"],
+                                "text": user_text,
                             }
                         )
 
@@ -816,7 +818,7 @@ class LLMRails(BaseGuardrails):
                         user_message = None
                         for prev_msg in reversed(messages[:idx]):
                             if prev_msg["role"] == "user":
-                                user_message = prev_msg["content"]
+                                user_message = get_content_text(prev_msg["content"])
                                 break
 
                         if user_message:
@@ -851,7 +853,7 @@ class LLMRails(BaseGuardrails):
                     events.append(
                         {
                             "type": "UtteranceUserActionFinished",
-                            "final_transcript": msg["content"],
+                            "final_transcript": get_content_text(msg["content"]),
                         }
                     )
 

--- a/nemoguardrails/rails/llm/utils.py
+++ b/nemoguardrails/rails/llm/utils.py
@@ -18,6 +18,27 @@ from typing import Any, Dict, List, Tuple, Union
 from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id
 
 
+def get_content_text(content) -> str:
+    """Normalize an OpenAI message ``content`` field to a plain string.
+
+    The OpenAI API allows ``content`` to be a plain string **or** a list of
+    content parts (the multi-part format used for multimodal messages)::
+
+        [{"type": "text", "text": "..."}, {"type": "image_url", ...}]
+
+    All ``type: text`` parts are extracted and joined with a single space so
+    the rest of the pipeline always receives a ``str``.  Non-list values are
+    returned unchanged.
+    """
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return content
+
+
 def get_history_cache_key(messages: List[dict]) -> str:
     """Compute the cache key for a sequence of messages.
 
@@ -34,17 +55,7 @@ def get_history_cache_key(messages: List[dict]) -> str:
 
     for msg in messages:
         if msg["role"] == "user":
-            # Check if content is a string or a list (multimodal content)
-            if isinstance(msg["content"], list):
-                # For multimodal content, join all text parts
-                text_parts = []
-                for item in msg["content"]:
-                    if item.get("type") == "text":
-                        text_parts.append(item.get("text", ""))
-                key_items.append(" ".join(text_parts))
-            else:
-                # Use the content directly without json.dumps
-                key_items.append(msg["content"])
+            key_items.append(get_content_text(msg["content"]))
         elif msg["role"] == "assistant":
             key_items.append(msg["content"])
         elif msg["role"] == "context":

--- a/nemoguardrails/rails/llm/utils.py
+++ b/nemoguardrails/rails/llm/utils.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Tuple, Union
 from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id
 
 
-def get_content_text(content) -> str:
+def get_content_text(content: Any) -> str:
     """Normalize an OpenAI message ``content`` field to a plain string.
 
     The OpenAI API allows ``content`` to be a plain string **or** a list of
@@ -27,16 +27,17 @@ def get_content_text(content) -> str:
         [{"type": "text", "text": "..."}, {"type": "image_url", ...}]
 
     All ``type: text`` parts are extracted and joined with a single space so
-    the rest of the pipeline always receives a ``str``.  Non-list values are
-    returned unchanged.
+    the rest of the pipeline always receives a ``str``.  ``None`` is
+    normalised to an empty string; any other non-list value is converted via
+    ``str()``.
     """
     if isinstance(content, list):
         return " ".join(
-            part.get("text", "")
-            for part in content
-            if isinstance(part, dict) and part.get("type") == "text"
+            str(part.get("text", "") or "") for part in content if isinstance(part, dict) and part.get("type") == "text"
         )
-    return content
+    if content is None:
+        return ""
+    return str(content)
 
 
 def get_history_cache_key(messages: List[dict]) -> str:

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1627,8 +1627,11 @@ class TestGetContentText:
     def test_plain_string_passthrough(self):
         assert get_content_text("Hello") == "Hello"
 
-    def test_none_passthrough(self):
-        assert get_content_text(None) is None
+    def test_none_returns_empty_string(self):
+        assert get_content_text(None) == ""
+
+    def test_non_string_non_list_converted_via_str(self):
+        assert get_content_text(42) == "42"
 
     def test_single_text_part(self):
         content = [{"type": "text", "text": "Hello"}]
@@ -1663,9 +1666,7 @@ def simple_rails_config():
         {
             "models": [{"type": "main", "engine": "fake", "model": "fake"}],
             "user_messages": {"express greeting": ["Hello!"]},
-            "flows": [
-                {"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}
-            ],
+            "flows": [{"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}],
             "bot_messages": {"express greeting": ["Hi there!"]},
         }
     )
@@ -1735,9 +1736,7 @@ def test_tool_message_with_multipart_user_content(simple_rails_config):
         {
             "role": "assistant",
             "content": None,
-            "tool_calls": [
-                {"id": "call_abc", "function": {"name": "get_weather", "arguments": "{}"}}
-            ],
+            "tool_calls": [{"id": "call_abc", "function": {"name": "get_weather", "arguments": "{}"}}],
         },
         {
             "role": "tool",

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1616,11 +1616,6 @@ def test_load_library_sorts_files_for_deterministic_overrides(tmp_path, monkeypa
     assert rails.config.bot_messages["test det msg"] == ["from_a"]
 
 
-# ---------------------------------------------------------------------------
-# Tests for OpenAI multi-part content normalization (Issue #1741)
-# ---------------------------------------------------------------------------
-
-
 class TestGetContentText:
     """Unit tests for the get_content_text() normalisation helper."""
 
@@ -1662,13 +1657,24 @@ class TestGetContentText:
 
 @pytest.fixture
 def simple_rails_config():
-    return RailsConfig.parse_object(
-        {
-            "models": [{"type": "main", "engine": "fake", "model": "fake"}],
-            "user_messages": {"express greeting": ["Hello!"]},
-            "flows": [{"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}],
-            "bot_messages": {"express greeting": ["Hi there!"]},
-        }
+    return RailsConfig.from_content(
+        colang_content="""
+define user express greeting
+  "Hello!"
+
+define bot express greeting
+  "Hi there!"
+
+define flow
+  user express greeting
+  bot express greeting
+""",
+        yaml_content="""
+models:
+  - type: main
+    engine: fake
+    model: fake
+""",
     )
 
 
@@ -1721,7 +1727,7 @@ async def test_multipart_content_mixed_parts(simple_rails_config):
     result = await rails.generate_async(messages=messages)
 
     assert result["role"] == "assistant"
-    assert isinstance(result["content"], str)
+    assert result["content"] == "Hi there!"
 
 
 def test_tool_message_with_multipart_user_content(simple_rails_config):

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -24,6 +24,7 @@ from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.rails.llm.utils import get_content_text
 from tests.conftest import REASONING_TRACE_MOCK_PATH
 from tests.utils import FakeLLMModel, clean_events, event_sequence_conforms
 
@@ -1613,3 +1614,167 @@ def test_load_library_sorts_files_for_deterministic_overrides(tmp_path, monkeypa
     rails = LLMRails(config, llm=FakeLLMModel(responses=["unused"]))
 
     assert rails.config.bot_messages["test det msg"] == ["from_a"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for OpenAI multi-part content normalization (Issue #1741)
+# ---------------------------------------------------------------------------
+
+
+class TestGetContentText:
+    """Unit tests for the get_content_text() normalisation helper."""
+
+    def test_plain_string_passthrough(self):
+        assert get_content_text("Hello") == "Hello"
+
+    def test_none_passthrough(self):
+        assert get_content_text(None) is None
+
+    def test_single_text_part(self):
+        content = [{"type": "text", "text": "Hello"}]
+        assert get_content_text(content) == "Hello"
+
+    def test_multiple_text_parts_joined(self):
+        content = [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]
+        assert get_content_text(content) == "Hello World"
+
+    def test_non_text_parts_skipped(self):
+        content = [
+            {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+            {"type": "text", "text": "Describe this image"},
+        ]
+        assert get_content_text(content) == "Describe this image"
+
+    def test_empty_list_returns_empty_string(self):
+        assert get_content_text([]) == ""
+
+    def test_list_with_only_non_text_parts(self):
+        content = [{"type": "image_url", "image_url": {"url": "http://example.com/img.png"}}]
+        assert get_content_text(content) == ""
+
+    def test_missing_text_key_in_part(self):
+        content = [{"type": "text"}]
+        assert get_content_text(content) == ""
+
+
+@pytest.fixture
+def simple_rails_config():
+    return RailsConfig.parse_object(
+        {
+            "models": [{"type": "main", "engine": "fake", "model": "fake"}],
+            "user_messages": {"express greeting": ["Hello!"]},
+            "flows": [
+                {"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}
+            ],
+            "bot_messages": {"express greeting": ["Hi there!"]},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_multipart_content_single_turn(simple_rails_config):
+    """Multi-part content on a single user turn is normalised before rail evaluation."""
+    llm = FakeLLMModel(responses=["  express greeting"])
+    rails = LLMRails(config=simple_rails_config, llm=llm)
+
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
+    result = await rails.generate_async(messages=messages)
+
+    assert result["role"] == "assistant"
+    assert isinstance(result["content"], str)
+    assert result["content"] == "Hi there!"
+
+
+@pytest.mark.asyncio
+async def test_multipart_content_multi_turn_does_not_crash(simple_rails_config):
+    """Multi-part content in a non-final turn must not raise TypeError in get_colang_history."""
+    llm = FakeLLMModel(responses=["  express greeting", "  express greeting"])
+    rails = LLMRails(config=simple_rails_config, llm=llm)
+
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Hello!"}]},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": [{"type": "text", "text": "Hello again!"}]},
+    ]
+    result = await rails.generate_async(messages=messages)
+
+    assert result["role"] == "assistant"
+    assert isinstance(result["content"], str)
+
+
+@pytest.mark.asyncio
+async def test_multipart_content_mixed_parts(simple_rails_config):
+    """Only text parts are extracted; image_url parts are silently dropped."""
+    llm = FakeLLMModel(responses=["  express greeting"])
+    rails = LLMRails(config=simple_rails_config, llm=llm)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+                {"type": "text", "text": "Hello!"},
+            ],
+        }
+    ]
+    result = await rails.generate_async(messages=messages)
+
+    assert result["role"] == "assistant"
+    assert isinstance(result["content"], str)
+
+
+def test_tool_message_with_multipart_user_content(simple_rails_config):
+    """Colang 1.0 tool-message branch: previous user multipart content is normalised
+    before being stored in the UserMessage event (line 817)."""
+    rails = LLMRails(config=simple_rails_config, llm=FakeLLMModel(responses=[]))
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What is the weather?"}],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_abc", "function": {"name": "get_weather", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "Sunny, 72F",
+            "tool_call_id": "call_abc",
+        },
+    ]
+    events = rails._get_events_for_messages(messages, state=None)
+
+    user_message_events = [e for e in events if e.get("type") == "UserMessage"]
+    assert len(user_message_events) >= 1
+    # All UserMessage events must carry the normalised string, not the list repr
+    for event in user_message_events:
+        assert event["text"] == "What is the weather?"
+
+
+def test_colang2_multipart_content_normalization():
+    """Colang 2.0 user-message branch: multipart content is normalised in
+    UtteranceUserActionFinished (line 852)."""
+    config = RailsConfig.from_content(
+        colang_content="""
+flow greeting
+  user said "Hello!"
+  bot say "Hi there!"
+
+flow main
+  activate greeting
+""",
+        yaml_content="""
+colang_version: "2.x"
+models: []
+""",
+    )
+    rails = LLMRails(config=config)
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
+    events = rails._get_events_for_messages(messages, state=None)
+
+    utterance_events = [e for e in events if e.get("type") == "UtteranceUserActionFinished"]
+    assert len(utterance_events) == 1
+    assert utterance_events[0]["final_transcript"] == "Hello!"


### PR DESCRIPTION
## Problem

When a user message uses the [OpenAI multi-part content format](https://platform.openai.com/docs/guides/vision):

```json
{"role": "user", "content": [{"type": "text", "text": "You are a dotard and I hate you"}]}
```

`_get_events_for_messages` assigns `msg["content"]` (the list) directly into `UtteranceUserActionFinished.final_transcript` and `UserMessage.text` without normalising it to a string. This causes two bugs:

**Bug 1 — Silent guardrail bypass:** Every LLM prompt (self-check input, intent matching, etc.) receives the Python repr of the list instead of the actual user text. Content-safety rails evaluate garbage and silently pass the real message through unblocked.

**Bug 2 — TypeError crash in multi-turn:** When `mask_prev_user_message` fires in a subsequent turn, `get_colang_history()` calls `history.rsplit(utterance_to_replace, 1)` where `utterance_to_replace` is the list, crashing with:

```
TypeError: must be str or None, not list
```

## Fix

Add `get_content_text(content)` to `nemoguardrails/rails/llm/utils.py`. It joins all `type: text` parts with a space and passes non-list values through unchanged. Apply it at all four user-message content access points in `_get_events_for_messages`:

| Location | Colang path |
|---|---|
| `UtteranceUserActionFinished.final_transcript` | 1.0 |
| `UserMessage.text` (non-final turns) | 1.0 |
| Tool-message user-lookup fallback | 1.0 |
| `UtteranceUserActionFinished.final_transcript` | 2.0 |

Also refactors the pre-existing inline multipart-list handling in `get_history_cache_key` to reuse the same helper, eliminating duplicate logic.

## Tests

11 new tests added to `tests/test_llmrails.py`:

**`TestGetContentText` — 8 unit tests for the helper:**
- plain string passthrough
- `None` passthrough
- single text part extracted
- multiple text parts joined with space
- non-text parts (image_url) skipped
- empty list returns empty string
- image-only list returns empty string
- missing `text` key in part handled gracefully

**Integration tests:**
- `test_multipart_content_single_turn` — single-turn `generate_async` with multipart content returns correct string response
- `test_multipart_content_multi_turn_does_not_crash` — multipart content in non-final turns does not raise TypeError
- `test_multipart_content_mixed_parts` — image_url parts are silently dropped, text parts extracted correctly
- `test_tool_message_with_multipart_user_content` — Colang 1.0 tool-message branch: UserMessage events carry the normalised string
- `test_colang2_multipart_content_normalization` — Colang 2.0 path: UtteranceUserActionFinished carries the normalised string

All 54 tests in `tests/test_llmrails.py` pass. Coverage confirmed on every added and modified line.

Fixes #1741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbled self-check prompts caused by improper handling of OpenAI multi-part content lists.
  * Resolved TypeError crash in `get_colang_history` when processing multimodal messages.
  * Improved normalization of multi-part message content into plain strings for consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->