### PR TITLE
ci: add review response reminder workflow

### DIFF
--- a/.github/workflows/review-response-reminder.yml
+++ b/.github/workflows/review-response-reminder.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         env:
@@ -41,6 +40,11 @@ jobs:
             const pull_number = context.payload.pull_request.number;
             const author = context.payload.pull_request.user?.login;
             const authorMention = author ? `@${author} ` : "";
+
+            if (context.payload.pull_request.state !== "open") {
+              core.info(`PR #${pull_number}: state is ${context.payload.pull_request.state}; skipping.`);
+              return;
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,

--- a/.github/workflows/review-response-reminder.yml
+++ b/.github/workflows/review-response-reminder.yml
@@ -1,0 +1,76 @@
+name: Review response reminder
+
+# Posts a one-time reminder comment when a maintainer labels a PR as needing the
+# author to respond to review comments. Maintainer-gated: it only fires when the
+# label is applied, and applying labels requires write access. The lifecycle is
+# manual: a maintainer removes the label when satisfied; the comment is not
+# auto-removed.
+#
+# Uses pull_request_target so it has a write token even on fork PRs. Safe ONLY
+# because the job does not check out or execute PR head code; it reads event
+# metadata and calls the comments API. Do not add a checkout of the PR head here.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- no checkout or execution of PR head
+  # code; the job reads event metadata and posts a comment only.
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: review-response-reminder-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    if: "${{ github.event.label.name == 'status: awaiting author' }}"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        env:
+          MARKER: "### Open review comments need your response"
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = process.env.MARKER;
+            const pull_number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user?.login;
+            const authorMention = author ? `@${author} ` : "";
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => {
+              return comment.user?.type === "Bot" && comment.body?.startsWith(marker);
+            });
+
+            if (existing) {
+              core.info(`PR #${pull_number}: reminder comment already present; skipping.`);
+              return;
+            }
+
+            const body = [
+              marker,
+              "",
+              `${authorMention}this PR is waiting on you. Reply to each open review comment so a reviewer can confirm it is resolved. For every comment, leave a reply that either points to the change you made or explains why no change is needed.`,
+              "",
+              "Pushing a fix without replying is not enough: reviewers cannot tell which comments a commit addresses, so each thread needs an explicit reply.",
+              "",
+              `Review readiness guide: https://github.com/${owner}/${repo}/blob/develop/CONTRIBUTING.md#review-readiness`,
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body,
+            });


### PR DESCRIPTION
## Description

Adds a maintainer-triggered workflow (`review-response-reminder.yml`) that posts
a single reminder comment when a maintainer applies the `status: awaiting author`
label to a PR. The comment tells the author the PR is waiting on them and that
they must reply on each open review thread, even when they have already pushed a
fix, so a reviewer can confirm resolution at a glance.

Motivation: when an author addresses review comments by silently pushing a change
without replying on the thread, a maintainer cannot easily tell which comments
are resolved and has to reverse-engineer the diff against every comment. This
nudge makes the review-readiness expectation explicit and points to
`CONTRIBUTING.md#review-readiness`.

Design notes:
- Maintainer-gated by construction: it only fires on `pull_request_target:
  [labeled]` for `status: awaiting author`, and applying labels requires write
  access. No automatic firing, no per-PR noise.
- The comment is idempotent (marker-guarded), so re-applying the label does not
  post duplicates.
- Manual lifecycle: a maintainer removes the label when satisfied; the comment is
  not auto-removed. It is a reminder, not an enforcement check.
- Follows existing conventions from `pr-merge-guidance.yml` / `triage-label.yml`:
  SHA-pinned `actions/github-script`, no checkout of PR head code under
  `pull_request_target` (zizmor `dangerous-triggers` ignore documented inline),
  per-PR concurrency, and `issues: write` + `pull-requests: write` permissions.

## Related Issue(s)

<!-- fill in -->


## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the CONTRIBUTING guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable. <!-- references CONTRIBUTING#review-readiness; no new docs needed -->
- [ ] I've added tests if applicable. <!-- workflow logic; no unit-testable code path -->
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed. <!-- pending review -->
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated reminders now post on pull requests labeled for author response, including a link to the review readiness guide to facilitate efficient review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->