### PR TITLE
ci: update codecov action

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: inputs.with-coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           directory: ./coverage/reports/
           env_vars: PYTHON


### PR DESCRIPTION
## Description

Updates the Codecov GitHub Action from `v5` to `v7` in the reusable test workflow.

The Python 3.11 PR test leg is the only matrix entry that uploads coverage, and it failed after tests passed because Codecov could not verify the downloaded CLI signature:

- Failing job: https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/27142627876/job/80111644388?pr=2007
- Codecov `v7` release note says the wrapper now fetches the uploader PGP verification key from the `codecovsecops` Keybase account: https://github.com/codecov/codecov-action

  ## Related Iss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code coverage reporting tool to a newer version in the CI/CD workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->