### PR TITLE
feat(server): add `/v1/guardrail/checks` endpoint

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -35,9 +35,11 @@ from starlette.responses import RedirectResponse, StreamingResponse
 
 from nemoguardrails import LLMRails, RailsConfig, utils
 from nemoguardrails.rails.llm.config import Model
-from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.rails.llm.options import GenerationResponse, RailStatus
 from nemoguardrails.server.datastore.datastore import DataStore
 from nemoguardrails.server.schemas.openai import (
+    GuardrailCheckRequest,
+    GuardrailCheckResponse,
     GuardrailsChatCompletion,
     GuardrailsChatCompletionRequest,
     OpenAIModelsList,
@@ -328,6 +330,20 @@ def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsCon
     return config.model_copy(update={"models": models})
 
 
+def _inject_model(config: RailsConfig, model_name: str) -> RailsConfig:
+    """Inject the request's model into a RailsConfig using env-based engine/base_url."""
+    engine = os.environ.get("MAIN_MODEL_ENGINE")
+    if not engine:
+        engine = "openai"
+        log.warning("MAIN_MODEL_ENGINE not set, defaulting to 'openai'. ")
+    parameters = {}
+    base_url = os.environ.get("MAIN_MODEL_BASE_URL")
+    if base_url:
+        parameters["base_url"] = base_url
+    main_model = Model(model=model_name, type="main", engine=engine, parameters=parameters)
+    return _update_models_in_config(config, main_model)
+
+
 async def _get_rails(config_ids: List[str], model_name: Optional[str] = None) -> LLMRails:
     """Returns the rails instance for the given config id and model.
 
@@ -373,18 +389,7 @@ async def _get_rails(config_ids: List[str], model_name: Optional[str] = None) ->
         raise ValueError("No valid rails configuration found.")
 
     if model_name:
-        engine = os.environ.get("MAIN_MODEL_ENGINE")
-        if not engine:
-            engine = "openai"
-            log.warning("MAIN_MODEL_ENGINE not set, defaulting to 'openai'. ")
-
-        parameters = {}
-        base_url = os.environ.get("MAIN_MODEL_BASE_URL")
-        if base_url:
-            parameters["base_url"] = base_url
-
-        main_model = Model(model=model_name, type="main", engine=engine, parameters=parameters)
-        full_llm_rails_config = _update_models_in_config(full_llm_rails_config, main_model)
+        full_llm_rails_config = _inject_model(full_llm_rails_config, model_name)
 
     llm_rails = LLMRails(config=full_llm_rails_config, verbose=True)
     llm_rails_instances[configs_cache_key] = llm_rails
@@ -641,6 +646,79 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             error_message="Internal server error",
             config_id=config_ids[0] if config_ids else None,
         )
+
+
+def _map_rail_status(status: RailStatus) -> str:
+    """Map internal RailStatus to API status string."""
+    return status.value
+
+
+@app.post(
+    "/v1/guardrail/checks",
+    response_model=GuardrailCheckResponse,
+    response_model_exclude_none=True,
+)
+async def guardrail_check(body: GuardrailCheckRequest, request: Request):
+    """Guardrail check request."""
+    api_request_headers.set(request.headers)
+
+    if not body.messages:
+        raise HTTPException(status_code=422, detail="messages must be non-empty")
+
+    config_ids = None
+    config = body.guardrails.config
+
+    if isinstance(config, dict):
+        try:
+            rails_config = RailsConfig.from_content(config=config)
+            if body.model:
+                rails_config = _inject_model(rails_config, body.model)
+            llm_rails = LLMRails(config=rails_config, verbose=True)
+        except Exception as ex:
+            log.exception(ex)
+            raise HTTPException(status_code=422, detail=f"Invalid inline config: {ex}")
+    else:
+        if isinstance(config, str):
+            config_ids = [config]
+        elif body.guardrails.config_ids:
+            config_ids = list(body.guardrails.config_ids)
+        elif app.default_config_id:
+            config_ids = [app.default_config_id]
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="No guardrails config_id provided and server has no default configuration",
+            )
+        try:
+            llm_rails = await _get_rails(config_ids, model_name=body.model)
+        except ValueError as ex:
+            log.exception(ex)
+            raise HTTPException(status_code=422, detail=str(ex))
+
+    if llm_rails.config.colang_version != "1.0":
+        raise HTTPException(
+            status_code=422,
+            detail="check_async does not support Colang 2.0 configurations.",
+        )
+
+    try:
+        messages = list(body.messages)
+        if body.guardrails.context:
+            messages.insert(0, {"role": "context", "content": body.guardrails.context})
+
+        result = await llm_rails.check_async(messages=messages)
+
+        return GuardrailCheckResponse(
+            status=_map_rail_status(result.status),
+            content=result.content,
+            rail=result.rail,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as ex:
+        log.exception(ex)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 # By default, there are no challenges

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -654,7 +654,7 @@ def _map_rail_status(status: RailStatus) -> str:
 
 
 @app.post(
-    "/v1/guardrail/checks",
+    "/v1/checks",
     response_model=GuardrailCheckResponse,
     response_model_exclude_none=True,
 )

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -165,3 +165,37 @@ class OpenAIModelsList(BaseModel):
     """Standard OpenAI models list response."""
 
     data: list[OpenAIModel] = Field(..., description="List of OpenAI model objects.")
+
+
+class GuardrailCheckDataInput(GuardrailsDataInput):
+    """Guardrails input options specific to the checks endpoint."""
+
+    config: Optional[Union[str, dict]] = Field(
+        default=None,
+        description="The id of the configuration or its dict representation to be used.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_config_exclusivity(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("config") is not None:
+            if data.get("config_id") is not None or data.get("config_ids") is not None:
+                raise ValueError("config is mutually exclusive with config_id and config_ids")
+        return data
+
+
+class GuardrailCheckRequest(OpenAIChatCompletionRequest):
+    """Request body for the /v1/guardrail/checks endpoint."""
+
+    guardrails: GuardrailCheckDataInput = Field(
+        default_factory=GuardrailCheckDataInput,
+        description="Guardrails specific options for the request.",
+    )
+
+
+class GuardrailCheckResponse(BaseModel):
+    """Response from the /v1/guardrail/checks endpoint."""
+
+    status: str = Field(..., description="Overall check result: passed, modified, or blocked.")
+    content: str = Field(..., description="Content after rails processing.")
+    rail: Optional[str] = Field(default=None, description="Name of the blocking rail, if any.")

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -185,7 +185,7 @@ class GuardrailCheckDataInput(GuardrailsDataInput):
 
 
 class GuardrailCheckRequest(OpenAIChatCompletionRequest):
-    """Request body for the /v1/guardrail/checks endpoint."""
+    """Request body for the /v1/checks endpoint."""
 
     guardrails: GuardrailCheckDataInput = Field(
         default_factory=GuardrailCheckDataInput,
@@ -194,7 +194,7 @@ class GuardrailCheckRequest(OpenAIChatCompletionRequest):
 
 
 class GuardrailCheckResponse(BaseModel):
-    """Response from the /v1/guardrail/checks endpoint."""
+    """Response from the /v1/checks endpoint."""
 
     status: str = Field(..., description="Overall check result: passed, modified, or blocked.")
     content: str = Field(..., description="Content after rails processing.")

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
+from fastapi.testclient import TestClient
+
+from nemoguardrails.rails.llm.options import RailsResult, RailStatus
+from nemoguardrails.server import api
+
+client = TestClient(api.app)
+
+ENDPOINT = "/v1/guardrail/checks"
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    original_default = api.app.default_config_id
+    api.llm_rails_instances.clear()
+    yield
+    api.app.default_config_id = original_default
+    api.llm_rails_instances.clear()
+
+
+def _mock_rails(check_result: RailsResult, colang_version: str = "1.0") -> MagicMock:
+    mock = MagicMock()
+    mock.check_async = AsyncMock(return_value=check_result)
+    mock.config.colang_version = colang_version
+    return mock
+
+
+def _post(body: dict, **kwargs):
+    return client.post(ENDPOINT, json=body, **kwargs)
+
+
+def _checked(result, config_id="test", colang_version="1.0"):
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=_mock_rails(result, colang_version)):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": config_id},
+            }
+        )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# --- Status mapping ---
+
+
+@pytest.mark.parametrize(
+    "rail_status, expected",
+    [
+        (RailStatus.PASSED, "passed"),
+        (RailStatus.MODIFIED, "modified"),
+        (RailStatus.BLOCKED, "blocked"),
+    ],
+)
+def test_status_mapping(rail_status, expected):
+    result = RailsResult(status=rail_status, content="x")
+    data = _checked(result)
+    assert data["status"] == expected
+
+
+# --- Content and rail fields ---
+
+
+def test_content_returned_on_passed():
+    result = RailsResult(status=RailStatus.PASSED, content="hello there")
+    data = _checked(result)
+    assert data["content"] == "hello there"
+    assert data.get("rail") is None
+
+
+def test_content_returned_on_modified():
+    result = RailsResult(status=RailStatus.MODIFIED, content="sanitized text")
+    data = _checked(result)
+    assert data["content"] == "sanitized text"
+
+
+def test_content_returned_on_blocked():
+    result = RailsResult(
+        status=RailStatus.BLOCKED, content="I'm sorry, I can't help with that.", rail="self check input"
+    )
+    data = _checked(result)
+    assert data["status"] == "blocked"
+    assert data["content"] == "I'm sorry, I can't help with that."
+    assert data["rail"] == "self check input"
+
+
+def test_rail_null_on_passed():
+    result = RailsResult(status=RailStatus.PASSED, content="ok")
+    data = _checked(result)
+    assert "rail" not in data
+
+
+# --- Config resolution ---
+
+
+def test_config_id_resolves():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock) as mock_get:
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "my_config"},
+            }
+        )
+
+    assert resp.status_code == 200
+    mock_get.assert_called_once_with(["my_config"], model_name="test")
+
+
+def test_config_string_resolves_via_get_rails():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock) as mock_get:
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config": "my_config"},
+            }
+        )
+
+    assert resp.status_code == 200
+    mock_get.assert_called_once_with(["my_config"], model_name="test")
+
+
+def test_inline_config():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock_llm_rails = _mock_rails(result)
+
+    with (
+        patch("nemoguardrails.server.api.RailsConfig") as mock_config_cls,
+        patch("nemoguardrails.server.api.LLMRails", return_value=mock_llm_rails),
+    ):
+        mock_config_cls.from_content.return_value = MagicMock()
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config": {"models": [], "rails": {}}},
+            }
+        )
+
+    assert resp.status_code == 200
+    mock_config_cls.from_content.assert_called_once()
+
+
+def test_default_config_used_when_none_specified():
+    api.app.default_config_id = "my_default"
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock) as mock_get:
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        )
+
+    assert resp.status_code == 200
+    mock_get.assert_called_once_with(["my_default"], model_name="test")
+
+
+# --- Validation ---
+
+
+def test_empty_messages_returns_422():
+    resp = _post(
+        {
+            "model": "test",
+            "messages": [],
+            "guardrails": {"config_id": "test"},
+        }
+    )
+    assert resp.status_code == 422
+
+
+def test_config_and_config_id_mutually_exclusive():
+    resp = _post(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "guardrails": {"config": "a", "config_id": "b"},
+        }
+    )
+    assert resp.status_code == 422
+
+
+def test_no_config_no_default_returns_422():
+    api.app.default_config_id = None
+    resp = _post(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+    assert resp.status_code == 422
+    assert "config" in resp.json()["detail"].lower()
+
+
+# --- Colang 2.0 rejection ---
+
+
+def test_colang_v2_returns_422():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result, colang_version="2.x")
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "test"},
+            }
+        )
+
+    assert resp.status_code == 422
+    assert "colang 2.0" in resp.json()["detail"].lower()
+
+
+# --- Error handling ---
+
+
+def test_get_rails_failure_returns_422():
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, side_effect=ValueError("bad config")):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "bad"},
+            }
+        )
+
+    assert resp.status_code == 422
+
+
+def test_check_async_failure_returns_500():
+    mock = MagicMock()
+    mock.check_async = AsyncMock(side_effect=RuntimeError("boom"))
+    mock.config.colang_version = "1.0"
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "test"},
+            }
+        )
+
+    assert resp.status_code == 500
+
+
+# --- Context forwarding ---
+
+
+def test_context_prepended_to_messages():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "test", "context": {"topic": "science"}},
+            }
+        )
+
+    assert resp.status_code == 200
+    call_args = mock.check_async.call_args
+    messages = call_args.kwargs.get("messages") or call_args[0][0]
+    assert messages[0]["role"] == "context"
+    assert messages[0]["content"] == {"topic": "science"}

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -25,7 +25,7 @@ from nemoguardrails.server import api
 
 client = TestClient(api.app)
 
-ENDPOINT = "/v1/guardrail/checks"
+ENDPOINT = "/v1/checks"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

This PR add `/v1/guardrail/checks` endpoint, wired through `check_async()`

Briefly, 

- `options.py`: added log field to `RailsResult` to surface generation log from `check_async`
- `llmrails.py`: threaded log=response.log through all three `RailsResult` return sites in `check_async()`
- `schemas/openai.py`: added `GuardrailCheckRequest`, `GuardrailCheckResponse`, `RailStatusEntry`, `GuardrailCheckDataOutput` models matching upstream OpenAPI spec
- `api.py`: endpoint + helpers (_inject_model, _filter_log, _map_rail_status, _build_rails_status). Extracted _inject_model() from _get_rails to share with inline config path

This PR deals with the following [issue](https://github.com/NVIDIA-NeMo/Guardrails/issues/2014)

## Test Plan

1. Added `tests/server/test_guardrail_checks.py`, tests seem to pass:

```bash
pytest tests/server/test_guardrail_checks.py
======================== test session starts =========================
platform darwin -- Python 3.12.0, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/mmisiura/repos/forked/NeMo-Guardrails
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml, tox.ini!)
plugins: httpx-0.36.0, recording-0.13.4, langsmith-0.4.30, anyio-4.11.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 16 items                                                   

tests/server/test_guardrail_checks.py ................  
```

2. Tested against live server; examples of requests (also tested with optional ` "options": {"log": {"activated_rails": true}}`

- input to be blocked by self check rail

```bash
curl -s -X POST http://localhost:8000/v1/guardrail/checks \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen3.6-35B-A3B",
    "messages": [{"role": "user", "content": "my email is John.Doe@test.com"}],
    "guardrails": {"config_id": "checks_live_test"}
  }' | jq
```

```json
{
  "status": "blocked",
  "rails_status": {
    "self check input": {
      "status": "blocked"
    }
  },
  "guardrails_data": {
    "config_ids": [
      "checks_live_test"
    ],
    "log": {
      "activated_rails": [],
      "stats": {
        "input_rails_duration": 3.91440486907959,
        "dialog_rails_duration": null,
        "generation_rails_duration": null,
        "output_rails_duration": null,
        "total_duration": 3.9169669151306152,
        "llm_calls_duration": 3.8865039348602295,
        "llm_calls_count": 1,
        "llm_calls_total_prompt_tokens": 144,
        "llm_calls_total_completion_tokens": 522,
        "llm_calls_total_tokens": 666
      }
    }
  }
}
```

- input not to be blocked by self check rail

```bash
curl -s -X POST http://localhost:8000/v1/guardrail/checks \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen3.6-35B-A3B",
    "messages": [{"role": "user", "content": "my email is my private matter"}],
    "guardrails": {"config_id": "checks_live_test"}
  }' | jq
```

```json
{
  "status": "success",
  "rails_status": {
    "self check input": {
      "status": "success"
    },
    "detect sensitive data on input": {
      "status": "success"
    }
  },
  "guardrails_data": {
    "config_ids": [
      "checks_live_test"
    ],
    "log": {
      "activated_rails": [],
      "stats": {
        "input_rails_duration": 4.953992128372192,
        "dialog_rails_duration": null,
        "generation_rails_duration": null,
        "output_rails_duration": null,
        "total_duration": 4.959690093994141,
        "llm_calls_duration": 4.178013324737549,
        "llm_calls_count": 1,
        "llm_calls_total_prompt_tokens": 142,
        "llm_calls_total_completion_tokens": 590,
        "llm_calls_total_tokens": 732
      }
    }
  }
}
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

cc @Pouyanpi @tgasser-nv 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/v1/guardrail/checks` API endpoint for validating messages against guardrails
  * Added per-rail status reporting to track which guardrails are triggered
  * Enhanced guardrail check results with comprehensive logging information across all outcomes

* **Improvements**
  * Guardrail checks now provide consistent logging data regardless of result status (blocked, modified, or passed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->