### PR TITLE
docs: expand How It Works toward the architecture template

### DIFF
--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -12,9 +12,33 @@ content:
 
 The NeMo Guardrails library acts as an intermediary between application code and LLM requests and responses. Once Guardrails is integrated in an application, all LLM inference requests are first checked by Guardrails to ensure user requests are safe and not malicious. If they are, the request is passed to the LLM for inference. Guardrails also checks the LLM response once it's available, making sure it's appropriate before being passed back to the user.
 
+## High-Level Architecture Diagram
+
 ![Programmable Guardrails Flow](../_static/images/programmable_guardrails.png "Programmable Guardrails Flow")
 
 Each application can configure its own set of guardrails, depending on the use-case. Guardrails requests can trigger calls to third-party APIs, LLMs fine-tuned to implement Guardrail functionality, or to the Application LLM. Guardrails hides this complexity from clients, orchestrating the workflows behind-the-scenes so applications can focus on their business logic.
+
+## Component Layers
+
+NeMo Guardrails applies guardrails at multiple stages of the LLM interaction. Each stage uses a different *rail type*:
+
+- **Input rails** validate and sanitize user inputs before the LLM is called — for example, content safety, jailbreak detection, topic control, and PII masking.
+- **Retrieval rails** filter and validate retrieved knowledge (documents and chunks) so that only trusted context is provided to the LLM in RAG pipelines.
+- **Dialog rails** steer and constrain the multi-turn conversation, enforcing flow logic and policies across turns.
+- **Execution rails** control and validate tool and function calls — their arguments and results — to safely interact with external systems.
+- **Output rails** evaluate and post-process model responses, filtering, editing, or blocking unsafe or off-policy content before it reaches users.
+
+Input and output rails are the most common. For the full list of rail types and the use cases each one applies to, see [Guardrail Types](/about-nemo-guardrails-library/rail-types).
+
+## Data Flow
+
+When Guardrails is integrated into an application, each LLM interaction flows through the configured rails:
+
+1. The application sends a user request to Guardrails rather than directly to the LLM.
+2. **Input rails** check the request to confirm it is safe and not malicious; unsafe requests can be blocked or modified before proceeding.
+3. If the request passes, it is sent to the LLM for inference. Depending on the configuration, Guardrails may also apply **retrieval rails** (for RAG context), **dialog rails** (for conversation flow), and **execution rails** (for tool calls) at this stage.
+4. **Output rails** check the LLM response once it is available, filtering or editing it as needed to ensure it is appropriate.
+5. The validated response is returned to the user.
 
 ## Related Resources
 

--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -32,13 +32,13 @@ Input and output rails are the most common. For the full list of rail types and 
 
 ## Data Flow
 
-When Guardrails is integrated into an application, each LLM interaction flows through the configured rails:
+When Guardrails is integrated into an application, a user message passes through a sequence of stages, depending on which rails are configured:
 
-1. The application sends a user request to Guardrails rather than directly to the LLM.
-2. **Input rails** check the request to confirm it is safe and not malicious; unsafe requests can be blocked or modified before proceeding.
-3. If the request passes, it is sent to the LLM for inference. Depending on the configuration, Guardrails may also apply **retrieval rails** (for RAG context), **dialog rails** (for conversation flow), and **execution rails** (for tool calls) at this stage.
-4. **Output rails** check the LLM response once it is available, filtering or editing it as needed to ensure it is appropriate.
-5. The validated response is returned to the user.
+1. **Input stage** — the user input is first processed by the **input rails**, which decide whether it is allowed, altered, or rejected.
+2. **Retrieval stage** — if a knowledge base is configured, relevant context is retrieved and processed by **retrieval rails** to validate, filter, and transform it before it is injected into the prompt.
+3. **Dialog stage** — if dialog rails are configured, the message is processed by the dialog flows, which steer the conversation and ultimately produce a bot message.
+4. **Execution stage** — if custom actions or tools are defined, they run under the control of **execution rails**, which govern which actions can execute and validate their inputs and outputs. Results may be incorporated back into the response, supporting the multi-step (agentic) flows that return to the LLM.
+5. **Output stage** — the **output rails** decide whether the final response is allowed, altered, or rejected before it is returned to the user.
 
 ## Related Resources
 


### PR DESCRIPTION
## What

Expands `docs/about/how-it-works.mdx` (the *Architecture Overview* / How It Works page) toward the **architecture** documentation template used by NVIDIA's tech-docs template-library, for which this page is the cited example.

## Why

In a template-library conformance audit, this page was a stub (intro + one diagram + Related Resources) and didn't include the architecture template's sections.

## Change (purely additive — nothing removed)

- **High-Level Architecture Diagram** — heading placed over the existing diagram.
- **Component Layers** — concise summary of the five rail types (input, retrieval, dialog, execution, output), **sourced verbatim in meaning from the existing [Guardrail Types](/about-nemo-guardrails-library/rail-types) page**, with a link there for full detail.
- **Data Flow** — the request → input rails → LLM → output rails → response path, drawn from the page's own intro plus the rail-stage mapping on the Guardrail Types page.

Frontmatter, the intro paragraph, the diagram, and Related Resources are preserved verbatim.

## Deliberately out of scope

The template also defines a **Deployment Topologies** section. I did not add it because it isn't documented in the current source, and I didn't want to fabricate architecture detail for a safety product — flagging it as a gap for maintainers who have that context.

Opened as **draft** — the Component Layers / Data Flow framing should be reviewed by the Guardrails team for technical accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded "How It Works" documentation with new high-level architecture diagram, component layers breakdown, and detailed step-by-step data flow explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->