### PR TITLE
fix(docs): Skip Fern bash-script tests on Windows

### DIFF
--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CHECK_DOCS_LINKS = REPO_ROOT / "scripts" / "check-docs-links.sh"
@@ -38,6 +41,7 @@ def run_link_check(file_path: Path, env: dict[str, str] | None = None) -> subpro
     )
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="bash script not available on Windows")
 def test_reports_broken_local_markdown_links_with_source_line_numbers(
     tmp_path: Path,
 ) -> None:
@@ -67,6 +71,7 @@ def test_reports_broken_local_markdown_links_with_source_line_numbers(
     assert "inside-code-fence.md" not in output
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="bash script not available on Windows")
 def test_ignores_links_inside_inline_code_and_html_comments(tmp_path: Path) -> None:
     md_path = tmp_path / "guide.md"
     md_path.write_text(
@@ -90,6 +95,7 @@ def test_ignores_links_inside_inline_code_and_html_comments(tmp_path: Path) -> N
     assert "inside-comment.md" not in output
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="bash script not available on Windows")
 def test_resolves_guardrails_fern_routes(tmp_path: Path) -> None:
     md_path = tmp_path / "guide.mdx"
     md_path.write_text(
@@ -112,6 +118,7 @@ def test_resolves_guardrails_fern_routes(tmp_path: Path) -> None:
     assert result.returncode == 0, output
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="bash script not available on Windows")
 def test_rejects_mdx_suffixes_for_links_that_resolve_as_fern_routes() -> None:
     temp_dir = Path(tempfile.mkdtemp(prefix="check-docs-route-suffix-", dir=REPO_ROOT / "docs"))
     try:
@@ -161,6 +168,7 @@ def test_rejects_mdx_suffixes_for_links_that_resolve_as_fern_routes() -> None:
         shutil.rmtree(temp_dir)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="bash script not available on Windows")
 def test_fails_loudly_on_malformed_html_comments(tmp_path: Path) -> None:
     md_path = tmp_path / "guide.md"
     md_path.write_text(


### PR DESCRIPTION
## Description

The Full Tests which check both Windows and Linux only run nightly. The unrelated PR #2016 had failing Windows tests on [this run](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/27308433539/job/80672269540#step:15:276). The errors are all in Fern and doc-related changes, introduced in #2015 . This PR wasn't blocked because the Full-Tests weren't run prior to merge.

The 5 test failures all stem from the same issue:

test_reports_broken_local_markdown_links_with_source_line_numbers
test_ignores_links_inside_inline_code_and_html_comments
test_resolves_guardrails_fern_routes
test_rejects_mdx_suffixes_for_links_that_resolve_as_fern_routes
test_fails_loudly_on_malformed_html_comments

All are calling bash to run check-docs-links.sh, which fails because WSL is not available on the Windows runner.

This PR is a temporary fix by removing these tests when running on Windows. However, our users with a Windows laptop would reasonably expect everything to work the same as on MacOS and Linux and this needs to be fixed for them.

## Related Issue(s)

#2015 : The PR introducing the regression
#2017 : This PR temporarily disabling `tests/test_docs_links.py` under Windows .

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test compatibility on Windows by skipping docs link-checking tests when the required bash-based tool is unavailable on that platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->