### PR TITLE
ci: gate automated reviews on triage labels and auto-label new PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -83,4 +83,9 @@ reviews:
     # Review draft PRs/MRs.
     # Default: false
     drafts: false
+    # Only auto-review PRs labeled `status: triaged` (auto-applied for maintainers
+    # / NVIDIA-NeMo org members; a maintainer adds it after triage for external
+    # contributors). Gates review noise on agent/external PRs.
+    labels:
+      - "status: triaged"
     # Base branches (other than the default branch) to review. Accepts regex patterns. Use '.*' to match all branches.

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -1,0 +1,55 @@
+name: triage auto-label
+
+# Manages the triage-state labels that gate automated review from CodeRabbit
+# and Greptile:
+#   - On open: maintainers / NVIDIA-NeMo org members / collaborators get
+#     "status: triaged"; everyone else gets "status: needs triage".
+#   - When a maintainer adds "status: triaged", "status: needs triage" is
+#     removed automatically.
+#
+# Uses pull_request_target so it has a write token even on fork PRs. Safe ONLY
+# because no job checks out or executes PR head code -- they read event metadata
+# and call the labels API. Do not add a checkout of the PR head here.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  initial-label:
+    if: github.event.action != 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const trusted = ["OWNER", "MEMBER", "COLLABORATOR"].includes(
+              context.payload.pull_request.author_association
+            );
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [trusted ? "status: triaged" : "status: needs triage"],
+            });
+
+  clear-needs-triage:
+    if: "github.event.action == 'labeled' && github.event.label.name == 'status: triaged'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: "status: needs triage",
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -2,8 +2,10 @@ name: triage auto-label
 
 # Manages the triage-state labels that gate automated review from CodeRabbit
 # and Greptile:
-#   - On open: maintainers / NVIDIA-NeMo org members / collaborators get
-#     "status: triaged"; everyone else gets "status: needs triage".
+#   - On open/reopen with no triage label yet: maintainers / NVIDIA-NeMo org
+#     members / collaborators get "status: triaged"; everyone else gets
+#     "status: needs triage". A PR that already carries either label keeps it
+#     (reopening a triaged PR does not reset it to "needs triage").
 #   - When a maintainer adds "status: triaged", "status: needs triage" is
 #     removed automatically.
 #
@@ -26,6 +28,15 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
+            const existing = context.payload.pull_request.labels.map(
+              (label) => label.name
+            );
+            if (
+              existing.includes("status: triaged") ||
+              existing.includes("status: needs triage")
+            ) {
+              return;
+            }
             const trusted = ["OWNER", "MEMBER", "COLLABORATOR"].includes(
               context.payload.pull_request.author_association
             );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,13 @@ Automated code review tools such as CodeRabbit and Greptile are part of the
 pre-review workflow. A PR is ready for maintainer review only after the author
 has addressed unresolved human and automated review comments.
 
+Automated code review is gated on triage. New and reopened PRs from
+maintainers, repository collaborators, or NVIDIA-NeMo organization members are
+labeled `status: triaged` automatically. Other PRs open as `status: needs
+triage`; a maintainer applies `status: triaged` after confirming the PR is
+linked to a triaged issue assigned to the contributor. CodeRabbit and Greptile
+are configured to review only PRs with `status: triaged`.
+
 Before requesting maintainer review:
 
 - Address every automated code review comment, or reply with a clear reason why

--- a/greptile.json
+++ b/greptile.json
@@ -1,4 +1,6 @@
 {
+  "labels": ["status: triaged"],
+  "triggerOnDrafts": false,
   "triggerOnUpdates": true,
   "shouldUpdateDescription": false,
   "fixWithAI": true,


### PR DESCRIPTION
## Description

Add triage-state labeling for pull requests so trusted authors are labeled `status: triaged` automatically and other contributors start as `status: needs triage`.

Configure CodeRabbit and Greptile to run only on PRs labeled `status: triaged`, reducing automated review noise before maintainer triage.

Document the triage-gated automated review flow in CONTRIBUTING.md.


## Related Issue(s)
None
<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
