### PR TITLE
fix(iorails): Apply inference-time llm_params on top of Model.parameters in ModelEngine

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -195,6 +195,10 @@ class EngineRegistry:
         provider_name = engine.model_config.engine or "unknown"
         operation_name = "chat"
 
+        # Merge the model's config parameters with per-call kwargs (GenerationOptions.llm_params)
+        # Per-call kwargs have priority.
+        merged_params = {**engine.body_param_defaults, **kwargs}
+
         # Compose: span (always created — no-op when tracer is None) and
         # duration metric (only when metrics enabled).  Token usage is
         # emitted after the call returns since it depends on
@@ -208,9 +212,9 @@ class EngineRegistry:
         with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
             # Request params are known before the call, so set them first —
             # they land on the span even if the call raises.
-            set_llm_request_attributes(span, kwargs)
+            set_llm_request_attributes(span, merged_params)
             with duration_ctx:
-                result = await engine.chat_completion(messages, **kwargs)
+                result = await engine.chat_completion(messages, **merged_params)
             # Set response/usage and content attrs inside the span context so
             # the helpers see the live LLM CLIENT span and the attributes land
             # before it closes.  Both are skipped on exception, which never
@@ -270,6 +274,13 @@ class EngineRegistry:
         provider_name = engine.model_config.engine or "unknown"
         operation_name = "chat"
 
+        # Merge the model's configured parameter defaults with the per-call
+        # kwargs (per-call wins), above set_llm_request_attributes, so the span
+        # reflects the request body.  Excluding "stream"/"stream_options" from
+        # body_param_defaults also prevents a duplicate-keyword TypeError when
+        # stream_call() passes its own stream=True into _prepare_request().
+        merged_params = {**engine.body_param_defaults, **kwargs}
+
         # Capture the latest non-None response fields from the stream so we
         # can set the LLM span's response/usage attrs and emit the token
         # metric after the stream completes.  Providers spread these across
@@ -295,7 +306,7 @@ class EngineRegistry:
         with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
             # Set request params + stream=True before the first chunk so they
             # land on the span even if the stream errors mid-flight.
-            set_llm_request_attributes(span, kwargs, stream=True)
+            set_llm_request_attributes(span, merged_params, stream=True)
             with duration_ctx:
                 # Gate timing-state setup on ``_metrics_enabled`` so the
                 # cold path skips ``time.monotonic()`` and the per-chunk
@@ -304,7 +315,7 @@ class EngineRegistry:
                 # — it's never read in that branch.
                 t0 = time.monotonic() if self._metrics_enabled else 0.0
                 last_chunk_time: Optional[float] = None
-                async for chunk in engine.stream_chat_completion(messages, **kwargs):
+                async for chunk in engine.stream_chat_completion(messages, **merged_params):
                     if self._metrics_enabled:
                         # Per OTEL semconv, "first chunk" / "output chunk"
                         # mean content-bearing chunks — gate on

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -82,6 +82,13 @@ _RESERVED_LLM_PARAMETERS = frozenset(
         # be used in streaming or non-streaming mode. Defer to inference-time
         # `llm_params`.
         "stream_options",
+        # client-only options — these configure the OpenAI-compatible client
+        # (constructor kwargs), not the chat-completion request body.  IORails
+        # doesn't wire the shared client yet; reserve them so they're never
+        # forwarded as body fields, leaving proper client support to a future
+        # refactor.
+        "default_headers",
+        "default_query",
     }
 )
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -51,6 +51,36 @@ _ENGINE_BASE_URLS = {
 
 _CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
 
+# Parameter keys the engine reserves and handles itself, so they are NOT
+# forwarded into the /v1/chat/completions request body.  Everything else in
+# a model's ``parameters`` config block becomes a per-request default via
+# ``ModelEngine.body_param_defaults``.
+_RESERVED_LLM_PARAMETERS = frozenset(
+    {
+        # transport / retry — consumed by ModelEngine.__init__ and
+        # _resolve_base_url, never part of the request body
+        "base_url",
+        "timeout",
+        "timeout_connect",
+        "max_attempts",
+        # secret — carried in the Authorization header, never echoed into the body
+        "api_key",
+        # model identity / positional — set explicitly by _prepare_request;
+        # would collide with the "model" body field set there.  After Model
+        # validation these never appear in parameters, but exclude them
+        # defensively against direct construction.
+        "model",
+        "model_name",
+        "messages",
+        # streaming control — owned by the engine.  "stream" in particular
+        # collides with the explicit stream=True kwarg that stream_call()
+        # passes into _prepare_request(), which would raise TypeError on a
+        # duplicate keyword argument.
+        "stream",
+        "stream_options",
+    }
+)
+
 
 class _RequestParams(NamedTuple):
     """Pre-built parameters for an HTTP request to the completions endpoint."""
@@ -189,6 +219,12 @@ class ModelEngine(BaseEngine):
             timeout_connect=float(params.get("timeout_connect") or DEFAULT_TIMEOUT_CONNECT),
             max_attempts=int(params.get("max_attempts") or DEFAULT_MAX_ATTEMPTS),
         )
+
+        # Default `llm_params` used on inference are the subset of Model.parameters after
+        # filtering out keys in _RESERVED_LLM_PARAMETERS.
+        self.body_param_defaults: dict[str, Any] = {
+            key: value for key, value in params.items() if key not in _RESERVED_LLM_PARAMETERS
+        }
 
     def _resolve_base_url(self) -> str:
         """Resolve the base URL from model parameters or engine type.

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -24,7 +24,8 @@ import json
 import logging
 import os
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
+from types import MappingProxyType
 from typing import Any, NamedTuple, Optional, cast
 
 import aiohttp
@@ -77,6 +78,9 @@ _RESERVED_LLM_PARAMETERS = frozenset(
         # passes into _prepare_request(), which would raise TypeError on a
         # duplicate keyword argument.
         "stream",
+        # Can't set Model-level `stream_options` because the same model can
+        # be used in streaming or non-streaming mode. Defer to inference-time
+        # `llm_params`.
         "stream_options",
     }
 )
@@ -221,10 +225,11 @@ class ModelEngine(BaseEngine):
         )
 
         # Default `llm_params` used on inference are the subset of Model.parameters after
-        # filtering out keys in _RESERVED_LLM_PARAMETERS.
-        self.body_param_defaults: dict[str, Any] = {
-            key: value for key, value in params.items() if key not in _RESERVED_LLM_PARAMETERS
-        }
+        # filtering out keys in _RESERVED_LLM_PARAMETERS.  Exposed as a read-only
+        # MappingProxyType view so callers can't mutate the shared per-engine defaults.
+        self.body_param_defaults: Mapping[str, Any] = MappingProxyType(
+            {key: value for key, value in params.items() if key not in _RESERVED_LLM_PARAMETERS}
+        )
 
     def _resolve_base_url(self) -> str:
         """Resolve the base URL from model parameters or engine type.

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -154,6 +154,28 @@ def _mock_sse_response(raw_chunks: list[dict]):
     return mock_response
 
 
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def _registry_with_main_params(parameters: dict, tracer):
+    """Build an EngineRegistry whose ``main`` model carries ``parameters``,
+    wired to ``tracer`` so model_call / stream_model_call produce real spans we
+    can read back. Used by the parameter-defaults merge tests, which need a
+    model with non-empty ``parameters`` (the shared NEMOGUARDS_CONFIG models
+    have none)."""
+    config = RailsConfig.from_content(
+        config={
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "nim",
+                    "model": "meta/llama-3.3-70b-instruct",
+                    "parameters": parameters,
+                }
+            ]
+        }
+    )
+    return EngineRegistry(config.models, config.rails.config, tracer=tracer)
+
+
 class TestEngineRegistryInit:
     """Test EngineRegistry creates engines from config."""
 
@@ -503,6 +525,192 @@ class TestEngineRegistryModelCallSpanAttributes:
         assert "gen_ai.usage.input_tokens" not in attrs
         assert "gen_ai.response.model" not in attrs
         assert attrs["error.type"] == "RuntimeError"
+
+
+class TestEngineRegistryParameterDefaults:
+    """``model_call`` / ``stream_model_call`` merge ModelEngine.body_param_defaults
+    (the model's ``parameters`` config minus transport/secret/streaming keys)
+    under the per-call kwargs. Both the request body and the gen_ai.request.*
+    span attrs reflect the defaults, with per-call llm_params overriding."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_model_call_applies_config_defaults(self, span_exporter):
+        """No per-call kwargs → the model's parameter defaults populate both the
+        request body and the request span attrs."""
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params({"temperature": 0.7, "max_tokens": 256}, tracer)
+        engine = registry._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await registry.model_call("main", [{"role": "user", "content": "hi"}])
+
+        body = engine.chat_completion.call_args[1]
+        assert body["temperature"] == 0.7
+        assert body["max_tokens"] == 256
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == 0.7
+        assert attrs["gen_ai.request.max_tokens"] == 256
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_model_call_per_call_kwargs_override_defaults(self, span_exporter):
+        """A per-call kwarg overrides the config default for that key; the other
+        defaults are retained, in both body and span."""
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params({"temperature": 0.7, "max_tokens": 256}, tracer)
+        engine = registry._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await registry.model_call("main", [{"role": "user", "content": "hi"}], temperature=0.1)
+
+        body = engine.chat_completion.call_args[1]
+        assert body["temperature"] == 0.1  # per-call override wins
+        assert body["max_tokens"] == 256  # config default retained
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == 0.1
+        assert attrs["gen_ai.request.max_tokens"] == 256
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_llm_params_take_precedence_over_config_parameters(self, span_exporter):
+        """Precedence guard: when the same key is set in BOTH the static
+        Model.parameters config AND the per-call llm_params, the per-call value
+        must win in the request body actually sent to the engine. Reversing the
+        merge order ({**kwargs, **defaults}, config winning) flips the sent
+        temperature back to the config value and fails this test."""
+        config_temperature = 0.7
+        per_call_temperature = 0.1
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params({"temperature": config_temperature}, tracer)
+        engine = registry._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await registry.model_call("main", [{"role": "user", "content": "hi"}], temperature=per_call_temperature)
+
+        sent_body = engine.chat_completion.call_args[1]
+        assert sent_body["temperature"] == per_call_temperature
+        assert sent_body["temperature"] != config_temperature  # the static config default must not win
+        # The span reflects the same value that was sent.
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == per_call_temperature
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_model_call_excludes_non_body_keys(self, span_exporter):
+        """Transport (base_url/timeout) and streaming-control (stream) keys in
+        parameters never reach the request body; only the sampling param does."""
+        tracer, _ = span_exporter
+        registry = _registry_with_main_params(
+            {"base_url": "https://custom.example.com", "timeout": 5, "stream": True, "temperature": 0.5},
+            tracer,
+        )
+        engine = registry._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await registry.model_call("main", [{"role": "user", "content": "hi"}])
+
+        body = engine.chat_completion.call_args[1]
+        assert body == {"temperature": 0.5}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_model_call_applies_defaults_and_override(self, span_exporter):
+        """Streaming path merges the same way: defaults populate the body
+        (captured off the engine call) and the span attrs (with stream=True),
+        and a per-call kwarg overrides its default."""
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params({"temperature": 0.7, "max_tokens": 256}, tracer)
+        engine = registry._get_engine("main", ModelEngine)
+
+        captured: dict = {}
+
+        async def _capturing_stream(messages, **kwargs):  # noqa: ARG001 (signature dictated by ModelEngine)
+            captured.update(kwargs)
+            yield LLMResponseChunk(delta_content="hi", finish_reason="stop")
+
+        engine.stream_chat_completion = _capturing_stream
+
+        async for _ in registry.stream_model_call("main", [{"role": "user", "content": "hi"}], temperature=0.1):
+            pass
+
+        assert captured["temperature"] == 0.1  # per-call override wins
+        assert captured["max_tokens"] == 256  # config default retained
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.stream"] is True
+        assert attrs["gen_ai.request.temperature"] == 0.1
+        assert attrs["gen_ai.request.max_tokens"] == 256
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_llm_params_take_precedence_over_config_parameters(self, span_exporter):
+        """Streaming precedence guard: when the same key is set in BOTH the
+        static Model.parameters config AND the per-call llm_params, the per-call
+        value must win in what stream_model_call forwards to the engine.
+        Reversing the merge order ({**kwargs, **defaults}, config winning) flips
+        the streamed temperature back to the config value and fails this test."""
+        config_temperature = 0.7
+        per_call_temperature = 0.1
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params({"temperature": config_temperature}, tracer)
+        engine = registry._get_engine("main", ModelEngine)
+
+        captured: dict = {}
+
+        async def _capturing_stream(messages, **kwargs):  # noqa: ARG001 (signature dictated by ModelEngine)
+            captured.update(kwargs)
+            yield LLMResponseChunk(delta_content="hi", finish_reason="stop")
+
+        engine.stream_chat_completion = _capturing_stream
+
+        async for _ in registry.stream_model_call(
+            "main", [{"role": "user", "content": "hi"}], temperature=per_call_temperature
+        ):
+            pass
+
+        assert captured["temperature"] == per_call_temperature
+        assert captured["temperature"] != config_temperature  # the static config default must not win
+        # The span reflects the same value that was forwarded.
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == per_call_temperature
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_model_call_with_stream_param_does_not_raise_type_error(self, span_exporter):
+        """A model whose parameters include ``stream`` drives the real
+        stream_call/_prepare_request path without a duplicate-keyword TypeError
+        (stream is excluded from body_param_defaults). Only the sampling param
+        reaches the sent body; transport/streaming keys are dropped."""
+        tracer, exporter = span_exporter
+        registry = _registry_with_main_params(
+            {"stream": True, "base_url": "https://custom.example.com", "temperature": 0.5}, tracer
+        )
+        engine = registry._get_engine("main", ModelEngine)
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(
+            return_value=_mock_sse_response(
+                [
+                    {
+                        "id": "chatcmpl-stream",
+                        "model": "meta/llama-3.3-70b-instruct",
+                        "choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}],
+                    },
+                ]
+            )
+        )
+        engine._running = True
+
+        # Must not raise TypeError("got multiple values for keyword argument 'stream'").
+        async for _ in registry.stream_model_call("main", [{"role": "user", "content": "hi"}]):
+            pass
+
+        sent_body = engine._client.post.call_args.kwargs["json"]
+        assert sent_body["temperature"] == 0.5
+        assert sent_body["stream"] is True  # set explicitly by stream_call, not from parameters
+        assert "base_url" not in sent_body
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.request.temperature"] == 0.5
+        assert attrs["gen_ai.request.stream"] is True
 
 
 class TestEngineRegistryStartErrors:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -380,6 +380,22 @@ class TestModelEngineBodyParamDefaults:
         assert engine.body_param_defaults == {"max_tokens": 64}
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_excludes_client_only_keys(self):
+        """default_headers / default_query configure the OpenAI-compatible
+        client, not the chat-completion body, so they never reach the body
+        defaults; a sampling param alongside them is kept."""
+        engine = ModelEngine(
+            _make_model(
+                parameters={
+                    "default_headers": {"X-Tenant": "acme"},
+                    "default_query": {"api-version": "2024-02-01"},
+                    "temperature": 0.5,
+                }
+            )
+        )
+        assert engine.body_param_defaults == {"temperature": 0.5}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
     def test_excludes_identity_keys_defensively(self):
         """model / model_name / messages are stripped even when present in
         parameters. The Model validator normally lifts model/model_name into

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -328,6 +328,77 @@ class TestModelEngineConfig:
         assert engine._client is None
 
 
+class TestModelEngineBodyParamDefaults:
+    """Test ModelEngine.body_param_defaults: sampling params from a model's
+    ``parameters`` config become per-request body defaults, while transport,
+    secret, identity, and streaming-control keys are excluded."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_keeps_sampling_params(self):
+        """Sampling/body params (temperature, max_tokens, seed, top_p, ...) all
+        pass through to body_param_defaults unchanged."""
+        engine = ModelEngine(_make_model(parameters={"temperature": 0.3, "max_tokens": 256, "seed": 42, "top_p": 0.9}))
+        assert engine.body_param_defaults == {
+            "temperature": 0.3,
+            "max_tokens": 256,
+            "seed": 42,
+            "top_p": 0.9,
+        }
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_excludes_transport_and_retry_keys(self):
+        """Transport/retry keys consumed by __init__ and _resolve_base_url are
+        not echoed into the body; a sampling param alongside them is kept."""
+        engine = ModelEngine(
+            _make_model(
+                engine="nim",
+                parameters={
+                    "base_url": "https://custom.example.com",
+                    "timeout": 120,
+                    "timeout_connect": 30,
+                    "max_attempts": 5,
+                    "temperature": 0.5,
+                },
+            )
+        )
+        assert engine.body_param_defaults == {"temperature": 0.5}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_excludes_secret_and_streaming_keys(self):
+        """api_key (secret, header-only) and stream/stream_options (engine-owned)
+        never reach the body defaults."""
+        engine = ModelEngine(
+            _make_model(
+                parameters={
+                    "api_key": "sk-should-not-leak",
+                    "stream": True,
+                    "stream_options": {"include_usage": True},
+                    "max_tokens": 64,
+                }
+            )
+        )
+        assert engine.body_param_defaults == {"max_tokens": 64}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_excludes_identity_keys_defensively(self):
+        """model / model_name / messages are stripped even when present in
+        parameters. The Model validator normally lifts model/model_name into
+        the model field, so these only leak via direct construction — mutate
+        parameters after build to simulate that path."""
+        model = _make_model(parameters={"temperature": 0.2})
+        model.parameters.update(
+            {"model": "shadow", "model_name": "shadow", "messages": [{"role": "user", "content": "x"}]}
+        )
+        engine = ModelEngine(model)
+        assert engine.body_param_defaults == {"temperature": 0.2}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
+    def test_empty_parameters_yields_empty_defaults(self):
+        """A model with no parameters has empty body_param_defaults."""
+        engine = ModelEngine(_make_model(parameters={}))
+        assert engine.body_param_defaults == {}
+
+
 class TestModelEngineLifecycle:
     """Test the ModelEngine start() and stop() client lifecycle."""
 


### PR DESCRIPTION
## Description

IORails was silently dropping `llm_params` sampling fields configured in a model's parameters (i.e. `Model.parameters`). It took `GenerationOptions.llm_params` at inference-time only.

This PR filters out reserved parameters (`_RESERVED_LLM_PARAMETERS`) in the `Model.parameters` dict and stores these per-model so they're used on every call. If `GenerationOptions.llm_params` keys are provided they overwrite the `Model.parameters` values.

## Related Issue(s)

#2009 Introduced LLM span attributes including parameters.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE poetry run pytest -n auto --dist worksteal
========================================================== test session starts ==========================================================
platform darwin -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-model-param-merge
configfile: pytest.ini
testpaths: tests, docs/colang-2/examples, benchmark/tests
plugins: anyio-4.12.1, langsmith-0.7.12, xdist-3.8.0, httpx-0.35.0, asyncio-0.26.0, profiling-1.8.1, cov-7.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [4820 items]
................................................................................................................................. [  2%]
................................................................................................................................. [  5%]
......................................................................................................s.sss...................... [  8%]
................................................................................................................................. [ 10%]
................................................................................................................................. [ 13%]
................................................................................................................................. [ 16%]
.................................................................................ssssssss.........ssssss...ss...s................ [ 18%]
.....................s.s..s..sssss............................................................................................... [ 21%]
............s...................s...s............................................................................................ [ 24%]
......................................ss.............s...............s........s....s......s...................................... [ 26%]
....s.......................................................................................................ss................... [ 29%]
................................................................................................................................. [ 32%]
................................................................................................................................. [ 34%]
....................................................................s............................................................ [ 37%]
................................................................................................................................. [ 40%]
.....................................sss.ss...........................................sssssss........................ssssssssssss [ 42%]
ssssss.........................ss.......................................s........................................................ [ 45%]
...........ss......s............................................................................................................. [ 48%]
...ss......................s.s.sss............................................................s.................................. [ 50%]
...............................................................s.s.sss........................................................... [ 53%]
.............................................................................................s................................... [ 56%]
................................................................................................................................. [ 58%]
................................................................................................................................. [ 61%]
................................................................................................................................. [ 64%]
................................................................................................................................. [ 66%]
................................................................................................................................. [ 69%]
................................................................................................................................. [ 72%]
...........................................................s......................................................s.............s [ 74%]
sss.ssssss..............................................................................ss....................................... [ 77%]
........................................................................sssss.ss.............sssssss.s........................... [ 80%]
..............................s..s................................s.............................................................. [ 82%]
.........ssssssss.............................................................sss.........s.s.................................... [ 85%]
................s..............................s.s.........ss........s........................................................... [ 88%]
...........s...........................................ssss.sss..ss...ssss.s.....ssss...s........................................ [ 90%]
................................................................................................................................. [ 93%]
......ssss...s...............................................................................ssssss.ss........................... [ 96%]
......ss..........................s.............................................................................................. [ 99%]
...............................................                                                                                   [100%]
================================================== 4640 passed, 180 skipped in 37.63s ===================================================
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
