### PR TITLE
ci: add PR size labeling workflow

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -71,12 +71,16 @@ jobs:
 
             for (const stale of current) {
               if (stale === label) continue;
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: stale,
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  name: stale,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
             }
 
             if (!current.includes(label)) {

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -1,0 +1,89 @@
+name: PR size label
+
+# Applies a "size: XS/S/M/L/XL" label to PRs from a weighted diff score
+# (code + 50% docs + 50% tests), excluding poetry.lock and recorded test data
+# so generated fixtures do not dominate the size.
+#
+# Uses pull_request_target so it has a write token on fork PRs. Safe because the
+# job only reads the PR file list via the API and calls the labels API; it never
+# checks out or executes PR head code. Do not add a checkout of the PR head here.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- no checkout or execution of PR head
+  # code; the job reads the PR file list and calls the labels API only.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-size-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const isExcluded = (name) =>
+              name === "poetry.lock" ||
+              name.includes("/cassettes/") ||
+              name.includes("/recordings/") ||
+              name.includes("/fixtures/");
+
+            const isDocs = (name) =>
+              name.startsWith("docs/") || name.endsWith(".md");
+
+            const isTests = (name) => name.startsWith("tests/");
+
+            let code = 0;
+            let docs = 0;
+            let tests = 0;
+            for (const file of files) {
+              if (isExcluded(file.filename)) continue;
+              const changed = file.additions + file.deletions;
+              if (isDocs(file.filename)) docs += changed;
+              else if (isTests(file.filename)) tests += changed;
+              else code += changed;
+            }
+
+            const score = code + Math.floor(docs / 2) + Math.floor(tests / 2);
+            const size =
+              score < 10 ? "XS" :
+              score < 50 ? "S" :
+              score < 250 ? "M" :
+              score < 1000 ? "L" : "XL";
+            const label = `size: ${size}`;
+
+            const current = context.payload.pull_request.labels
+              .map((existing) => existing.name)
+              .filter((name) => name.startsWith("size: "));
+
+            for (const stale of current) {
+              if (stale === label) continue;
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: stale,
+              });
+            }
+
+            if (!current.includes(label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label],
+              });
+            }


### PR DESCRIPTION
## Description

Apply a "size: XS/S/M/L/XL" label to pull requests based on a weighted diff score (code + 50% docs + 50% tests), excluding poetry.lock and recorded test data so generated fixtures do not dominate the size.

Runs on pull_request_target with no checkout of PR head code; the job reads the PR file list and calls the labels API only.



## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request size classification to streamline the code review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->