### PR TITLE
feat(iorails): Tool-calling - streaming tools from main LLM

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -89,6 +89,25 @@ STREAM_MAX_CONCURRENCY = 256
 _GENERATION_ERROR_TYPE = "generation_error"
 
 
+def _is_stream_error_chunk(chunk: Union[str, dict]) -> bool:
+    """True when a streamed chunk is an error/violation payload.
+
+    Covers both the ``generation_error`` payload pushed on a generation failure
+    and the ``guardrails_violation`` payload emitted when output rails block.
+    Handles plain-string chunks and the ``{"text": ...}`` frames produced when
+    ``include_metadata=True``. The cheap ``"error"`` substring guard keeps the
+    per-chunk hot path from JSON-parsing ordinary text tokens.
+    """
+    text = chunk.get("text") if isinstance(chunk, dict) else chunk
+    if not isinstance(text, str) or '"error"' not in text:
+        return False
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(parsed, dict) and "error" in parsed
+
+
 def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict]:
     """Serialize ToolCall objects to OpenAI /chat/completions shape.
 
@@ -737,6 +756,10 @@ class IORails(BaseGuardrails):
                             # the caller (including any output-rails error JSON
                             # injected on block).
                             delivered: list[str] = []
+                            # Set if an error / guardrails-violation payload reaches
+                            # the consumer, so the terminal tool-call chunk is
+                            # suppressed (never surface tool calls after a failure/block).
+                            error_emitted = False
                             try:
                                 log.info("[%s] stream_async called", req_id)
                                 log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
@@ -754,6 +777,8 @@ class IORails(BaseGuardrails):
 
                                     async for chunk in base_iterator:
                                         if chunk is not None:
+                                            if _is_stream_error_chunk(chunk):
+                                                error_emitted = True
                                             if self._content_capture_enabled:
                                                 # Plain strings are the normal path.
                                                 # Dicts arrive when include_metadata=True;
@@ -767,11 +792,24 @@ class IORails(BaseGuardrails):
                                                     if isinstance(text, str) and text:
                                                         delivered.append(text)
                                             yield chunk
-                                    # Yield assembled tool calls as a terminal JSON chunk
-                                    # after all text content (and output rails) have
-                                    # finished.
-                                    if accumulated_tool_calls:
-                                        yield json.dumps({"tool_calls": _serialize_tool_calls(accumulated_tool_calls)})
+                                    # Yield assembled tool calls as a terminal chunk after
+                                    # all text content (and output rails) have finished —
+                                    # but only on a clean stream. If an error or guardrails
+                                    # violation was already surfaced, suppress the tool calls
+                                    # so the caller never receives a tool-call after a
+                                    # failure/block.
+                                    if accumulated_tool_calls and not error_emitted:
+                                        tool_calls_payload = json.dumps(
+                                            {"tool_calls": _serialize_tool_calls(accumulated_tool_calls)}
+                                        )
+                                        if self._content_capture_enabled:
+                                            delivered.append(tool_calls_payload)
+                                        # Match the stream's chunk shape: a {"text": ...}
+                                        # frame under include_metadata, a raw string otherwise.
+                                        if include_metadata:
+                                            yield {"text": tool_calls_payload}
+                                        else:
+                                            yield tool_calls_payload
                                 finally:
                                     if not task.done():
                                         task.cancel()

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -602,6 +602,9 @@ class IORails(BaseGuardrails):
             llm_kwargs = options.llm_params
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
+        # Assembled tool calls from the stream — populated by _generation_task
+        # and consumed by _wrapped_iterator after the content stream ends.
+        accumulated_tool_calls: list[ToolCall] = []
 
         async def _generation_task(request_span):
             """Background task: input rails → stream LLM chunks → push to handler.
@@ -629,14 +632,19 @@ class IORails(BaseGuardrails):
                     return
 
                 # Step 2: Stream main LLM content from structured response.
-                # Only delta_content is forwarded. Reasoning is dropped for compatibility
-                # with LLMRails. Tool-calls are not yet supported by IORails
+                # delta_content is forwarded as text chunks; delta_tool_calls are
+                # accumulated and surfaced as a terminal JSON chunk after the text
+                # stream ends. Reasoning is dropped for LLMRails compatibility.
                 log.info("[%s] Streaming main LLM", req_id)
                 content_parts: list[str] = []
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
                     if chunk.delta_content:
                         content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content)
+                    if chunk.delta_tool_calls:
+                        # Slice-assign to mutate the shared list in place so
+                        # _wrapped_iterator sees the update without nonlocal.
+                        accumulated_tool_calls[:] = chunk.delta_tool_calls
 
                 # While LLMResponseChunk.delta_reasoning is dropped explicitly,
                 # think-tags embedded in delta_content are not. Give a warning
@@ -649,6 +657,9 @@ class IORails(BaseGuardrails):
                         "(output rails will process reasoning tokens)",
                         req_id,
                     )
+
+                if accumulated_tool_calls and not content_parts:
+                    log.info("[%s] Tool-call-only stream: output rails skipped", req_id)
 
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
             except Exception as e:
@@ -756,6 +767,11 @@ class IORails(BaseGuardrails):
                                                     if isinstance(text, str) and text:
                                                         delivered.append(text)
                                             yield chunk
+                                    # Yield assembled tool calls as a terminal JSON chunk
+                                    # after all text content (and output rails) have
+                                    # finished.
+                                    if accumulated_tool_calls:
+                                        yield json.dumps({"tool_calls": _serialize_tool_calls(accumulated_tool_calls)})
                                 finally:
                                     if not task.done():
                                         task.cancel()
@@ -821,8 +837,15 @@ class IORails(BaseGuardrails):
                 for chunk in user_output_chunks:
                     yield chunk
 
-            # Run output rails on the accumulated context
+            # Run output rails on the accumulated context. Skip when content is empty
+            # (e.g. tool-call-only response) to avoid a pointless is_output_safe("") call.
             req_id = get_request_id()
+            if not bot_response_chunk:
+                if not stream_first:
+                    for chunk in user_output_chunks:
+                        yield chunk
+                continue
+
             log.info("[%s] Running output rails", req_id)
             output_result = await self.rails_manager.is_output_safe(messages, bot_response_chunk)
             if not output_result.is_safe:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -128,6 +128,22 @@ def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict]:
     ]
 
 
+def _terminal_tool_call_chunk(
+    tool_calls: list[ToolCall], include_metadata: Optional[bool]
+) -> tuple[str, Union[str, dict]]:
+    """Frame assembled tool calls as the stream's terminal chunk.
+
+    Returns ``(payload, framed)``: ``payload`` is the OpenAI-native
+    ``{"tool_calls": ...}`` JSON string used for content capture, and
+    ``framed`` is what to yield — a ``{"text": payload}`` dict under
+    ``include_metadata``, a raw string otherwise — matching the shape of
+    the surrounding stream.
+    """
+    payload = json.dumps({"tool_calls": _serialize_tool_calls(tool_calls)})
+    framed: Union[str, dict] = {"text": payload} if include_metadata else payload
+    return payload, framed
+
+
 def _build_assistant_message(content: str, tool_calls: Optional[list[ToolCall]]) -> LLMMessage:
     """Build the assistant message returned by ``generate``.
 
@@ -621,8 +637,10 @@ class IORails(BaseGuardrails):
             llm_kwargs = options.llm_params
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
-        # Assembled tool calls from the stream — populated by _generation_task
-        # and consumed by _wrapped_iterator after the content stream ends.
+        # Tool calls assembled by the stream: _generation_task rebinds this (via
+        # nonlocal) to the engine's finalized list and _wrapped_iterator reads it
+        # after the content stream drains. The engine emits the complete list once
+        # (see ModelEngine.stream_call), so a plain rebind is sufficient.
         accumulated_tool_calls: list[ToolCall] = []
 
         async def _generation_task(request_span):
@@ -636,6 +654,7 @@ class IORails(BaseGuardrails):
 
             Inherits the request ID from the caller context via create_task().
             """
+            nonlocal accumulated_tool_calls
             req_id = get_request_id()
             t0 = time.monotonic()
             try:
@@ -661,9 +680,9 @@ class IORails(BaseGuardrails):
                         content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content)
                     if chunk.delta_tool_calls:
-                        # Slice-assign to mutate the shared list in place so
-                        # _wrapped_iterator sees the update without nonlocal.
-                        accumulated_tool_calls[:] = chunk.delta_tool_calls
+                        # Engine emits the complete finalized list once (see
+                        # ModelEngine.stream_call), so rebind rather than accumulate.
+                        accumulated_tool_calls = chunk.delta_tool_calls
 
                 # While LLMResponseChunk.delta_reasoning is dropped explicitly,
                 # think-tags embedded in delta_content are not. Give a warning
@@ -792,24 +811,17 @@ class IORails(BaseGuardrails):
                                                     if isinstance(text, str) and text:
                                                         delivered.append(text)
                                             yield chunk
-                                    # Yield assembled tool calls as a terminal chunk after
-                                    # all text content (and output rails) have finished —
-                                    # but only on a clean stream. If an error or guardrails
-                                    # violation was already surfaced, suppress the tool calls
-                                    # so the caller never receives a tool-call after a
-                                    # failure/block.
+                                    # Emit assembled tool calls as the terminal chunk once
+                                    # text + output rails finish, but only on a clean stream:
+                                    # suppress after an error/guardrails block so the caller
+                                    # never receives a tool call following a failure.
                                     if accumulated_tool_calls and not error_emitted:
-                                        tool_calls_payload = json.dumps(
-                                            {"tool_calls": _serialize_tool_calls(accumulated_tool_calls)}
+                                        payload, framed = _terminal_tool_call_chunk(
+                                            accumulated_tool_calls, include_metadata
                                         )
                                         if self._content_capture_enabled:
-                                            delivered.append(tool_calls_payload)
-                                        # Match the stream's chunk shape: a {"text": ...}
-                                        # frame under include_metadata, a raw string otherwise.
-                                        if include_metadata:
-                                            yield {"text": tool_calls_payload}
-                                        else:
-                                            yield tool_calls_payload
+                                            delivered.append(payload)
+                                        yield framed
                                 finally:
                                     if not task.done():
                                         task.cancel()

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -513,6 +513,8 @@ class ModelEngine(BaseEngine):
                 # chunks — multiple SSE events in one TCP segment would be merged
                 # into one unparseable blob.  readline() splits on \n correctly.
                 tool_calls: dict[int, dict] = {}
+                tool_calls_emitted = False
+                last_chunk_id = None
                 while True:
                     raw_line = await response.content.readline()
                     if not raw_line:
@@ -534,25 +536,40 @@ class ModelEngine(BaseEngine):
                         log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
                         continue
 
+                    last_chunk_id = raw_chunk.get("id") or last_chunk_id
                     _accumulate_tool_call_delta(tool_calls, raw_chunk)
 
                     parsed_chunk = _parse_chat_completion_chunk(raw_chunk)
 
-                    # Finalize accumulated tool calls onto the finish_reason chunk.
-                    # _parse_chat_completion_chunk returns None for empty-delta finish
-                    # chunks (no content/reasoning/usage), so create a bare chunk to
-                    # carry delta_tool_calls when needed.
+                    # Finalize accumulated tool calls onto the terminating chunk.
+                    # A streamed tool call ends with a finish_reason — "tool_calls"
+                    # when the model chose freely, but "stop" when tool_choice forced
+                    # a specific function. Gate on *any* finish_reason (with tool calls
+                    # accumulated), not the literal "tool_calls", or forced calls never
+                    # surface. _parse_chat_completion_chunk returns None for empty-delta
+                    # finish chunks, so synthesize a carrier chunk to hold the calls.
                     choices = raw_chunk.get("choices") or []
-                    if tool_calls and choices and choices[0].get("finish_reason") == "tool_calls":
+                    finish_reason = choices[0].get("finish_reason") if choices else None
+                    if tool_calls and not tool_calls_emitted and finish_reason:
                         if parsed_chunk is None:
                             parsed_chunk = LLMResponseChunk(
-                                finish_reason="tool_calls",
+                                finish_reason=finish_reason,
                                 request_id=raw_chunk.get("id"),
                             )
                         parsed_chunk.delta_tool_calls = _finalize_tool_calls(tool_calls)
+                        tool_calls_emitted = True
 
                     if parsed_chunk is not None:
                         yield parsed_chunk
+
+                # Safety net: a provider that ends the stream with [DONE]/EOF and no
+                # finish_reason chunk still gets its accumulated tool calls surfaced.
+                if tool_calls and not tool_calls_emitted:
+                    yield LLMResponseChunk(
+                        finish_reason="tool_calls",
+                        request_id=last_chunk_id,
+                        delta_tool_calls=_finalize_tool_calls(tool_calls),
+                    )
 
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.debug("[%s] Stream completed time=%.1fms", req_id, elapsed_ms)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -231,10 +231,11 @@ def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) ->
         # OpenAI/NIM always send it for parallel calls. The collision check below
         # flags the rare case where a provider omits it for parallel calls.
         index = tool_call_delta.get("index", 0)
+        function = tool_call_delta.get("function") or {}
         if index not in tool_calls:
             tool_calls[index] = {
                 "id": tool_call_delta.get("id") or "",
-                "name": (tool_call_delta.get("function") or {}).get("name") or "",
+                "name": function.get("name") or "",
                 "arguments_buffer": "",
             }
         else:
@@ -257,14 +258,16 @@ def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) ->
                         existing_id,
                     )
                 tool_calls[index]["id"] = incoming_id
-            name = (tool_call_delta.get("function") or {}).get("name")
+            name = function.get("name")
             if name:
                 tool_calls[index]["name"] = name
-        arguments_fragment = (tool_call_delta.get("function") or {}).get("arguments") or ""
+        arguments_fragment = function.get("arguments") or ""
         if arguments_fragment:
             tool_calls[index]["arguments_buffer"] += arguments_fragment
 
 
+# TODO: duplicates _finalize_tool_calls in
+# nemoguardrails/llm/models/openai_chat.py . Needs consolidating.
 def _finalize_tool_calls(tool_calls: dict[int, dict]) -> list[ToolCall]:
     """Assemble accumulated tool-call fragments into ToolCall objects.
 
@@ -498,6 +501,15 @@ class ModelEngine(BaseEngine):
         content should gate on ``chunk.delta_content`` rather than
         assuming every yielded chunk carries one.
 
+        Tool calls (when the request declared ``tools``) are accumulated
+        from streamed ``delta.tool_calls`` fragments and surfaced as a
+        single ``LLMResponseChunk`` whose ``delta_tool_calls`` carries the
+        COMPLETE finalized list exactly once — on the first chunk with a
+        ``finish_reason`` (``"tool_calls"`` for a free choice, ``"stop"``
+        for a forced ``tool_choice``), or via a post-loop safety net if the
+        provider omits a parseable finish frame. No other chunk carries
+        ``delta_tool_calls``, so consumers may treat it as last-write-wins.
+
         Args:
             messages: List of message dicts in OpenAI format.
             **kwargs: Additional parameters for the request body (temperature, max_tokens, etc.)
@@ -546,8 +558,6 @@ class ModelEngine(BaseEngine):
                     if not line:
                         continue
 
-                    # Debug-log raw SSE line before any processing. Bounded via
-                    # truncate() for now to match the other payload logs.
                     log.debug("[%s] SSE line: %s", req_id, truncate(line))
 
                     if not line.startswith("data: "):
@@ -580,6 +590,17 @@ class ModelEngine(BaseEngine):
                     choices = raw_chunk.get("choices") or []
                     finish_reason = choices[0].get("finish_reason") if choices else None
                     if tool_calls and not tool_calls_emitted and finish_reason and parsed_chunk is not None:
+                        if finish_reason not in ("tool_calls", "stop"):
+                            # Abnormal terminator (e.g. "length", "content_filter")
+                            # while a tool call is mid-assembly: surface what we have
+                            # but warn, because the JSON arguments are likely truncated
+                            # and will degrade to {} in _finalize_tool_calls.
+                            log.warning(
+                                "[%s] tool-call stream ended with finish_reason=%r; "
+                                "assembled tool-call arguments may be truncated or incomplete",
+                                req_id,
+                                finish_reason,
+                            )
                         parsed_chunk.delta_tool_calls = _finalize_tool_calls(tool_calls)
                         tool_calls_emitted = True
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -225,6 +225,11 @@ def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) ->
         return
     delta = choices[0].get("delta") or {}
     for tool_call_delta in delta.get("tool_calls") or []:
+        # ``index`` ties fragmented argument deltas back to their tool call (only
+        # the first delta per call carries id/name; later ones carry just args +
+        # the same index). It defaults to 0 for single-call streams that omit it;
+        # OpenAI/NIM always send it for parallel calls. The collision check below
+        # flags the rare case where a provider omits it for parallel calls.
         index = tool_call_delta.get("index", 0)
         if index not in tool_calls:
             tool_calls[index] = {
@@ -233,8 +238,25 @@ def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) ->
                 "arguments_buffer": "",
             }
         else:
-            if tool_call_delta.get("id"):
-                tool_calls[index]["id"] = tool_call_delta["id"]
+            incoming_id = tool_call_delta.get("id")
+            if incoming_id:
+                existing_id = tool_calls[index]["id"]
+                if existing_id and incoming_id != existing_id:
+                    # A distinct tool call (different id) landed on an existing
+                    # accumulator slot — happens when a provider omits ``index`` for
+                    # parallel calls, collapsing them into one slot (id/name
+                    # overwritten, arguments concatenated into invalid JSON). Warn
+                    # rather than silently corrupt; strict per-provider validation
+                    # is the canonicalization layer's job.
+                    log.warning(
+                        "[%s] tool-call id %r collided with accumulator slot %d (existing id %r); "
+                        "provider likely omitted 'index' for parallel tool calls — result may be corrupted",
+                        get_request_id(),
+                        incoming_id,
+                        index,
+                        existing_id,
+                    )
+                tool_calls[index]["id"] = incoming_id
             name = (tool_call_delta.get("function") or {}).get("name")
             if name:
                 tool_calls[index]["name"] = name
@@ -524,8 +546,9 @@ class ModelEngine(BaseEngine):
                     if not line:
                         continue
 
-                    # Debug-log raw SSE line before any processing
-                    log.debug("[%s] SSE line: %s", req_id, line)
+                    # Debug-log raw SSE line before any processing. Bounded via
+                    # truncate() for now to match the other payload logs.
+                    log.debug("[%s] SSE line: %s", req_id, truncate(line))
 
                     if not line.startswith("data: "):
                         continue

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -523,6 +523,10 @@ class ModelEngine(BaseEngine):
                     line = raw_line.decode("utf-8").strip()
                     if not line:
                         continue
+
+                    # Debug-log raw SSE line before any processing
+                    log.debug("[%s] SSE line: %s", req_id, line)
+
                     if not line.startswith("data: "):
                         continue
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -40,7 +40,7 @@ from nemoguardrails.guardrails._http import (
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, get_request_id, truncate
 from nemoguardrails.rails.llm.config import Model
-from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, UsageInfo
+from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 
 log = logging.getLogger(__name__)
 
@@ -210,6 +210,65 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
         request_id=chunk.get("id"),
         usage=_parse_usage(usage_dict) if usage_dict else None,
     )
+
+
+def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) -> None:
+    """Update the tool-call accumulator with any tool_call deltas from a raw SSE chunk.
+
+    OpenAI streams argument JSON as fragments across many chunks; NIM delivers
+    complete arguments in one delta. Both are handled uniformly: ``tool_calls``
+    is keyed by the OpenAI ``index`` field and mutated in place on every call.
+    Finalize with ``_finalize_tool_calls`` once ``finish_reason=="tool_calls"``.
+    """
+    choices = raw_chunk.get("choices") or []
+    if not choices:
+        return
+    delta = choices[0].get("delta") or {}
+    for tool_call_delta in delta.get("tool_calls") or []:
+        index = tool_call_delta.get("index", 0)
+        if index not in tool_calls:
+            tool_calls[index] = {
+                "id": tool_call_delta.get("id") or "",
+                "name": (tool_call_delta.get("function") or {}).get("name") or "",
+                "arguments_buffer": "",
+            }
+        else:
+            if tool_call_delta.get("id"):
+                tool_calls[index]["id"] = tool_call_delta["id"]
+            name = (tool_call_delta.get("function") or {}).get("name")
+            if name:
+                tool_calls[index]["name"] = name
+        arguments_fragment = (tool_call_delta.get("function") or {}).get("arguments") or ""
+        if arguments_fragment:
+            tool_calls[index]["arguments_buffer"] += arguments_fragment
+
+
+def _finalize_tool_calls(tool_calls: dict[int, dict]) -> list[ToolCall]:
+    """Assemble accumulated tool-call fragments into ToolCall objects.
+
+    Called once when the stream emits finish_reason='tool_calls'. Arguments
+    are parsed from the accumulated JSON buffer; malformed or empty buffers
+    degrade gracefully to an empty dict (matching openai_chat.py behaviour).
+    """
+    result = []
+    for index in sorted(tool_calls.keys()):
+        entry = tool_calls[index]
+        raw_arguments = entry.get("arguments_buffer", "")
+        try:
+            arguments = json.loads(raw_arguments) if raw_arguments else {}
+        except json.JSONDecodeError:
+            arguments = {}
+        result.append(
+            ToolCall(
+                id=entry.get("id", ""),
+                type="function",
+                function=ToolCallFunction(
+                    name=entry.get("name", ""),
+                    arguments=arguments,
+                ),
+            )
+        )
+    return result
 
 
 class ModelEngineError(Exception):
@@ -453,6 +512,7 @@ class ModelEngine(BaseEngine):
                 # response.content uses readany() which returns arbitrary byte
                 # chunks — multiple SSE events in one TCP segment would be merged
                 # into one unparseable blob.  readline() splits on \n correctly.
+                tool_calls: dict[int, dict] = {}
                 while True:
                     raw_line = await response.content.readline()
                     if not raw_line:
@@ -474,7 +534,23 @@ class ModelEngine(BaseEngine):
                         log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
                         continue
 
+                    _accumulate_tool_call_delta(tool_calls, raw_chunk)
+
                     parsed_chunk = _parse_chat_completion_chunk(raw_chunk)
+
+                    # Finalize accumulated tool calls onto the finish_reason chunk.
+                    # _parse_chat_completion_chunk returns None for empty-delta finish
+                    # chunks (no content/reasoning/usage), so create a bare chunk to
+                    # carry delta_tool_calls when needed.
+                    choices = raw_chunk.get("choices") or []
+                    if tool_calls and choices and choices[0].get("finish_reason") == "tool_calls":
+                        if parsed_chunk is None:
+                            parsed_chunk = LLMResponseChunk(
+                                finish_reason="tool_calls",
+                                request_id=raw_chunk.get("id"),
+                            )
+                        parsed_chunk.delta_tool_calls = _finalize_tool_calls(tool_calls)
+
                     if parsed_chunk is not None:
                         yield parsed_chunk
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -573,16 +573,13 @@ class ModelEngine(BaseEngine):
                     # when the model chose freely, but "stop" when tool_choice forced
                     # a specific function. Gate on *any* finish_reason (with tool calls
                     # accumulated), not the literal "tool_calls", or forced calls never
-                    # surface. _parse_chat_completion_chunk returns None for empty-delta
-                    # finish chunks, so synthesize a carrier chunk to hold the calls.
+                    # surface. finish_reason keeps that chunk alive in
+                    # _parse_chat_completion_chunk, so parsed_chunk is non-None here; if a
+                    # provider ever omits a parseable finish frame, the post-loop safety
+                    # net below surfaces the calls instead.
                     choices = raw_chunk.get("choices") or []
                     finish_reason = choices[0].get("finish_reason") if choices else None
-                    if tool_calls and not tool_calls_emitted and finish_reason:
-                        if parsed_chunk is None:
-                            parsed_chunk = LLMResponseChunk(
-                                finish_reason=finish_reason,
-                                request_id=raw_chunk.get("id"),
-                            )
+                    if tool_calls and not tool_calls_emitted and finish_reason and parsed_chunk is not None:
                         parsed_chunk.delta_tool_calls = _finalize_tool_calls(tool_calls)
                         tool_calls_emitted = True
 

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -30,6 +30,7 @@ from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.types import LLMResponseChunk
+from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
@@ -121,36 +122,28 @@ def _wire_mocks(iorails, *, input_safe=True, output_safe=True, stream=_mock_stre
 @pytest_asyncio.fixture
 async def iorails():
     """IORails with output rails but streaming NOT enabled."""
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        iorails = IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
-    async with iorails:
+    async with started_iorails(NEMOGUARDS_CONFIG) as iorails:
         yield iorails
 
 
 @pytest_asyncio.fixture
 async def iorails_stream_first():
     """IORails with output rails and streaming enabled (stream_first=True)."""
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        iorails = IORails(RailsConfig.from_content(config=_make_streaming_config(stream_first=True)))
-    async with iorails:
+    async with started_iorails(_make_streaming_config(stream_first=True)) as iorails:
         yield iorails
 
 
 @pytest_asyncio.fixture
 async def iorails_stream_check_first():
     """IORails with output rails and streaming enabled (stream_first=False)."""
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        iorails = IORails(RailsConfig.from_content(config=_make_streaming_config(stream_first=False)))
-    async with iorails:
+    async with started_iorails(_make_streaming_config(stream_first=False)) as iorails:
         yield iorails
 
 
 @pytest_asyncio.fixture
 async def iorails_input_only():
     """IORails with input rails only, no output rails."""
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        iorails = IORails(RailsConfig.from_content(config=_INPUT_ONLY_CONFIG))
-    async with iorails:
+    async with started_iorails(_INPUT_ONLY_CONFIG) as iorails:
         yield iorails
 
 

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -770,3 +770,54 @@ class TestStreamAsyncToolCalling:
         parsed = json.loads(chunks[0])
         assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"
         assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_suppressed_after_output_rails_block(self, iorails_stream_first):
+        """A blocked output rail suppresses the terminal tool-call chunk.
+
+        Regression (PR #2024 review): a mixed text+tool-call response that gets
+        blocked must not emit tool_calls after the guardrails_violation error —
+        the caller must never receive a tool-call after a block.
+        """
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="blocked")
+        )
+        main_engine = iorails_stream_first.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(
+            content_deltas=["Some text"],
+            tool_call_chunks=[_NIM_TOOL_CALL_CHUNK],
+        )
+        main_engine._running = True
+
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        # The block surfaces a guardrails_violation error chunk ...
+        assert any(isinstance(c, str) and "guardrails_violation" in c for c in chunks)
+        # ... and the terminal tool-call chunk must NOT follow it.
+        assert not any(isinstance(c, str) and '"tool_calls"' in c for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_include_metadata_tool_call_only_yields_dict_frame(self, iorails_input_only):
+        """With include_metadata=True the terminal tool-call chunk is a dict frame.
+
+        Regression (PR #2024 review): metadata mode must stay shape-consistent —
+        every chunk is a ``{"text": ...}`` dict, including the terminal tool-call
+        payload, never a bare JSON string.
+        """
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
+        main_engine._running = True
+
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+
+        # No raw-string tool-call chunk leaked into a metadata stream.
+        assert not any(isinstance(c, str) and '"tool_calls"' in c for c in chunks)
+        # The tool calls arrive as a dict frame with the payload under "text".
+        tool_frames = [c for c in chunks if isinstance(c, dict) and '"tool_calls"' in (c.get("text") or "")]
+        assert len(tool_frames) == 1
+        parsed = json.loads(tool_frames[0]["text"])
+        assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -34,7 +34,7 @@ from nemoguardrails.guardrails.iorails import (
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
-from nemoguardrails.types import LLMResponseChunk
+from nemoguardrails.types import LLMResponseChunk, ToolCall, ToolCallFunction
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
@@ -775,6 +775,35 @@ class TestStreamAsyncToolCalling:
         parsed = json.loads(chunks[0])
         assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"
         assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_terminal_chunk_keeps_complete_list_when_engine_emits_over_multiple_chunks(self, iorails_input_only):
+        """Group B regression (PR #2024 review): no tool calls lost if the engine
+        surfaces delta_tool_calls on more than one chunk.
+
+        The engine contract is "complete finalized list, emitted once" (see
+        ModelEngine.stream_call), so _generation_task rebinds the channel rather
+        than slice-appending. If a future engine emitted delta_tool_calls
+        cumulatively across several chunks, the last (complete) emission must
+        still win — earlier calls must not be dropped by the rebind.
+        """
+        call_a = ToolCall(id="a", type="function", function=ToolCallFunction(name="fn_a", arguments={"x": 1}))
+        call_b = ToolCall(id="b", type="function", function=ToolCallFunction(name="fn_b", arguments={"y": 2}))
+
+        async def _two_emission_stream(model_type, messages, **kwargs):
+            # First emission: partial set; second: complete cumulative set.
+            yield LLMResponseChunk(delta_tool_calls=[call_a])
+            yield LLMResponseChunk(finish_reason="tool_calls", delta_tool_calls=[call_a, call_b])
+
+        iorails_input_only.engine_registry.stream_model_call = _two_emission_stream
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert len(chunks) == 1
+        parsed = json.loads(chunks[0])
+        names = [tc["function"]["name"] for tc in parsed["tool_calls"]]
+        assert names == ["fn_a", "fn_b"]
 
     @pytest.mark.asyncio
     async def test_tool_calls_suppressed_after_output_rails_block(self, iorails_stream_first):

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -734,3 +734,39 @@ class TestStreamAsyncToolCalling:
 
         iorails_stream_first.rails_manager.is_output_safe.assert_not_called()
         assert any('"tool_calls"' in c for c in chunks if isinstance(c, str))
+
+    @pytest.mark.asyncio
+    async def test_forced_tool_choice_finish_reason_stop_surfaces_terminal_json(self, iorails_input_only):
+        """Forced tool_choice yields finish_reason='stop'; the tool call must still surface.
+
+        Regression for the e2e failure where forced tool calls returned zero
+        chunks because finalization was gated on finish_reason=='tool_calls'.
+        """
+        forced_chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_forced",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                            }
+                        ]
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[forced_chunk])
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert len(chunks) == 1
+        parsed = json.loads(chunks[0])
+        assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -570,3 +570,174 @@ class TestStreamAsyncEndToEnd:
 
         assert "".join(chunks) == "The answer is 42"
         assert "think" not in "".join(chunks)
+
+
+def _build_tool_call_sse_mock(*, content_deltas=None, tool_call_chunks, finish_chunk=None):
+    """Build an aiohttp mock that streams optional content then tool-call SSE chunks.
+
+    ``tool_call_chunks`` is a list of raw SSE body dicts (already shaped as
+    ``{"choices": [{"delta": {"tool_calls": [...]}, "finish_reason": ...}]}``)
+    appended after any ``content_deltas``.  ``finish_chunk`` is an optional
+    explicit terminal chunk dict; defaults to a bare ``finish_reason`` chunk
+    when omitted (OpenAI style).
+    """
+    lines = []
+    for text in content_deltas or []:
+        payload = json.dumps({"choices": [{"delta": {"content": text}}]})
+        lines.append(f"data: {payload}\n".encode())
+    for chunk_body in tool_call_chunks:
+        lines.append(f"data: {json.dumps(chunk_body)}\n".encode())
+    if finish_chunk is not None:
+        lines.append(f"data: {json.dumps(finish_chunk)}\n".encode())
+    lines.append(b"data: [DONE]\n")
+
+    line_iter = iter(lines)
+
+    async def _readline():
+        return next(line_iter, b"")
+
+    mock_content = MagicMock()
+    mock_content.readline = _readline
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.content = mock_content
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    return mock_client
+
+
+# Single NIM-style chunk: complete args on the finish_reason chunk.
+_NIM_TOOL_CALL_CHUNK = {
+    "choices": [
+        {
+            "delta": {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_nim",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    }
+                ]
+            },
+            "finish_reason": "tool_calls",
+        }
+    ]
+}
+
+
+class TestStreamAsyncToolCalling:
+    """Tool calling in the IORails streaming path."""
+
+    @pytest.mark.asyncio
+    async def test_tools_in_llm_params_forwarded_to_stream_model_call(self, iorails_input_only):
+        """Tools provided via llm_params are forwarded unchanged to stream_model_call."""
+        tool = {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+        options = GenerationOptions(llm_params={"tools": [tool], "tool_choice": "auto"})
+
+        captured_kwargs: dict = {}
+
+        async def _capturing_stream(model_type, messages, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield LLMResponseChunk(delta_content="ok")
+
+        iorails_input_only.engine_registry.stream_model_call = _capturing_stream
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True, reason=None))
+
+        await _collect(
+            iorails_input_only.stream_async(
+                messages=[{"role": "user", "content": "hi"}],
+                options=options,
+            )
+        )
+
+        assert captured_kwargs.get("tools") == [tool]
+        assert captured_kwargs.get("tool_choice") == "auto"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_only_yields_terminal_json(self, iorails_input_only):
+        """A tool-call-only response yields a single terminal JSON chunk containing tool_calls."""
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert len(chunks) == 1
+        parsed = json.loads(chunks[0])
+        assert "tool_calls" in parsed
+        assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_text_and_tool_calls_text_first_then_terminal_json(self, iorails_input_only):
+        """Content chunks come first; terminal tool-call JSON follows after all text."""
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(
+            content_deltas=["Checking", " weather"],
+            tool_call_chunks=[_NIM_TOOL_CALL_CHUNK],
+        )
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        tool_json_chunks = [c for c in chunks if isinstance(c, str) and '"tool_calls"' in c]
+        text_chunks = [c for c in chunks if c not in tool_json_chunks]
+        assert "".join(text_chunks) == "Checking weather"
+        assert len(tool_json_chunks) == 1
+        assert json.loads(tool_json_chunks[0])["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_fragmented_args_assembled_into_complete_json_string(self, iorails_input_only):
+        """OpenAI-style argument fragments are concatenated and parsed into a complete JSON string."""
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+
+        frag1 = {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "c1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": ""},
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        frag2 = {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": '{"city"'}}]}}]}
+        frag3 = {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": ': "Paris"}'}}]}}]}
+        finish = {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]}
+
+        main_engine._client = _build_tool_call_sse_mock(
+            tool_call_chunks=[frag1, frag2, frag3],
+            finish_chunk=finish,
+        )
+        main_engine._running = True
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert len(chunks) == 1
+        parsed = json.loads(chunks[0])
+        assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_tool_call_only_does_not_invoke_output_rails(self, iorails_stream_first):
+        """Tool-call-only stream skips is_output_safe (no text content to check)."""
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_stream_first.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
+        main_engine._running = True
+
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        iorails_stream_first.rails_manager.is_output_safe.assert_not_called()
+        assert any('"tool_calls"' in c for c in chunks if isinstance(c, str))

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -743,9 +743,7 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_forced_tool_choice_finish_reason_stop_surfaces_terminal_json(self, iorails_input_only):
         """Forced tool_choice yields finish_reason='stop'; the tool call must still surface.
-
-        Regression for the e2e failure where forced tool calls returned zero
-        chunks because finalization was gated on finish_reason=='tool_calls'.
+        If tool_choice is `auto`, the finish_reason is `tool_calls`
         """
         forced_chunk = {
             "choices": [
@@ -777,15 +775,9 @@ class TestStreamAsyncToolCalling:
         assert parsed["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
 
     @pytest.mark.asyncio
-    async def test_terminal_chunk_keeps_complete_list_when_engine_emits_over_multiple_chunks(self, iorails_input_only):
-        """Group B regression (PR #2024 review): no tool calls lost if the engine
-        surfaces delta_tool_calls on more than one chunk.
-
-        The engine contract is "complete finalized list, emitted once" (see
-        ModelEngine.stream_call), so _generation_task rebinds the channel rather
-        than slice-appending. If a future engine emitted delta_tool_calls
-        cumulatively across several chunks, the last (complete) emission must
-        still win — earlier calls must not be dropped by the rebind.
+    async def test_model_engine_accumulates_tool_calls(self, iorails_input_only):
+        """Ensure ModelEngine.stream_call() accumulates all delta_tool_calls before
+        emitting once after the stream ends.
         """
         call_a = ToolCall(id="a", type="function", function=ToolCallFunction(name="fn_a", arguments={"x": 1}))
         call_b = ToolCall(id="b", type="function", function=ToolCallFunction(name="fn_b", arguments={"y": 2}))
@@ -807,12 +799,7 @@ class TestStreamAsyncToolCalling:
 
     @pytest.mark.asyncio
     async def test_tool_calls_suppressed_after_output_rails_block(self, iorails_stream_first):
-        """A blocked output rail suppresses the terminal tool-call chunk.
-
-        Regression (PR #2024 review): a mixed text+tool-call response that gets
-        blocked must not emit tool_calls after the guardrails_violation error —
-        the caller must never receive a tool-call after a block.
-        """
+        """A blocked output rail suppresses the terminal tool-call chunk."""
         iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails_stream_first.rails_manager.is_output_safe = AsyncMock(
             return_value=RailResult(is_safe=False, reason="blocked")
@@ -833,12 +820,7 @@ class TestStreamAsyncToolCalling:
 
     @pytest.mark.asyncio
     async def test_include_metadata_tool_call_only_yields_dict_frame(self, iorails_input_only):
-        """With include_metadata=True the terminal tool-call chunk is a dict frame.
-
-        Regression (PR #2024 review): metadata mode must stay shape-consistent —
-        every chunk is a ``{"text": ...}`` dict, including the terminal tool-call
-        payload, never a bare JSON string.
-        """
+        """With include_metadata=True the terminal tool-call chunk is a dict frame."""
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
@@ -858,11 +840,7 @@ class TestStreamAsyncToolCalling:
 
     @pytest.mark.asyncio
     async def test_tool_calls_recorded_in_captured_content(self, iorails_input_only):
-        """When content capture is on, the terminal tool-call payload is recorded on the span.
-
-        Regression (PR #2024 review): the tool-call JSON must reach ``delivered`` so
-        the request span's captured output_text includes tool calls.
-        """
+        """When content capture is on, the terminal tool-call payload is recorded on the span."""
         iorails_input_only._content_capture_enabled = True
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -25,7 +25,12 @@ import pytest_asyncio
 
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.guardrails_types import RailResult
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, STREAM_MAX_CONCURRENCY, IORails
+from nemoguardrails.guardrails.iorails import (
+    REFUSAL_MESSAGE,
+    STREAM_MAX_CONCURRENCY,
+    IORails,
+    _is_stream_error_chunk,
+)
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
@@ -821,3 +826,70 @@ class TestStreamAsyncToolCalling:
         assert len(tool_frames) == 1
         parsed = json.loads(tool_frames[0]["text"])
         assert parsed["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_recorded_in_captured_content(self, iorails_input_only):
+        """When content capture is on, the terminal tool-call payload is recorded on the span.
+
+        Regression (PR #2024 review): the tool-call JSON must reach ``delivered`` so
+        the request span's captured output_text includes tool calls.
+        """
+        iorails_input_only._content_capture_enabled = True
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
+        main_engine._running = True
+
+        with patch("nemoguardrails.guardrails.iorails.set_request_content") as mock_set:
+            await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        mock_set.assert_called_once()
+        # set_request_content(request_span, messages, output_text)
+        output_text = mock_set.call_args.args[2]
+        assert output_text is not None and "tool_calls" in output_text
+
+    @pytest.mark.asyncio
+    async def test_output_rails_streaming_skips_empty_content_batch(self, iorails_stream_check_first):
+        """An empty-content batch skips the is_output_safe check and passes the chunk through.
+
+        Covers the empty-content guard in _run_output_rails_in_streaming on the
+        stream_first=False path (e.g. a batch that formats to an empty string).
+        """
+        iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        async def _empty_content_handler():
+            yield ""  # formats to an empty bot_response_chunk -> guard fires
+
+        out = [
+            chunk
+            async for chunk in iorails_stream_check_first._run_output_rails_in_streaming(
+                streaming_handler=_empty_content_handler(),
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+
+        iorails_stream_check_first.rails_manager.is_output_safe.assert_not_called()
+        assert out == [""]
+
+
+class TestIsStreamErrorChunk:
+    """Unit tests for _is_stream_error_chunk (terminal-chunk error/violation detection)."""
+
+    def test_error_json_string(self):
+        assert _is_stream_error_chunk('{"error": {"type": "guardrails_violation"}}') is True
+
+    def test_metadata_frame_with_error(self):
+        assert _is_stream_error_chunk({"text": '{"error": {"type": "generation_error"}}'}) is True
+
+    def test_non_error_json_string(self):
+        assert _is_stream_error_chunk('{"tool_calls": []}') is False
+
+    def test_plain_text(self):
+        assert _is_stream_error_chunk("just some text") is False
+
+    def test_malformed_json_with_error_substring(self):
+        # Has the "error" marker but is not valid JSON -> JSONDecodeError branch.
+        assert _is_stream_error_chunk('{"error": ') is False
+
+    def test_non_string_text(self):
+        assert _is_stream_error_chunk({"text": None}) is False

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -56,6 +56,33 @@ def _make_model(
     )
 
 
+def _mock_streaming_response(raw_lines, status=200):
+    """Create a mock aiohttp response with a readline()-based content mock.
+
+    Splits each raw_line on ``\\n`` boundaries so that readline() returns
+    one line at a time, matching real aiohttp StreamReader behaviour.
+    """
+    all_lines = []
+    for raw in raw_lines:
+        for part in raw.split(b"\n"):
+            if part:
+                all_lines.append(part + b"\n")
+
+    line_iter = iter(all_lines)
+
+    async def _readline():
+        return next(line_iter, b"")
+
+    mock_content = MagicMock()
+    mock_content.readline = _readline
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = status
+    mock_response.content = mock_content
+    return mock_response
+
+
 class TestModelEngineError:
     """Test the ModelEngineError Exception type fields."""
 
@@ -668,34 +695,6 @@ class TestModelEngineStreamCall:
         lines.append(b"data: [DONE]\n\n")
         return lines
 
-    @staticmethod
-    def _mock_streaming_response(raw_lines, status=200):
-        """Create a mock aiohttp response with a readline()-based content mock.
-
-        Splits each raw_line on ``\\n`` boundaries so that readline() returns
-        one line at a time, matching real aiohttp StreamReader behaviour.
-        """
-        # Flatten raw_lines into individual \n-terminated lines
-        all_lines = []
-        for raw in raw_lines:
-            for part in raw.split(b"\n"):
-                if part:
-                    all_lines.append(part + b"\n")
-
-        line_iter = iter(all_lines)
-
-        async def _readline():
-            return next(line_iter, b"")
-
-        mock_content = MagicMock()
-        mock_content.readline = _readline
-
-        mock_response = AsyncMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.status = status
-        mock_response.content = mock_content
-        return mock_response
-
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_stream_call_yields_content_chunks(self):
@@ -703,7 +702,7 @@ class TestModelEngineStreamCall:
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["Hello", " world", "!"])
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -730,7 +729,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"reasoning_content": " more"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -757,7 +756,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "answer", "reasoning_content": "thought"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -779,7 +778,7 @@ class TestModelEngineStreamCall:
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["ok"])
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -799,7 +798,7 @@ class TestModelEngineStreamCall:
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["ok"])
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -849,7 +848,7 @@ class TestModelEngineStreamCall:
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["ok"])
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -878,7 +877,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -904,7 +903,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -928,7 +927,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -966,7 +965,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
             b"data: [DONE]\n\n",
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -989,7 +988,7 @@ class TestModelEngineStreamCall:
             b'data: {"choices": [{"delta": {"content": "Hi"}}]}\n\n',
             # No "data: [DONE]" — readline() will return b"" next
         ]
-        mock_response = self._mock_streaming_response(raw_lines)
+        mock_response = _mock_streaming_response(raw_lines)
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -1038,6 +1037,229 @@ class TestModelEngineStreamCall:
             chunks.append(chunk)
 
         assert [c.delta_content for c in chunks] == ["Hi", "!"]
+
+
+class TestStreamCallToolCalls:
+    """stream_call() tool-call accumulation: fragment assembly and finalization."""
+
+    @staticmethod
+    def _make_sse_lines(chunk_dicts):
+        """Encode a list of chunk dicts as SSE byte lines, terminated with [DONE]."""
+        lines = []
+        for d in chunk_dicts:
+            lines.append(f"data: {json.dumps(d)}\n".encode())
+        lines.append(b"data: [DONE]\n")
+        return lines
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_nim_style_single_chunk_tool_call(self):
+        """NIM-style: complete args in one delta on the finish_reason chunk."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert len(chunks) == 1
+        assert chunks[0].finish_reason == "tool_calls"
+        assert chunks[0].delta_tool_calls is not None
+        assert len(chunks[0].delta_tool_calls) == 1
+        tc = chunks[0].delta_tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert tc.function.arguments == {"city": "Paris"}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_openai_style_fragmented_args_assembled(self):
+        """OpenAI-style: args fragment across multiple chunks, finalized on empty finish chunk."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": ""},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": '{"city"'}}]}}]},
+                {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": ': "Paris"}'}}]}}]},
+                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert len(chunks) == 1
+        assert chunks[0].finish_reason == "tool_calls"
+        tc = chunks[0].delta_tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert tc.function.arguments == {"city": "Paris"}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_assembled_by_index(self):
+        """Multiple parallel tool calls (different indices) are both present in delta_tool_calls."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "fn_a", "arguments": '{"x": 1}'},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 1,
+                                        "id": "c2",
+                                        "type": "function",
+                                        "function": {"name": "fn_b", "arguments": '{"y": 2}'},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert len(chunks) == 1
+        tcs = chunks[0].delta_tool_calls
+        assert len(tcs) == 2
+        assert tcs[0].function.name == "fn_a"
+        assert tcs[0].function.arguments == {"x": 1}
+        assert tcs[1].function.name == "fn_b"
+        assert tcs[1].function.arguments == {"y": 2}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_reasoning_then_tool_calls(self):
+        """NIM-style: reasoning preamble chunks followed by a single tool-call finish chunk."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {"choices": [{"delta": {"reasoning_content": "let me think"}}]},
+                {"choices": [{"delta": {"reasoning_content": " about this"}}]},
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        reasoning_chunks = [c for c in chunks if c.delta_reasoning]
+        tool_chunks = [c for c in chunks if c.delta_tool_calls]
+        assert len(reasoning_chunks) == 2
+        assert len(tool_chunks) == 1
+        assert tool_chunks[0].delta_tool_calls[0].function.name == "get_weather"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_malformed_args_degrade_to_empty_dict(self):
+        """Truncated or invalid JSON arguments produce an empty arguments dict."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "f", "arguments": '{"city": "Par'},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert chunks[0].delta_tool_calls[0].function.arguments == {}
 
 
 class TestModelEngineConstants:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1261,6 +1261,83 @@ class TestStreamCallToolCalls:
 
         assert chunks[0].delta_tool_calls[0].function.arguments == {}
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_forced_tool_choice_finish_reason_stop(self):
+        """Forced tool_choice makes providers send finish_reason='stop' (not 'tool_calls').
+
+        Regression: the finalizer must surface accumulated tool calls on ANY
+        finish_reason, otherwise a forced tool call never reaches the caller.
+        """
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        tool_chunks = [c for c in chunks if c.delta_tool_calls]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].delta_tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert tc.function.arguments == {"city": "Paris"}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_tool_calls_finalized_without_finish_reason_chunk(self):
+        """Safety net: tool calls surface even if the stream ends ([DONE]) with no finish chunk."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        tool_chunks = [c for c in chunks if c.delta_tool_calls]
+        assert len(tool_chunks) == 1
+        assert tool_chunks[0].delta_tool_calls[0].function.arguments == {"city": "Paris"}
+
 
 class TestModelEngineConstants:
     """Test values of model-engine-specific constants."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1338,6 +1338,55 @@ class TestStreamCallToolCalls:
         assert len(tool_chunks) == 1
         assert tool_chunks[0].delta_tool_calls[0].function.arguments == {"city": "Paris"}
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls_without_index_warns(self):
+        """Distinct parallel calls that omit `index` collapse to slot 0 — warn, don't silently corrupt.
+
+        ``index`` is the only key tying argument fragments to their call. If a
+        provider omits it for parallel calls they default to slot 0; the
+        accumulator can't recover the split, so it must at least surface a warning
+        rather than corrupt silently. (OpenAI/NIM always send `index` here.)
+        """
+        engine = ModelEngine(_make_model())
+        # Two distinct calls (different ids), both omitting `index` -> both -> slot 0.
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {"id": "c1", "type": "function", "function": {"name": "fn_a", "arguments": "{}"}}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {"id": "c2", "type": "function", "function": {"name": "fn_b", "arguments": "{}"}}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        with patch("nemoguardrails.guardrails.model_engine.log") as mock_log:
+            _ = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert mock_log.warning.called, "expected a collision warning for index-less parallel tool calls"
+        assert "collided with accumulator slot" in mock_log.warning.call_args.args[0]
+
 
 class TestModelEngineConstants:
     """Test values of model-engine-specific constants."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1387,6 +1387,53 @@ class TestStreamCallToolCalls:
         assert mock_log.warning.called, "expected a collision warning for index-less parallel tool calls"
         assert "collided with accumulator slot" in mock_log.warning.call_args.args[0]
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_abnormal_finish_reason_warns_but_still_surfaces_tool_call(self):
+        """finish_reason='length' mid-tool-call: surface what we have but warn it may be truncated.
+
+        When the model hits its token limit while streaming tool-call arguments,
+        finish_reason is 'length' (not 'tool_calls'/'stop') and the JSON buffer
+        is incomplete. The finalizer must still emit the call (arguments degrade
+        to {}) AND log a warning so the truncation is not silent.
+        """
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {"name": "get_weather", "arguments": '{"city": "Par'},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "length",
+                        }
+                    ]
+                },
+            ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        with patch("nemoguardrails.guardrails.model_engine.log") as mock_log:
+            chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        tool_chunks = [c for c in chunks if c.delta_tool_calls]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].delta_tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert tc.function.arguments == {}
+        assert mock_log.warning.called, "expected a truncation warning for finish_reason='length'"
+        assert "may be truncated" in mock_log.warning.call_args.args[0]
+
 
 class TestModelEngineConstants:
     """Test values of model-engine-specific constants."""


### PR DESCRIPTION
## Description

This PR adds streaming tool-calling functionality to Guardrails as part of the PR stack below. No introspection of the tool calls or return values is done, just passing back and forth between the Main LLM to decide which tool calls to make, and how to respond based on prior conversation turns and tool results the harness executed.

* **Merged** #2016 : Non-streaming tool-calling connected to main LLM for inference and back to the client with the response. No canonicalization.
* **This PR** : Streaming tool-calling implementation. Just propagating tool calls to the Main LLM and back again without canonicalization..
* #2030  : Add canonical internal dataclasses for tool-calling. Implement tool-calling rails to check the LLM-generated function call matches the provided tool signature and schema , and that the response from the function execution matches the signature and schema.
* **TODO** : Docs PR describing the feature as implemented.

## Related Issue(s)

Stacked PR on top of #2016 (which added non-streaming tool-calling).

## Verification

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test
...............ss....ss......s.........ss....s................................................................. [  2%]
............................................................................................................... [  4%]
......s..........................................................sss...s....................................... [  6%]
............................................................................................................... [  9%]
........................................................................s...................................... [ 11%]
............................................................................................................... [ 13%]
............................................................................................................... [ 16%]
............................................................................................................... [ 18%]
............................................................................................................... [ 20%]
.............................................................................s.........s.s..................... [ 22%]
.............ss.sssss.....................................................s.................................... [ 25%]
..............................s................................................................................ [ 27%]
............................................................................................................... [ 29%]
....s.ssssss.s............sss.sss...ss..s................s.sssssss............................................. [ 32%]
............................................................................................................... [ 34%]
............................................................................................................... [ 36%]
....................................ss......................................................................... [ 38%]
............................................................................................................... [ 41%]
.................................sssss...........................s.....................................sssssss. [ 43%]
.......................sssss.ssss..sssssss.ss....................ss............................................ [ 45%]
...........s............s.s...............................ss..................................s................ [ 48%]
............s.ssss............................................................................................. [ 50%]
.................s.ssss........................................................................................ [ 52%]
.................................................................s............................................. [ 54%]
............................................................................................................... [ 57%]
.................s............................................................................................. [ 59%]
............................................................................................................... [ 61%]
............................................................................................................... [ 64%]
............s.............................................................s.................................... [ 66%]
............................................................................................................... [ 68%]
.............................................................................................................ss [ 71%]
............................................................................................................... [ 73%]
...............................................................................s..........................sssss [ 75%]
ss.sss.................s.s..................................................................................... [ 77%]
.......................................................ssssssss................................................ [ 80%]
............................................................................................................... [ 82%]
..................sssssss...........................sss........................................................ [ 84%]
....................................s......s..ss......ss....................................................... [ 87%]
..............................................................................................s................ [ 89%]
........................................................sssssss..ss.ssssssssss................................. [ 91%]
......................................sss...................................s.................................. [ 93%]
...............................sss.sss.ss...............................................ss..................... [ 96%]
.......................................................................................................s....... [ 98%]
........................................................................                                        [100%]
========================================= 4665 passed, 180 skipped in 41.69s ==========================================
```


### Integration test (Using [`e2e_streaming_main_llm.py`](https://gist.github.com/tgasser-nv/e1bf5a10b28f75a85aba051f3554172e))

See attached log file for all INFO and DEBUG logging, only INFO lines are listed below. This integration script uses a dummy tool to find the weather conditions in Paris. It checks on both a NIM-model `meta/llama-3.3-70b-instruct` and an OpenAI model `gpt-4o-mini`. 

Here's the full log, with all chunks logged out:

[20260613_streaming_tool_calls_raw_chunks.txt](https://github.com/user-attachments/files/28929578/20260613_streaming_tool_calls_raw_chunks.txt)


```
$ poetry run python ~/utils/toolcalling/e2e_streaming_main_llm.py --debug  |& tee ~/logs/20260613_streaming_tool_calls_raw_chunks.txt

2026-06-14 10:01:35 INFO: Registered model engine: type=main, model=gpt-4o-mini, base_url=https://api.openai.com
2026-06-14 10:01:35 INFO: RailsManager initialized: input_flows=[], output_flows=[], input_parallel=False, output_parallel=False
2026-06-14 10:01:35 INFO: [5235496e0538eace] stream_async called
2026-06-14 10:01:35 INFO: [5235496e0538eace] Running input rails
2026-06-14 10:01:35 INFO: [5235496e0538eace] Streaming main LLM
2026-06-14 10:01:35 INFO: [5235496e0538eace] HTTP POST (stream) https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-14 10:01:42 INFO: [5235496e0538eace] Tool-call-only stream: output rails skipped
2026-06-14 10:01:42 INFO: [5235496e0538eace] generation task completed time=6659.2ms
2026-06-14 10:01:42 INFO: [5235496e0538eace] stream_async completed time=6660.0ms
2026-06-14 10:01:42 INFO: [57f026a937dc19fe] stream_async called
2026-06-14 10:01:42 INFO: [57f026a937dc19fe] Running input rails
2026-06-14 10:01:42 INFO: [57f026a937dc19fe] Streaming main LLM
2026-06-14 10:01:42 INFO: [57f026a937dc19fe] HTTP POST (stream) https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-14 10:01:48 INFO: [57f026a937dc19fe] generation task completed time=6459.1ms
2026-06-14 10:01:48 INFO: [57f026a937dc19fe] stream_async completed time=6459.4ms
2026-06-14 10:01:48 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-14 10:01:48 INFO: RailsManager initialized: input_flows=[], output_flows=[], input_parallel=False, output_parallel=False
2026-06-14 10:01:48 INFO: [5dad0055b1a0f908] stream_async called
2026-06-14 10:01:48 INFO: [5dad0055b1a0f908] Running input rails
2026-06-14 10:01:48 INFO: [5dad0055b1a0f908] Streaming main LLM
2026-06-14 10:01:48 INFO: [5dad0055b1a0f908] HTTP POST (stream) https://integrate.api.nvidia.com/v1/chat/completions model=''
2026-06-14 10:01:55 INFO: [5dad0055b1a0f908] Tool-call-only stream: output rails skipped
2026-06-14 10:01:55 INFO: [5dad0055b1a0f908] generation task completed time=7377.5ms
2026-06-14 10:01:55 INFO: [5dad0055b1a0f908] stream_async completed time=7378.1ms
2026-06-14 10:01:55 INFO: [a9da9ed549aebbf8] stream_async called
2026-06-14 10:01:55 INFO: [a9da9ed549aebbf8] Running input rails
2026-06-14 10:01:55 INFO: [a9da9ed549aebbf8] Streaming main LLM
2026-06-14 10:01:55 INFO: [a9da9ed549aebbf8] HTTP POST (stream) https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-14 10:02:12 INFO: [a9da9ed549aebbf8] generation task completed time=17050.4ms
2026-06-14 10:02:12 INFO: [a9da9ed549aebbf8] stream_async completed time=17050.8ms
INFO: text streamed before the tool call: ''
INFO: answer mentions returned temperature ('18'): True
INFO: text streamed before the tool call: ''
INFO: answer mentions returned temperature ('18'): True

```

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls can now be streamed and emitted as a final JSON chunk, alongside text content when present.

* **Bug Fixes**
  * Improved handling of tool-call-only responses; output-rail safety checks are properly skipped when appropriate.

* **Tests**
  * Added comprehensive test coverage for tool-call streaming scenarios, including fragmented arguments assembly and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->