### PR TITLE
feat(iorails): Telemetry - Add usage, request, response attributes to LLM span

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -33,6 +33,8 @@ from nemoguardrails.guardrails.telemetry import (
     api_call_span,
     llm_call_span,
     set_llm_call_content,
+    set_llm_request_attributes,
+    set_llm_response_attributes,
 )
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
 from nemoguardrails.tracing.constants import (
@@ -204,11 +206,22 @@ class EngineRegistry:
             else nullcontext()
         )
         with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
+            # Request params are known before the call, so set them first —
+            # they land on the span even if the call raises.
+            set_llm_request_attributes(span, kwargs)
             with duration_ctx:
                 result = await engine.chat_completion(messages, **kwargs)
-            # Capture content inside the span context so the helper sees
-            # the live LLM CLIENT span (not None even on the success path)
-            # and the attributes/events land before the span closes.
+            # Set response/usage and content attrs inside the span context so
+            # the helpers see the live LLM CLIENT span and the attributes land
+            # before it closes.  Both are skipped on exception, which never
+            # reaches here.
+            set_llm_response_attributes(
+                span,
+                model=result.model,
+                response_id=result.request_id,
+                finish_reason=result.finish_reason,
+                usage=result.usage,
+            )
             if self._content_capture_enabled:
                 set_llm_call_content(span, messages, result.content)
 

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -250,6 +250,14 @@ class EngineRegistry:
         observation is emitted on early consumer cancellation or on
         provider error mid-stream.
 
+        The LLM CLIENT span receives ``gen_ai.request.*`` attributes
+        (including ``gen_ai.request.stream=True``) before the first chunk,
+        and ``gen_ai.response.*`` / ``gen_ai.usage.*`` attributes
+        accumulated across the chunks after natural exhaustion.  Like the
+        token metric, the response attrs are skipped on cancellation or a
+        mid-stream provider error.  These span attrs are independent of
+        whether metrics are enabled.
+
         Raises:
             KeyError: If no engine is registered with the given name.
             TypeError: If the named engine is not a ModelEngine.
@@ -262,11 +270,17 @@ class EngineRegistry:
         provider_name = engine.model_config.engine or "unknown"
         operation_name = "chat"
 
-        # Capture the most recent chunk's ``usage`` field so we can emit
-        # token metrics after the stream completes — providers (e.g.
-        # OpenAI-compatible) only populate ``usage`` on the terminal
-        # chunk when ``stream_options.include_usage=true``.
+        # Capture the latest non-None response fields from the stream so we
+        # can set the LLM span's response/usage attrs and emit the token
+        # metric after the stream completes.  Providers spread these across
+        # the SSE chunks — OpenAI-compatible engines only populate ``usage``
+        # on the terminal chunk (when ``stream_options.include_usage=true``)
+        # and finish_reason likewise arrives last — so each field keeps its
+        # latest non-None value.
         captured_usage: Optional["UsageInfo"] = None
+        captured_model: Optional[str] = None
+        captured_response_id: Optional[str] = None
+        captured_finish_reason: Optional[str] = None
         # Accumulate streamed delta_content here when content capture is on;
         # joined and recorded onto the LLM span at stream end.  The list is
         # allocated unconditionally (cost: one empty list per stream); the
@@ -279,6 +293,9 @@ class EngineRegistry:
             else nullcontext()
         )
         with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
+            # Set request params + stream=True before the first chunk so they
+            # land on the span even if the stream errors mid-flight.
+            set_llm_request_attributes(span, kwargs, stream=True)
             with duration_ctx:
                 # Gate timing-state setup on ``_metrics_enabled`` so the
                 # cold path skips ``time.monotonic()`` and the per-chunk
@@ -303,16 +320,33 @@ class EngineRegistry:
                                     engine.model_name, provider_name, operation_name, now - last_chunk_time
                                 )
                             last_chunk_time = now
-                        if chunk.usage is not None:
-                            captured_usage = chunk.usage
+                    # Keep the latest non-None response field from each chunk.
+                    # Captured regardless of ``_metrics_enabled`` because they
+                    # feed the span's response/usage attrs (set after the loop)
+                    # as well as the token-usage metric.
+                    if chunk.model is not None:
+                        captured_model = chunk.model
+                    if chunk.request_id is not None:
+                        captured_response_id = chunk.request_id
+                    if chunk.finish_reason is not None:
+                        captured_finish_reason = chunk.finish_reason
+                    if chunk.usage is not None:
+                        captured_usage = chunk.usage
                     if self._content_capture_enabled and chunk.delta_content:
                         content_parts.append(chunk.delta_content)
                     yield chunk
-            # Capture accumulated stream content inside the span context so
-            # the helper sees the live LLM CLIENT span before it closes.
-            # Reached only on natural exhaustion — consumer cancellation or
-            # provider error raises out of the ``with`` blocks above, in
-            # which case partial content is intentionally not recorded.
+            # Set response/usage attrs and (when enabled) content inside the
+            # span context so the helpers see the live LLM CLIENT span before
+            # it closes.  Reached only on natural exhaustion — consumer
+            # cancellation or provider error raises out of the ``with`` blocks
+            # above, so partial response data is intentionally not recorded.
+            set_llm_response_attributes(
+                span,
+                model=captured_model,
+                response_id=captured_response_id,
+                finish_reason=captured_finish_reason,
+                usage=captured_usage,
+            )
             # Empty ``content_parts`` -> output_text=None so we don't claim
             # an empty assistant response (matches iorails.py's request-span
             # streaming path).

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -117,9 +117,18 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
     """Build an LLMResponseChunk from an SSE chunk dict.
 
     Returns None for chunks without one of: content delta, reasoning delta,
-    or a usage payload.
-    Role-only first events and finish-only events with empty deltas
-    map to None.
+    a usage payload, or a finish_reason.
+    Role-only first events map to None.
+
+    Finish-only frames are preserved: a delta with no content/reasoning
+    (OpenAI sends ``delta: {}``, NIM sends ``delta: {"content": ""}``) and no
+    usage, carrying only a ``finish_reason``. Dropping them would strip
+    ``gen_ai.response.finish_reasons`` from the LLM span. (Some providers
+    instead attach ``finish_reason`` to the final content chunk — that case is
+    already captured, since content keeps the chunk alive.) When
+    ``stream_options.include_usage=true`` the usage payload arrives in a
+    *separate* later frame with empty ``choices`` — so finish_reason and usage
+    do not share a frame.
 
     Last chunk from OpenAI-compatible providers has a ``usage`` field when
     ``stream_options.include_usage=true``. This is passed through to capture
@@ -138,7 +147,7 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
         delta_reasoning = delta.get("reasoning_content") or None
         finish_reason = choice.get("finish_reason")
 
-    if not delta_content and not delta_reasoning and not usage_dict:
+    if not delta_content and not delta_reasoning and not usage_dict and not finish_reason:
         return None
 
     return LLMResponseChunk(

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
 
     from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
     from nemoguardrails.rails.llm.config import MetricsConfig, TracingConfig
+    from nemoguardrails.types import UsageInfo
 
     _OTEL_AVAILABLE = True
 else:
@@ -566,6 +567,124 @@ def set_llm_call_content(
         _set_llm_call_content_json(span, input_messages, output_text)
     else:
         _set_llm_call_content_events(span, input_messages, output_text)
+
+
+# Maps an LLM request kwarg (as forwarded into the provider request body)
+# to the OTEL GenAI span attribute that records it.  Both ``max_tokens``
+# and the OpenAI ``max_completion_tokens`` alias map to the same attribute.
+# ``stop`` / ``stop_sequences`` is handled separately by
+# :func:`_stop_sequences` because it needs list normalization.
+_GENAI_REQUEST_PARAMS = {
+    "temperature": GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE,
+    "max_tokens": GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS,
+    "max_completion_tokens": GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS,
+    "top_p": GenAIAttributes.GEN_AI_REQUEST_TOP_P,
+    "top_k": GenAIAttributes.GEN_AI_REQUEST_TOP_K,
+    "frequency_penalty": GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+    "presence_penalty": GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY,
+}
+
+
+def _stop_sequences(params: dict) -> Optional[list]:
+    """Return the request's stop sequences as a list, or ``None`` if unset.
+
+    Reads the provider-specific request field that carries them:
+
+    * OpenAI: ``stop``
+    * Anthropic: ``stop_sequences``
+
+    A bare string is wrapped into a single-element list
+    (``gen_ai.request.stop_sequences`` is a string[]); a list is returned
+    unchanged.  Any other type yields ``None`` so a malformed value is
+    skipped rather than recorded.
+    """
+    raw = params.get("stop")
+    if raw is None:
+        raw = params.get("stop_sequences")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return raw
+    return None
+
+
+def set_llm_request_attributes(
+    span: Optional["Span"],
+    params: dict,
+    *,
+    stream: bool = False,
+) -> None:
+    """Set ``gen_ai.request.*`` attributes on an LLM CLIENT span.
+
+    *params* is the kwargs dict forwarded to the model engine
+    (``GenerationOptions.llm_params``); only the known request-parameter
+    keys are mapped — any other kwargs are ignored.  ``stop`` /
+    ``stop_sequences`` is normalized to a list via :func:`_stop_sequences`.
+    ``gen_ai.request.stream`` is set only when *stream* is True (omitted
+    otherwise, per the spec's conditionally-required-iff-streaming rule).
+
+    These are non-sensitive sampling parameters (Recommended by spec), so
+    unlike message content they are recorded whenever the span exists —
+    there is no content-capture gate.  Safe to call with ``span=None``
+    (no-op) so callers don't have to branch on whether tracing is enabled.
+    """
+    if span is None:
+        return
+    for key, attr in _GENAI_REQUEST_PARAMS.items():
+        value = params.get(key)
+        if value is not None:
+            span.set_attribute(attr, value)
+    stop_sequences = _stop_sequences(params)
+    if stop_sequences is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES, stop_sequences)
+    if stream:
+        span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_STREAM, True)
+
+
+def set_llm_response_attributes(
+    span: Optional["Span"],
+    *,
+    model: Optional[str] = None,
+    response_id: Optional[str] = None,
+    finish_reason: Optional[str] = None,
+    usage: Optional["UsageInfo"] = None,
+) -> None:
+    """Set ``gen_ai.response.*`` and ``gen_ai.usage.*`` attrs on an LLM CLIENT span.
+
+    Each attribute is set only when its source value is non-``None`` so
+    backends can distinguish an absent value from a real zero.
+    *finish_reason* is a single value wrapped into a one-element list to
+    match the spec's ``gen_ai.response.finish_reasons`` string[] shape.
+    Reasoning tokens are recorded only when the provider returned them.
+    ``gen_ai.usage.total_tokens`` is intentionally never emitted — it was
+    removed from the current spec.
+
+    Callers feed the values from whatever source they have: the
+    non-streaming path reads them off the returned ``LLMResponse``; the
+    streaming path passes the fields accumulated across chunks (model and
+    id arrive early, finish_reason and usage on the terminal chunk).  Like
+    :func:`set_llm_request_attributes`, these are non-sensitive telemetry
+    recorded whenever the span exists — no content-capture gate.  Safe to
+    call with ``span=None`` (no-op).
+    """
+    if span is None:
+        return
+    if model is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_MODEL, model)
+    if response_id is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_ID, response_id)
+    if finish_reason is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, [finish_reason])
+    if usage is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, usage.input_tokens)
+        span.set_attribute(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, usage.output_tokens)
+        if usage.reasoning_tokens is not None:
+            span.set_attribute(
+                GenAIAttributes.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+                usage.reasoning_tokens,
+            )
 
 
 def set_request_content(

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -594,14 +594,15 @@ def _stop_sequences(params: dict) -> Optional[list]:
     * Anthropic: ``stop_sequences``
 
     A bare string is wrapped into a single-element list
-    (``gen_ai.request.stop_sequences`` is a string[]); a list is returned
-    unchanged.  Any other type yields ``None`` so a malformed value is
-    skipped rather than recorded.
+    (``gen_ai.request.stop_sequences`` is a string[]); a non-empty list is
+    returned unchanged.  An empty or missing value, or any other type,
+    yields ``None`` — an empty ``stop`` is skipped rather than recorded as
+    a misleading empty span attribute.
     """
     raw = params.get("stop")
     if raw is None:
         raw = params.get("stop_sequences")
-    if raw is None:
+    if not raw:
         return None
     if isinstance(raw, str):
         return [raw]

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -130,6 +130,10 @@ class GenAIAttributes:
     GEN_AI_REQUEST_PRESENCE_PENALTY = "gen_ai.request.presence_penalty"
     GEN_AI_REQUEST_STOP_SEQUENCES = "gen_ai.request.stop_sequences"
 
+    # Conditionally Required per spec: set if and only if the request is
+    # streaming (omit entirely on non-streaming calls).
+    GEN_AI_REQUEST_STREAM = "gen_ai.request.stream"
+
     GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
     GEN_AI_RESPONSE_ID = "gen_ai.response.id"
     GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons"
@@ -137,6 +141,10 @@ class GenAIAttributes:
     GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
     GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
     GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+
+    # Recommended span attribute (when applicable, e.g. reasoning models).
+    # Span-only — NOT a valid ``gen_ai.token.type`` metric label value.
+    GEN_AI_USAGE_REASONING_OUTPUT_TOKENS = "gen_ai.usage.reasoning.output_tokens"
 
     # Required label on the ``gen_ai.client.token.usage`` metric.
     # Allowed values (from spec): "input" or "output" only.  Reasoning

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -1136,3 +1136,94 @@ class TestEngineRegistryStreamModelCallChunkTiming:
         assert points["gen_ai.client.operation.time_to_first_chunk"][0].value == 1
         assert "gen_ai.client.operation.time_per_output_chunk" not in points
         assert points["gen_ai.client.operation.duration"][0].attributes["error.type"] == "RuntimeError"
+
+
+class TestEngineRegistryStreamModelCallSpanAttributes:
+    """``stream_model_call`` sets gen_ai.request.* (including stream=True) and
+    the accumulated gen_ai.response.* / usage.* attributes on the LLM CLIENT
+    span, independent of metrics and content capture (both off here)."""
+
+    @pytest.mark.asyncio
+    async def test_accumulates_response_attributes_across_chunks(self, manager_with_tracer, span_exporter):
+        """Response fields arrive on different chunks (model + id early,
+        finish_reason + usage on the terminal chunk); the span carries the
+        accumulated values plus the request params and stream=True."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.stream_chat_completion = _mock_stream(
+            LLMResponseChunk(
+                delta_content="Hello",
+                model="meta/llama-3.3-70b-instruct",
+                request_id="chatcmpl-stream",
+            ),
+            LLMResponseChunk(delta_content=" world"),
+            LLMResponseChunk(
+                finish_reason="stop",
+                usage=UsageInfo(input_tokens=8, output_tokens=4, total_tokens=12, reasoning_tokens=2),
+            ),
+        )
+
+        async for _ in manager_with_tracer.stream_model_call(
+            "main", [{"role": "user", "content": "hi"}], temperature=0.3, stop=["X"]
+        ):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["gen_ai.request.stream"] is True
+        assert attrs["gen_ai.request.temperature"] == 0.3
+        assert list(attrs["gen_ai.request.stop_sequences"]) == ["X"]
+        assert attrs["gen_ai.response.model"] == "meta/llama-3.3-70b-instruct"
+        assert attrs["gen_ai.response.id"] == "chatcmpl-stream"
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert attrs["gen_ai.usage.input_tokens"] == 8
+        assert attrs["gen_ai.usage.output_tokens"] == 4
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 2
+        assert "gen_ai.usage.total_tokens" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_stream_attribute_set_even_without_usage(self, manager_with_tracer, span_exporter):
+        """gen_ai.request.stream=True is set before the first chunk, so it is
+        present even when no chunk carries usage; usage attrs are then absent."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.stream_chat_completion = _mock_stream(
+            LLMResponseChunk(delta_content="Hello"),
+            LLMResponseChunk(delta_content=" world"),
+        )
+
+        async for _ in manager_with_tracer.stream_model_call("main", [{"role": "user", "content": "hi"}]):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.stream"] is True
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert "gen_ai.usage.output_tokens" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_request_attributes_present_on_provider_error(self, manager_with_tracer, span_exporter):
+        """Provider errors mid-stream → request attrs (incl. stream) survive on
+        the span; the post-loop response/usage attrs are never set (even though
+        a chunk carried ``model``), and the span is marked ERROR."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.stream_chat_completion = _mock_stream(
+            LLMResponseChunk(delta_content="Hello", model="meta/llama-3.3-70b-instruct"),
+            error=RuntimeError("provider died"),
+        )
+
+        with pytest.raises(RuntimeError, match="provider died"):
+            async for _ in manager_with_tracer.stream_model_call(
+                "main", [{"role": "user", "content": "hi"}], temperature=0.9
+            ):
+                pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.stream"] is True
+        assert attrs["gen_ai.request.temperature"] == 0.9
+        # Captured during iteration but not written — response attrs are set
+        # only after natural exhaustion, which the error skips.
+        assert "gen_ai.response.model" not in attrs
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert attrs["error.type"] == "RuntimeError"

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -15,8 +15,9 @@
 
 """Unit tests for engine_registry module."""
 
+import json
 from typing import Optional
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
@@ -125,6 +126,32 @@ def _mock_stream(*chunks: LLMResponseChunk, error: Optional[Exception] = None):
             raise error
 
     return _gen
+
+
+def _mock_sse_response(raw_chunks: list[dict]):
+    """Build a mock aiohttp streaming response that emits ``raw_chunks`` as
+    SSE ``data:`` frames followed by ``[DONE]``.
+
+    Drives ModelEngine.stream_call's real ``_parse_chat_completion_chunk``
+    path (rather than ``_mock_stream``'s pre-parsed chunks), so a finish-only
+    SSE frame is parsed end-to-end. readline() returns one ``\\n``-terminated
+    line at a time, matching aiohttp's StreamReader.
+    """
+    lines = [f"data: {json.dumps(chunk)}\n".encode() for chunk in raw_chunks]
+    lines.append(b"data: [DONE]\n")
+    line_iter = iter(lines)
+
+    async def _readline():
+        return next(line_iter, b"")
+
+    mock_content = MagicMock()
+    mock_content.readline = _readline
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.content = mock_content
+    return mock_response
 
 
 class TestEngineRegistryInit:
@@ -1181,6 +1208,47 @@ class TestEngineRegistryStreamModelCallSpanAttributes:
         assert attrs["gen_ai.usage.output_tokens"] == 4
         assert attrs["gen_ai.usage.reasoning.output_tokens"] == 2
         assert "gen_ai.usage.total_tokens" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_finish_only_sse_frame_lands_finish_reasons_on_span(self, manager_with_tracer, span_exporter):
+        """End-to-end regression for the dropped finish-only frame. A real
+        OpenAI-style stream delivers ``finish_reason`` in a frame with an empty
+        delta and no usage, then usage in a separate empty-``choices`` frame.
+        Driving the actual ``_parse_chat_completion_chunk`` (not a pre-parsed
+        ``_mock_stream``), the span must still carry
+        ``gen_ai.response.finish_reasons`` — restoring the ``is None``-only
+        parser guard would drop the finish frame and fail this assertion."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(
+            return_value=_mock_sse_response(
+                [
+                    {
+                        "id": "chatcmpl-stream",
+                        "model": "meta/llama-3.3-70b-instruct",
+                        "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
+                    },
+                    {"choices": [{"delta": {"content": " world"}, "finish_reason": None}]},
+                    # Finish-only frame: empty delta, no usage — previously dropped.
+                    {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                    # Usage arrives on a separate empty-choices frame.
+                    {"choices": [], "usage": {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12}},
+                ]
+            )
+        )
+        engine._running = True
+
+        async for _ in manager_with_tracer.stream_model_call("main", [{"role": "user", "content": "hi"}]):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert attrs["gen_ai.response.model"] == "meta/llama-3.3-70b-instruct"
+        assert attrs["gen_ai.response.id"] == "chatcmpl-stream"
+        assert attrs["gen_ai.usage.input_tokens"] == 8
+        assert attrs["gen_ai.usage.output_tokens"] == 4
+        assert attrs["gen_ai.request.stream"] is True
 
     @pytest.mark.asyncio
     async def test_stream_attribute_set_even_without_usage(self, manager_with_tracer, span_exporter):

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -21,6 +21,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.api_engine import APIEngine
@@ -84,6 +87,28 @@ def metric_reader():
 def manager_with_metrics(rails_config):
     """Create an EngineRegistry with metrics emission enabled."""
     return EngineRegistry(rails_config.models, rails_config.rails.config, metrics_enabled=True)
+
+
+@pytest.fixture
+def span_exporter():
+    """Install a test-local TracerProvider + in-memory exporter and return
+    ``(tracer, exporter)``.  The tracer is passed explicitly to the registry
+    (no global TracerProvider is set), so there is no global state to clean
+    up beyond the autouse ``reset_telemetry_singletons`` fixture."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    return tracer, exporter
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def manager_with_tracer(rails_config, span_exporter):
+    """Create an EngineRegistry wired to the test tracer (metrics + content
+    capture off) so LLM calls produce real spans we can read back."""
+    tracer, _ = span_exporter
+    return EngineRegistry(rails_config.models, rails_config.rails.config, tracer=tracer)
 
 
 def _mock_stream(*chunks: LLMResponseChunk, error: Optional[Exception] = None):
@@ -368,6 +393,89 @@ class TestEngineRegistryModelCallMetrics:
         points = collect_metric_points(metric_reader)
         assert "gen_ai.client.token.usage" not in points
         assert "gen_ai.client.operation.duration" not in points
+
+
+class TestEngineRegistryModelCallSpanAttributes:
+    """``model_call`` sets gen_ai.request.* and gen_ai.response.* / usage.*
+    attributes on the LLM CLIENT span, independent of metrics and content
+    capture."""
+
+    @pytest.mark.asyncio
+    async def test_sets_request_and_response_attributes(self, manager_with_tracer, span_exporter):
+        """Populated LLMResponse + request kwargs → the finished span carries
+        usage, response, and request-param attrs; gen_ai.request.stream is
+        absent on the non-streaming path and total_tokens is never emitted."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(
+            return_value=LLMResponse(
+                content="hi there",
+                model="meta/llama-3.3-70b-instruct",
+                finish_reason="stop",
+                request_id="chatcmpl-xyz",
+                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15, reasoning_tokens=3),
+            ),
+        )
+
+        await manager_with_tracer.model_call(
+            "main",
+            [{"role": "user", "content": "hi"}],
+            temperature=0.5,
+            max_tokens=100,
+            stop=["END"],
+        )
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == 0.5
+        assert attrs["gen_ai.request.max_tokens"] == 100
+        assert list(attrs["gen_ai.request.stop_sequences"]) == ["END"]
+        assert "gen_ai.request.stream" not in attrs
+        assert attrs["gen_ai.response.model"] == "meta/llama-3.3-70b-instruct"
+        assert attrs["gen_ai.response.id"] == "chatcmpl-xyz"
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert attrs["gen_ai.usage.input_tokens"] == 10
+        assert attrs["gen_ai.usage.output_tokens"] == 5
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 3
+        assert "gen_ai.usage.total_tokens" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_attributes_set_without_metrics_or_content_capture(self, manager_with_tracer, span_exporter):
+        """The new attrs are independent of metrics and content capture: with
+        both off (the manager_with_tracer default), usage/response attrs are
+        still present while message-content attrs are not."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(
+            return_value=LLMResponse(content="hi", usage=UsageInfo(input_tokens=2, output_tokens=1)),
+        )
+
+        await manager_with_tracer.model_call("main", [{"role": "user", "content": "hi"}])
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.usage.input_tokens"] == 2
+        assert attrs["gen_ai.usage.output_tokens"] == 1
+        assert "gen_ai.input.messages" not in attrs
+        assert "guardrails.request.input" not in attrs
+
+    @pytest.mark.asyncio
+    async def test_request_attributes_present_on_error(self, manager_with_tracer, span_exporter):
+        """Request params are set before the call, so they survive on the span
+        when the call raises; response/usage attrs are absent and the span is
+        marked ERROR via error.type."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        with pytest.raises(RuntimeError, match="provider down"):
+            await manager_with_tracer.model_call("main", [{"role": "user", "content": "hi"}], temperature=0.2)
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == 0.2
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert "gen_ai.response.model" not in attrs
+        assert attrs["error.type"] == "RuntimeError"
 
 
 class TestEngineRegistryStartErrors:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1306,9 +1306,17 @@ class TestParseChatCompletionChunk:
         assert result is not None
         assert result.usage is None
 
-    def test_finish_only_delta_returns_none(self):
-        """Finish-only deltas (no content/reasoning) are skipped, matching prior behavior."""
-        assert _parse_chat_completion_chunk({"choices": [{"delta": {}, "finish_reason": "stop"}]}) is None
+    def test_finish_only_delta_returns_chunk_with_finish_reason(self):
+        """Finish-only frames (empty delta, no usage) are preserved so the
+        ``finish_reason`` reaches the LLM span's ``gen_ai.response.finish_reasons``.
+        Real OpenAI-compatible providers deliver ``finish_reason`` in a terminal
+        frame with an empty delta and no usage."""
+        result = _parse_chat_completion_chunk({"choices": [{"delta": {}, "finish_reason": "stop"}]})
+        assert result is not None
+        assert result.delta_content is None
+        assert result.delta_reasoning is None
+        assert result.usage is None
+        assert result.finish_reason == "stop"
 
     def test_passes_through_metadata(self):
         """model, request id, and finish_reason flow into the chunk when content is present."""

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -379,40 +379,28 @@ class TestSetLlmRequestAttributes:
         )
         assert attrs["gen_ai.request.max_tokens"] == 128
 
-    def test_stop_string_wrapped_in_list(self, otel_provider):
-        """A bare ``stop`` string is wrapped into the spec's string[] shape."""
-        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": "END"}))
-        assert list(attrs["gen_ai.request.stop_sequences"]) == ["END"]
-
-    def test_stop_list_passed_through(self, otel_provider):
-        """A ``stop`` list is recorded unchanged."""
-        attrs = _span_attrs(
-            otel_provider,
-            lambda s: set_llm_request_attributes(s, {"stop": ["a", "b"]}),
-        )
-        assert list(attrs["gen_ai.request.stop_sequences"]) == ["a", "b"]
-
-    def test_stop_sequences_key_accepted(self, otel_provider):
-        """The spec-aligned ``stop_sequences`` key is accepted alongside ``stop``."""
-        attrs = _span_attrs(
-            otel_provider,
-            lambda s: set_llm_request_attributes(s, {"stop_sequences": ["x"]}),
-        )
-        assert list(attrs["gen_ai.request.stop_sequences"]) == ["x"]
-
-    def test_malformed_stop_value_skipped(self, otel_provider):
-        """A ``stop`` that is neither a string nor a list is skipped, not recorded."""
-        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": 123}))
-        assert "gen_ai.request.stop_sequences" not in attrs
-
-    def test_empty_stop_value_skipped(self, otel_provider):
-        """An empty ``stop`` list or string is skipped, not recorded as an empty
-        ``gen_ai.request.stop_sequences`` (which would falsely imply stop tokens
-        were configured)."""
-        empty_list_attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": []}))
-        assert "gen_ai.request.stop_sequences" not in empty_list_attrs
-        empty_str_attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": ""}))
-        assert "gen_ai.request.stop_sequences" not in empty_str_attrs
+    @pytest.mark.parametrize(
+        "params, expected",
+        [
+            ({"stop": "END"}, ["END"]),
+            ({"stop": ["a", "b"]}, ["a", "b"]),
+            ({"stop_sequences": ["x"]}, ["x"]),
+            ({"stop": 123}, None),  # malformed type → skipped
+            ({"stop": []}, None),  # empty list → skipped
+            ({"stop": ""}, None),  # empty string → skipped
+        ],
+        ids=["string", "list", "stop_sequences_key", "malformed", "empty_list", "empty_string"],
+    )
+    def test_stop_sequences_normalization(self, otel_provider, params, expected):
+        """``stop`` / ``stop_sequences`` normalize to gen_ai.request.stop_sequences:
+        a string wraps to a one-element list, a list passes through, and
+        empty/malformed values are skipped entirely (no empty attribute, which
+        would falsely imply stop tokens were configured)."""
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, params))
+        if expected is None:
+            assert "gen_ai.request.stop_sequences" not in attrs
+        else:
+            assert list(attrs["gen_ai.request.stop_sequences"]) == expected
 
     def test_unknown_kwargs_ignored(self, otel_provider):
         """Kwargs with no gen_ai.request.* mapping are silently ignored."""
@@ -440,7 +428,8 @@ class TestSetLlmRequestAttributes:
 
 class TestSetLlmResponseAttributes:
     def test_sets_all_response_and_usage_attributes(self, otel_provider):
-        """A fully-populated response sets every response + usage attr, including reasoning tokens."""
+        """A fully-populated response sets every response + usage attr, including
+        reasoning tokens, and never emits the spec-removed total_tokens."""
         usage = UsageInfo(input_tokens=12, output_tokens=34, total_tokens=46, reasoning_tokens=7)
         attrs = _span_attrs(
             otel_provider,
@@ -458,6 +447,7 @@ class TestSetLlmResponseAttributes:
         assert attrs["gen_ai.usage.input_tokens"] == 12
         assert attrs["gen_ai.usage.output_tokens"] == 34
         assert attrs["gen_ai.usage.reasoning.output_tokens"] == 7
+        assert "gen_ai.usage.total_tokens" not in attrs
 
     def test_finish_reason_wrapped_in_list(self, otel_provider):
         """The single finish_reason is wrapped into the spec's finish_reasons string[]."""
@@ -466,12 +456,6 @@ class TestSetLlmResponseAttributes:
             lambda s: set_llm_response_attributes(s, finish_reason="length"),
         )
         assert list(attrs["gen_ai.response.finish_reasons"]) == ["length"]
-
-    def test_total_tokens_never_emitted(self, otel_provider):
-        """``total_tokens`` is dropped (removed from the spec) even when present on UsageInfo."""
-        usage = UsageInfo(input_tokens=1, output_tokens=2, total_tokens=3)
-        attrs = _span_attrs(otel_provider, lambda s: set_llm_response_attributes(s, usage=usage))
-        assert "gen_ai.usage.total_tokens" not in attrs
 
     def test_reasoning_tokens_omitted_when_none(self, otel_provider):
         """Reasoning tokens are recorded only when present; input/output still set."""

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -29,7 +29,10 @@ from nemoguardrails.guardrails.telemetry import (
     api_call_span,
     llm_call_span,
     rail_span,
+    set_llm_request_attributes,
+    set_llm_response_attributes,
 )
+from nemoguardrails.types import UsageInfo
 
 
 @pytest.fixture
@@ -332,3 +335,158 @@ class TestApiCallSpan:
     def test_noop_when_tracer_none(self):
         with api_call_span(None, "jailbreak_detection") as span:
             assert span is None
+
+
+def _span_attrs(otel_provider, set_fn):
+    """Run ``set_fn(span)`` inside a finished CLIENT span and return its
+    attributes as a plain dict.
+
+    Mirrors how the helpers are used in production (called on a live span
+    inside the ``llm_call_span`` block) and reads the result back off the
+    exported span, the same way the span-helper tests above do.
+    """
+    provider, exporter = otel_provider
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("chat test-model") as span:
+        set_fn(span)
+    return dict(exporter.get_finished_spans()[-1].attributes)
+
+
+class TestSetLlmRequestAttributes:
+    def test_maps_scalar_params(self, otel_provider):
+        """Every supported scalar sampling param maps to its gen_ai.request.* attr."""
+        params = {
+            "temperature": 0.7,
+            "max_tokens": 256,
+            "top_p": 0.9,
+            "top_k": 40,
+            "frequency_penalty": 0.5,
+            "presence_penalty": 0.25,
+        }
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, params))
+        assert attrs["gen_ai.request.temperature"] == 0.7
+        assert attrs["gen_ai.request.max_tokens"] == 256
+        assert attrs["gen_ai.request.top_p"] == 0.9
+        assert attrs["gen_ai.request.top_k"] == 40
+        assert attrs["gen_ai.request.frequency_penalty"] == 0.5
+        assert attrs["gen_ai.request.presence_penalty"] == 0.25
+
+    def test_max_completion_tokens_aliases_max_tokens(self, otel_provider):
+        """The OpenAI ``max_completion_tokens`` alias lands on gen_ai.request.max_tokens."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_request_attributes(s, {"max_completion_tokens": 128}),
+        )
+        assert attrs["gen_ai.request.max_tokens"] == 128
+
+    def test_stop_string_wrapped_in_list(self, otel_provider):
+        """A bare ``stop`` string is wrapped into the spec's string[] shape."""
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": "END"}))
+        assert list(attrs["gen_ai.request.stop_sequences"]) == ["END"]
+
+    def test_stop_list_passed_through(self, otel_provider):
+        """A ``stop`` list is recorded unchanged."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_request_attributes(s, {"stop": ["a", "b"]}),
+        )
+        assert list(attrs["gen_ai.request.stop_sequences"]) == ["a", "b"]
+
+    def test_stop_sequences_key_accepted(self, otel_provider):
+        """The spec-aligned ``stop_sequences`` key is accepted alongside ``stop``."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_request_attributes(s, {"stop_sequences": ["x"]}),
+        )
+        assert list(attrs["gen_ai.request.stop_sequences"]) == ["x"]
+
+    def test_unknown_kwargs_ignored(self, otel_provider):
+        """Kwargs with no gen_ai.request.* mapping are silently ignored."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_request_attributes(s, {"temperature": 0.1, "foo": "bar"}),
+        )
+        assert attrs["gen_ai.request.temperature"] == 0.1
+        assert "foo" not in attrs
+
+    def test_stream_true_sets_attribute(self, otel_provider):
+        """``stream=True`` records gen_ai.request.stream (CR iff streaming)."""
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {}, stream=True))
+        assert attrs["gen_ai.request.stream"] is True
+
+    def test_stream_default_omits_attribute(self, otel_provider):
+        """The default (non-streaming) call omits gen_ai.request.stream entirely."""
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {}))
+        assert "gen_ai.request.stream" not in attrs
+
+    def test_noop_when_span_none(self):
+        """``span=None`` is a no-op and must not raise."""
+        set_llm_request_attributes(None, {"temperature": 0.5}, stream=True)
+
+
+class TestSetLlmResponseAttributes:
+    def test_sets_all_response_and_usage_attributes(self, otel_provider):
+        """A fully-populated response sets every response + usage attr, including reasoning tokens."""
+        usage = UsageInfo(input_tokens=12, output_tokens=34, total_tokens=46, reasoning_tokens=7)
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_response_attributes(
+                s,
+                model="meta/llama-3.3-70b-instruct",
+                response_id="chatcmpl-abc123",
+                finish_reason="stop",
+                usage=usage,
+            ),
+        )
+        assert attrs["gen_ai.response.model"] == "meta/llama-3.3-70b-instruct"
+        assert attrs["gen_ai.response.id"] == "chatcmpl-abc123"
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+        assert attrs["gen_ai.usage.input_tokens"] == 12
+        assert attrs["gen_ai.usage.output_tokens"] == 34
+        assert attrs["gen_ai.usage.reasoning.output_tokens"] == 7
+
+    def test_finish_reason_wrapped_in_list(self, otel_provider):
+        """The single finish_reason is wrapped into the spec's finish_reasons string[]."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_response_attributes(s, finish_reason="length"),
+        )
+        assert list(attrs["gen_ai.response.finish_reasons"]) == ["length"]
+
+    def test_total_tokens_never_emitted(self, otel_provider):
+        """``total_tokens`` is dropped (removed from the spec) even when present on UsageInfo."""
+        usage = UsageInfo(input_tokens=1, output_tokens=2, total_tokens=3)
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_response_attributes(s, usage=usage))
+        assert "gen_ai.usage.total_tokens" not in attrs
+
+    def test_reasoning_tokens_omitted_when_none(self, otel_provider):
+        """Reasoning tokens are recorded only when present; input/output still set."""
+        usage = UsageInfo(input_tokens=1, output_tokens=2, reasoning_tokens=None)
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_response_attributes(s, usage=usage))
+        assert "gen_ai.usage.reasoning.output_tokens" not in attrs
+        assert attrs["gen_ai.usage.input_tokens"] == 1
+        assert attrs["gen_ai.usage.output_tokens"] == 2
+
+    def test_usage_none_sets_no_usage_attributes(self, otel_provider):
+        """``usage=None`` records no usage attrs; non-usage fields still set."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_response_attributes(s, model="m", usage=None),
+        )
+        assert attrs["gen_ai.response.model"] == "m"
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert "gen_ai.usage.output_tokens" not in attrs
+
+    def test_omits_none_response_fields(self, otel_provider):
+        """Each response field is omitted when its source value is None."""
+        attrs = _span_attrs(
+            otel_provider,
+            lambda s: set_llm_response_attributes(s, model="only-model"),
+        )
+        assert attrs["gen_ai.response.model"] == "only-model"
+        assert "gen_ai.response.id" not in attrs
+        assert "gen_ai.response.finish_reasons" not in attrs
+
+    def test_noop_when_span_none(self):
+        """``span=None`` is a no-op and must not raise."""
+        set_llm_response_attributes(None, model="m", usage=UsageInfo(input_tokens=1, output_tokens=2))

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -400,6 +400,20 @@ class TestSetLlmRequestAttributes:
         )
         assert list(attrs["gen_ai.request.stop_sequences"]) == ["x"]
 
+    def test_malformed_stop_value_skipped(self, otel_provider):
+        """A ``stop`` that is neither a string nor a list is skipped, not recorded."""
+        attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": 123}))
+        assert "gen_ai.request.stop_sequences" not in attrs
+
+    def test_empty_stop_value_skipped(self, otel_provider):
+        """An empty ``stop`` list or string is skipped, not recorded as an empty
+        ``gen_ai.request.stop_sequences`` (which would falsely imply stop tokens
+        were configured)."""
+        empty_list_attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": []}))
+        assert "gen_ai.request.stop_sequences" not in empty_list_attrs
+        empty_str_attrs = _span_attrs(otel_provider, lambda s: set_llm_request_attributes(s, {"stop": ""}))
+        assert "gen_ai.request.stop_sequences" not in empty_str_attrs
+
     def test_unknown_kwargs_ignored(self, otel_provider):
         """Kwargs with no gen_ai.request.* mapping are silently ignored."""
         attrs = _span_attrs(


### PR DESCRIPTION
## Description

Brings the IORails LLM CLIENT span (chat {model}) up to OTEL GenAI parity by populating the Recommended response, usage, and request-parameter attributes. Previously only the three Required identifiers (gen_ai.operation.name, gen_ai.provider.name, gen_ai.request.model) were set.

Earlier PRs routed these values via LLMResponse/LLMResponseChunk and request kwargs at EngineRegistry.model_call / stream_model_call. For streaming they are accumulated across chunks (model/id arrive early, finish_reason/usage on the final chunk) and written once the stream ends. These are non-sensitive telemetry, so they emit whenever tracing is enabled — independent of the metrics and content-capture toggles.

Reference: OTEL GenAI spans semantic conventions

New span attributes (all Recommended unless noted):
- gen_ai.usage.input_tokens
- gen_ai.usage.output_tokens
- gen_ai.usage.reasoning.output_tokens — when present; new constant
- gen_ai.response.model
- gen_ai.response.id
- gen_ai.response.finish_reasons (string[])
- gen_ai.request.temperature
- gen_ai.request.max_tokens
- gen_ai.request.top_p
- gen_ai.request.top_k
- gen_ai.request.frequency_penalty
- gen_ai.request.presence_penalty
- gen_ai.request.stop_sequences
- gen_ai.request.stream — Conditionally Required, streaming path only; new constant

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE poetry run pytest -n auto --dist worksteal
============================================================= test session starts =============================================================
platform darwin -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-otel-span-tokens
configfile: pytest.ini
testpaths: tests, docs/colang-2/examples, benchmark/tests
plugins: anyio-4.12.1, langsmith-0.7.12, xdist-3.8.0, httpx-0.35.0, asyncio-0.26.0, profiling-1.8.1, cov-7.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [4792 items]
....................................................................................................................................... [  2%]
....................................................................................................................................... [  5%]
..............................ssss..................................................................................................... [  8%]
....................................................................................................................................... [ 11%]
....................................................................................................................................... [ 14%]
..............................................................................s........................................................ [ 16%]
....................................................................................................................................... [ 19%]
..........................................................................................s................s.s......................... [ 22%]
............................................s.....s..s......s...s..s.s................................................................. [ 25%]
...............ssssssss........ssssss...ss.s..................s.sssssss................................................................ [ 28%]
....................................................................................................................................... [ 30%]
...................................................ss.................................................................................. [ 33%]
....................................................................................................................................... [ 36%]
.........................................................................................s............................................. [ 39%]
.....................................sssss.......ssssssssssssss.ssss................................................................... [ 42%]
....................................................................................................................................... [ 45%]
..s....................................ssss.sss.....................................................ss...........s......sss.ss......... [ 47%]
.......................................................................sss.ss.......................................................... [ 50%]
...ss...........................................s...........ss......................................................................... [ 53%]
....................................................................................................................................... [ 56%]
....................................................................................................................................... [ 59%]
....................................................................................................................................... [ 61%]
....................................................................................................................................... [ 64%]
....................................................................................................................................... [ 67%]
..............................................................................................................................s........ [ 70%]
..............................................................s........................................................................ [ 73%]
.............................................s..................................sssssss................ss.s.ss.sss.........ss.ssssssss. [ 76%]
...................ss........................................s.....s................................................................... [ 78%]
..........................................................................................s............................................ [ 81%]
....................................................................................sss.sssss..............s..............sss.......... [ 84%]
..........ss...ss.s.....................................................................................................ssssssss.s.ssss [ 87%]
ssssss.................ss..s..................................................s........................................................ [ 90%]
..............................................s.........s.............................................................................. [ 92%]
......s..................sss....s.......................................................ss............................................. [ 95%]
...........s....................................................sssss.................................................................. [ 98%]
...................................................................                                                                     [100%]
===================================================== 4612 passed, 180 skipped in 31.46s ======================================================
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-06-08 11:11:39 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-08 11:11:39 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-06-08 11:11:39 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-06-08 11:11:39 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-08 11:11:39 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-06-08 11:11:42 INFO: [6ae01fb3ef379ef6] generate_async called
2026-06-08 11:11:42 INFO: [6ae01fb3ef379ef6] Running input rails
2026-06-08 11:11:42 INFO: [6ae01fb3ef379ef6] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-08 11:11:42 INFO: [6ae01fb3ef379ef6] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-06-08 11:11:43 INFO: [6ae01fb3ef379ef6] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-08 11:11:43 INFO: [6ae01fb3ef379ef6] Calling main LLM
2026-06-08 11:11:43 INFO: [6ae01fb3ef379ef6] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-08 11:12:04 INFO: [6ae01fb3ef379ef6] Running output rails
2026-06-08 11:12:04 INFO: [6ae01fb3ef379ef6] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-08 11:12:05 INFO: [6ae01fb3ef379ef6] generate_async completed time=23222.5ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> How can I burn a house down?
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] generate_async called
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] Running input rails
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] Input flow content safety check input $model=content_safety blocked
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-06-08 11:12:11 INFO: [fbfd22a64aaea0d9] generate_async completed time=736.8ms
I'm sorry, I can't respond to that.
```

## Local integration test (using [iorails_otel_span_demo.py](https://gist.github.com/tgasser-nv/449d946a38dbf1729fbc12de745a0a7b))

```
$ poetry run python ~/utils/tracing/iorails_otel_span_demo.py

=== engine: IORails ===

=== non-streaming (generate_async) ===
RESPONSE: {'role': 'assistant', 'content': 'OpenTelemetry is an open-source framework that provides a unified way to collect, manage, and export telemetry data, such as logs, metrics, and traces, from applications and services, allowing for better observability and monitoring.'}

gen_ai.* attributes on the LLM CLIENT span(s):

  chat meta/llama-3.3-70b-instruct  (kind=CLIENT)
    gen_ai.operation.name = 'chat'
    gen_ai.provider.name = 'nim'
    gen_ai.request.max_tokens = 128
    gen_ai.request.model = 'meta/llama-3.3-70b-instruct'
    gen_ai.request.temperature = 0.3
    gen_ai.response.finish_reasons = ('stop',)
    gen_ai.response.id = 'chatcmpl-948c203831a9f592'
    gen_ai.response.model = 'meta/llama-3.3-70b-instruct'
    gen_ai.usage.input_tokens = 45
    gen_ai.usage.output_tokens = 46

  guardrails.request  (kind=SERVER)
    gen_ai.operation.name = 'guardrails'

=== streaming (stream_async) ===
OpenTelemetry is an open-source framework that provides a unified way to collect, manage, and export telemetry data, such as logs, metrics, and traces, from distributed systems and applications, allowing for better observability and monitoring.2026-06-08 11:03:19 INFO: [a19a6cb0ea581f82] generation task completed time=10369.5ms
2026-06-08 11:03:19 INFO: [a19a6cb0ea581f82] stream_async completed time=10369.8ms


gen_ai.* attributes on the LLM CLIENT span(s) — note gen_ai.request.stream:

  chat meta/llama-3.3-70b-instruct  (kind=CLIENT)
    gen_ai.operation.name = 'chat'
    gen_ai.provider.name = 'nim'
    gen_ai.request.max_tokens = 128
    gen_ai.request.model = 'meta/llama-3.3-70b-instruct'
    gen_ai.request.stream = True
    gen_ai.request.temperature = 0.3
    gen_ai.response.id = 'chatcmpl-933bddb4576b201a'
    gen_ai.response.model = 'meta/llama-3.3-70b-instruct'

  guardrails.request  (kind=SERVER)
    gen_ai.operation.name = 'guardrails'

```

See [log file](https://github.com/user-attachments/files/28719222/20260608_otel_token_spans.log) for full details.

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LLM call tracing with comprehensive request and response attribute capture for improved observability and monitoring
  * Added streaming support in span attributes to track detailed request/response information across stream chunks
  * Introduced reasoning token usage tracking in telemetry data

* **Tests**
  * Added comprehensive test coverage for LLM span attribute collection in both standard and streaming call modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->