### PR TITLE
  docs: add AI-assisted contribution policy and coding-agent guide    

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_proposal.yml
@@ -1,0 +1,70 @@
+name: Refactor Proposal
+description: Propose a maintainer-led refactor for discussion
+title: "refactor: "
+labels: ["enhancement", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refactors are maintainer-led and are not accepted as unsolicited pull requests.
+
+        Use this form to explain the problem and proposed direction. Maintainers decide whether the refactor should happen, what plan is acceptable, and who, if anyone, should be assigned to implement it.
+  - type: checkboxes
+    attributes:
+      label: Required checks
+      description: Confirm before submitting this proposal.
+      options:
+        - label: I searched existing issues and pull requests for related refactor proposals.
+          required: true
+        - label: I understand that opening this issue does not mean a refactor PR will be accepted.
+          required: true
+        - label: I understand that a refactor PR should not be opened unless a maintainer approves the plan and assigns the work.
+          required: true
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What is hard to maintain, unsafe, confusing, or blocking today?
+      placeholder: Describe the current design problem and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed direction
+      description: What structural direction do you think maintainers should consider?
+      placeholder: Keep this high level unless maintainers have asked for detailed design.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Migration and compatibility notes
+      description: What public APIs, config formats, docs, or user workflows could be affected?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Validation plan
+      description: What tests, docs checks, or compatibility checks would be needed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Risks
+      description: List known risks, open questions, and possible alternatives.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Relevant branch or files
+      description: Optional. Share a WIP branch, affected files, or investigation notes if useful.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Are you interested in helping after maintainer approval?
+      description: This does not assign you to the work. Maintainers decide ownership after triage.
+      options:
+        - I am only proposing this for maintainer consideration.
+        - I can help with investigation if maintainers ask.
+        - I can help implement after maintainers approve a plan and assign the work.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_proposal.yml
@@ -1,7 +1,7 @@
 name: Refactor Proposal
 description: Propose a maintainer-led refactor for discussion
 title: "refactor: "
-labels: ["enhancement", "status: needs triage"]
+labels: ["refactoring", "status: needs triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/PULL-REQUEST-TEMPLATE.md
+++ b/.github/PULL-REQUEST-TEMPLATE.md
@@ -1,18 +1,37 @@
 ## Description
 
 <!-- Describe the big picture of your changes to communicate to the maintainers
-  why we should accept this pull request. -->
+  why we should accept this pull request. Include any areas that need careful
+  review. -->
 
 ## Related Issue(s)
 
 <!--
-  If this PR fixes any issues, please link to the issue here.
+  Every PR must link to a triaged issue assigned to the PR author.
   - Fixes #<issue_number>
+  - Issue assignee: @<username>
 -->
+
+## Verification
+
+<!-- CI runs the automated test suite. Note any verification beyond CI (manual
+  checks, live/credentialed paths, docs build) and any relevant check you could
+  not run, with residual risk. -->
+
+## AI Assistance
+
+<!-- If AI tools helped create or substantially modify this PR, disclose the tool
+  used and the extent of assistance. If not applicable, write "Not used." -->
 
 ## Checklist
 
 - [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
+- [ ] This PR links to a triaged issue assigned to me.
+- [ ] My PR title follows the project commit convention.
 - [ ] I've updated the documentation if applicable.
 - [ ] I've added tests if applicable.
+- [ ] I've noted any verification beyond CI and any checks I couldn't run.
+- [ ] I did not update generated changelog files manually.
+- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
+- [ ] If AI tools assisted this contribution, I reviewed and edited their output and can explain every change.
 - [ ] @mentions of the person or team responsible for reviewing proposed changes.

--- a/.github/PULL-REQUEST-TEMPLATE.md
+++ b/.github/PULL-REQUEST-TEMPLATE.md
@@ -20,8 +20,8 @@
 
 ## AI Assistance
 
-<!-- If AI tools helped create or substantially modify this PR, disclose the tool
-  used and the extent of assistance. If not applicable, write "Not used." -->
+- [ ] No AI tools were used.
+- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).
 
 ## Checklist
 
@@ -33,5 +33,4 @@
 - [ ] I've noted any verification beyond CI and any checks I couldn't run.
 - [ ] I did not update generated changelog files manually.
 - [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
-- [ ] If AI tools assisted this contribution, I reviewed and edited their output and can explain every change.
 - [ ] @mentions of the person or team responsible for reviewing proposed changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ as tox and package coverage.
 | Serial, deterministic run | `make test WORKERS=1` (no parallelism, still unsets live keys) |
 | Coverage | `make test-coverage` |
 | Pre-commit hooks | `poetry run pre-commit run --all-files` |
-| Docs build | `poetry run sphinx-build -b html docs _build/docs` |
+| Docs check | `make docs-fern` |
 | Ruff diagnosis | `poetry run ruff check path/to/file.py` |
 | Ruff formatting diagnosis | `poetry run ruff format path/to/file.py` |
 | Pyright diagnosis | `poetry run pyright` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,7 @@ runtime, public-API, and provider-integration rules.
 ## Repository Map
 
 - Main package: `nemoguardrails/`
-- Tests: `tests/`, plus doctest/example coverage from
-  `docs/configure-rails/colang/colang-2/examples` and `benchmark/tests` through
-  `pytest.ini`
+- Tests: `tests/` and `benchmark/tests` (the `testpaths` in `pytest.ini`)
 - Schemas and validation snapshots: `schemas/`
 - Default development branch: `develop`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md
+
+`CONTRIBUTING.md` is canonical for public contribution workflow: issues,
+assignment, pull requests, refactors, changelogs, validation, commits, and DCO.
+`AI_POLICY.md` is canonical for public AI-assisted contribution policy.
+
+When working inside `nemoguardrails/`, also follow `nemoguardrails/AGENTS.md` for
+runtime, public-API, and provider-integration rules.
+
+## Quick Rules
+
+- Agent-specific rule: do not submit issues, PRs, or draft PRs through browser
+  automation, the GitHub API, `gh`, or similar tooling. Draft text for a human to
+  review and submit, following the repo's issue/PR templates so it can be
+  submitted as-is.
+- Do not push branches or prepare public-submission-ready PR materials unless
+  the linked issue is triaged and assigned to the human contributor.
+- Do not implement refactors unless a maintainer has approved the plan and
+  assigned the work.
+- Never edit `CHANGELOG.md` or `CHANGELOG-Colang.md` manually.
+- Do not commit secrets, credentials, or sensitive provider data, and do not
+  fabricate results, approvals, or citations. See `AI_POLICY.md` Safety and
+  Privacy for the canonical list.
+- Do not add generated media, large generated assets, or synthetic datasets
+  without clear provenance and maintainer alignment.
+- Unit tests must not call live LLM or provider services.
+- Do not add license headers manually. Pre-commit handles license insertion.
+- Do not add comments unless explicitly requested; keep existing comments,
+  docstrings, and license headers unless your change makes them inaccurate.
+- Use Poetry for Python commands: `poetry run python ...`,
+  `poetry run pytest ...`, `poetry run pre-commit ...`.
+
+## Repository Map
+
+- Main package: `nemoguardrails/`
+- Tests: `tests/`, plus doctest/example coverage from
+  `docs/configure-rails/colang/colang-2/examples` and `benchmark/tests` through
+  `pytest.ini`
+- Schemas and validation snapshots: `schemas/`
+- Default development branch: `develop`
+
+## Setup
+
+- Install development dependencies:
+
+  ```bash
+  poetry install --with dev
+  ```
+
+- Install documentation dependencies when working on docs:
+
+  ```bash
+  poetry install --with dev,docs
+  ```
+
+- Do not add dependencies to `pyproject.toml` or update `poetry.lock` unless the
+  task requires it. For temporary local investigation, use:
+
+  ```bash
+  poetry run pip install <package-name>
+  ```
+
+- When a dependency change is required, keep it in the narrowest appropriate
+  dependency group or optional extra, add clear compatibility bounds, and avoid
+  moving optional integration dependencies into the default install path.
+
+## Validation
+
+Canonical command reference: `CONTRIBUTING.md` Validation. The table below adds
+agent-operational diagnosis commands; see `CONTRIBUTING.md` for shared rows such
+as tox and package coverage.
+
+| Task | Command |
+| --- | --- |
+| Run the test suite | `make test` (pytest-xdist parallel; unsets live-provider keys so unit tests cannot reach live services; runs all `pytest.ini` testpaths) |
+| Focused test | `make test TEST=path/to/test_file.py::test_name` (extra flags via `ARGS="-k ... -q"`) |
+| Serial, deterministic run | `make test WORKERS=1` (no parallelism, still unsets live keys) |
+| Coverage | `make test-coverage` |
+| Pre-commit hooks | `poetry run pre-commit run --all-files` |
+| Docs build | `poetry run sphinx-build -b html docs _build/docs` |
+| Ruff diagnosis | `poetry run ruff check path/to/file.py` |
+| Ruff formatting diagnosis | `poetry run ruff format path/to/file.py` |
+| Pyright diagnosis | `poetry run pyright` |
+
+| Change type | Minimum validation |
+| --- | --- |
+| Docs or repository metadata only | `poetry run pre-commit run --files <changed files>`; build docs when rendering, links, examples, or docs configuration may be affected |
+| Runtime bug fix | Focused regression test plus pre-commit on changed files; broaden when shared behavior is touched |
+| Public API, config, or Colang behavior | Focused tests plus related docs/examples; add broader package tests when compatibility risk is meaningful |
+| Server, streaming, tracing, actions, or generation | Targeted tests for the changed path and fallback/unsupported path |
+| Packaging, dependencies, or lockfiles | Relevant install/package checks plus pre-commit; keep dependency diffs separate from unrelated changes |
+
+- For PR-ready code changes, pre-commit is the authoritative lint, format,
+  license-header, and type-checking path.
+- Standalone Ruff, Ruff format, and Pyright runs are local diagnosis only; run
+  pre-commit on changed files before handoff and report if it is skipped.
+- `make test` runs every `pytest.ini` testpath, so it includes `benchmark/tests`,
+  not just `tests/`; scope with `TEST=`. The default suite needs no network:
+  `tests/conftest.py` swaps the default FastEmbed model for a deterministic
+  provider, so only `real_embeddings`-marked tests use the real model.
+- Diagnose isolation flakiness by comparing `make test` with `make test
+  WORKERS=1` (same env-safety, no parallelism); `serial`/`slow` markers in
+  `pytest.ini` are advisory and not enforced by the parallel runner.
+- `make test-serial` and bare `poetry run pytest` do NOT unset live-provider
+  keys; prefer `make test` / `make test WORKERS=1` so unit tests cannot reach
+  live services.
+
+## Contribution Workflow
+
+- Follow `CONTRIBUTING.md` for issue, assignment, PR title, refactor, changelog,
+  validation, commit, and DCO policy.
+- Follow `AI_POLICY.md` for disclosure, human accountability, safety, and
+  privacy requirements.
+- For non-trivial features, API changes, refactors, or behavior changes without
+  clear maintainer direction (a linked issue that is triaged, assigned to you,
+  and has an agreed approach recorded in the thread), stop at a proposal or
+  implementation plan (an issue comment, or a throwaway `PLAN.md` PR maintainers
+  can review) rather than implementing.
+- If work is exploratory, draft an issue comment with the branch and relevant
+  files instead of opening a PR.
+- Use the Conventional Commit-style titles described in `CONTRIBUTING.md`.
+- Do not prefix PR titles or commit messages with agent markers, and do not add
+  AI tools or agents as commit co-authors (no `Co-Authored-By` trailers for AI).
+
+## Review Readiness
+
+- Follow `CONTRIBUTING.md` for review-readiness policy (CodeRabbit, Greptile,
+  human comments, readiness labels): address or reply to every open review comment
+  before requesting maintainer review, do not resolve reviewers' own threads, and
+  do not self-apply the readiness label.
+
+## Code Changes
+
+- For maintainer-approved refactors, add or update characterization tests before
+  changing subtle behavior; when the existing suite does not cover the refactored
+  code, keep the equivalence check you used to prove behavior is unchanged.
+
+## Documentation And Generated Files
+
+- Update docs when changing user-visible behavior, public APIs, configuration
+  syntax, examples, or installation requirements.
+- For optional integrations, document whether the integration is optional, which
+  extras or packages are required, which API keys or environment variables are
+  expected, and whether the integration uses the default OpenAI-compatible
+  framework path or the LangChain framework.
+- When documenting model or provider examples, state the relevant model type,
+  routing mode, supported modes, and known limitations rather than assuming the
+  example generalizes to every backend.
+- Use current generally-available model IDs in docs/examples (verify against the
+  provider's docs), and do not change shipped default model parameters as a
+  documentation update.
+- Do not hand-edit generated files or lockfiles unless the task explicitly
+  requires regenerating them with project tooling.
+- Put release-note context in issue or PR draft text instead of changelog files.
+- For notebook documentation, follow `CONTRIBUTING.md`. Do not run
+  `build_notebook_docs.py` unless explicitly asked; it currently runs broad git
+  staging and pre-commit commands. Use a clean worktree if it must be run.
+
+## Review Mode
+
+- When reviewing a branch, compare against the merge base with `develop` and
+  inspect tests as well as implementation.
+- Before handing off, run pre-commit first (per Validation, so line locations are
+  stable), then a structured code review (for example `codex review` or
+  `/code-review`) with a security pass for auth, input-handling, deserialization,
+  or external-call changes. Treat findings as advisory: verify each against the
+  real code path and loop until clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,12 @@ as tox and package coverage.
   and has an agreed approach recorded in the thread), stop at a proposal or
   implementation plan (an issue comment, or a throwaway `PLAN.md` PR maintainers
   can review) rather than implementing.
+- Before preparing PR-shaped work, check for duplicate or in-flight effort with
+  read-only `gh` (distinct from the no-`gh`-submission rule above):
+  `gh issue view <issue> --comments`, `gh pr list --state open --search "<issue>
+  in:body"`, and `gh pr list --state open --search "<area keywords>"`. If an open
+  PR already covers the change, do not prepare a duplicate; if your approach
+  differs materially, surface that difference in the issue draft for a maintainer.
 - If work is exploratory, draft an issue comment with the branch and relevant
   files instead of opening a PR.
 - Use the Conventional Commit-style titles described in `CONTRIBUTING.md`.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,39 @@
+# AI Usage Policy
+
+NeMo Guardrails welcomes responsible AI-assisted contributions. AI tools can be
+useful for exploration, implementation, review, and documentation, but the human
+submitter remains responsible for the contribution.
+
+## Contributor Responsibilities
+
+- Disclose AI assistance in the pull request description when AI tools create or
+  substantially modify code, tests, docs, issues, or comments. Include the tool
+  used and the extent of assistance.
+- Issues must be opened manually by a human through the repository issue
+  templates. AI tools may help draft an issue, but agents must not submit issues
+  directly.
+- Review, edit, and verify AI-generated content before submitting it. Do not
+  paste unreviewed AI output into issues, PR descriptions, code comments, docs,
+  or review comments.
+- Understand every submitted change well enough to explain what it does, why it
+  is needed, and how it interacts with the surrounding code.
+- Keep AI-assisted pull requests cohesive, scoped, and useful. Duplicate,
+  low-value, mechanical, or noisy contributions may be closed.
+- Do not add AI tools as commit co-authors. Contributions should be authored by
+  the human submitter and must still satisfy the DCO or GPG-signing
+  requirements in `CONTRIBUTING.md`.
+
+## Safety and Privacy
+
+- Do not commit API keys, credentials, private endpoints, proprietary prompts,
+  raw provider logs, or sensitive request/response data.
+- Do not use AI tools to fabricate test results, benchmark results, citations,
+  maintainer approvals, or compatibility claims.
+- Generated media, large generated assets, or synthetic datasets require clear
+  provenance and maintainer alignment before inclusion.
+
+## Maintainer Expectations
+
+AI assistance does not lower the review bar. Maintainers may ask contributors to
+explain, simplify, test, rewrite, or withdraw AI-assisted work that is not ready
+for review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,496 +1,217 @@
-# CONTRIBUTING GUIDELINES
+# Contributing Guidelines
 
-Welcome to the NeMo Guardrails contributing guide. We're excited to have you here and grateful for your contributions. This document provides guidelines and instructions for contributing to this project.
+Welcome to NeMo Guardrails. This guide explains the contribution workflow,
+local setup, validation commands, and review expectations for this repository.
 
-> [!WARNING]
-> We have recently migrated to using Poetry for dependency management and packaging. Please ensure you have Poetry installed and use it for all dependency management tasks.
+Coding agents should also read [AGENTS.md](./AGENTS.md). AI-assisted public
+contributions must follow [AI_POLICY.md](./AI_POLICY.md).
 
-## Table of Contents
+## Before You Contribute
 
-- [How to Contribute](#how-to-contribute)
-  - [Reporting Bugs](#reporting-bugs)
-  - [Suggesting Enhancements and New Features](#suggesting-enhancements-and-new-features)
-  - [Code Contributions](#code-contributions)
-    - [Getting Started](#getting-started)
-    - [Contribution Workflow](#contribution-workflow)
-    - [Pull Request Checklist](#pull-request-checklist)
-    - [Folder Structure](#folder-structure)
-    - [Coding Style](#coding-style)
-    - [Submitting Your Work](#submitting-your-work)
-- [Community and Support](#community-and-support)
+- Search existing [issues](https://github.com/NVIDIA-NeMo/Guardrails/issues)
+  and [pull requests](https://github.com/NVIDIA-NeMo/Guardrails/pulls) before
+  opening anything new.
+- Use the GitHub issue templates for bugs, feature requests, and documentation
+  issues. Blank issues are disabled.
+- Use [Discussions](https://github.com/NVIDIA-NeMo/Guardrails/discussions) for
+  support questions and "How do I...?" questions.
+- Do not open a pull request before the related issue has been triaged and
+  assigned to you.
 
-# How to Contribute
+Issues must be opened manually by a human using the GitHub issue templates. AI
+tools may help draft or refine issue text, but agents must not open issues
+directly through browser automation, the GitHub API, the `gh` CLI, or similar
+tooling. The person opening the issue is responsible for reviewing, editing, and
+owning the content.
 
-You can contribute to this project in several ways, including:
+## Issues and Proposals
 
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements and New Features](#suggesting-enhancements-and-new-features)
-- [Documentation Improvements](#documentation-improvements)
-- [Code Contributions](#code-contributions)
+Anyone is welcome to open an issue. Opening an issue does not mean you are
+committing to implement it; it is fine to report a bug, propose an idea, or
+share a design concern for someone else to pick up later.
 
-## Reporting Bugs
+If an issue author is not interested or available to implement the change,
+another contributor may ask to take it over. Wait for maintainer assignment
+before opening a PR.
 
-### Steps to Review Before Reporting a Bug
+Useful issue comments:
 
-When preparing to report a bug, please follow these steps to ensure efficiency:
+```text
+I am opening this for tracking, but I am not planning to implement it.
+```
 
-- **Review Existing Issues**: Search the [issue tracker](https://github.com/NVIDIA-NeMo/Guardrails/issues) to confirm that the problem you’re experiencing has not been reported already.
-- **Confirm the Nature of the Issue**: Ensure that what you are reporting is a genuine bug, not a support question or topic better suited for our [Discussions](https://github.com/NVIDIA-NeMo/Guardrails/discussions) page.
-- **Reopen Related Issues**: If you discover a closed issue that mirrors your current experience, create a new issue and reference the closed one with a link to provide context.
-- **Check Release Updates**: Look at the latest release notes to see if your issue is mentioned, along with any upgrade instructions or known issues.
+```text
+I would like to work on this.
+Proposed approach: <1-3 sentence summary>
+Planned validation: <tests/docs/checks>
+```
 
-### Documenting the Problem Clearly and Thoroughly
+```text
+Is this still being worked on? If not, I would be happy to take it over.
+Proposed approach: <1-3 sentence summary>
+```
 
-To ensure your issue report is easy to find and understand, follow these steps:
+Refactors are maintainer-led and are not accepted as unsolicited PRs. If you
+believe a refactor is needed, open a refactor proposal issue and wait for
+maintainer feedback. Maintainers decide whether the refactor should happen, what
+plan is acceptable, and who, if anyone, should be assigned to implement it.
 
-- **Create a Clear, Descriptive Title**: Choose a concise and specific title that identifies the problem.
-- **Detailed Reproduction Steps**: Provide a step-by-step guide to reproduce the issue. Include all necessary details to avoid ambiguity. Can you reproduce the issue following these steps?
-- **Observed vs. Expected Behavior**: Describe what actually happened when you followed the reproduction steps, and explain why this behavior is problematic. Additionally, outline what you expected to happen and why this would be the correct behavior.
-- **Minimal Configuration**: Share a minimal configuration that triggers the issue. If your configuration contains information that you don't like to remain on the repo, consider providing it in a [Gist](https://gist.github.com/) or an example repository after redacting any private data (e.g., private package repositories or specific names).
-- **Reproducibility Details**: If the issue is intermittent, specify how often it occurs and under what conditions it typically happens.
+For work in progress, experiments, or early ideas, share the branch name and
+relevant files in the issue instead of opening a premature PR.
 
-**Additional Context to Include**:
+## Pull Request Requirements
 
-- **Recent Onset vs. Longstanding Issue**: Clarify whether the issue started recently (e.g., after an update) or has been persistent. If it started recently, check if you can reproduce the issue in an older version, and specify the most recent version where it did not occur.
-- **Configuration and Environment Details**:
+Pull requests must be linked to a triaged issue. The PR author must be assigned
+to that issue before opening the PR. PRs without a linked issue, or opened by
+someone who is not assigned to the linked issue, may be closed or redirected
+without review.
 
-- The version of NeMo Guardrails you are using (e.g., `nemoguardrails --version`).
-- The Python version in use.
-- The name and version of the operating system (e.g., Ubuntu 22.04, macOS 14.2).
+Before opening a PR:
 
-> **Note**: These information are requested in the template while you are reporting the issue.
+- Fork the repository and create a branch from `develop`.
+- Keep the PR cohesive and reviewable.
+- Avoid low-value mechanical PRs such as isolated formatting churn, broad
+  cleanup without a clear user benefit, or typo-only sweeps.
+- Use the pull request template and list the tests/checks you ran.
+- Use a clear [Conventional Commit](https://www.conventionalcommits.org/)
+  style PR title, for example `fix: ...`, `feat: ...`, `docs: ...`,
+  `test: ...`, `refactor: ...`, `perf: ...`, `style: ...`, `chore: ...`,
+  `ci: ...`, or `revert: ...`. Use scopes when helpful, for example
+  `fix(server): ...`.
+- Do not update `CHANGELOG.md` or `CHANGELOG-Colang.md` manually. Changelog
+  entries are generated by the release workflow.
 
-**Ensuring Accurate Reproduction Steps**:
+## Review Readiness
 
-To maximize the chances of others understanding and reproducing your issue:
+Automated code review tools such as CodeRabbit and Greptile are part of the
+pre-review workflow. A PR is ready for maintainer review only after the author
+has addressed unresolved human and automated review comments.
 
-- Test the issue in a clean environment.
+Before requesting maintainer review:
 
-This thorough approach helps rule out local setup issues and assists others in accurately replicating your environment for further analysis.
+- Address every automated code review comment, or reply with a clear reason why
+  no change is needed.
+- When an automated review tool supports resolution confirmation, wait for the
+  tool to confirm that the issue is resolved. CodeRabbit may resolve
+  conversations itself; other tools, including Greptile, may require a follow-up
+  comment or rerun.
+- Address every human reviewer comment, or reply with a clear reason why no
+  change is needed.
+- Do not resolve human reviewer conversations unless you opened the
+  conversation, or the reviewer explicitly asks you to resolve it. Human review
+  conversations should normally be resolved by the reviewer who opened them.
 
-## Suggesting Enhancements and New Features
+The repository may use a `status: ready for maintainer review` label for PRs
+that have completed this author-response step. Do not request or apply that
+label while human or automated review comments still need author action.
 
-This section provides instructions on how to submit enhancement or feature suggestions for NeMo Guardrails, whether they involve brand-new features or improvements to current functionality. By following these guidelines, you help maintainers and the community better understand your suggestion and identify any related discussions.
+## AI-Assisted Contributions
 
-Before Submitting a Suggested Enhancement
+AI-assisted contributions are welcome when they meet the same quality bar as any
+other contribution. If AI tools helped create or substantially modify a
+contribution:
 
-- **Review Existing Issues**: Ensure that your suggestion has not already been submitted by checking the [issue tracker](https://github.com/NVIDIA-NeMo/Guardrails/issues) for similar ideas or proposals.
+- Disclose the tool and extent of assistance in the PR description.
+- Review and edit AI-generated text before submitting it.
+- Make sure you understand every code change and can explain how it interacts
+  with the surrounding system.
+- Do not add AI tools as commit co-authors.
 
-### How to Submit an Enhancement Suggestion?
+See [AI_POLICY.md](./AI_POLICY.md) for the full policy.
 
-Enhancement suggestions for NeMo Guardrails should be submitted through the main [issue tracker](https://github.com/NVIDIA-NeMo/Guardrails/issues), using the corresponding issue template provided. Follow these guidelines when submitting:
+## Development Setup
 
-- **Create a Clear, Descriptive Title**: Choose a title that clearly identifies the nature of your enhancement.
-- **Detailed Description**: Provide a comprehensive description of the proposed enhancement. Include specific steps, examples, or scenarios that illustrate how the feature would work or be implemented.
-- **Current vs. Proposed Behavior**: Describe the existing behavior or functionality and explain how you would like it to change or be improved. Clarify why this new behavior or feature is beneficial to users and the project.
+NeMo Guardrails supports Python 3.10 through 3.13. Install Git, Poetry
+`>=1.8,<2.0`, and the compiler/dev tools needed to build Annoy on your platform.
 
-By providing clear and detailed information, you make it easier for maintainers and the community to assess and discuss your proposal.
-
-## Documentation Improvements
-
-Improving the project documentation is a valuable way to contribute to NeMo Guardrails. By enhancing the documentation, you help users understand the project better, learn how to use it effectively, and contribute to the project more easily. You can contribute to the documentation in several ways:
-
-- **Fixing Typos and Grammar**: If you notice any typos, grammatical errors, or formatting issues in the documentation, feel free to correct them.
-- **Clarifying Content**: If you find sections of the documentation that are unclear or confusing, you can propose changes to make them more understandable.
-- **Adding Examples**: Providing examples and use cases can help users better understand how to use the project effectively.
-- **New Content**: Creating new content such as tutorials, FAQs, Troubleshooting, etc.
-
-### Fern Documentation Workflow
-
-The migrated documentation source lives in `docs/` as MDX files and is built with Fern. Use the Makefile targets for Fern documentation work so the workflow stays consistent with the rest of the repository.
+Clone the repository and install development dependencies:
 
 ```bash
-make docs-fern-strict
+git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
+cd nemoguardrails
+poetry install --with dev
 ```
 
-Use the following targets for common Fern documentation tasks:
+Install documentation dependencies when working on docs:
 
-| Target | Description |
-| ------ | ----------- |
-| `make docs-fern` | Run the Fern docs check. |
-| `make docs-fern-strict` | Run the Fern docs check with the pinned Fern CLI version. |
-| `make docs-fern-live` | Serve the Fern docs locally. |
-| `make docs-fern-preview-watch` | Watch local changes and publish a Fern preview for the current branch. |
-| `make docs-fern-generate-sdk` | Regenerate the Python SDK reference pages with Fern's library docs generator. |
-| `make docs-fern-publish-staging` | Publish the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails). Only NeMo Guardrails maintainers can run this target. |
-| `make docs-fern-publish-public` | Publish the Fern docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), which is used for the [public documentation site](https://docs.nvidia.com/nemo/guardrails). Only NeMo Guardrails maintainers can run this target. |
-
-For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When a documentation pull request merges into `develop`, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
-
-Publishing the Fern docs to the public instance is a manual maintainer action after staging verification.
-
-The Fern CLI version is pinned in `fern/fern.config.json`. Do not run `fern upgrade` as part of normal documentation changes.
-
-When editing the migrated docs:
-
-- Edit `.mdx` files directly.
-- Do not edit deleted legacy `.md` source files.
-- Do not run the old conversion scripts unless you are intentionally restarting the migration from the legacy source.
-- After regenerating the Python SDK reference, verify that the generated sidebar does not contain duplicate page and folder entries.
-
-## Code Contributions
-
-If you’re contributing for the first time and are searching for an issue to work on, we encourage you to check the [Contributing page](https://github.com/NVIDIA-NeMo/Guardrails/contribute) for suitable candidates. We strive to keep a selection of issues curated for first-time contributors, but sometimes there may be delays in updating. If you don’t find anything that fits, don’t hesitate to ask for guidance.
-If you would like to take on an issue, feel free to comment on the issue. We are more than happy to discuss solutions on the issue.
-
-> **Note**: Before submitting a pull request, ensure that you have read and understood the [Contribution Workflow](#contribution-workflow) section. Always open an issue before submitting a pull request so that others can access it in future and potentially discuss the changes you plan to make. We do not accept pull requests without an associated issue.
-
-### Getting Started
-
-To get started quickly, follow the steps below.
-
-1. Ensure you have Python 3.10+ and [Git](https://git-scm.com/) installed on your system. You can check your Python version by running:
-
-   ```bash
-   python --version
-   # or
-   python3 --version
-   ```
-
-   > Note: we suggest you use `pyenv` to manage your Python versions. You can find the installation instructions [here](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation).
-
-2. Clone the project repository:
-
-   ```bash
-   git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
-   ```
-
-3. Navigate to the project directory:
-
-   ```bash
-   cd nemoguardrails
-   ```
-
-4. we use `Poetry` to manage the project dependencies. To install Poetry follow the instructions [here](https://python-poetry.org/docs/#installation):
-
-   > Note: This project requires Poetry version >=1.8,<2.0. Please ensure you are using a compatible version before running any Poetry commands.
-
-   Ensure you have `poetry` installed:
-
-   ```bash
-   poetry --version
-   ```
-
-5. Install the dev dependencies:
-
-   ```bash
-   poetry install --with dev
-   ```
-
-   The preceding command installs pre-commit, pytest, and other development tools.
-   Specify `--with dev,docs` to add the dependencies for building the documentation.
-
-6. If needed, you can install extra dependencies as below:
-
-    ```bash
-    poetry install --extras "openai tracing"
-    # or Alternatively using the following command
-    poetry install -E openai -E tracing
-
-    ```
-
-   to install all the extras:
-
-   ```bash
-   poetry install --all-extras
-   ```
-
-   > **Note**: `dev` is not part of the extras but it is an optional dependency group, so you need to install it as instructed above.
-
-7. Set up pre-commit hooks:
-
-   ```
-   pre-commit install
-   ```
-
-   This will ensure that the pre-commit checks, including Black, are run before each commit.
-
-8. Run the tests:
-
-   ```bash
-   poetry run pytest
-   ```
-
-   This will run the test suite to ensure everything is set up correctly.
-
-> **Note**: You should use `poetry run` to run commands within the virtual environment. If you want to avoid prefixing commands with `poetry run`, you can activate the environment using `poetry shell`. This will start a new shell with the virtual environment activated, allowing you to run commands directly.
-
-### Contribution Workflow
-
-This project follows the [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) branching model which involves the use of several branch types:
-
-- `main`: Latest stable release branch.
-- `develop`: Development branch for integrating features.
-- `feature/...`: Feature branches for new features and non-emergency bug fixes.
-- `release/...`: Release branches for the final versions published to PyPI.
-- `hotfix/...`: Hotfix branches for emergency bug fixes.
-
-Additionally, we recommend the use of `docs/...` documentation branches for contributions that update only the project documentation. You can find a comprehensive guide on using GitFlow here: [GitFlow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
-
-To contribute your work, follow the following process:
-
-1. **Fork the Repository**: Fork the project repository to your GitHub account.
-2. **Clone Your Fork**: Clone your fork to your local machine.
-3. **Create a Feature Branch**: Create a branch from the `develop` branch.
-4. **Develop**: Make your changes locally and commit them.
-5. **Push Changes**: Push your changes to your GitHub fork.
-6. **Open a Pull Request (PR)**: Create a PR against the main project's `develop` branch.
-
-### Pull Request Checklist
-
-Before submitting your Pull Request (PR) on GitHub, please ensure you have completed the following steps. This checklist helps maintain the quality and consistency of the codebase.
-
-1. **Documentation**:
-
-    Ensure that all new code is properly documented. Update the README, API documentation, and any other relevant documentation if your changes introduce new features or change existing functionality.
-
-2. **Tests Passing**:
-
-    Run the project's test suite to make sure all tests pass. Include new tests if you are adding new features or fixing bugs. If applicable, ensure your code is compatible with different Python versions or environments.
-
-    You can run the tests using `pytest`:
-
-    ```bash
-    poetry run pytest
-    ```
-
-    Or using `make`:
-
-    ```bash
-    make tests
-    ```
-
-    You can use `tox` to run the tests for the supported Python versions:
-
-    ```bash
-    tox
-    ```
-
-    We recommend you to run the test coverage to ensure that your changes are well tested:
-
-    ```bash
-    make test_coverage
-    ```
-
-3. **Changelog Updated**:
-
-    Update the `CHANGELOG.md` file with a brief description of your changes, following the existing format. This is important for keeping track of new features, improvements, and bug fixes.
-
-    > **Note**: If your new feature concerns Colang, please update the `CHANGELOG_Colang.md` file.
-
-4. **Code Style and Quality**:
-
-    Adhere to the project's coding style guidelines. Keep your code clean and readable.
-
-5. **Commit Guidelines**:
-
-    Follow the commit message guidelines, ensuring clear and descriptive commit messages. Sign your commits as per the Developer Certificate of Origin (DCO) or GPG-sign them for verification.
-
-6. **No Merge Conflicts**:
-
-    Before submitting, rebase your branch onto the latest version of the `develop` branch to ensure your PR can be merged smoothly.
-
-7. **Self Review**:
-
-    Self-review your changes and compare them to the contribution guidelines to ensure you haven't missed anything.
-
-By following this checklist, you help streamline the review process and increase the chances of your contribution being merged without significant revisions. Your MR/PR will be reviewed by at least one of the maintainers, who may request changes or further details.
-
-### Folder Structure
-
-The project is structured as follows:
-
-```
-.
-├── chat-ui
-├── docs
-├── examples
-├── nemoguardrails
-├── qa
-├── tests
+```bash
+poetry install --with dev,docs
 ```
 
-- `chat-ui`: includes a static build of the Guardrails Chat UI. This UI is forked from [https://github.com/mckaywrigley/chatbot-ui](https://github.com/mckaywrigley/chatbot-ui) and is served by the NeMo Guardrails server. The source code for the Chat UI is not included as part of this repository.
-- `docs`: includes the official documentation of the project.
-- `examples`: various examples, including guardrails configurations (example bots, using different LLMs and others), notebooks, or Python scripts.
-- `nemoguardrails`: the source code for the main `nemoguardrails` package.
-- `qa`: a set of scripts the QA team uses.
-- `tests`: the automated tests set that runs automatically as part of the CI pipeline.
+Valid optional extras are `sdd`, `eval`, `gcp`, `tracing`, `jailbreak`,
+`multilingual`, `server`, `chat-ui`, and `all`. For example:
 
-### Coding Style
+```bash
+poetry install --with dev -E server -E tracing
+```
 
-We follow the [Black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) coding style for this project. To maintain consistent code quality and style, the [pre-commit](https://pre-commit.com) framework is used. This tool automates the process of running various checks, such as linters and formatters, before each commit. It helps catch issues early and ensures all contributions adhere to our coding standards.
+For temporary local investigation tools, use the Poetry-managed environment
+without modifying project dependencies:
 
-### Setting Up Pre-Commit
+```bash
+poetry run pip install <package-name>
+```
 
-1. **Install Pre-Commit**:
+Do not commit environment-only dependency changes.
 
-    First, you need to install pre-commit on your local machine. It can be installed via `poetry`:
+## Validation
 
-    ```bash
-    poetry add pre-commit
-    ```
+Run Python commands through Poetry.
 
-    Alternatively, you can use other installation methods as listed in the [pre-commit installation guide](https://pre-commit.com/#install).
+| Task | Command |
+| --- | --- |
+| Focused tests | `poetry run pytest path/to/test_file.py` |
+| Full test suite | `poetry run pytest` |
+| Supported Python versions | `poetry run tox` |
+| Pre-commit hooks | `poetry run pre-commit run --all-files` |
+| Docs build | `poetry run sphinx-build -b html docs _build/docs` |
+| Package coverage | `poetry run pytest --cov=nemoguardrails --cov-report=term-missing tests/` |
 
-2. **Configure Pre-Commit in Your Local Repository**:
+Run the smallest meaningful test set first, then broaden validation when the
+change touches shared runtime behavior, public APIs, packaging, server behavior,
+tracing, or docs.
 
-    In the root of the project repository, there should be a [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) file which contains the configuration and the hooks we use. Run the following command in the root of the repository to set up the git hook scripts:
+Set up local pre-commit hooks if you want checks to run before every commit:
 
-    ```bash
-    pre-commit install
-    ```
+```bash
+poetry run pre-commit install
+```
 
-3. **Running Pre-Commit**
+The pre-commit configuration runs Ruff, Ruff format, license-header insertion,
+and Pyright.
 
-   **Automatic Checks**: Once `pre-commit` is installed, the configured hooks will automatically run on each Git commit. If any changes are necessary, the commit will fail, and you'll need to make the suggested changes.
+## Documentation and Notebooks
 
-   **Manual Run**: You can manually run all hooks against all the files with the following command:
+Update documentation when changing user-visible behavior, public APIs,
+configuration syntax, examples, or installation requirements. Use the docs build
+command above before submitting docs changes when practical.
 
-   ```bash
-   pre-commit run --all-files
-   ```
+For notebook documentation, place the notebook in its own folder and generate a
+matching `README.md` with:
 
-    To do steps 2 and 3 in one command:
+```bash
+poetry run python build_notebook_docs.py PATH/TO/SUBFOLDER
+```
 
-    ```bash
-    make pre_commit
-    ```
+Important: `build_notebook_docs.py` currently runs broad git staging and
+pre-commit commands. Use a clean worktree before running it. Coding agents
+should not run it unless explicitly asked.
 
-### Installing Dependencies Without Modifying `pyproject.toml`
+## Commit Signing
 
-To install a dependency using Poetry without adding it to the `pyproject.toml` file, you can use `pip` within the Poetry-managed virtual environment. Here's how to do it:
+Public contributions must satisfy the Developer Certificate of Origin (DCO).
+Use one of these options:
 
-1. **Activate the Poetry virtual environment**:
-   - Run `poetry shell` to activate the virtual environment managed by Poetry.
+- Submit GPG-signed commits.
+- Add a `Signed-off-by` line to commit messages.
 
-   > **Note**: If you don't want to activate the virtual environment, you can use `poetry run` to run commands within the virtual environment.
-
-2. **Install the package using `pip`**:
-   - Once inside the virtual environment, you can use `pip` to install the package without affecting the `pyproject.toml`. For example:
-
-     ```bash
-     pip install <package-name>
-     # or if the virtual environment is not activated
-     poetry run pip install <package-name>
-     ```
-
-This will install the package only in the virtual environment without tracking it in `pyproject.toml`.
-
-This method is useful when you need a package temporarily or for personal development tools that you don't want to be part of your project's formal dependencies.
-
-**Important Considerations**:
-
-- Using `pip` directly inside a Poetry-managed environment bypasses Poetry's dependency resolution, so be cautious of potential conflicts with other dependencies.
-- This approach does not update the lock file (`poetry.lock`), meaning these changes are not reproducible for others or on different environments unless manually replicated.
-- If you decided to add the dependency permanently, you should add it to the `pyproject.toml` file using Poetry's `add` command.
-
-This workaround is commonly used because Poetry currently does not have a built-in feature to install packages without modifying `pyproject.toml`.
-
-## Jupyter Notebook Documentation
-
-For certain features, you can provide documentation in the form of a Jupyter notebook. In addition to the notebook, we also require that you generate a README.md file next to the Jupyter notebook, with the same content. To achieve this, follow the following process:
-
-1. Place the jupyter notebook in a separate sub-folder.
-
-2. Install `nbdoc`:
-
-   ```bash
-   poetry run pip install nbdoc
-   ```
-
-3. Use the `build_notebook_docs.py` script from the root of the project to perform the conversion:
-
-   ```bash
-   poetry run python build_notebook_docs.py PATH/TO/SUBFOLDER
-   ```
-
-### Submitting Your Work
-
-We require that all contributions are certified under the terms of the Developer Certificate of Origin (DCO), Version 1.1. This certifies that the contribution is your original work or you have the right to submit it under the same or compatible license. Any public contribution that contains commits that are not signed off will not be accepted.
-
-To simplify the process, we accept GPG-signed commits as fulfilling the requirements of the DCO.
-
-#### Why GPG Signatures?
-
-A GPG-signed commit provides cryptographic assurance that the commit was made by the holder of the corresponding private key. By configuring your commits to be signed by GPG, you not only enhance the security of the repository but also implicitly certify that you have the rights to submit the work under the project's license and agree to the DCO terms.
-
-#### Setting Up Git for Signed Commits
-
-1. **Generate a GPG key pair**:
-
-    If you don't already have a GPG key, you can generate a new GPG key pair by following the instructions here: [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key).
-
-2. **Add your GPG key to your GitHub/GitLab account**:
-
-   After generating your GPG key, add it to your GitHub account by following these steps: [Adding a new GPG key to your GitHub account](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
-
-3. **Configure Git to sign commits:**
-
-   Tell Git to use your GPG key by default for signing your commits:
-
-   ```bash
-   git config --global user.signingkey YOUR_GPG_KEY_ID
-   ```
-
-4. **Sign commits**:
-
-   Sign individual commits using the `-S` flag
-
-   ```bash
-   git commit -S -m "Your commit message"
-   ```
-
-   Or, enable commit signing by default (recommended):
-
-   ```bash
-   git config --global commit.gpgsign true
-   ```
-
-**Troubleshooting and Help**: If you encounter any issues or need help with setting up commit signing, please refer to the [GitHub documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
-Feel free to contact the project maintainers if you need further assistance.
-
-#### Developer Certificate of Origin (DCO)
-
-To ensure the quality and legality of the code base, all contributors are required to certify the origin of their contributions under the terms of the Developer Certificate of Origin (DCO), Version 1.1:
-
-  ```
-  Developer Certificate of Origin
-  Version 1.1
-
-  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-  1 Letterman Drive
-  Suite D4700
-  San Francisco, CA, 94129
-
-  Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
-
-  Developer's Certificate of Origin 1.1
-
-  By making a contribution to this project, I certify that:
-
-  (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
-
-  (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-
-  (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
-
-  (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
-  ```
-
-#### Why the DCO is Important
-
-The DCO helps to ensure that contributors have the right to submit their contributions under the project's license, protecting both the contributors and the project. It's a lightweight way to manage contributions legally without requiring a more cumbersome Contributor License Agreement (CLA).
-
-#### Summary
-
-- A GPG-signed commit will be accepted as a declaration that you agree to the terms of the DCO.
-- Alternatively, you can manually add a "Signed-off-by" line to your commit messages to comply with the DCO.
-
-By following these guidelines, you help maintain the integrity and legal compliance of the project.
+PR titles and commit messages should follow the project commit convention
+described above. A GPG-signed commit is accepted as a declaration that you agree
+to the DCO terms. For details, see the
+[Developer Certificate of Origin](https://developercertificate.org/) and
+[GitHub's signing commits documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ## Community and Support
 
-For general questions or discussion about the project, use the [discussions](https://github.com/NVIDIA-NeMo/Guardrails/discussions) section.
-
-Thank you for contributing to NeMo Guardrails!
+For general questions and discussion, use
+[GitHub Discussions](https://github.com/NVIDIA-NeMo/Guardrails/discussions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,12 +160,12 @@ Run Python commands through Poetry.
 
 | Task | Command |
 | --- | --- |
-| Focused tests | `poetry run pytest path/to/test_file.py` |
-| Full test suite | `poetry run pytest` |
+| Focused tests | `make test TEST=path/to/test_file.py::test_name` |
+| Full test suite | `make test` |
 | Supported Python versions | `poetry run tox` |
 | Pre-commit hooks | `poetry run pre-commit run --all-files` |
 | Docs check | `make docs-fern` |
-| Package coverage | `poetry run pytest --cov=nemoguardrails --cov-report=term-missing tests/` |
+| Package coverage | `make test-coverage` |
 
 Run the smallest meaningful test set first, then broaden validation when the
 change touches shared runtime behavior, public APIs, packaging, server behavior,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Run Python commands through Poetry.
 | Full test suite | `poetry run pytest` |
 | Supported Python versions | `poetry run tox` |
 | Pre-commit hooks | `poetry run pre-commit run --all-files` |
-| Docs build | `poetry run sphinx-build -b html docs _build/docs` |
+| Docs check | `make docs-fern` |
 | Package coverage | `poetry run pytest --cov=nemoguardrails --cov-report=term-missing tests/` |
 
 Run the smallest meaningful test set first, then broaden validation when the
@@ -183,8 +183,13 @@ and Pyright.
 ## Documentation and Notebooks
 
 Update documentation when changing user-visible behavior, public APIs,
-configuration syntax, examples, or installation requirements. Use the docs build
-command above before submitting docs changes when practical.
+configuration syntax, examples, or installation requirements.
+
+Documentation lives in `docs/` as MDX and is built with Fern. Edit the `.mdx`
+files directly and check changes with `make docs-fern` (`make docs-fern-live`
+serves locally; `make docs-check-links` validates links). The Fern CLI version
+is pinned in `fern/fern.config.json`; do not run `fern upgrade` as part of normal
+documentation changes.
 
 For notebook documentation, place the notebook in its own folder and generate a
 matching `README.md` with:

--- a/nemoguardrails/AGENTS.md
+++ b/nemoguardrails/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md
+
+Subtree guidance for the `nemoguardrails/` package. This supplements the
+repository-root `AGENTS.md`, `CONTRIBUTING.md`, and `AI_POLICY.md`; all
+root-level rules still apply. The rules below are the runtime, public-API, and
+provider-integration specifics that matter when editing this package.
+
+## Architecture Map
+
+- `Guardrails` (`guardrails/guardrails.py`) is the modern entry point; it
+  delegates to `IORails` (`guardrails/iorails.py`, input/output rails dispatched
+  through the engine registry) or to the legacy `LLMRails`
+  (`rails/llm/llmrails.py`, the full event-driven Colang pipeline).
+- `RailsConfig` (`rails/llm/config.py`) is the user-facing config, loaded via
+  `from_path`/`from_content`.
+- Colang has two runtimes, 1.0 (`colang/v1_0/`) and 2.x (`colang/v2_x/`),
+  dispatched by `colang/__init__.py`; actions resolve through
+  `actions/action_dispatcher.py`.
+- LLM access goes through the framework/provider abstraction (`llm/frameworks/`,
+  `types.py`): the default OpenAI-compatible client or the LangChain framework.
+- Built-in rails live in `library/` (optional, lazily imported); the FastAPI
+  server is in `server/`; request-scoped state lives in `context.py`.
+
+## Code Changes
+
+- Preserve public APIs unless the task explicitly changes them. Treat public
+  imports, constructor signatures, documented methods, config schemas, server
+  request/response shapes, Colang behavior, examples, and shipped defaults as
+  compatibility-sensitive.
+- Keep sync and async API behavior aligned for `LLMRails`, `Guardrails`, and
+  related public methods.
+- Keep optional providers, frameworks, extras, and secret-bearing integrations
+  optional. Do not move integration dependencies into the default install path
+  unless the task is specifically about packaging policy.
+- When changing API request or response shapes, keep required fields explicit
+  and never mirror API keys, credentials, or provider secrets back in response
+  bodies. Secrets belong in headers, environment variables, or local
+  configuration paths.
+- Route LLM calls through existing framework/model abstractions and helpers such
+  as `nemoguardrails.actions.llm.utils.llm_call` unless the surrounding code
+  already establishes a more specific path. Avoid ad hoc provider calls that
+  bypass shared parameter handling, tracing, metrics, or streaming behavior.
+- For OpenAI-compatible providers, prefer the built-in default framework and
+  OpenAI-compatible client path. Use the LangChain framework only for engines
+  that need LangChain or when the task explicitly changes LangChain behavior.
+- Treat HTTP header names as case-insensitive. Only normalize or compare header
+  values case-insensitively when the relevant HTTP spec or provider contract
+  defines them that way.
+- Avoid broad filesystem walks, import-time side effects, and global state
+  changes in runtime paths unless the surrounding code already establishes that
+  pattern.
+- Wrap provider/LLM failures in the domain exceptions in
+  `nemoguardrails/exceptions.py` (`LLMCallException`, `LLMClientError`
+  subclasses) and re-raise with `from`; do not raise bare exceptions.
+- Use a module-level `log = logging.getLogger(__name__)`; never `print`.
+- Sync public methods delegate to their `_async` twin via
+  `get_or_create_event_loop()` and must raise if called inside a running loop;
+  keep the logic in the async method.
+- The public surface is what top-level `__all__` exports. Domain types in
+  `types.py` are plain dataclasses (keep them dependency-free); config models use
+  Pydantic with `@model_validator` and `ConfigDict(extra="forbid")`.
+- Deprecate with `warnings.warn(..., DeprecationWarning, stacklevel=...)` and
+  keep the old path working.
+
+## NeMo Guardrails Invariants
+
+- Preserve non-text model metadata such as reasoning content, usage data, finish
+  reasons, request IDs, and streamed metadata chunks. Do not drop reasoning-only
+  or usage-only chunks just because `delta_content` or message content is empty.
+- Keep observability signals independently configurable. Tracing, metrics, logs,
+  and anonymous usage telemetry have different contracts and should not be
+  enabled, disabled, or configured as a single implicit bundle.
+- When touching rails execution, action dispatch, generation, streaming, state,
+- Mark experimental behavior clearly in docs and keep it isolated from stable
+  contracts.
+
+## Testing
+
+- Test config-driven behavior against a real `RailsConfig` (for example
+  `RailsConfig.from_content` with YAML), not `SimpleNamespace` or attribute
+  stubs, when adding or wiring a config field. Stubbing the whole config tree
+  does not validate the wiring you are adding.
+- For metadata or stats propagation changes, assert on the actual propagation
+  targets (for example both `LLMCallInfo` fields and `LLMStats` counters) and
+  reset every context variable the code path touches in fixtures.
+- Mock LLMs with the project's test doubles, not bespoke mocks: `FakeLLMModel`
+  (`nemoguardrails/testing/fake_model.py`) for deterministic responses and token
+  usage, and the `TestChat` harness (`nemoguardrails/testing/chat_harness.py`,
+  `>>`/`<<`) for end-to-end rail tests.
+- Mock provider HTTP with `pytest-httpx` (`httpx_mock`) and set secrets via
+  `monkeypatch`. There is no global live-test mode; gate any real-network test
+  behind an explicit skip.
+
+## Adding A Provider Or Library Integration
+
+When adding a new optional third-party integration (LLM provider, embedding
+provider, or similar library):
+
+- Keep the dependency optional: import the third-party package lazily inside
+  `__init__` or the method that needs it, wrapped in a `try/except ImportError`
+  that names the poetry extra to install. Never import it at module top level in
+  a way that breaks core import when the package is absent.
+- Add the dependency as an optional dependency under a poetry extra in
+  `pyproject.toml`; do not add it to the default runtime dependencies.
+- Packaging-patch hygiene: read the current `pyproject.toml` and `poetry.lock`
+  first, anchor edits to lines that actually exist, and regenerate the lock with
+  project tooling. Do not generate dependency edits from memory or templates; if
+  the lock cannot be regenerated, stop and flag that it will be inconsistent.
+- Follow the existing provider pattern. For an embedding provider, mimic
+  `nemoguardrails/embeddings/providers/openai.py`: subclass the `EmbeddingModel`
+  ABC, set `engine_name`, implement `encode()` and `encode_async()`, and register
+  the class with one `register_embedding_provider(...)` call in
+  `providers/__init__.py`. For an LLM provider, implement the `LLMModel` protocol
+  and route through the default OpenAI-compatible framework unless LangChain is
+  required.
+- Tests must not call the live service: mock the client (`MagicMock`/`AsyncMock`
+  or httpx fixtures, as in `tests/test_embeddings_openai.py`); guard any
+  real-network test behind an explicit skip (there is no global live-test mode).
+- Document the engine/provider name, the required extra, and the expected API
+  keys or environment variables, and note whether it uses the default framework
+  or LangChain.
+- Keep the registration name and constructor signature consistent with sibling
+  providers.

--- a/nemoguardrails/AGENTS.md
+++ b/nemoguardrails/AGENTS.md
@@ -70,7 +70,6 @@ provider-integration specifics that matter when editing this package.
 - Keep observability signals independently configurable. Tracing, metrics, logs,
   and anonymous usage telemetry have different contracts and should not be
   enabled, disabled, or configured as a single implicit bundle.
-- When touching rails execution, action dispatch, generation, streaming, state,
 - Mark experimental behavior clearly in docs and keep it isolated from stable
   contracts.
 

--- a/nemoguardrails/CLAUDE.md
+++ b/nemoguardrails/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,5 +18,4 @@ markers =
 
 testpaths =
     tests
-    docs/colang-2/examples
     benchmark/tests


### PR DESCRIPTION
## Description

Adds an AI-assisted contribution policy and an agent-facing operating guide, and
tidies the contributor docs:
- `AI_POLICY.md` : disclosure, accountability, safety/privacy for AI-assisted work.
- `AGENTS.md` (+ `CLAUDE.md` symlink) and nested `nemoguardrails/AGENTS.md`, operational rules for coding agents, layered on the canonical docs.
- `CONTRIBUTING.md`,  streamlined rewrite.
- Refactor-proposal issue template + PR template update.
- `pytest.ini` ,  drop the Colang-2 examples testpath.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines and AI-assisted contribution policy documentation.
  * Updated GitHub pull request and issue templates with enhanced submission guidance and verification requirements.
  * Added package architecture reference and contribution best practices.
  * Reorganized and clarified contributing workflow and review procedures.

* **Chores**
  * Updated test discovery configuration to reflect current test organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->