### PR TITLE
docs: document Fern docs publishing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,12 +112,12 @@ Use the following targets for common Fern documentation tasks:
 | `make docs-fern-live` | Serve the Fern docs locally. |
 | `make docs-fern-preview-watch` | Watch local changes and publish a Fern preview for the current branch. |
 | `make docs-fern-generate-sdk` | Regenerate the Python SDK reference pages with Fern's library docs generator. |
-| `make docs-fern-publish-staging` | Publish the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails). |
-| `make docs-fern-publish-public` | Publish the Fern docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), which is used for the [public documentation site](https://docs.nvidia.com/nemo/guardrails). |
+| `make docs-fern-publish-staging` | Publish the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails). Only NeMo Guardrails maintainers can run this target. |
+| `make docs-fern-publish-public` | Publish the Fern docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), which is used for the [public documentation site](https://docs.nvidia.com/nemo/guardrails). Only NeMo Guardrails maintainers can run this target. |
 
-For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
+For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When a documentation pull request merges into `develop`, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
 
-Publishing the Fern docs to the public instance is done by the maintainers.
+Publishing the Fern docs to the public instance is a manual maintainer action after staging verification.
 
 The Fern CLI version is pinned in `fern/fern.config.json`. Do not run `fern upgrade` as part of normal documentation changes.
 
@@ -163,15 +163,15 @@ To get started quickly, follow the steps below.
 
 4. we use `Poetry` to manage the project dependencies. To install Poetry follow the instructions [here](https://python-poetry.org/docs/#installation):
 
-> Note: This project requires Poetry version >=1.8,<2.0. Please ensure you are using a compatible version before running any Poetry commands.
+   > Note: This project requires Poetry version >=1.8,<2.0. Please ensure you are using a compatible version before running any Poetry commands.
 
-  Ensure you have `poetry` installed:
+   Ensure you have `poetry` installed:
 
    ```bash
    poetry --version
    ```
 
-1. Install the dev dependencies:
+5. Install the dev dependencies:
 
    ```bash
    poetry install --with dev
@@ -180,7 +180,7 @@ To get started quickly, follow the steps below.
    The preceding command installs pre-commit, pytest, and other development tools.
    Specify `--with dev,docs` to add the dependencies for building the documentation.
 
-2. If needed, you can install extra dependencies as below:
+6. If needed, you can install extra dependencies as below:
 
     ```bash
     poetry install --extras "openai tracing"
@@ -189,15 +189,15 @@ To get started quickly, follow the steps below.
 
     ```
 
-    to install all the extras:
+   to install all the extras:
 
-    ```bash
-    poetry install --all-extras
-    ```
+   ```bash
+   poetry install --all-extras
+   ```
 
-> **Note**: `dev` is not part of the extras but it is an optional dependency group, so you need to install it as instructed above.
+   > **Note**: `dev` is not part of the extras but it is an optional dependency group, so you need to install it as instructed above.
 
-1. Set up pre-commit hooks:
+7. Set up pre-commit hooks:
 
    ```
    pre-commit install
@@ -205,7 +205,7 @@ To get started quickly, follow the steps below.
 
    This will ensure that the pre-commit checks, including Black, are run before each commit.
 
-2. Run the tests:
+8. Run the tests:
 
    ```bash
    poetry run pytest
@@ -364,9 +364,9 @@ To install a dependency using Poetry without adding it to the `pyproject.toml` f
 1. **Activate the Poetry virtual environment**:
    - Run `poetry shell` to activate the virtual environment managed by Poetry.
 
-> **Note**: If you don't want to activate the virtual environment, you can use `poetry run` to run commands within the virtual environment.
+   > **Note**: If you don't want to activate the virtual environment, you can use `poetry run` to run commands within the virtual environment.
 
-1. **Install the package using `pip`**:
+2. **Install the package using `pip`**:
    - Once inside the virtual environment, you can use `pip` to install the package without affecting the `pyproject.toml`. For example:
 
      ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,8 @@ Use the following targets for common Fern documentation tasks:
 | `make docs-fern-preview-watch` | Watch local changes and publish a Fern preview for the current branch. |
 | `make docs-fern-generate-sdk` | Regenerate the Python SDK reference pages with Fern's library docs generator. |
 
+For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
+
 The Fern CLI version is pinned in `fern/fern.config.json`. Do not run `fern upgrade` as part of normal documentation changes.
 
 When editing the migrated docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,12 @@ Use the following targets for common Fern documentation tasks:
 | `make docs-fern-live` | Serve the Fern docs locally. |
 | `make docs-fern-preview-watch` | Watch local changes and publish a Fern preview for the current branch. |
 | `make docs-fern-generate-sdk` | Regenerate the Python SDK reference pages with Fern's library docs generator. |
-| `make docs-fern-publish-public` | Publish the Fern docs to the public instance. |
+| `make docs-fern-publish-staging` | Publish the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails). |
+| `make docs-fern-publish-public` | Publish the Fern docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), which is used for the [public documentation site](https://docs.nvidia.com/nemo/guardrails). |
 
 For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
 
-To publish the staged docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), run `make docs-fern-publish-public`.
+Publishing the Fern docs to the public instance is done by the maintainers.
 
 The Fern CLI version is pinned in `fern/fern.config.json`. Do not run `fern upgrade` as part of normal documentation changes.
 
@@ -170,7 +171,7 @@ To get started quickly, follow the steps below.
    poetry --version
    ```
 
-6. Install the dev dependencies:
+1. Install the dev dependencies:
 
    ```bash
    poetry install --with dev
@@ -179,7 +180,7 @@ To get started quickly, follow the steps below.
    The preceding command installs pre-commit, pytest, and other development tools.
    Specify `--with dev,docs` to add the dependencies for building the documentation.
 
-7. If needed, you can install extra dependencies as below:
+2. If needed, you can install extra dependencies as below:
 
     ```bash
     poetry install --extras "openai tracing"
@@ -196,7 +197,7 @@ To get started quickly, follow the steps below.
 
 > **Note**: `dev` is not part of the extras but it is an optional dependency group, so you need to install it as instructed above.
 
-7. Set up pre-commit hooks:
+1. Set up pre-commit hooks:
 
    ```
    pre-commit install
@@ -204,7 +205,7 @@ To get started quickly, follow the steps below.
 
    This will ensure that the pre-commit checks, including Black, are run before each commit.
 
-8. Run the tests:
+2. Run the tests:
 
    ```bash
    poetry run pytest
@@ -365,7 +366,7 @@ To install a dependency using Poetry without adding it to the `pyproject.toml` f
 
 > **Note**: If you don't want to activate the virtual environment, you can use `poetry run` to run commands within the virtual environment.
 
-2. **Install the package using `pip`**:
+1. **Install the package using `pip`**:
    - Once inside the virtual environment, you can use `pip` to install the package without affecting the `pyproject.toml`. For example:
 
      ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,11 @@ Use the following targets for common Fern documentation tasks:
 | `make docs-fern-live` | Serve the Fern docs locally. |
 | `make docs-fern-preview-watch` | Watch local changes and publish a Fern preview for the current branch. |
 | `make docs-fern-generate-sdk` | Regenerate the Python SDK reference pages with Fern's library docs generator. |
+| `make docs-fern-publish-public` | Publish the Fern docs to the public instance. |
 
 For pull requests that modify documentation, the docs build workflow checks the Fern docs and publishes a PR preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
+
+To publish the staged docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), run `make docs-fern-publish-public`.
 
 The Fern CLI version is pinned in `fern/fern.config.json`. Do not run `fern upgrade` as part of normal documentation changes.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help
 .PHONY: test test-parallel test-serial test-benchmark test-watch test-coverage test-profile warm-fastembed-cache
-.PHONY: docs-fern docs-fern-strict docs-fern-live docs-fern-preview-watch docs-fern-generate-sdk docs-fern-fix-empty-links docs-check-links docs-check-redirects
+.PHONY: docs-fern docs-fern-strict docs-fern-live docs-fern-preview-watch docs-fern-generate-sdk docs-fern-fix-empty-links docs-check-links docs-check-redirects docs-fern-publish-staging docs-fern-publish-public
 .PHONY: pre-commit
 
 .DEFAULT_GOAL := help
@@ -21,6 +21,7 @@ FASTEMBED_CACHE ?= .cache/fastembed
 FASTEMBED_MODEL ?= sentence-transformers/all-MiniLM-L6-v2
 FASTEMBED_ENV ?= env FASTEMBED_CACHE_PATH=$(FASTEMBED_CACHE)
 FERN_STAGING_INSTANCE ?= nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails
+FERN_PUBLIC_INSTANCE ?= nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails
 
 test:
 	$(UNIT_TEST_ENV) $(PYTEST) -n $(WORKERS) --dist $(DIST) $(ARGS) $(TEST)
@@ -55,6 +56,9 @@ docs-fern-live: docs-fern-generate-sdk
 
 docs-fern-publish-staging: docs-fern-generate-sdk
 	FERN_VERSION=$$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@$${FERN_VERSION}" generate --docs --instance "$(FERN_STAGING_INSTANCE)"
+
+docs-fern-publish-public: docs-fern-generate-sdk
+	FERN_VERSION=$$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@$${FERN_VERSION}" generate --docs --instance "$(FERN_PUBLIC_INSTANCE)"
 
 docs-fern-preview-watch: docs-fern-generate-sdk
 	node scripts/watch-fern-preview.mjs
@@ -101,6 +105,7 @@ help:
 		'  docs-fern-strict      Check Fern docs using the pinned Fern CLI' \
 		'  docs-fern-live        Serve Fern docs locally' \
 		'  docs-fern-publish-staging Publish Fern docs to the staging instance' \
+		'  docs-fern-publish-public Publish Fern docs to the public instance' \
 		'  docs-fern-preview-watch Watch and publish Fern preview for the current branch' \
 		'  docs-fern-generate-sdk Regenerate Python SDK reference pages with Fern' \
 		'  docs-fern-fix-empty-links Replace empty Markdown links with titles from Fern navigation' \

--- a/docs/LIVE_DOCS.mdx
+++ b/docs/LIVE_DOCS.mdx
@@ -53,6 +53,10 @@ make docs-fern-strict
 
 This regenerates the SDK reference, normalizes it, and runs `fern check`.
 
+### CI Publishing
+
+The docs build workflow checks Fern docs on documentation pull requests and publishes a Fern preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
+
 ### Direct Fern Command
 
 ```bash

--- a/docs/LIVE_DOCS.mdx
+++ b/docs/LIVE_DOCS.mdx
@@ -57,6 +57,12 @@ This regenerates the SDK reference, normalizes it, and runs `fern check`.
 
 The docs build workflow checks Fern docs on documentation pull requests and publishes a Fern preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
 
+To publish the staged docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), run:
+
+```bash
+make docs-fern-publish-public
+```
+
 ### Direct Fern Command
 
 ```bash

--- a/docs/LIVE_DOCS.mdx
+++ b/docs/LIVE_DOCS.mdx
@@ -55,9 +55,9 @@ This regenerates the SDK reference, normalizes it, and runs `fern check`.
 
 ### CI Publishing
 
-The docs build workflow checks Fern docs on documentation pull requests and publishes a Fern preview for same-repository branches. When docs-related changes land on `develop`, including by merging a documentation pull request, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
+The docs build workflow checks Fern docs on documentation pull requests and publishes a Fern preview for same-repository branches. When a documentation pull request merges into `develop`, the workflow publishes the Fern docs to the [staging instance](https://nvidia-nemo-guardrails-staging.docs.buildwithfern.com/nemo/guardrails).
 
-To publish the staged docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails), run:
+After staging verification, maintainers with NVIDIA Fern admin access can publish the staged docs to the [public instance](https://nvidia-nemo-guardrails.docs.buildwithfern.com/nemo/guardrails):
 
 ```bash
 make docs-fern-publish-public


### PR DESCRIPTION
## Description

Document the Fern docs publishing workflow for documentation changes:

- PRs run Fern validation and publish previews for same-repository branches.
- Docs-related changes that land on `develop` publish to the staging instance.
- `make docs-fern-publish-public` publishes the staged docs to the public Fern instance.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Verification

- `make -n docs-fern-publish-public`

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.