### PR TITLE
docs: improve pages referred in the docs template lib

### DIFF
--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -1,24 +1,71 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "Architecture Overview"
+title: "How It Works"
 sidebar-title: "How It Works"
-description: "High level explanation of how Guardrails works."
+description: "Understand the request flow, runtime layers, and integration points in the NVIDIA NeMo Guardrails library."
 keywords:
     ["guardrails architecture", "event-driven runtime", "llmrails", "colang"]
 content:
     type: "concept"
 ---
 
-The NeMo Guardrails library acts as an intermediary between application code and LLM requests and responses. Once Guardrails is integrated in an application, all LLM inference requests are first checked by Guardrails to ensure user requests are safe and not malicious. If they are, the request is passed to the LLM for inference. Guardrails also checks the LLM response once it's available, making sure it's appropriate before being passed back to the user.
+The NVIDIA NeMo Guardrails library sits between your application and the LLM, tool, or retrieval systems that the application uses. It loads a guardrails configuration, evaluates incoming user messages against the configured rails, orchestrates any required LLM calls or custom actions, and returns either an approved response or a configured safe alternative.
 
-![Programmable Guardrails Flow](../_static/images/programmable_guardrails.png "Programmable Guardrails Flow")
+Use this page to understand the main request path. For deeper event-level details, refer to [Colang Architecture Guide](/reference/colang-architecture-guide).
 
-Each application can configure its own set of guardrails, depending on the use-case. Guardrails requests can trigger calls to third-party APIs, LLMs fine-tuned to implement Guardrail functionality, or to the Application LLM. Guardrails hides this complexity from clients, orchestrating the workflows behind-the-scenes so applications can focus on their business logic.
+## High-Level Architecture Diagram
+
+The following diagram shows how a user message moves through the major guardrail stages. Each stage is optional and runs only when your configuration enables the corresponding rail type.
+
+![Sequence diagram showing the NVIDIA NeMo Guardrails library request flow from user input through input rails, retrieval rails, dialog rails, execution rails, output rails, LLM calls, custom actions, and the final application response.](../_static/puml/master_rails_flow.png "NVIDIA NeMo Guardrails library request flow")
+
+## Functional Layers
+
+The NVIDIA NeMo Guardrails library separates application integration, policy configuration, runtime orchestration, and external systems. This separation lets your application call one guardrailed interface while the library handles the configured checks and workflows.
+
+| Layer | Role |
+| --- | --- |
+| **Application integration** | Sends messages through the Python SDK or the guardrails server and receives the final response. |
+| **Guardrails configuration** | Defines models, prompts, rails, Colang flows, knowledge base settings, and custom actions. |
+| **Runtime orchestration** | Loads the configuration, processes events, executes rails, calls actions, and coordinates LLM requests. |
+| **External systems** | Provide LLM inference, retrieval content, moderation services, tool calls, or other custom validation logic. |
+
+## Request Flow
+
+When an application sends a user message, the NVIDIA NeMo Guardrails library evaluates the message in the configured order:
+
+1. **Input rails** inspect the user message before the application LLM is called. These rails can allow, alter, or reject the message.
+2. **Retrieval rails** run when the configuration uses a knowledge base or retrieved context. These rails can filter or transform retrieved chunks before they enter the prompt.
+3. **Dialog rails** use Colang flows and runtime events to guide the conversation, choose the next step, or decide whether the bot should respond or execute an action.
+4. **Execution rails** validate and control custom actions or tools, including their inputs and outputs.
+5. **Output rails** inspect the generated response before it returns to the user. These rails can allow, edit, or block the response.
+
+For more information about where each rail type runs, refer to [Guardrail Types](/about-nemo-guardrails-library/rail-types).
+
+## Runtime Behavior
+
+The runtime uses an event-driven design. A user message becomes an event, and the runtime processes that event through the active Colang flows and configured rails. Depending on the configuration, the runtime can generate a canonical user intent, decide the next step, execute a custom action, retrieve knowledge base chunks, call the application LLM, or generate the final bot message.
+
+Applications do not need to implement this orchestration themselves. They call the NVIDIA NeMo Guardrails library through the SDK or server, and the library coordinates the underlying workflow.
+
+## External Integration Points
+
+The NVIDIA NeMo Guardrails library can work with several external systems.
+
+| Integration | Details |
+| --- | --- |
+| **Application LLM** | The model that generates responses for your application. |
+| **Guardrail models and services** | Specialized models, NVIDIA NIM microservices, or third-party APIs that perform safety, jailbreak, topic, PII, or other checks. |
+| **Knowledge bases** | Documents or chunks that support retrieval-augmented generation workflows. |
+| **Custom actions and tools** | Python functions, LangChain tools, or external APIs that add application-specific logic. |
 
 ## Related Resources
 
-Use the following resources to learn more about the Guardrails library:
+Use the following resources to learn more about the NVIDIA NeMo Guardrails library:
 
 - [Guardrail Types](/about-nemo-guardrails-library/rail-types)
+- [Colang Architecture Guide](/reference/colang-architecture-guide)
+- [Guardrails Sequence Diagrams](/reference/guardrails-sequence-diagrams)
+- [About Configuring Guardrails](/configure-guardrails)
 - [Get Started](/get-started/installation-guide)

--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -1,8 +1,8 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "How It Works"
-sidebar-title: "How It Works"
+title: "Architecture Overview"
+sidebar-title: "Architecture Overview"
 description: "Understand the request flow, runtime layers, and integration points in the NVIDIA NeMo Guardrails library."
 keywords:
     ["guardrails architecture", "event-driven runtime", "llmrails", "colang"]
@@ -65,7 +65,5 @@ The NVIDIA NeMo Guardrails library can work with several external systems.
 Use the following resources to learn more about the NVIDIA NeMo Guardrails library:
 
 - [Guardrail Types](/about-nemo-guardrails-library/rail-types)
-- [Colang Architecture Guide](/reference/colang-architecture-guide)
-- [Guardrails Sequence Diagrams](/reference/guardrails-sequence-diagrams)
-- [About Configuring Guardrails](/configure-guardrails)
 - [Get Started](/get-started/installation-guide)
+- [Guardrail Catalog](/configure-guardrails/guardrail-catalog)

--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -12,24 +12,24 @@ content:
 
 The NVIDIA NeMo Guardrails library sits between your application and the LLM, tool, or retrieval systems that the application uses. It loads a guardrails configuration, evaluates incoming user messages against the configured rails, orchestrates any required LLM calls or custom actions, and returns either an approved response or a configured safe alternative.
 
-Use this page to understand the main request path. For deeper event-level details, refer to [Colang Architecture Guide](/reference/colang-architecture-guide).
+Use this page to understand the guardrails process at a high level. For deeper event-level details, refer to [Colang Architecture Guide](../reference/colang-architecture-guide), [Guardrails Sequence Diagrams](../reference/guardrails-sequence-diagrams), and [Use Case Diagrams](../reference/use-case-diagrams).
 
 ## High-Level Architecture Diagram
 
-The following diagram shows how a user message moves through the major guardrail stages. Each stage is optional and runs only when your configuration enables the corresponding rail type.
+The following diagram shows how guardrails intervene in the application's request flow.
 
-![Sequence diagram showing the NVIDIA NeMo Guardrails library request flow from user input through input rails, retrieval rails, dialog rails, execution rails, output rails, LLM calls, custom actions, and the final application response.](../_static/puml/master_rails_flow.png "NVIDIA NeMo Guardrails library request flow")
+![Programmable Guardrails Flow](../_static/images/programmable_guardrails.png "Programmable Guardrails Flow")
 
 ## Functional Layers
 
 The NVIDIA NeMo Guardrails library separates application integration, policy configuration, runtime orchestration, and external systems. This separation lets your application call one guardrailed interface while the library handles the configured checks and workflows.
 
-| Layer | Role |
-| --- | --- |
-| **Application integration** | Sends messages through the Python SDK or the guardrails server and receives the final response. |
-| **Guardrails configuration** | Defines models, prompts, rails, Colang flows, knowledge base settings, and custom actions. |
-| **Runtime orchestration** | Loads the configuration, processes events, executes rails, calls actions, and coordinates LLM requests. |
-| **External systems** | Provide LLM inference, retrieval content, moderation services, tool calls, or other custom validation logic. |
+| Layer                        | Role                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Application integration**  | Sends messages through the Python SDK or the guardrails server and receives the final response.              |
+| **Guardrails configuration** | Defines models, prompts, rails, Colang flows, knowledge base settings, and custom actions.                   |
+| **Runtime orchestration**    | Loads the configuration, processes events, executes rails, calls actions, and coordinates LLM requests.      |
+| **External systems**         | Provide LLM inference, retrieval content, moderation services, tool calls, or other custom validation logic. |
 
 ## Request Flow
 
@@ -53,12 +53,12 @@ Applications do not need to implement this orchestration themselves. They call t
 
 The NVIDIA NeMo Guardrails library can work with several external systems.
 
-| Integration | Details |
-| --- | --- |
-| **Application LLM** | The model that generates responses for your application. |
+| Integration                       | Details                                                                                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Application LLM**               | The model that generates responses for your application.                                                                       |
 | **Guardrail models and services** | Specialized models, NVIDIA NIM microservices, or third-party APIs that perform safety, jailbreak, topic, PII, or other checks. |
-| **Knowledge bases** | Documents or chunks that support retrieval-augmented generation workflows. |
-| **Custom actions and tools** | Python functions, LangChain tools, or external APIs that add application-specific logic. |
+| **Knowledge bases**               | Documents or chunks that support retrieval-augmented generation workflows.                                                     |
+| **Custom actions and tools**      | Python functions, LangChain tools, or external APIs that add application-specific logic.                                       |
 
 ## Related Resources
 

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -187,7 +187,7 @@ You can integrate the NeMo Guardrails library into your application using the to
 
 ## Integration Paths
 
-You can integrate the NVIDIA NeMo Guardrails library directly into a Python application or run it behind an API server.
+You can integrate the NVIDIA NeMo Guardrails library directly into a Python application or run a FastAPI service and call endpoints over HTTP/REST.
 
 | Path                   | Best For                                                                               | Entry Point                                                                             |
 | ---------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -201,5 +201,5 @@ Continue exploring the NVIDIA NeMo Guardrails library through these resources:
 
 - [How It Works](/about-nemo-guardrails-library/how-it-works) for the request flow and runtime layers.
 - [Guardrail Types](/about-nemo-guardrails-library/rail-types) for the stages where rails run.
-- [About Configuring Guardrails](/configure-guardrails) for YAML files, Colang flows, custom actions, and related settings.
+- [About Configuring Guardrails](/configure-guardrails/configure-rails) for YAML files, Colang flows, custom actions, and related settings.
 - [Get Started](/get-started/installation-guide) to install the library and run the first examples.

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -4,9 +4,10 @@
 title: "Overview"
 sidebar-title: "Overview"
 description: "Add programmable guardrails to LLM applications with this open-source Python library."
-keywords: ["nemo guardrails", "llm safety", "content moderation", "guardrails python"]
+keywords:
+    ["nemo guardrails", "llm safety", "content moderation", "guardrails python"]
 content:
-  type: "concept"
+    type: "concept"
 ---
 
 The NVIDIA NeMo Guardrails library ([PyPI](https://pypi.org/project/nemoguardrails/) | [GitHub](https://github.com/NVIDIA-NeMo/Guardrails)) is an open-source Python package for adding programmable guardrails to LLM-based applications. Use it to block, alter, or validate unsafe, off-topic, malicious, or policy-violating user inputs and model responses.
@@ -17,12 +18,12 @@ The library provides configuration files, Colang flows, built-in guardrails, cus
 
 [NVIDIA NeMo](https://www.nvidia.com/en-us/ai-data-science/products/nemo/) is a suite of microservices, tools, and libraries for building, deploying, and scaling LLM-based applications. The NVIDIA NeMo Guardrails library provides the developer-facing Python package for building and testing guardrails, while the NVIDIA NeMo Guardrails microservice provides a production-ready container image built on top of the same guardrails configuration model.
 
-| | Library | Microservice |
-| --- | --- | --- |
-| Distribution | PyPI package | Container image backed by this library |
-| Deployment | Self-managed Python environment | Kubernetes with Helm |
-| Scaling | Application-level | Managed by the orchestrator |
-| Configuration | YAML and Colang | Same YAML and Colang format |
+|               | Library                         | Microservice                           |
+| ------------- | ------------------------------- | -------------------------------------- |
+| Distribution  | PyPI package                    | Container image backed by this library |
+| Deployment    | Self-managed Python environment | Kubernetes with Helm                   |
+| Scaling       | Application-level               | Managed by the orchestrator            |
+| Configuration | YAML and Colang                 | Same YAML and Colang format            |
 
 Configurations are portable between the library and microservice, so you can develop locally with the library and deploy to production with the microservice.
 
@@ -49,24 +50,150 @@ The NVIDIA NeMo Guardrails library helps teams add policy enforcement and safety
 
 Teams use the NVIDIA NeMo Guardrails library in the following scenarios.
 
-| Use Case | What It Helps With | Where to Start |
-| --- | --- | --- |
-| Content safety | Check user inputs and model outputs for unsafe or inappropriate content. | [Content Safety](/configure-guardrails/guardrail-catalog/content-safety) |
-| Jailbreak protection | Detect attempts to bypass instructions or safety controls. | [Jailbreak Protection](/configure-guardrails/guardrail-catalog/jailbreak-protection) |
-| Topic control | Keep conversations inside approved subject boundaries. | [Topic Control](/configure-guardrails/guardrail-catalog/topic-control) |
-| PII detection | Detect, block, or mask sensitive data in inputs, outputs, and retrieved content. | [PII Detection](/configure-guardrails/guardrail-catalog/pii-detection) |
-| Agentic security | Validate tool calls and protect agents that interact with external systems. | [Agentic Security](/configure-guardrails/guardrail-catalog/agentic-security) |
-| Custom guardrails | Build application-specific checks with Python actions, LangChain tools, or third-party APIs. | [Custom Actions](/configure-guardrails/actions) |
+<Accordion title="🛡️ Add Content Safety">
+
+Content safety guardrails help ensure that both user inputs and LLM outputs are safe and appropriate.
+The NeMo Guardrails library provides multiple approaches to content safety:
+
+- **LLM self-checking**: Use the LLM itself to check inputs and outputs for harmful content.
+- **NVIDIA safety models**: Integrate with [Llama 3.1 NemoGuard 8B Content Safety](https://build.nvidia.com/nvidia/llama-3_1-nemotron-safety-guard-8b-v3) for robust content moderation.
+- **Community models**: Use [LlamaGuard](/configure-guardrails/guardrail-catalog/third-party/llama-guard), [Fiddler Guardrails](/configure-guardrails/guardrail-catalog/third-party/fiddler), and other community content safety solutions.
+- **Third-party APIs**: Integrate with [ActiveFence](/configure-guardrails/guardrail-catalog/third-party/active-fence), [Cisco AI Defense](/configure-guardrails/guardrail-catalog/third-party/ai-defense), and other moderation services.
+
+For practical examples, try the following tutorials:
+
+- [Content Safety - Text](/get-started/tutorials/nemotron-safety-guard-deployment)
+- [Content Safety - Multimodal](/get-started/tutorials/multimodal)
+</Accordion>
+
+<Accordion title="🔒 Add Jailbreak Protection">
+
+Jailbreak protection helps prevent adversarial attempts from bypassing safety measures and manipulating the LLM into generating harmful or unwanted content.
+The NeMo Guardrails library provides multiple layers of jailbreak protection:
+
+- **Self-check jailbreak detection**: Use the LLM to identify jailbreak attempts.
+- **Heuristic detection**: Use pattern-based detection for common jailbreak techniques.
+- **NVIDIA NemoGuard**: Integrate with [NemoGuard Jailbreak Detection NIM](/get-started/tutorials/nemoguard-jailbreakdetect-deployment) for advanced threat detection.
+- **Third-party integrations**: Use [Prompt Security](/configure-guardrails/guardrail-catalog/third-party/prompt-security), [Pangea AI Guard](/configure-guardrails/guardrail-catalog/third-party/pangea), and other services.
+
+For practical examples, try the following tutorial:
+
+- [Detect Jailbreak Attempts](/get-started/tutorials/nemoguard-jailbreakdetect-deployment)
+</Accordion>
+
+<Accordion title="🎯 Control Topic Conversation">
+
+Topic control guardrails ensure that conversations stay within predefined subject boundaries and prevent the LLM from engaging in off-topic discussions.
+This is implemented through:
+
+- **Dialog rails**: Pre-define conversational flows using the Colang language.
+- **Topical rails**: Control what topics the bot can and cannot discuss.
+- **NVIDIA NemoGuard**: Integrate with [NemoGuard Topic Control NIM](/get-started/tutorials/nemoguard-topiccontrol-deployment) for semantic topic detection.
+
+For practical examples, try the following tutorial:
+
+- [Restrict Topics](/get-started/tutorials/nemoguard-topiccontrol-deployment)
+</Accordion>
+
+<Accordion title="🔐 Detect and Mask PII">
+
+Personally Identifiable Information (PII) detection helps protect user privacy by detecting and masking sensitive data in user inputs, LLM outputs, and retrieved content.
+The NeMo Guardrails library supports PII detection through multiple integrations:
+
+- **Gliner**: Use [NVIDIA GLiNER-PII](/configure-guardrails/guardrail-catalog/third-party/gliner) for detecting entities such as names, email addresses, phone numbers, social security numbers, and more.
+- **Presidio-based detection**: Use [Microsoft Presidio](/configure-guardrails/guardrail-catalog/third-party/presidio) for detecting entities such as names, email addresses, phone numbers, social security numbers, and more.
+- **Private AI**: Integrate with [Private AI](/configure-guardrails/guardrail-catalog/third-party/privateai) for advanced PII detection and masking.
+- **AutoAlign**: Use [AutoAlign PII detection](/configure-guardrails/guardrail-catalog/third-party/auto-align) with customizable entity types.
+- **GuardrailsAI**: Access [GuardrailsAI PII validators](/configure-guardrails/guardrail-catalog/third-party/guardrails-ai) from the Guardrails Hub.
+
+PII detection can be configured to either detect and block content containing PII or to mask PII entities before processing.
+
+For more information, refer to the [Presidio Integration](/configure-guardrails/guardrail-catalog/third-party/presidio) and [PII Detection](/configure-guardrails/guardrail-catalog/pii-detection#presidio-based-sensitive-data-detection) in the Guardrail Catalog.
+
+</Accordion>
+
+<Accordion title="🤖 Add Agentic Security">
+
+Agentic security provides specialized guardrails for LLM-based agents that use tools and interact with external systems.
+This includes:
+
+- **Tool call validation**: Execute rails that validate tool inputs and outputs before and after invocation.
+- **Agent workflow protection**: Integrate with [LangGraph](/integration-with-third-party-libraries/langchain/langgraph-integration) for multi-agent safety. Requires the LangChain opt-in (`NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`) and the matching `langchain-*` packages.
+- **Secure tool integration**: Review guidelines for safely connecting LLMs to external resources (refer to [Security Guidelines](/resources/guidelines)).
+- **Action monitoring**: Monitor detailed logging and tracing of agent actions.
+
+Key security considerations for agent systems:
+
+1. Isolate all authentication information from the LLM.
+2. Validate and sanitize all tool inputs.
+3. Apply execution rails to tool calls.
+4. Monitor agent behavior for unexpected actions.
+
+For more information, refer to the [Tools Integration Guide](/integration-with-third-party-libraries/tools-integration), [Security Guidelines](/resources/guidelines), and [LangGraph Integration](/integration-with-third-party-libraries/langchain/langgraph-integration).
+
+</Accordion>
+
+<Accordion title="🔧 Build Your Own or Use Third-party Guardrail Solutions">
+
+The NeMo Guardrails library provides extensive flexibility for creating custom guardrails tailored to your specific requirements. You can either build your own guardrails or use third-party guardrails.
+If you have a script or tool that runs a custom guardrail, you can use it in NeMo Guardrails by following one of these approaches:
+
+1. **Python actions**: Create custom actions in Python for complex logic and external integrations. For more information, refer to the [Custom Actions](/configure-guardrails/actions).
+
+2. **LangChain tool integration**: Register LangChain tools as custom actions. Requires the LangChain framework. For more information, refer to the [Tools Integration](/integration-with-third-party-libraries/tools-integration).
+
+3. **Third-party API integration**: Integrate external moderation and validation services. For a complete list of supported third-party guardrail services, refer to [Third-Party APIs](/configure-guardrails/guardrail-catalog/third-party) in the Guardrail Catalog.
+</Accordion>
+
+<Accordion title="🔌 Integrate NeMo Guardrails Library into Your Application">
+
+You can integrate the NeMo Guardrails library into your application using the tools provided by the library.
+
+1. **Python SDK**: Use the Python SDK to add guardrails directly into your Python application.
+
+    ```python
+    from nemoguardrails import LLMRails, RailsConfig
+
+    config = RailsConfig.from_path("./config")
+    rails = LLMRails(config)
+
+    response = rails.generate(
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
+    ```
+
+    The `generate` method accepts the same message format as the OpenAI Chat Completions API.
+
+2. **API Server**: You can solely set up a guardrails server after programming guardrails using the Python SDK. You can then start a local NeMo Guardrails server with the following command.
+
+    ```bash
+    nemoguardrails server --config ./config --port 8000
+    ```
+
+    The server exposes API endpoints such as `/v1/chat/completions` for guardrailed chat completions.
+
+    ```bash
+    curl -X POST http://localhost:8000/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "config_id": "my-config",
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+
+    {/* The server exposes HTTP APIs compatible with OpenAI's `/v1/chat/completions` endpoint. You can then use the server in your application by sending requests to the server's endpoint. */}
+
+</Accordion>
 
 ## Integration Paths
 
 You can integrate the NVIDIA NeMo Guardrails library directly into a Python application or run it behind an API server.
 
-| Path | Best For | Entry Point |
-| --- | --- | --- |
-| Python SDK | Applications that can call the library directly from Python. | [Using Python APIs](/run-guardrailed-inference/using-python-apis/overview) |
-| Guardrails server | Applications that need an HTTP endpoint compatible with OpenAI-style chat completions. | [Using the Guardrails Server](/run-guardrailed-inference/using-fastapi-server/overview) |
-| Framework integrations | Applications that already use frameworks such as LangChain or LangGraph. | [LangChain Integrations](/integration-with-third-party-libraries/langchain) |
+| Path                   | Best For                                                                               | Entry Point                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Python SDK             | Applications that can call the library directly from Python.                           | [Using Python APIs](/run-guardrailed-inference/using-python-apis/overview)              |
+| Guardrails server      | Applications that need an HTTP endpoint compatible with OpenAI-style chat completions. | [Using the Guardrails Server](/run-guardrailed-inference/using-fastapi-server/overview) |
+| Framework integrations | Applications that already use frameworks such as LangChain or LangGraph.               | [LangChain Integrations](/integration-with-third-party-libraries/langchain)             |
 
 ## Learn More
 

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -1,169 +1,78 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "Overview of the NeMo Guardrails Library"
+title: "Overview"
 sidebar-title: "Overview"
 description: "Add programmable guardrails to LLM applications with this open-source Python library."
 keywords: ["nemo guardrails", "llm safety", "content moderation", "guardrails python"]
 content:
   type: "concept"
 ---
-The NVIDIA NeMo Guardrails library ([PyPI](https://pypi.org/project/nemoguardrails/) | [GitHub](https://github.com/NVIDIA-NeMo/Guardrails)) is an open-source Python package for adding programmable guardrails to LLM-based applications. Guardrails make your LLM-based application safer and more secure by blocking inappropriate, off-topic or malicious user inputs or LLM responses.
 
-## NeMo Guardrails Library within the NVIDIA NeMo Software Stack
+The NVIDIA NeMo Guardrails library ([PyPI](https://pypi.org/project/nemoguardrails/) | [GitHub](https://github.com/NVIDIA-NeMo/Guardrails)) is an open-source Python package for adding programmable guardrails to LLM-based applications. Use it to block, alter, or validate unsafe, off-topic, malicious, or policy-violating user inputs and model responses.
 
-[NVIDIA NeMo](https://www.nvidia.com/en-us/ai-data-science/products/nemo/) is a suite of microservices, tools, and libraries for building, deploying, and scaling LLM-based applications.
+The library provides configuration files, Colang flows, built-in guardrails, custom actions, and integration APIs so you can add safety and control logic without rewriting your application or model backend.
 
-NeMo Guardrails is part of the NVIDIA NeMo software stack. It takes part in adding programmable guardrails to LLM-based applications. The NeMo Guardrails library provides tools to build guardrails and integrate them into your LLM-based applications at development time. The NeMo Guardrails microservice as part of the [NeMo microservices platform](https://docs.nvidia.com/nemo/microservices/latest/about/index.html) is a production-ready container image built on top of this library, designed for Kubernetes deployment with Helm charts.
+## How It Fits in the NVIDIA NeMo Software Stack
 
-|                  | NeMo Guardrails Library          | NeMo Guardrails Microservice     |
-|------------------|----------------------------------|----------------------------------|
-| Distribution     | PyPI (`pip install`)             | Container image (backed by this library) |
-| Deployment       | Self-managed Python environment  | Kubernetes with Helm             |
-| Scaling          | Application-level                | Managed by orchestrator          |
-| Configuration    | YAML + Colang                    | Same YAML + Colang format        |
+[NVIDIA NeMo](https://www.nvidia.com/en-us/ai-data-science/products/nemo/) is a suite of microservices, tools, and libraries for building, deploying, and scaling LLM-based applications. The NVIDIA NeMo Guardrails library provides the developer-facing Python package for building and testing guardrails, while the NVIDIA NeMo Guardrails microservice provides a production-ready container image built on top of the same guardrails configuration model.
+
+| | Library | Microservice |
+| --- | --- | --- |
+| Distribution | PyPI package | Container image backed by this library |
+| Deployment | Self-managed Python environment | Kubernetes with Helm |
+| Scaling | Application-level | Managed by the orchestrator |
+| Configuration | YAML and Colang | Same YAML and Colang format |
 
 Configurations are portable between the library and microservice, so you can develop locally with the library and deploy to production with the microservice.
 
+## Core Building Blocks
+
+The NVIDIA NeMo Guardrails library is organized around the following building blocks:
+
+- **Rails**: Input, retrieval, dialog, execution, and output rails run at different stages of an LLM interaction.
+- **Configuration**: YAML files define models, prompts, rails, tracing, and other runtime settings.
+- **Colang flows**: Colang defines conversational flows, guardrail logic, and event-driven behavior.
+- **Custom actions**: Python functions, tools, or external APIs extend guardrails with application-specific checks.
+- **Runtime interfaces**: The Python SDK and guardrails server let applications send messages through a guardrailed interface.
+
+## Benefits
+
+The NVIDIA NeMo Guardrails library helps teams add policy enforcement and safety checks around LLM applications while keeping the application architecture flexible.
+
+- Add guardrails before and after LLM calls without changing the application LLM.
+- Reuse the same YAML and Colang configuration across local development and microservice deployment.
+- Combine built-in guardrails, NVIDIA safety models, community models, third-party APIs, and custom Python actions.
+- Inspect and control user inputs, retrieved content, tool calls, and model outputs in one guardrails workflow.
+
 ## Use Cases
 
-The following are the top use cases of the NeMo Guardrails library that you can apply to protect your LLM applications.
+Teams use the NVIDIA NeMo Guardrails library in the following scenarios.
 
-<Accordion title="🛡️ Add Content Safety">
+| Use Case | What It Helps With | Where to Start |
+| --- | --- | --- |
+| Content safety | Check user inputs and model outputs for unsafe or inappropriate content. | [Content Safety](/configure-guardrails/guardrail-catalog/content-safety) |
+| Jailbreak protection | Detect attempts to bypass instructions or safety controls. | [Jailbreak Protection](/configure-guardrails/guardrail-catalog/jailbreak-protection) |
+| Topic control | Keep conversations inside approved subject boundaries. | [Topic Control](/configure-guardrails/guardrail-catalog/topic-control) |
+| PII detection | Detect, block, or mask sensitive data in inputs, outputs, and retrieved content. | [PII Detection](/configure-guardrails/guardrail-catalog/pii-detection) |
+| Agentic security | Validate tool calls and protect agents that interact with external systems. | [Agentic Security](/configure-guardrails/guardrail-catalog/agentic-security) |
+| Custom guardrails | Build application-specific checks with Python actions, LangChain tools, or third-party APIs. | [Custom Actions](/configure-guardrails/actions) |
 
-Content safety guardrails help ensure that both user inputs and LLM outputs are safe and appropriate.
-The NeMo Guardrails library provides multiple approaches to content safety:
+## Integration Paths
 
-- **LLM self-checking**: Use the LLM itself to check inputs and outputs for harmful content.
-- **NVIDIA safety models**: Integrate with [Llama 3.1 NemoGuard 8B Content Safety](https://build.nvidia.com/nvidia/llama-3_1-nemotron-safety-guard-8b-v3) for robust content moderation.
-- **Community models**: Use [LlamaGuard](/configure-guardrails/guardrail-catalog/third-party/llama-guard), [Fiddler Guardrails](/configure-guardrails/guardrail-catalog/third-party/fiddler), and other community content safety solutions.
-- **Third-party APIs**: Integrate with [ActiveFence](/configure-guardrails/guardrail-catalog/third-party/active-fence), [Cisco AI Defense](/configure-guardrails/guardrail-catalog/third-party/ai-defense), and other moderation services.
+You can integrate the NVIDIA NeMo Guardrails library directly into a Python application or run it behind an API server.
 
-For practical examples, try the following tutorials:
+| Path | Best For | Entry Point |
+| --- | --- | --- |
+| Python SDK | Applications that can call the library directly from Python. | [Using Python APIs](/run-guardrailed-inference/using-python-apis/overview) |
+| Guardrails server | Applications that need an HTTP endpoint compatible with OpenAI-style chat completions. | [Using the Guardrails Server](/run-guardrailed-inference/using-fastapi-server/overview) |
+| Framework integrations | Applications that already use frameworks such as LangChain or LangGraph. | [LangChain Integrations](/integration-with-third-party-libraries/langchain) |
 
-- [Content Safety - Text](/get-started/tutorials/nemotron-safety-guard-deployment)
-- [Content Safety - Multimodal](/get-started/tutorials/multimodal)
-</Accordion>
+## Learn More
 
-<Accordion title="🔒 Add Jailbreak Protection">
+Continue exploring the NVIDIA NeMo Guardrails library through these resources:
 
-Jailbreak protection helps prevent adversarial attempts from bypassing safety measures and manipulating the LLM into generating harmful or unwanted content.
-The NeMo Guardrails library provides multiple layers of jailbreak protection:
-
-- **Self-check jailbreak detection**: Use the LLM to identify jailbreak attempts.
-- **Heuristic detection**: Use pattern-based detection for common jailbreak techniques.
-- **NVIDIA NemoGuard**: Integrate with [NemoGuard Jailbreak Detection NIM](/get-started/tutorials/nemoguard-jailbreakdetect-deployment) for advanced threat detection.
-- **Third-party integrations**: Use [Prompt Security](/configure-guardrails/guardrail-catalog/third-party/prompt-security), [Pangea AI Guard](/configure-guardrails/guardrail-catalog/third-party/pangea), and other services.
-
-For practical examples, try the following tutorial:
-
-- [Detect Jailbreak Attempts](/get-started/tutorials/nemoguard-jailbreakdetect-deployment)
-</Accordion>
-
-<Accordion title="🎯 Control Topic Conversation">
-
-Topic control guardrails ensure that conversations stay within predefined subject boundaries and prevent the LLM from engaging in off-topic discussions.
-This is implemented through:
-
-- **Dialog rails**: Pre-define conversational flows using the Colang language.
-- **Topical rails**: Control what topics the bot can and cannot discuss.
-- **NVIDIA NemoGuard**: Integrate with [NemoGuard Topic Control NIM](/get-started/tutorials/nemoguard-topiccontrol-deployment) for semantic topic detection.
-
-For practical examples, try the following tutorial:
-
-- [Restrict Topics](/get-started/tutorials/nemoguard-topiccontrol-deployment)
-</Accordion>
-
-<Accordion title="🔐 Detect and Mask PII">
-
-Personally Identifiable Information (PII) detection helps protect user privacy by detecting and masking sensitive data in user inputs, LLM outputs, and retrieved content.
-The NeMo Guardrails library supports PII detection through multiple integrations:
-
-- **Gliner**: Use [NVIDIA GLiNER-PII](/configure-guardrails/guardrail-catalog/third-party/gliner) for detecting entities such as names, email addresses, phone numbers, social security numbers, and more.
-- **Presidio-based detection**: Use [Microsoft Presidio](/configure-guardrails/guardrail-catalog/third-party/presidio) for detecting entities such as names, email addresses, phone numbers, social security numbers, and more.
-- **Private AI**: Integrate with [Private AI](/configure-guardrails/guardrail-catalog/third-party/privateai) for advanced PII detection and masking.
-- **AutoAlign**: Use [AutoAlign PII detection](/configure-guardrails/guardrail-catalog/third-party/auto-align) with customizable entity types.
-- **GuardrailsAI**: Access [GuardrailsAI PII validators](/configure-guardrails/guardrail-catalog/third-party/guardrails-ai) from the Guardrails Hub.
-
-PII detection can be configured to either detect and block content containing PII or to mask PII entities before processing.
-
-For more information, refer to the [Presidio Integration](/configure-guardrails/guardrail-catalog/third-party/presidio) and [PII Detection](/configure-guardrails/guardrail-catalog/pii-detection#presidio-based-sensitive-data-detection) in the Guardrail Catalog.
-</Accordion>
-
-<Accordion title="🤖 Add Agentic Security">
-
-Agentic security provides specialized guardrails for LLM-based agents that use tools and interact with external systems.
-This includes:
-
-- **Tool call validation**: Execute rails that validate tool inputs and outputs before and after invocation.
-- **Agent workflow protection**: Integrate with [LangGraph](/integration-with-third-party-libraries/langchain/langgraph-integration) for multi-agent safety. Requires the LangChain opt-in (`NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`) and the matching `langchain-*` packages.
-- **Secure tool integration**: Review guidelines for safely connecting LLMs to external resources (refer to [Security Guidelines](/resources/guidelines)).
-- **Action monitoring**: Monitor detailed logging and tracing of agent actions.
-
-Key security considerations for agent systems:
-
-1. Isolate all authentication information from the LLM.
-2. Validate and sanitize all tool inputs.
-3. Apply execution rails to tool calls.
-4. Monitor agent behavior for unexpected actions.
-
-For more information, refer to the [Tools Integration Guide](/integration-with-third-party-libraries/tools-integration), [Security Guidelines](/resources/guidelines), and [LangGraph Integration](/integration-with-third-party-libraries/langchain/langgraph-integration).
-</Accordion>
-
-<Accordion title="🔧 Build Your Own or Use Third-party Guardrail Solutions">
-
-The NeMo Guardrails library provides extensive flexibility for creating custom guardrails tailored to your specific requirements. You can either build your own guardrails or use third-party guardrails.
-If you have a script or tool that runs a custom guardrail, you can use it in NeMo Guardrails by following one of these approaches:
-
-1. **Python actions**: Create custom actions in Python for complex logic and external integrations. For more information, refer to the [Custom Actions](/configure-guardrails/actions).
-
-2. **LangChain tool integration**: Register LangChain tools as custom actions. Requires the LangChain framework. For more information, refer to the [Tools Integration](/integration-with-third-party-libraries/tools-integration).
-
-3. **Third-party API integration**: Integrate external moderation and validation services. For a complete list of supported third-party guardrail services, refer to [Third-Party APIs](/configure-guardrails/guardrail-catalog/third-party) in the Guardrail Catalog.
-</Accordion>
-
-<Accordion title="🔌 Integrate NeMo Guardrails Library into Your Application">
-
-You can integrate the NeMo Guardrails library into your application using the tools provided by the library.
-
-1. **Python SDK**: Use the Python SDK to add guardrails directly into your Python application.
-
-    ```python
-    from nemoguardrails import LLMRails, RailsConfig
-
-    config = RailsConfig.from_path("./config")
-    rails = LLMRails(config)
-
-    response = rails.generate(
-        messages=[{"role": "user", "content": "Hello!"}]
-    )
-    ```
-
-    The `generate` method accepts the same message format as the OpenAI Chat Completions API.
-
-2. **API Server**: You can solely set up a guardrails server after programming guardrails using the Python SDK. You can then start a local NeMo Guardrails server with the following command.
-
-    ```bash
-    nemoguardrails server --config ./config --port 8000
-    ```
-
-    The server exposes API endpoints such as `/v1/chat/completions` for guardrailed chat completions.
-
-    ```bash
-    curl -X POST http://localhost:8000/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -d '{
-        "config_id": "my-config",
-        "messages": [{"role": "user", "content": "Hello!"}]
-      }'
-    ```
-
-    {/* The server exposes HTTP APIs compatible with OpenAI's `/v1/chat/completions` endpoint. You can then use the server in your application by sending requests to the server's endpoint. */}
-
-</Accordion>
-
----
-
-## Next Steps
-
-To get started with NeMo Guardrails, begin by [installing the library](/get-started/installation-guide) and try out one of the [tutorials](/get-started/tutorials).
+- [How It Works](/about-nemo-guardrails-library/how-it-works) for the request flow and runtime layers.
+- [Guardrail Types](/about-nemo-guardrails-library/rail-types) for the stages where rails run.
+- [About Configuring Guardrails](/configure-guardrails) for YAML files, Colang flows, custom actions, and related settings.
+- [Get Started](/get-started/installation-guide) to install the library and run the first examples.

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.45.0"
+  "version": "5.50.5"
 }


### PR DESCRIPTION
## Description
Refreshes the About documentation pages used by the template library so readers get a clearer introduction to the NVIDIA NeMo Guardrails library and its runtime model.
This PR:
- Reworks `docs/about/overview.mdx` with clearer product positioning, core building blocks, benefits, use cases, integration paths, and learning links.
- Updates `docs/about/how-it-works.mdx` to explain the request flow, functional layers, runtime behavior, and external integration points.
- Updates the Fern docs configuration version.
## Related Issue(s)
No linked issue identified in the current PR metadata.
## Verification
- CI: `Check Fern docs` passed.
- CI: `Lint Code` passed.
- CI: `Publish Fern preview` passed.
- CI: Python test matrices were still pending when this description was drafted.
- Local validation was not run for this description-only update.
## AI Assistance
- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Cursor/GPT-5.5).
## Checklist
- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @Pouyanpi @cparisien @tgasser-nv