### PR TITLE
ci: add zizmor workflow linting and harden GitHub Actions

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -32,6 +32,9 @@ on:
       CODECOV_TOKEN:
         required: false
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -88,7 +91,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: inputs.with-coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           directory: ./coverage/reports/
           env_vars: PYTHON

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -28,6 +28,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/close-contribution-workflow-violation.yml
+++ b/.github/workflows/close-contribution-workflow-violation.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       pull-requests: write # Needed to comment on and close the PR.
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      - uses: actions/github-script@v9
         env:
           COMMENT_MARKER: "<!-- contribution-workflow-violation -->"
           TARGET_LABEL: "status: contribution workflow violation"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -29,23 +29,29 @@ jobs:
       - name: Check if tag already exists
         id: check-tag
         run: |
-          if git tag -l "${{ steps.version.outputs.tag }}" | grep -q "${{ steps.version.outputs.tag }}"; then
+          if git tag -l "${STEPS_VERSION_OUTPUTS_TAG}" | grep -q "${STEPS_VERSION_OUTPUTS_TAG}"; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag ${{ steps.version.outputs.tag }} already exists"
+            echo "Tag ${STEPS_VERSION_OUTPUTS_TAG} already exists"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag ${{ steps.version.outputs.tag }} does not exist"
+            echo "Tag ${STEPS_VERSION_OUTPUTS_TAG} does not exist"
           fi
+        env:
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}
 
       - name: Create and push tag
         if: steps.check-tag.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin ${{ steps.version.outputs.tag }}
+          git tag -a ${STEPS_VERSION_OUTPUTS_TAG} -m "Release ${STEPS_VERSION_OUTPUTS_TAG}"
+          git push origin ${STEPS_VERSION_OUTPUTS_TAG}
+        env:
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}
 
       - name: Tag already exists
         if: steps.check-tag.outputs.exists == 'true'
         run: |
-          echo "::warning::Tag ${{ steps.version.outputs.tag }} already exists, skipping tag creation"
+          echo "::warning::Tag ${STEPS_VERSION_OUTPUTS_TAG} already exists, skipping tag creation"
+        env:
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] -- this job pushes the release tag with
+        # `git push origin`, which needs the checkout's persisted credentials;
+        # the job uploads no artifacts, so the token is not exposed.
         uses: actions/checkout@v6.0.3
         with:
           ref: develop

--- a/.github/workflows/develop-coverage.yml
+++ b/.github/workflows/develop-coverage.yml
@@ -7,10 +7,14 @@ on:
     paths-ignore:
       - "**/*.md"
 
+permissions:
+  contents: read
+
 jobs:
   develop-coverage:
     uses: ./.github/workflows/_test.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       os: Ubuntu
       image: ubuntu-latest

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Check Fern docs
         env:
@@ -76,6 +77,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Generate Python SDK reference
         env:
@@ -135,6 +137,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Publish Fern staging docs
         env:

--- a/.github/workflows/docs-remove-stale-reviews.yaml
+++ b/.github/workflows/docs-remove-stale-reviews.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
     remove:
-        uses: nvidia-merlin/.github/.github/workflows/docs-remove-stale-reviews-common.yaml@main
+        uses: nvidia-merlin/.github/.github/workflows/docs-remove-stale-reviews-common.yaml@1f3193bfbcf2ee0e740b03ff6e60860a9a35fdfe # main

--- a/.github/workflows/docs-remove-stale-reviews.yaml
+++ b/.github/workflows/docs-remove-stale-reviews.yaml
@@ -6,6 +6,10 @@ on:
         - cron: "42 0 * * 0"
     workflow_dispatch:
 
+permissions:
+    contents: write
+    pull-requests: read
+
 jobs:
     remove:
         uses: nvidia-merlin/.github/.github/workflows/docs-remove-stale-reviews-common.yaml@main

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -14,6 +14,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   full-tests-matrix:
     strategy:

--- a/.github/workflows/latest-deps-tests.yml
+++ b/.github/workflows/latest-deps-tests.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 22 * * *" # 10:00 PM UTC, daily
 
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   latest-deps-tests-matrix:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
 env:
   PYTHON_VERSION: "3.11"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-merge-guidance.yml
+++ b/.github/workflows/pr-merge-guidance.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post PR merge guidance
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number || '' }}
           BASE_BRANCH: ${{ github.event_name == 'push' && github.ref_name || '' }}

--- a/.github/workflows/pr-merge-guidance.yml
+++ b/.github/workflows/pr-merge-guidance.yml
@@ -1,6 +1,9 @@
 name: PR Merge Guidance
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- needed to comment on fork PRs; the
+  # job runs actions/github-script only and never checks out or executes PR
+  # head code, so untrusted code cannot run with the elevated token.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   push:

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {

--- a/.github/workflows/pr-tests-skip.yml
+++ b/.github/workflows/pr-tests-skip.yml
@@ -6,6 +6,8 @@ on:
       - "**/*.md"
       - ".github/**"
 
+permissions: {}
+
 jobs:
   pr-tests-summary:
     name: PR Tests Summary

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,9 @@ on:
       - "**/*.md"
       - ".github/**"
 
+permissions:
+  contents: read
+
 jobs:
   pr-tests-matrix:
     strategy:
@@ -19,7 +22,8 @@ jobs:
             with-coverage: true
       fail-fast: false
     uses: ./.github/workflows/_test.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       os: ${{ matrix.os }}
       image: ${{ matrix.image }}

--- a/.github/workflows/publish-pypi-approval.yml
+++ b/.github/workflows/publish-pypi-approval.yml
@@ -1,6 +1,10 @@
 name: Publish to PyPI (with Approval)
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- workflow_run fires only after the
+  # trusted "Build and Test Distribution" workflow succeeds; the head_branch is
+  # validated against a strict vX.Y.Z regex before any checkout, and checkout
+  # uses that validated tag, not attacker-controlled head code.
   workflow_run:
     workflows: ["Build and Test Distribution"]
     types:
@@ -20,9 +24,9 @@ jobs:
     steps:
       - name: Detect version tag from workflow event
         id: version
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
-
           echo "Workflow triggered by: $HEAD_BRANCH"
 
           if [[ "$HEAD_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/publish-pypi-approval.yml
+++ b/.github/workflows/publish-pypi-approval.yml
@@ -51,16 +51,19 @@ jobs:
         with:
           ref: ${{ steps.version.outputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate version matches tag
         run: |
           VERSION_IN_FILE=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          TAG_VERSION="${{ steps.version.outputs.version }}"
+          TAG_VERSION="${STEPS_VERSION_OUTPUTS_VERSION}"
           if [ "$VERSION_IN_FILE" != "$TAG_VERSION" ]; then
             echo "❌ Version mismatch: pyproject.toml=$VERSION_IN_FILE, tag=$TAG_VERSION"
             exit 1
           fi
           echo "✅ Version validated: $VERSION_IN_FILE matches tag $TAG_VERSION"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Download artifact
         uses: actions/download-artifact@v8
@@ -84,13 +87,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG_NAME="${{ steps.version.outputs.tag }}"
+          TAG_NAME="${STEPS_VERSION_OUTPUTS_TAG}"
 
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          CHANGELOG_SECTION=$(awk -v version="${{ steps.version.outputs.version }}" '
+          CHANGELOG_SECTION=$(awk -v version="${STEPS_VERSION_OUTPUTS_VERSION}" '
             /^## \[/ {
               if (found) exit
               if ($0 ~ "\\[" version "\\]") {

--- a/.github/workflows/publish-pypi-approval.yml
+++ b/.github/workflows/publish-pypi-approval.yml
@@ -78,7 +78,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           verbose: true
           packages-dir: dist/

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -7,6 +7,8 @@ on:
         description: 'Version of the wheel to publish (format X.Y.Z - no "v"!).'
         required: true
 
+permissions: {}
+
 jobs:
   publish-wheel:
     runs-on: ubuntu-latest
@@ -22,6 +24,9 @@ jobs:
           name: nemoguardrails-${{ github.event.inputs.version }}.whl
 
       - name: Publish package
+        # zizmor: ignore[use-trusted-publishing] -- publishes with a PyPI API
+        # token by design; migrating to OIDC trusted publishing is tracked
+        # separately.
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -27,7 +27,7 @@ jobs:
         # zizmor: ignore[use-trusted-publishing] -- publishes with a PyPI API
         # token by design; migrating to OIDC trusted publishing is tracked
         # separately.
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           verbose: true
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           PY
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/release-${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -77,9 +78,11 @@ jobs:
         run: |
           git cliff \
             --unreleased \
-            --tag     v${{ steps.version.outputs.version }} \
+            --tag     v${STEPS_VERSION_OUTPUTS_VERSION} \
             --strip all \
             > CHANGELOG.new.md
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Inject release block just above the previous entry
         run: |
@@ -97,7 +100,9 @@ jobs:
             && rm CHANGELOG.new.md
 
       - name: Update version with uv
-        run: uv version --no-sync "${{ steps.version.outputs.version }}"
+        run: uv version --no-sync "${STEPS_VERSION_OUTPUTS_VERSION}"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Update version in README.md
         env:

--- a/.github/workflows/review-response-reminder.yml
+++ b/.github/workflows/review-response-reminder.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+      - uses: actions/github-script@v9
         env:
           MARKER: "### Open review comments need your response"
         with:

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -1,9 +1,11 @@
 name: Build and Test Distribution
 
 on:
-  # zizmor: ignore[cache-poisoning] -- the cache key is the integrity-checked
-  # poetry.lock hash and restores a .venv for build/test only; it is not an
-  # input to the published wheel artifact.
+  # zizmor: ignore[cache-poisoning] -- this workflow has no pull_request
+  # trigger; it runs only on push to main/develop/tags and on schedule, so the
+  # restored .venv cache is only ever written by trusted refs (fork PRs cannot
+  # write a cache these runs restore). The build env can influence the wheel,
+  # so trigger scoping -- not the cache contents -- is what makes this safe.
   push:
     branches:
       - main

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -22,6 +22,8 @@ jobs:
       artifact_name: ${{ steps.set-artifact-name.outputs.artifact_name }}
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -50,11 +52,13 @@ jobs:
       - name: Set Artifact Name
         id: set-artifact-name
         run: |
-          if [ -n "${{ steps.get-tag-name.outputs.tag_name }}" ]; then
-            echo "artifact_name=${{ steps.get-tag-name.outputs.tag_name }}-build" >> $GITHUB_OUTPUT
+          if [ -n "${STEPS_GET_TAG_NAME_OUTPUTS_TAG_NAME}" ]; then
+            echo "artifact_name=${STEPS_GET_TAG_NAME_OUTPUTS_TAG_NAME}-build" >> $GITHUB_OUTPUT
           else
             echo "artifact_name=pr-build" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_GET_TAG_NAME_OUTPUTS_TAG_NAME: ${{ steps.get-tag-name.outputs.tag_name }}
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -15,6 +15,9 @@ on:
   schedule:
     - cron: "0 23 * * *" # 11:00 PM UTC, daily
 
+permissions:
+  contents: read
+
 jobs:
   build-wheel:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -1,6 +1,9 @@
 name: Build and Test Distribution
 
 on:
+  # zizmor: ignore[cache-poisoning] -- the cache key is the integrity-checked
+  # poetry.lock hash and restores a .venv for build/test only; it is not an
+  # input to the published wheel artifact.
   push:
     branches:
       - main

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -15,6 +15,9 @@ on:
       - "uv.lock"
       - ".github/workflows/test-docker.yml"
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -44,9 +44,9 @@ jobs:
           STEPS_RUNNER_ARCH_OUTPUTS_ARCH: ${{ steps.runner-arch.outputs.arch }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -25,6 +25,8 @@ jobs:
       # Checkout the code
       - name: Checkout
         uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       # Get runner architecture
       - name: Get runner architecture
@@ -33,8 +35,10 @@ jobs:
 
       - name: Set Docker tags
         run: |
-          ARCH=${{ steps.runner-arch.outputs.arch }}
+          ARCH=${STEPS_RUNNER_ARCH_OUTPUTS_ARCH}
           echo "TEST_TAG=${{ env.IMAGE }}:${{ github.sha }}-$ARCH" >> $GITHUB_ENV
+        env:
+          STEPS_RUNNER_ARCH_OUTPUTS_ARCH: ${{ steps.runner-arch.outputs.arch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -50,7 +54,7 @@ jobs:
 
       # Start the container in detached mode
       - name: Start container
-        run: docker run -d --name test_container -p 8000:8000 ${{ env.TEST_TAG }}
+        run: docker run -d --name test_container -p 8000:8000 ${TEST_TAG}
 
       # Wait for the container to be ready
       - name: Wait for container to be ready

--- a/.github/workflows/test-published-dist.yml
+++ b/.github/workflows/test-published-dist.yml
@@ -4,6 +4,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test-pypi-wheel:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -13,16 +13,20 @@ name: triage auto-label
 # and call the labels API. Do not add a checkout of the PR head here.
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- see header comment: no job checks out
+  # or executes PR head code, so the write token is never exposed to untrusted
+  # code. pull_request_target is required for a write token on fork PRs.
   pull_request_target:
     types: [opened, reopened, labeled]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   initial-label:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:
@@ -46,6 +50,8 @@ jobs:
   clear-needs-triage:
     if: "github.event.action == 'labeled' && github.event.label.name == 'status: triaged'"
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,42 @@
+name: GitHub Actions security
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+      - "**/action.yml"
+      - "**/action.yaml"
+  push:
+    branches: [develop]
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
+      - ".github/zizmor.yml"
+      - "**/action.yml"
+      - "**/action.yaml"
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          online-audits: true
+          token: ${{ github.token }}
+          version: "1.26.1"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  # This repo pins actions to version tags (e.g. `@v6`), kept current by
+  # Dependabot's github-actions updates. Allow ref (tag/branch) pins instead of
+  # requiring commit-hash pins so the policy matches the existing convention.
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,7 @@
 rules:
-  # This repo pins actions to version tags (e.g. `@v6`), kept current by
-  # Dependabot's github-actions updates. Allow ref (tag/branch) pins instead of
-  # requiring commit-hash pins so the policy matches the existing convention.
   unpinned-uses:
     config:
       policies:
-        "*": ref-pin
+        "actions/*": ref-pin
+        "github/*": ref-pin
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
     rev: v1.25.2
     hooks:
       - id: zizmor
-        args: ["--min-severity", "high"]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - LICENSE.md
           - --use-current-year
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
           - --license-filepath
           - LICENSE.md
           - --use-current-year
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.10.0
+    hooks:
+      - id: zizmor
+        args: ["--min-severity", "high"]
+
   - repo: local
     hooks:
       - id: ty

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - LICENSE.md
           - --use-current-year
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.10.0
+    rev: v1.25.2
     hooks:
       - id: zizmor
         args: ["--min-severity", "high"]


### PR DESCRIPTION
## Description

Adds [zizmor](https://docs.zizmor.sh/) as a pre-commit hook (also enforced in CI via
`lint.yml`'s `make pre-commit`) to lint GitHub Actions workflows, runs it at zizmor's
**default severity**, and resolves every finding it surfaces. Our workflows use privileged
triggers (`pull_request_target`, `workflow_run`), publish to PyPI, and push tags, so gating
them catches credential-persistence, template-injection, excessive-permission, and
cache-poisoning mistakes before they ship.

**Tooling**
- New `zizmor` pre-commit hook (pinned `v1.25.2`), at default severity.
- New `.github/zizmor.yml`: `unpinned-uses: ref-pin` so tag pins (`@v6`, kept current by
  Dependabot) satisfy the linter instead of requiring SHA pins.

**Least-privilege permissions (`excessive-permissions`)**
- Scoped `permissions:` blocks added to workflows that relied on the default token:
  `contents: read` where a checkout runs (incl. callers of the reusable `_test.yml`),
  `permissions: {}` for pure status / install-from-PyPI / token-publish jobs, and
  `contents: write` + `pull-requests: read` for `docs-remove-stale-reviews` (its reusable
  workflow pushes to `gh-pages`).

**Injection / credential hardening**
- Event-derived `${{ … }}` values moved out of `run:` bodies into `env:` / shell vars
  (`template-injection`).
- `persist-credentials: false` on checkouts that don't push (`artipacked`).
- `package-manager-cache: false` on `setup-node` in `docs-build` (closes a reachable
  cache-poisoning vector — `build-docs` runs on fork PRs).
- `pr-tests` passes only `CODECOV_TOKEN` to `_test.yml` instead of `secrets: inherit`
  (`secrets-inherit`); `_test.yml` declares it as an optional `workflow_call` secret.

**Documented suppressions** (inline `# zizmor: ignore[...]`, each with rationale)
- `dangerous-triggers` ×3 (`triage-label`, `pr-merge-guidance`, `publish-pypi-approval`) —
  none check out or execute PR-head code; event data read as data; `workflow_run` upstream
  has no PR trigger.
- `cache-poisoning` (`test-and-build-wheel`) — no `pull_request` trigger; trusted-ref-only
  runs, so fork PRs can't write the cache these runs restore.
- `artipacked` (`create-tag`) — needs the checkout's persisted credentials to `git push`
  the release tag; uploads no artifacts.
- `use-trusted-publishing` (`publish-wheel`) — intentional API-token publish; OIDC migration
  tracked separately.

Areas needing careful review: the `permissions:` scopes (esp. `docs-remove-stale-reviews`,
which must keep `contents: write` for its `gh-pages` push) and the `secrets-inherit` change
to the `_test.yml` interface.

## Verification

- Rebased on the latest `develop`. `uvx zizmor .github/workflows/` (default severity) →
  **No findings to report** across the full workflow set, including workflows `develop`
  recently added.
- `pre-commit run --all-files` passes (incl. the new `zizmor` hook).
- **Beyond CI / could not run locally:** the `secrets-inherit` change can only be confirmed
  on the first CI run — verify the Codecov upload still succeeds on the coverage job
  (Python 3.11). Logic is backward-compatible; residual risk is low.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable. <!-- N/A: CI config only -->
- [x] I've added tests if applicable. <!-- N/A: workflow lint config; gate verified via zizmor + pre-commit -->
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed. <!-- none yet -->
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced GitHub Actions workflows with explicit permissions configuration
  * Improved credential handling in deployment pipelines

* **Infrastructure**
  * Added automated code scanning integration for improved code quality
  * Refactored CI/CD workflows for better maintainability and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->