### PR TITLE
ci: label every new PR "status: needs triage" by default

### DIFF
--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -2,10 +2,9 @@ name: triage auto-label
 
 # Manages the triage-state labels that gate automated review from CodeRabbit
 # and Greptile:
-#   - On open/reopen with no triage label yet: maintainers / NVIDIA-NeMo org
-#     members / collaborators get "status: triaged"; everyone else gets
-#     "status: needs triage". A PR that already carries either label keeps it
-#     (reopening a triaged PR does not reset it to "needs triage").
+#   - On open/reopen with no triage label yet: every PR gets
+#     "status: needs triage" (no author-based exception). A PR that already
+#     carries either label keeps it (reopening a triaged PR does not reset it).
 #   - When a maintainer adds "status: triaged", "status: needs triage" is
 #     removed automatically.
 #
@@ -37,14 +36,11 @@ jobs:
             ) {
               return;
             }
-            const trusted = ["OWNER", "MEMBER", "COLLABORATOR"].includes(
-              context.payload.pull_request.author_association
-            );
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: [trusted ? "status: triaged" : "status: needs triage"],
+              labels: ["status: needs triage"],
             });
 
   clear-needs-triage:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,12 +87,11 @@ Automated code review tools such as CodeRabbit and Greptile are part of the
 pre-review workflow. A PR is ready for maintainer review only after the author
 has addressed unresolved human and automated review comments.
 
-Automated code review is gated on triage. New and reopened PRs from
-maintainers, repository collaborators, or NVIDIA-NeMo organization members are
-labeled `status: triaged` automatically. Other PRs open as `status: needs
-triage`; a maintainer applies `status: triaged` after confirming the PR is
-linked to a triaged issue assigned to the contributor. CodeRabbit and Greptile
-are configured to review only PRs with `status: triaged`.
+Automated code review is gated on triage. A new PR opens as `status: needs
+triage` (a reopened PR keeps whatever triage label it already has); a maintainer
+applies `status: triaged` after confirming the PR is linked to a triaged issue
+assigned to the contributor. CodeRabbit and Greptile are configured to review
+only PRs with `status: triaged`.
 
 Before requesting maintainer review:
 


### PR DESCRIPTION
## Description

Drop the author-association exception that auto-applied "status: triaged"
to maintainer/org-member PRs. Now every PR opens as "status: needs
triage" and a maintainer applies "status: triaged" after triage.

This keeps automated review (CodeRabbit/Greptile) gated until triage for all PRs uniformly, and avoids relying on a bot-applied "status: triaged" event, which Greptile does not act on.

Update CONTRIBUTING.md to describe the uniform needs-triage default.



<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR triage workflow to enforce consistent review requirements for all newly opened or reopened pull requests
  * Updated contribution guidelines to reflect changes to the automated code review process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->