### PR TITLE
ci: fix outdated CONTRIBUTING links in PR merge guidance

### DIFF
--- a/.github/workflows/pr-merge-guidance.yml
+++ b/.github/workflows/pr-merge-guidance.yml
@@ -158,8 +158,8 @@ jobs:
                 ...items,
                 "",
                 "Relevant guide:",
-                `- Signed commits: https://github.com/${owner}/${repo}/blob/develop/CONTRIBUTING.md#setting-up-git-for-signed-commits`,
-                `- Contribution workflow: https://github.com/${owner}/${repo}/blob/develop/CONTRIBUTING.md#contribution-workflow`,
+                `- Signed commits: https://github.com/${owner}/${repo}/blob/develop/CONTRIBUTING.md#commit-signing`,
+                `- Contribution guide: https://github.com/${owner}/${repo}/blob/develop/CONTRIBUTING.md`,
               ].join("\n");
 
               if (existingComment) {


### PR DESCRIPTION
## Description

 Follow-up to #1971. The PR merge guidance comment linked to two `CONTRIBUTING.md` anchors that no longer exist after the docs reorg on `develop`:

  - `#setting-up-git-for-signed-commits` → renamed section is now `## Commit Signing`, so this now points to `#commit-signing`.
  - `#contribution-workflow` → that section was removed/reorganized. Replaced with a bare link to `CONTRIBUTING.md` (no anchor) so it cannot go stale again.

## Related Issue(s)
#1971 

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
