### PR TITLE
feat(iorails): Connect tool-calling up in IORails

### DIFF
--- a/nemoguardrails/guardrails/actions/tool_result_action.py
+++ b/nemoguardrails/guardrails/actions/tool_result_action.py
@@ -126,16 +126,31 @@ class ToolResultRailAction(ToolRailAction):
         return None
 
     def _validate_result_name(self, result: "ToolResult", prior: "ToolCall") -> "RailResult | None":
-        """Return a blocking RailResult if the result name conflicts with the prior call's function name."""
-        if result.name and prior.function.name and result.name != prior.function.name:
+        """Return a blocking RailResult unless the result name matches the prior call's function name.
+
+        When the prior call's name is known, the result must carry that exact name: a
+        missing name no longer slips through on call_id linkage alone (it could mislabel a
+        result from a different tool), and a mismatched name is rejected. When the prior
+        call's name is unknown there is nothing to compare against, so the check returns None.
+        """
+        if not prior.function.name:
+            return None
+        if result.name == prior.function.name:
+            return None
+        if not result.name:
             return RailResult(
                 is_safe=False,
                 reason=(
-                    f"tool result name '{result.name}' does not match the called tool "
-                    f"'{prior.function.name}' for call_id '{result.call_id}'"
+                    f"tool result for call_id '{result.call_id}' is missing a name; expected '{prior.function.name}'"
                 ),
             )
-        return None
+        return RailResult(
+            is_safe=False,
+            reason=(
+                f"tool result name '{result.name}' does not match the called tool "
+                f"'{prior.function.name}' for call_id '{result.call_id}'"
+            ),
+        )
 
     def _validate_result_content(self, result: "ToolResult") -> "RailResult | None":
         """Return a blocking RailResult if the result content is not a string or list of dicts."""

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -36,7 +36,7 @@ from nemoguardrails.guardrails.telemetry import (
     set_llm_request_attributes,
     set_llm_response_attributes,
 )
-from nemoguardrails.guardrails.tool_schema import ToolResult, Toolset
+from nemoguardrails.guardrails.tool_schema import ToolExchange, ToolResult, Toolset
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
 from nemoguardrails.tracing.constants import (
     llm_operation_duration,
@@ -44,7 +44,7 @@ from nemoguardrails.tracing.constants import (
     record_time_to_first_chunk,
     record_token_usage,
 )
-from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, UsageInfo
+from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -398,20 +398,20 @@ class EngineRegistry:
         engine = self._get_engine(model_type, ModelEngine)
         return engine.extract_tool_results(messages)
 
-    def extract_tool_calls(self, model_type: str, messages: list[dict]) -> list[ToolCall]:
-        """Extract the prior tool calls from ``messages`` for the named model engine.
+    def extract_tool_exchanges(self, model_type: str, messages: list[dict]) -> list[ToolExchange]:
+        """Group ``messages`` into per-turn ``(tool_calls, tool_results)`` exchanges.
 
-        Delegates to the engine's ``extract_tool_calls`` so the calls that incoming
-        tool results link back to are normalized into the ``ToolCall`` list
-        ``RailsManager.are_tool_results_safe`` validates against. Symmetric to
-        ``extract_tool_results``.
+        Delegates to the engine's ``extract_tool_exchanges`` so each tool result is
+        validated against its own turn's calls. This keeps ``call_id`` linkage
+        turn-local, which ``RailsManager.are_tool_results_safe`` relies on so that ids
+        reused across turns (spec-allowed) are not flagged as ambiguous duplicates.
 
         Raises:
             KeyError: If no engine is registered with the given name.
             TypeError: If the named engine is not a ModelEngine.
         """
         engine = self._get_engine(model_type, ModelEngine)
-        return engine.extract_tool_calls(messages)
+        return engine.extract_tool_exchanges(messages)
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         """Route an API request to the named API engine.

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -44,7 +44,7 @@ from nemoguardrails.tracing.constants import (
     record_time_to_first_chunk,
     record_token_usage,
 )
-from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
+from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, UsageInfo
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -397,6 +397,21 @@ class EngineRegistry:
         """
         engine = self._get_engine(model_type, ModelEngine)
         return engine.extract_tool_results(messages)
+
+    def extract_tool_calls(self, model_type: str, messages: list[dict]) -> list[ToolCall]:
+        """Extract the prior tool calls from ``messages`` for the named model engine.
+
+        Delegates to the engine's ``extract_tool_calls`` so the calls that incoming
+        tool results link back to are normalized into the ``ToolCall`` list
+        ``RailsManager.are_tool_results_safe`` validates against. Symmetric to
+        ``extract_tool_results``.
+
+        Raises:
+            KeyError: If no engine is registered with the given name.
+            TypeError: If the named engine is not a ModelEngine.
+        """
+        engine = self._get_engine(model_type, ModelEngine)
+        return engine.extract_tool_calls(messages)
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         """Route an API request to the named API engine.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -160,16 +160,50 @@ def _build_assistant_message(content: str, tool_calls: Optional[list[ToolCall]])
     }
 
 
+def _coerce_generation_options(options: Optional[Union[dict, GenerationOptions]]) -> Optional[GenerationOptions]:
+    """Normalize the request ``options`` argument into a ``GenerationOptions`` or None."""
+    if isinstance(options, GenerationOptions):
+        return options
+    if isinstance(options, dict):
+        return GenerationOptions(**options)
+    return None
+
+
+def _unsupported_flows_reason(flows: list[str], supported: frozenset[str], label: str) -> Optional[str]:
+    """Return a fallback reason when any flow in *flows* is outside *supported*, else None.
+
+    Each flow id is normalized (call args / ``$model=`` suffix stripped) before the
+    membership check, so ``"content safety check input $model=x"`` matches the bare
+    flow name. A flow whose name normalizes to empty carries no recognizable rail name
+    and is ignored. *label* names the rail family in the message (e.g. ``"input"``,
+    ``"tool output"``); offending names are reported sorted and de-duplicated.
+    """
+    unsupported = set()
+    for flow in flows:
+        name = _get_flow_name(flow)
+        if name and name not in supported:
+            unsupported.add(name)
+    if not unsupported:
+        return None
+    return f"config has unsupported {label} flows: {sorted(unsupported)}"
+
+
 class IORails(BaseGuardrails):
     """Workflow engine for accelerated Input/Output rails inference."""
 
     # Rail sections and flows that this engine can handle. Configs using anything
     # outside these sets fall back to LLMRails.
-    SUPPORTED_RAILS = frozenset({"input", "output", "config"})
+    SUPPORTED_RAILS = frozenset({"input", "output", "config", "tool_input", "tool_output"})
     SUPPORTED_INPUT_FLOWS = frozenset(
         {"content safety check input", "topic safety check input", "jailbreak detection model"}
     )
     SUPPORTED_OUTPUT_FLOWS = frozenset({"content safety check output"})
+    # Tool-rail flows are direction-specific: tool_output may only carry the
+    # tool-call validator and tool_input only the tool-result validator. The
+    # supported sets double as the direction check so a misdirected flow falls
+    # back to LLMRails rather than raising in RailsManager at construction.
+    SUPPORTED_TOOL_OUTPUT_FLOWS = frozenset({"tool call validation"})
+    SUPPORTED_TOOL_INPUT_FLOWS = frozenset({"tool result validation"})
 
     @classmethod
     def unsupported_reason(cls, config: RailsConfig, llm: Optional[LLMModel] = None) -> Optional[str]:
@@ -181,21 +215,30 @@ class IORails(BaseGuardrails):
         if unsupported_rails:
             return f"config has rails outside the IORails-supported set: {unsupported_rails}"
 
-        unsupported_input = set()
-        for flow in config.rails.input.flows:
-            name = _get_flow_name(flow)
-            if name and name not in cls.SUPPORTED_INPUT_FLOWS:
-                unsupported_input.add(name)
-        if unsupported_input:
-            return f"config has unsupported input flows: {sorted(unsupported_input)}"
+        # Each rail family accepts only its own direction-specific flows, so an unknown
+        # or misdirected flow routes the config to LLMRails. The supported sets double
+        # as the direction check (tool_output allows only the call validator, etc.).
+        flow_checks = (
+            ("input", config.rails.input.flows, cls.SUPPORTED_INPUT_FLOWS),
+            ("output", config.rails.output.flows, cls.SUPPORTED_OUTPUT_FLOWS),
+            ("tool output", config.rails.tool_output.flows, cls.SUPPORTED_TOOL_OUTPUT_FLOWS),
+            ("tool input", config.rails.tool_input.flows, cls.SUPPORTED_TOOL_INPUT_FLOWS),
+        )
+        for label, flows, supported in flow_checks:
+            reason = _unsupported_flows_reason(flows, supported, label)
+            if reason is not None:
+                return reason
 
-        unsupported_output = set()
-        for flow in config.rails.output.flows:
-            name = _get_flow_name(flow)
-            if name and name not in cls.SUPPORTED_OUTPUT_FLOWS:
-                unsupported_output.add(name)
-        if unsupported_output:
-            return f"config has unsupported output flows: {sorted(unsupported_output)}"
+        # A duplicate tool flow raises RuntimeError in RailsManager at construction;
+        # surface it here as a fallback reason so the config routes to LLMRails
+        # cleanly instead of failing IORails init (matching how unsupported flows
+        # are handled).
+        for label, tool_flows in (
+            ("tool output", config.rails.tool_output.flows),
+            ("tool input", config.rails.tool_input.flows),
+        ):
+            if len(tool_flows) != len(set(tool_flows)):
+                return f"config has duplicate {label} flows: {tool_flows}"
 
         return None
 
@@ -226,6 +269,14 @@ class IORails(BaseGuardrails):
             metrics_enabled=self._metrics_enabled,
             content_capture_enabled=self._content_capture_enabled,
         )
+        # Tool rails are CPU-bound, run sequentially since we're not waiting on IO to complete
+        if config.rails.tool_output.parallel or config.rails.tool_input.parallel:
+            warnings.warn(
+                "rails.tool_output.parallel / rails.tool_input.parallel are not honored by IORails; "
+                "tool rails run sequentially.",
+                stacklevel=2,
+            )
+
         self.rails_manager = RailsManager(
             engine_registry=self.engine_registry,
             task_manager=LLMTaskManager(config),
@@ -233,6 +284,8 @@ class IORails(BaseGuardrails):
             output_flows=config.rails.output.flows,
             input_parallel=config.rails.input.parallel or False,
             output_parallel=config.rails.output.parallel or False,
+            tool_call_flows=config.rails.tool_output.flows,
+            tool_result_flows=config.rails.tool_input.flows,
             tracer=self._tracer,
             content_capture_enabled=self._content_capture_enabled,
         )
@@ -407,20 +460,46 @@ class IORails(BaseGuardrails):
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             return result
 
+    @staticmethod
+    def _guardrails_violation_payload(message: str, param: str) -> str:
+        """Build the JSON error payload emitted when a streaming rail blocks output.
+
+        Shared by the output-rails and tool-call-rails streaming block paths so both
+        surface the same ``guardrails_violation`` / ``content_blocked`` shape; ``param``
+        distinguishes which rail family blocked (``output_rails`` / ``tool_output_rails``).
+        """
+        return json.dumps(
+            {
+                "error": {
+                    "message": message,
+                    "type": "guardrails_violation",
+                    "param": param,
+                    "code": "content_blocked",
+                }
+            }
+        )
+
     async def _do_generate(
         self, messages: LLMMessages, req_id: str, request_span: Optional["Span"] = None, **kwargs
     ) -> LLMMessage:
-        """Core pipeline: input rails -> LLM call -> output rails."""
+        """Core pipeline: tool-result rails -> input rails -> LLM call -> tool-call + output rails."""
         log.info("[%s] generate_async called", req_id)
         log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
 
-        llm_kwargs = {}
-        options = kwargs.get("options")
-        if options and isinstance(options, dict):
-            options = GenerationOptions(**options)
-        if isinstance(options, GenerationOptions) and options.llm_params:
-            # Pass llm_params (including tool definitions) unchanged
-            llm_kwargs = options.llm_params
+        options = _coerce_generation_options(kwargs.get("options"))
+        # Pass llm_params (including tool definitions) unchanged to the LLM call.
+        llm_kwargs = options.llm_params if (options and options.llm_params) else {}
+        tool_input_enabled = options.rails.tool_input if options else True
+        tool_output_enabled = options.rails.tool_output if options else True
+
+        # Agent/client executes tool-calls and sends results to Main LLM with prior conversation history.
+        # Symmetric with INPUT rails
+        tool_result = await self.rails_manager.are_tool_results_safe(messages, enabled=tool_input_enabled)
+        if not tool_result.is_safe:
+            log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
+            if self._metrics_enabled:
+                record_request_blocked(RailDirection.INPUT)
+            return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         if self._speculative_generation:
             response = await self._do_generate_speculative(messages, req_id, llm_kwargs, request_span)
@@ -438,6 +517,18 @@ class IORails(BaseGuardrails):
         # The fallback mutates response.content to remove reasoning content.
         reasoning_content = response.reasoning or _extract_and_remove_think_tags(response)
         response_text = response.content
+
+        # Main LLM returns function calls to make based on available tools and conversation
+        # Symmetric with OUTPUT rails
+        if response.tool_calls:
+            tool_call = await self.rails_manager.are_tool_calls_safe(
+                response.tool_calls, llm_kwargs, enabled=tool_output_enabled
+            )
+            if not tool_call.is_safe:
+                log.info("[%s] Tool call blocked: %s", req_id, tool_call.reason)
+                if self._metrics_enabled:
+                    record_request_blocked(RailDirection.OUTPUT)
+                return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         # Output rails check the final answer, not reasoning traces.
         # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
@@ -628,13 +719,13 @@ class IORails(BaseGuardrails):
                 "disable output rails streaming."
             )
 
-        # Extract llm_params from GenerationOptions if provided
-        llm_kwargs: dict = {}
-        if options and isinstance(options, dict):
-            options = GenerationOptions(**options)
-        if isinstance(options, GenerationOptions) and options.llm_params:
-            # Pass llm_params (including tool definitions) unchanged
-            llm_kwargs = options.llm_params
+        # Normalize options once; the inner tasks below read both llm_params
+        # (passed unchanged to the LLM call, including tool definitions) and the
+        # per-request tool-rail toggles off the coerced GenerationOptions.
+        options = _coerce_generation_options(options)
+        llm_kwargs: dict = options.llm_params if (options and options.llm_params) else {}
+        tool_input_enabled = options.rails.tool_input if options else True
+        tool_output_enabled = options.rails.tool_output if options else True
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
         # Tool calls assembled by the stream: _generation_task rebinds this (via
@@ -658,6 +749,18 @@ class IORails(BaseGuardrails):
             req_id = get_request_id()
             t0 = time.monotonic()
             try:
+                # Step 0: Tool-result rails. Client/agent harness executes tool calls and sends
+                # results of execution to Main LLM along with prior conversation history
+                # Symmetric with INPUT rails for dialog use-case
+                tool_result = await self.rails_manager.are_tool_results_safe(messages, enabled=tool_input_enabled)
+                if not tool_result.is_safe:
+                    log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
+                    if self._metrics_enabled:
+                        record_request_blocked(RailDirection.INPUT)
+                    await streaming_handler.push_chunk(REFUSAL_MESSAGE)
+                    await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
+                    return
+
                 # Step 1: Input rails (non-streaming)
                 log.info("[%s] Running input rails", req_id)
                 input_result = await self.rails_manager.is_input_safe(messages)
@@ -816,12 +919,35 @@ class IORails(BaseGuardrails):
                                     # suppress after an error/guardrails block so the caller
                                     # never receives a tool call following a failure.
                                     if accumulated_tool_calls and not error_emitted:
-                                        payload, framed = _terminal_tool_call_chunk(
-                                            accumulated_tool_calls, include_metadata
+                                        # ToolCallRail checks tool calls from the main LLM (OUTPUT)
+                                        tool_call = await self.rails_manager.are_tool_calls_safe(
+                                            accumulated_tool_calls, llm_kwargs, enabled=tool_output_enabled
                                         )
-                                        if self._content_capture_enabled:
-                                            delivered.append(payload)
-                                        yield framed
+                                        if not tool_call.is_safe:
+                                            log.info(
+                                                "[%s] Streamed tool call blocked: %s",
+                                                req_id,
+                                                tool_call.reason,
+                                            )
+                                            if self._metrics_enabled:
+                                                record_request_blocked(RailDirection.OUTPUT)
+                                            violation = self._guardrails_violation_payload(
+                                                f"Blocked by tool output rails: {tool_call.reason}",
+                                                "tool_output_rails",
+                                            )
+                                            framed_violation: Union[str, dict] = (
+                                                {"text": violation} if include_metadata else violation
+                                            )
+                                            if self._content_capture_enabled:
+                                                delivered.append(violation)
+                                            yield framed_violation
+                                        else:
+                                            payload, framed = _terminal_tool_call_chunk(
+                                                accumulated_tool_calls, include_metadata
+                                            )
+                                            if self._content_capture_enabled:
+                                                delivered.append(payload)
+                                            yield framed
                                 finally:
                                     if not task.done():
                                         task.cancel()
@@ -902,15 +1028,9 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                error_data = {
-                    "error": {
-                        "message": f"Blocked by output rails: {output_result.reason}",
-                        "type": "guardrails_violation",
-                        "param": "output_rails",
-                        "code": "content_blocked",
-                    }
-                }
-                yield json.dumps(error_data)
+                yield self._guardrails_violation_payload(
+                    f"Blocked by output rails: {output_result.reason}", "output_rails"
+                )
                 return
 
             if not stream_first:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -128,6 +128,16 @@ def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict]:
     ]
 
 
+def _frame_for_stream(payload: str, include_metadata: Optional[bool]) -> Union[str, dict]:
+    """Frame a directly-yielded payload to match the surrounding stream's chunk shape.
+
+    Returns a ``{"text": payload}`` dict under ``include_metadata``, the raw string
+    otherwise — the same wrapping the StreamingHandler applies to ``push_chunk``'d
+    strings, so terminal and block chunks that bypass the handler stay shape-consistent.
+    """
+    return {"text": payload} if include_metadata else payload
+
+
 def _terminal_tool_call_chunk(
     tool_calls: list[ToolCall], include_metadata: Optional[bool]
 ) -> tuple[str, Union[str, dict]]:
@@ -140,8 +150,7 @@ def _terminal_tool_call_chunk(
     the surrounding stream.
     """
     payload = json.dumps({"tool_calls": _serialize_tool_calls(tool_calls)})
-    framed: Union[str, dict] = {"text": payload} if include_metadata else payload
-    return payload, framed
+    return payload, _frame_for_stream(payload, include_metadata)
 
 
 def _build_assistant_message(content: str, tool_calls: Optional[list[ToolCall]]) -> LLMMessage:
@@ -484,11 +493,12 @@ class IORails(BaseGuardrails):
 
     @staticmethod
     def _guardrails_violation_payload(message: str, param: str) -> str:
-        """Build the JSON error payload emitted when a streaming rail blocks output.
+        """Build the JSON error payload emitted when a streaming rail blocks the request.
 
-        Shared by the output-rails and tool-call-rails streaming block paths so both
-        surface the same ``guardrails_violation`` / ``content_blocked`` shape; ``param``
-        distinguishes which rail family blocked (``output_rails`` / ``tool_output_rails``).
+        Shared by every streaming block path so they all surface the same
+        ``guardrails_violation`` / ``content_blocked`` shape; ``param`` distinguishes which
+        rail family blocked (``input_rails`` / ``tool_input_rails`` / ``tool_output_rails`` /
+        ``output_rails``).
         """
         return json.dumps(
             {
@@ -793,7 +803,11 @@ class IORails(BaseGuardrails):
                     log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
                     if self._metrics_enabled:
                         record_request_blocked(RailDirection.INPUT)
-                    await streaming_handler.push_chunk(REFUSAL_MESSAGE)
+                    await streaming_handler.push_chunk(
+                        self._guardrails_violation_payload(
+                            f"Blocked by tool input rails: {tool_result.reason}", "tool_input_rails"
+                        )
+                    )
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
 
@@ -804,7 +818,11 @@ class IORails(BaseGuardrails):
                     log.info("[%s] Input blocked: %s", req_id, input_result.reason)
                     if self._metrics_enabled:
                         record_request_blocked(RailDirection.INPUT)
-                    await streaming_handler.push_chunk(REFUSAL_MESSAGE)
+                    await streaming_handler.push_chunk(
+                        self._guardrails_violation_payload(
+                            f"Blocked by input rails: {input_result.reason}", "input_rails"
+                        )
+                    )
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
 
@@ -930,6 +948,7 @@ class IORails(BaseGuardrails):
                                             streaming_handler=streaming_handler,
                                             messages=messages,
                                             enabled=output_enabled,
+                                            include_metadata=include_metadata,
                                         )
                                     else:
                                         base_iterator = streaming_handler
@@ -972,12 +991,9 @@ class IORails(BaseGuardrails):
                                                 f"Blocked by tool output rails: {tool_call.reason}",
                                                 "tool_output_rails",
                                             )
-                                            framed_violation: Union[str, dict] = (
-                                                {"text": violation} if include_metadata else violation
-                                            )
                                             if self._content_capture_enabled:
                                                 delivered.append(violation)
-                                            yield framed_violation
+                                            yield _frame_for_stream(violation, include_metadata)
                                         else:
                                             payload, framed = _terminal_tool_call_chunk(
                                                 accumulated_tool_calls, include_metadata
@@ -1017,6 +1033,7 @@ class IORails(BaseGuardrails):
         messages: LLMMessages,
         *,
         enabled: Union[bool, list[str]] = True,
+        include_metadata: Optional[bool] = False,
     ) -> AsyncGenerator[Union[str, dict], None]:
         """Buffer streamed chunks and run output rails on each batch.
 
@@ -1067,9 +1084,10 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                yield self._guardrails_violation_payload(
+                violation = self._guardrails_violation_payload(
                     f"Blocked by output rails: {output_result.reason}", "output_rails"
                 )
+                yield _frame_for_stream(violation, include_metadata)
                 return
 
             if not stream_first:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -511,6 +511,8 @@ class IORails(BaseGuardrails):
         options = _coerce_generation_options(kwargs.get("options"))
         # Pass llm_params (including tool definitions) unchanged to the LLM call.
         llm_kwargs = options.llm_params if (options and options.llm_params) else {}
+        input_enabled = options.rails.input if options else True
+        output_enabled = options.rails.output if options else True
         tool_input_enabled = options.rails.tool_input if options else True
         tool_output_enabled = options.rails.tool_output if options else True
 
@@ -525,9 +527,11 @@ class IORails(BaseGuardrails):
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
         if self._speculative_generation:
-            response = await self._do_generate_speculative(messages, req_id, llm_kwargs, request_span)
+            response = await self._do_generate_speculative(
+                messages, req_id, llm_kwargs, request_span, input_enabled=input_enabled
+            )
         else:
-            response = await self._do_generate_sequential(messages, req_id, llm_kwargs)
+            response = await self._do_generate_sequential(messages, req_id, llm_kwargs, input_enabled=input_enabled)
 
         if response is None:
             return {"role": "assistant", "content": REFUSAL_MESSAGE}
@@ -561,7 +565,7 @@ class IORails(BaseGuardrails):
         is_tool_call_only = bool(response.tool_calls) and not response_text
         if not is_tool_call_only:
             log.info("[%s] Running output rails", req_id)
-            output_result = await self.rails_manager.is_output_safe(messages, response_text)
+            output_result = await self.rails_manager.is_output_safe(messages, response_text, enabled=output_enabled)
             if not output_result.is_safe:
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
@@ -576,11 +580,11 @@ class IORails(BaseGuardrails):
         return _build_assistant_message(response_text, response.tool_calls)
 
     async def _do_generate_sequential(
-        self, messages: LLMMessages, req_id: str, llm_kwargs: dict
+        self, messages: LLMMessages, req_id: str, llm_kwargs: dict, *, input_enabled: Union[bool, list[str]] = True
     ) -> Optional[LLMResponse]:
         """Sequential path: input rails block before LLM generation starts."""
         log.info("[%s] Running input rails", req_id)
-        input_result = await self.rails_manager.is_input_safe(messages)
+        input_result = await self.rails_manager.is_input_safe(messages, enabled=input_enabled)
         if not input_result.is_safe:
             log.info("[%s] Input blocked: %s", req_id, input_result.reason)
             if self._metrics_enabled:
@@ -591,12 +595,18 @@ class IORails(BaseGuardrails):
         return await self.engine_registry.model_call("main", messages, **llm_kwargs)
 
     async def _do_generate_speculative(
-        self, messages: LLMMessages, req_id: str, llm_kwargs: dict, request_span: Optional["Span"] = None
+        self,
+        messages: LLMMessages,
+        req_id: str,
+        llm_kwargs: dict,
+        request_span: Optional["Span"] = None,
+        *,
+        input_enabled: Union[bool, list[str]] = True,
     ) -> Optional[LLMResponse]:
         """Speculative path: input rails and LLM generation race concurrently."""
         log.info("[%s] Speculative generation: launching input rails + LLM concurrently", req_id)
 
-        rails_task = asyncio.create_task(self.rails_manager.is_input_safe(messages))
+        rails_task = asyncio.create_task(self.rails_manager.is_input_safe(messages, enabled=input_enabled))
         gen_task = asyncio.create_task(self.engine_registry.model_call("main", messages, **llm_kwargs))
 
         try:
@@ -747,6 +757,8 @@ class IORails(BaseGuardrails):
         # per-request tool-rail toggles off the coerced GenerationOptions.
         options = _coerce_generation_options(options)
         llm_kwargs: dict = options.llm_params if (options and options.llm_params) else {}
+        input_enabled = options.rails.input if options else True
+        output_enabled = options.rails.output if options else True
         tool_input_enabled = options.rails.tool_input if options else True
         tool_output_enabled = options.rails.tool_output if options else True
 
@@ -787,7 +799,7 @@ class IORails(BaseGuardrails):
 
                 # Step 1: Input rails (non-streaming)
                 log.info("[%s] Running input rails", req_id)
-                input_result = await self.rails_manager.is_input_safe(messages)
+                input_result = await self.rails_manager.is_input_safe(messages, enabled=input_enabled)
                 if not input_result.is_safe:
                     log.info("[%s] Input blocked: %s", req_id, input_result.reason)
                     if self._metrics_enabled:
@@ -917,6 +929,7 @@ class IORails(BaseGuardrails):
                                         base_iterator = self._run_output_rails_in_streaming(
                                             streaming_handler=streaming_handler,
                                             messages=messages,
+                                            enabled=output_enabled,
                                         )
                                     else:
                                         base_iterator = streaming_handler
@@ -1002,6 +1015,8 @@ class IORails(BaseGuardrails):
         self,
         streaming_handler: AsyncIterator[Union[str, dict]],
         messages: LLMMessages,
+        *,
+        enabled: Union[bool, list[str]] = True,
     ) -> AsyncGenerator[Union[str, dict], None]:
         """Buffer streamed chunks and run output rails on each batch.
 
@@ -1047,7 +1062,7 @@ class IORails(BaseGuardrails):
                 continue
 
             log.info("[%s] Running output rails", req_id)
-            output_result = await self.rails_manager.is_output_safe(messages, bot_response_chunk)
+            output_result = await self.rails_manager.is_output_safe(messages, bot_response_chunk, enabled=enabled)
             if not output_result.is_safe:
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -188,6 +188,27 @@ def _unsupported_flows_reason(flows: list[str], supported: frozenset[str], label
     return f"config has unsupported {label} flows: {sorted(unsupported)}"
 
 
+def _duplicate_flows_reason(flows: list[str], label: str) -> Optional[str]:
+    """Return a fallback reason when *flows* contains a duplicate flow, else None.
+
+    A duplicate tool flow raises ``RuntimeError`` in RailsManager at construction, so
+    surfacing it here lets the config route to LLMRails cleanly instead of failing init.
+    Flow ids are normalized (call args / ``$model=`` suffix stripped) before comparison
+    -- matching :func:`_unsupported_flows_reason` -- so two entries that differ only by a
+    suffix the tool rails ignore are still caught as duplicates rather than running twice.
+    A flow whose name normalizes to empty carries no recognizable rail name and is skipped.
+    """
+    seen = set()
+    for flow in flows:
+        name = _get_flow_name(flow)
+        if not name:
+            continue
+        if name in seen:
+            return f"config has duplicate {label} flows: {flows}"
+        seen.add(name)
+    return None
+
+
 class IORails(BaseGuardrails):
     """Workflow engine for accelerated Input/Output rails inference."""
 
@@ -237,8 +258,9 @@ class IORails(BaseGuardrails):
             ("tool output", config.rails.tool_output.flows),
             ("tool input", config.rails.tool_input.flows),
         ):
-            if len(tool_flows) != len(set(tool_flows)):
-                return f"config has duplicate {label} flows: {tool_flows}"
+            reason = _duplicate_flows_reason(tool_flows, label)
+            if reason is not None:
+                return reason
 
         return None
 
@@ -494,6 +516,7 @@ class IORails(BaseGuardrails):
 
         # Agent/client executes tool-calls and sends results to Main LLM with prior conversation history.
         # Symmetric with INPUT rails
+        log.info("[%s] Running tool result rails", req_id)
         tool_result = await self.rails_manager.are_tool_results_safe(messages, enabled=tool_input_enabled)
         if not tool_result.is_safe:
             log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
@@ -752,6 +775,7 @@ class IORails(BaseGuardrails):
                 # Step 0: Tool-result rails. Client/agent harness executes tool calls and sends
                 # results of execution to Main LLM along with prior conversation history
                 # Symmetric with INPUT rails for dialog use-case
+                log.info("[%s] Running tool result rails", req_id)
                 tool_result = await self.rails_manager.are_tool_results_safe(messages, enabled=tool_input_enabled)
                 if not tool_result.is_safe:
                     log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -385,6 +385,23 @@ _RESULT_EXTRACTORS = {
 }
 
 
+def _tool_calls_from_message(message: dict) -> list[ToolCall]:
+    """Extract the tool calls from one assistant message into ``ToolCall`` objects.
+    Malformed tool calls fall back to just id, type, function"""
+    try:
+        return ChatMessage.from_dict(message).tool_calls or []
+    except ValueError:
+        return [
+            ToolCall(
+                id=raw.get("id", ""),
+                type=raw.get("type", "function"),
+                function=ToolCallFunction(name=(raw.get("function") or {}).get("name", ""), arguments={}),
+            )
+            for raw in message.get("tool_calls") or []
+            if isinstance(raw, dict)
+        ]
+
+
 def _extract_tool_exchanges_openai(messages: LLMMessages) -> list[ToolExchange]:
     """Group an OpenAI Chat Completions conversation into per-turn ``ToolExchange``es."""
     exchanges: list[ToolExchange] = []
@@ -403,7 +420,7 @@ def _extract_tool_exchanges_openai(messages: LLMMessages) -> list[ToolExchange]:
                 exchanges.append(open_exchange)
             open_exchange.results.append(_tool_result_from_message(message))
         elif role == "assistant" and message.get("tool_calls"):
-            open_exchange = ToolExchange(calls=ChatMessage.from_dict(message).tool_calls or [], results=[])
+            open_exchange = ToolExchange(calls=_tool_calls_from_message(message), results=[])
             exchanges.append(open_exchange)
         else:
             open_exchange = None

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -39,7 +39,7 @@ from nemoguardrails.guardrails._http import (
 )
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, get_request_id, truncate
-from nemoguardrails.guardrails.tool_schema import Tool, ToolResult, Toolset
+from nemoguardrails.guardrails.tool_schema import Tool, ToolExchange, ToolResult, Toolset
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 
@@ -349,25 +349,29 @@ _TOOL_PARSERS = {
 }
 
 
+def _tool_result_from_message(message: dict) -> ToolResult:
+    """Normalize one OpenAI Chat Completions ``role:"tool"`` message into a ``ToolResult``.
+
+    This shape has no error flag, so ``is_error`` is always ``False``.
+    """
+    return ToolResult(
+        call_id=message.get("tool_call_id"),
+        name=message.get("name"),
+        content=message.get("content"),
+    )
+
+
 def _extract_tool_results_openai(messages: LLMMessages) -> list[ToolResult]:
     """Extract OpenAI Chat Completions tool results into ``ToolResult`` objects.
 
     Chat Completions carries each tool result as a top-level ``{"role": "tool",
-    "tool_call_id", "content"}`` message (optionally ``name``). This shape has no
-    error flag, so ``is_error`` is always ``False``.
+    "tool_call_id", "content"}`` message (optionally ``name``).
     """
-    results: list[ToolResult] = []
-    for message in messages:
-        if not isinstance(message, dict) or message.get("role") != "tool":
-            continue
-        results.append(
-            ToolResult(
-                call_id=message.get("tool_call_id"),
-                name=message.get("name"),
-                content=message.get("content"),
-            )
-        )
-    return results
+    return [
+        _tool_result_from_message(message)
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "tool"
+    ]
 
 
 def _extract_tool_results_nim(messages: LLMMessages) -> list[ToolResult]:
@@ -381,38 +385,39 @@ _RESULT_EXTRACTORS = {
 }
 
 
-def _extract_tool_calls_openai(messages: LLMMessages) -> list[ToolCall]:
-    """Extract the prior tool calls from an OpenAI Chat Completions conversation.
-
-    These are the calls the model made on earlier turns -- the calls that incoming
-    ``role:"tool"`` results link back to. Chat Completions is stateless (the client
-    resends the full history), so the prior calls ride on the conversation's
-    ``role:"assistant"`` messages alongside the tool results. ``ChatMessage.from_dict``
-    parses JSON-string arguments into a dict; it raises ``ValueError`` on malformed
-    tool-call arguments, which the caller treats as fail-closed. Calls are collected
-    across every assistant turn and returned as-is (no dedupe), so a malformed history
-    with duplicate call ids is rejected by the tool-result rail rather than here.
-    """
-    calls: list[ToolCall] = []
+def _extract_tool_exchanges_openai(messages: LLMMessages) -> list[ToolExchange]:
+    """Group an OpenAI Chat Completions conversation into per-turn ``ToolExchange``es."""
+    exchanges: list[ToolExchange] = []
+    # The exchange currently accepting tool results: the most recent assistant tool-call
+    # turn, or an orphan opened by a leading/stray tool result. Any other message resets
+    # it to None so the next tool result starts a fresh exchange instead of attaching to
+    # a closed turn.
+    open_exchange: ToolExchange | None = None
     for message in messages:
-        if not isinstance(message, dict) or message.get("role") != "assistant":
+        if not isinstance(message, dict):
             continue
-        if not message.get("tool_calls"):
-            continue
-        parsed = ChatMessage.from_dict(message).tool_calls
-        if parsed:
-            calls.extend(parsed)
-    return calls
+        role = message.get("role")
+        if role == "tool":
+            if open_exchange is None:
+                open_exchange = ToolExchange(calls=[], results=[])
+                exchanges.append(open_exchange)
+            open_exchange.results.append(_tool_result_from_message(message))
+        elif role == "assistant" and message.get("tool_calls"):
+            open_exchange = ToolExchange(calls=ChatMessage.from_dict(message).tool_calls or [], results=[])
+            exchanges.append(open_exchange)
+        else:
+            open_exchange = None
+    return exchanges
 
 
-def _extract_tool_calls_nim(messages: LLMMessages) -> list[ToolCall]:
-    """Extract NIM tool calls. NIM uses the OpenAI Chat Completions shape."""
-    return _extract_tool_calls_openai(messages)
+def _extract_tool_exchanges_nim(messages: LLMMessages) -> list[ToolExchange]:
+    """Extract NIM tool exchanges. NIM uses the OpenAI Chat Completions shape."""
+    return _extract_tool_exchanges_openai(messages)
 
 
-_TOOL_CALL_EXTRACTORS = {
-    "openai": _extract_tool_calls_openai,
-    "nim": _extract_tool_calls_nim,
+_TOOL_EXCHANGE_EXTRACTORS = {
+    "openai": _extract_tool_exchanges_openai,
+    "nim": _extract_tool_exchanges_nim,
 }
 
 
@@ -808,15 +813,15 @@ class ModelEngine(BaseEngine):
         extractor = _RESULT_EXTRACTORS.get(self.model_config.engine, _extract_tool_results_openai)
         return extractor(messages)
 
-    def extract_tool_calls(self, messages: LLMMessages) -> list[ToolCall]:
-        """Extract the prior tool calls from ``messages`` into ``ToolCall`` objects.
+    def extract_tool_exchanges(self, messages: LLMMessages) -> list[ToolExchange]:
+        """Group ``messages`` into per-turn ``(tool_calls, tool_results)`` exchanges.
 
-        Pulls the tool calls the model made on earlier assistant turns -- the calls
-        that incoming tool results link back to -- so ``RailsManager.are_tool_results_safe``
-        can validate that linkage. Symmetric to ``extract_tool_results`` and keyed on
-        the model's engine (``_TOOL_CALL_EXTRACTORS``). OpenAI and NIM share the Chat
-        Completions shape; an engine with no registered extractor falls back to it.
-        Returns an empty list when there are no prior tool calls.
+        Each exchange pairs one assistant turn's tool calls with the tool results that
+        answer it, so ``RailsManager.are_tool_results_safe`` can validate ``call_id``
+        linkage turn-locally rather than across the whole flattened history (the latter
+        falsely flags ids reused across turns, which the OpenAI spec permits). Keyed on
+        the model's engine (``_TOOL_EXCHANGE_EXTRACTORS``); OpenAI and NIM share the Chat
+        Completions shape and an engine with no registered extractor falls back to it.
         """
-        extractor = _TOOL_CALL_EXTRACTORS.get(self.model_config.engine, _extract_tool_calls_openai)
+        extractor = _TOOL_EXCHANGE_EXTRACTORS.get(self.model_config.engine, _extract_tool_exchanges_openai)
         return extractor(messages)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -370,6 +370,41 @@ _RESULT_EXTRACTORS = {
 }
 
 
+def _extract_tool_calls_openai(messages: LLMMessages) -> list[ToolCall]:
+    """Extract the prior tool calls from an OpenAI Chat Completions conversation.
+
+    These are the calls the model made on earlier turns -- the calls that incoming
+    ``role:"tool"`` results link back to. Chat Completions is stateless (the client
+    resends the full history), so the prior calls ride on the conversation's
+    ``role:"assistant"`` messages alongside the tool results. ``ChatMessage.from_dict``
+    parses JSON-string arguments into a dict; it raises ``ValueError`` on malformed
+    tool-call arguments, which the caller treats as fail-closed. Calls are collected
+    across every assistant turn and returned as-is (no dedupe), so a malformed history
+    with duplicate call ids is rejected by the tool-result rail rather than here.
+    """
+    calls: list[ToolCall] = []
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        if not message.get("tool_calls"):
+            continue
+        parsed = ChatMessage.from_dict(message).tool_calls
+        if parsed:
+            calls.extend(parsed)
+    return calls
+
+
+def _extract_tool_calls_nim(messages: LLMMessages) -> list[ToolCall]:
+    """Extract NIM tool calls. NIM uses the OpenAI Chat Completions shape."""
+    return _extract_tool_calls_openai(messages)
+
+
+_TOOL_CALL_EXTRACTORS = {
+    "openai": _extract_tool_calls_openai,
+    "nim": _extract_tool_calls_nim,
+}
+
+
 class ModelEngineError(Exception):
     """Raised when a model engine call fails."""
 
@@ -760,4 +795,17 @@ class ModelEngine(BaseEngine):
         there are no tool results.
         """
         extractor = _RESULT_EXTRACTORS.get(self.model_config.engine, _extract_tool_results_openai)
+        return extractor(messages)
+
+    def extract_tool_calls(self, messages: LLMMessages) -> list[ToolCall]:
+        """Extract the prior tool calls from ``messages`` into ``ToolCall`` objects.
+
+        Pulls the tool calls the model made on earlier assistant turns -- the calls
+        that incoming tool results link back to -- so ``RailsManager.are_tool_results_safe``
+        can validate that linkage. Symmetric to ``extract_tool_results`` and keyed on
+        the model's engine (``_TOOL_CALL_EXTRACTORS``). OpenAI and NIM share the Chat
+        Completions shape; an engine with no registered extractor falls back to it.
+        Returns an empty list when there are no prior tool calls.
+        """
+        extractor = _TOOL_CALL_EXTRACTORS.get(self.model_config.engine, _extract_tool_calls_openai)
         return extractor(messages)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -272,17 +272,28 @@ def _accumulate_tool_call_delta(tool_calls: dict[int, dict], raw_chunk: dict) ->
 def _finalize_tool_calls(tool_calls: dict[int, dict]) -> list[ToolCall]:
     """Assemble accumulated tool-call fragments into ToolCall objects.
 
-    Called once when the stream emits finish_reason='tool_calls'. Arguments
-    are parsed from the accumulated JSON buffer; malformed or empty buffers
-    degrade gracefully to an empty dict (matching openai_chat.py behaviour).
+    Called once when the stream emits finish_reason='tool_calls'. An empty buffer (no
+    argument fragments streamed) is a no-argument call and becomes ``{}``; a non-empty
+    buffer that is not a valid JSON object (e.g. arguments truncated mid-stream) raises
+    ``ValueError`` so the malformed call fails closed rather than silently degrading to
+    empty arguments that could pass the tool-call rail. This mirrors the non-streaming
+    parser (``ChatMessage.from_dict``), which raises on the same bytes; ``stream_call``
+    wraps the error into ``ModelEngineError`` exactly as the non-streaming path does.
     """
     result = []
     for index in sorted(tool_calls.keys()):
         entry = tool_calls[index]
         raw_arguments = entry.get("arguments_buffer", "")
-        try:
-            arguments = json.loads(raw_arguments) if raw_arguments else {}
-        except json.JSONDecodeError:
+        if raw_arguments:
+            try:
+                arguments = json.loads(raw_arguments)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Tool call arguments are not valid JSON: {raw_arguments!r}") from exc
+            if not isinstance(arguments, dict):
+                raise ValueError(
+                    f"Tool call arguments must be a JSON object, got {type(arguments).__name__}: {raw_arguments!r}"
+                )
+        else:
             arguments = {}
         result.append(
             ToolCall(

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -43,7 +43,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.rail_action import RailAction
 from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
-from nemoguardrails.guardrails.tool_schema import ToolResult, Toolset
+from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_name
 from nemoguardrails.types import ToolCall
@@ -246,26 +246,23 @@ class RailsManager:
         """Validate incoming tool results (INPUT-direction tool rail).
 
         The tool-result counterpart to :meth:`is_input_safe`: takes the conversation
-        ``messages`` and returns a ``RailResult``. Extracts the tool results and the
-        prior assistant tool calls they link back to via the engine adapter.
+        ``messages`` and returns a ``RailResult``. Groups the conversation into per-turn
+        ``(calls, results)`` exchanges via the engine adapter and validates each result
+        against its own turn's calls, so call ids reused across turns (spec-allowed) are
+        not flagged as ambiguous duplicates.
         """
         active = self._enabled_tool_flows(self._tool_result_actions, enabled)
         if not active:
             return RailResult(is_safe=True)
         try:
-            tool_results = self.engine_registry.extract_tool_results(model_type, messages)
+            exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
         except Exception as e:
-            log.warning("[%s] tool result extraction failed; blocking: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"tool result extraction failed: {e}")
-        if not tool_results:
+            log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
+            return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
+        if not any(exchange.results for exchange in exchanges):
             return RailResult(is_safe=True)
-        try:
-            prior_calls = self.engine_registry.extract_tool_calls(model_type, messages)
-        except Exception as e:
-            log.warning("[%s] prior tool call extraction failed; blocking: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"prior tool call extraction failed: {e}")
 
-        rails = {flow: self._run_tool_result_rail(flow, tool_results, prior_calls) for flow in active}
+        rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
 
     @staticmethod
@@ -323,19 +320,27 @@ class RailsManager:
                 )
             return result
 
-    async def _run_tool_result_rail(
-        self, flow: str, tool_results: list[ToolResult], prior_calls: list[ToolCall]
-    ) -> RailResult:
-        """Dispatch a single tool-result rail to its action, wrapped in an INPUT rail span."""
+    async def _run_tool_result_rail(self, flow: str, exchanges: list[ToolExchange]) -> RailResult:
+        """Validate each turn's results against that turn's calls, wrapped in an INPUT rail span.
+
+        Each exchange is validated independently so ``call_id`` linkage stays turn-local;
+        the first unsafe exchange short-circuits.
+        """
+        action = self._tool_result_actions[flow]
         with rail_span(self._tracer, flow, RailDirection.INPUT) as span:
-            result = await self._tool_result_actions[flow].run(tool_results, prior_calls)
+            result = RailResult(is_safe=True)
+            for exchange in exchanges:
+                result = await action.run(exchange.results, exchange.calls)
+                if not result.is_safe:
+                    break
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
+                all_results = [r for exchange in exchanges for r in exchange.results]
                 set_rail_content(
                     span,
                     {
                         "tool_results": [
-                            {"call_id": r.call_id, "name": r.name, "is_error": r.is_error} for r in tool_results
+                            {"call_id": r.call_id, "name": r.name, "is_error": r.is_error} for r in all_results
                         ]
                     },
                     reason=result.reason if not result.is_safe else None,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -179,33 +179,38 @@ class RailsManager:
             actions[flow] = action
         return actions
 
-    async def is_input_safe(self, messages: list[dict]) -> RailResult:
-        """Run all enabled input rails, short-circuiting on the first failure.
+    async def is_input_safe(self, messages: list[dict], *, enabled: Union[bool, list[str]] = True) -> RailResult:
+        """Run the enabled input rails, short-circuiting on the first failure.
 
-        When parallel mode is enabled, all rails run concurrently and the first
-        unsafe result cancels remaining rails.
+        The per-request *enabled* toggle selects which configured input rails run:
+        ``True`` (the default) runs all, ``False`` runs none, and a list runs only the
+        named flows (matched on the normalized flow name). When parallel mode is enabled,
+        all selected rails run concurrently and the first unsafe result cancels the rest.
         """
-        if not self.input_flows:
+        active = self._enabled_flows(self.input_flows, enabled)
+        if not active:
             return RailResult(is_safe=True)
 
-        rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in self.input_flows}
+        rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in active}
         if self.input_parallel:
             return await self._run_rails_parallel(rails, RailDirection.INPUT)
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
 
-    async def is_output_safe(self, messages: list[dict], response: str) -> RailResult:
-        """Run all enabled output rails, short-circuiting on the first failure.
+    async def is_output_safe(
+        self, messages: list[dict], response: str, *, enabled: Union[bool, list[str]] = True
+    ) -> RailResult:
+        """Run the enabled output rails, short-circuiting on the first failure.
 
-        When parallel mode is enabled, all rails run concurrently and the first
-        unsafe result cancels remaining rails.
+        The per-request *enabled* toggle selects which configured output rails run:
+        ``True`` (the default) runs all, ``False`` runs none, and a list runs only the
+        named flows (matched on the normalized flow name). When parallel mode is enabled,
+        all selected rails run concurrently and the first unsafe result cancels the rest.
         """
-        if not self.output_flows:
+        active = self._enabled_flows(self.output_flows, enabled)
+        if not active:
             return RailResult(is_safe=True)
 
-        rails = {
-            flow: self._run_rail(flow, RailDirection.OUTPUT, messages, bot_response=response)
-            for flow in self.output_flows
-        }
+        rails = {flow: self._run_rail(flow, RailDirection.OUTPUT, messages, bot_response=response) for flow in active}
         if self.output_parallel:
             return await self._run_rails_parallel(rails, RailDirection.OUTPUT)
         return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
@@ -224,7 +229,7 @@ class RailsManager:
         (``tool_calls``) plus the request's declared tools (``llm_params``) and returns
         a ``RailResult``.
         """
-        active = self._enabled_tool_flows(self._tool_call_actions, enabled)
+        active = self._enabled_flows(list(self._tool_call_actions), enabled)
         if not active or not tool_calls:
             return RailResult(is_safe=True)
         try:
@@ -251,7 +256,7 @@ class RailsManager:
         against its own turn's calls, so call ids reused across turns (spec-allowed) are
         not flagged as ambiguous duplicates.
         """
-        active = self._enabled_tool_flows(self._tool_result_actions, enabled)
+        active = self._enabled_flows(list(self._tool_result_actions), enabled)
         if not active:
             return RailResult(is_safe=True)
         try:
@@ -266,7 +271,7 @@ class RailsManager:
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
 
     @staticmethod
-    def _enabled_tool_flows(actions: Mapping[str, ToolRailAction], enabled: Union[bool, list[str]]) -> list[str]:
+    def _enabled_flows(configured: list[str], enabled: Union[bool, list[str]]) -> list[str]:
         """Resolve the per-request enable toggle into the configured flows to run.
 
         ``True`` (the default) runs every configured flow; ``False`` runs none; a list
@@ -275,13 +280,13 @@ class RailsManager:
         non-empty list is never mistaken for ``True``.
 
         List membership is compared on the normalized flow name (``_get_flow_name``),
-        the same way ``_build_tool_actions`` and ``unsupported_reason`` do, so a request
-        toggle carrying the canonical rail name matches a configured flow that carries a
-        ``$model=``/``(...)`` suffix instead of silently dropping it (fail-open).
+        the same way ``_create_action``, ``_build_tool_actions`` and ``unsupported_reason``
+        do, so a request toggle carrying the canonical rail name matches a configured flow
+        that carries a ``$model=``/``(...)`` suffix instead of silently dropping it
+        (fail-open). Shared by the input, output, and tool rail families.
         """
-        configured = list(actions.keys())
         if enabled is True:
-            return configured
+            return list(configured)
         if enabled is False:
             return []
         requested = {_get_flow_name(name) or name for name in enabled}

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -24,7 +24,7 @@ unsafe result cancels remaining rails immediately.
 import asyncio
 import logging
 from collections.abc import Coroutine, Mapping
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 from nemoguardrails.guardrails.actions.content_safety_action import (
     ContentSafetyInputAction,
@@ -210,30 +210,80 @@ class RailsManager:
             return await self._run_rails_parallel(rails, RailDirection.OUTPUT)
         return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
 
-    async def are_tool_calls_safe(self, tool_calls: list[ToolCall], toolset: Toolset) -> RailResult:
-        """Run all enabled tool-call rails against the model's tool calls.
+    async def are_tool_calls_safe(
+        self,
+        tool_calls: list[ToolCall],
+        llm_params: Optional[dict],
+        *,
+        enabled: Union[bool, list[str]] = True,
+        model_type: str = "main",
+    ) -> RailResult:
+        """Validate the model's emitted tool calls (OUTPUT-direction tool rail).
 
-        Rails run sequentially, short-circuiting on the first failure.
-        Returns safe when no tool-call rails are configured.
+        The tool-call counterpart to :meth:`is_output_safe`: takes the model's output
+        (``tool_calls``) plus the request's declared tools (``llm_params``) and returns
+        a ``RailResult``.
         """
-        if not self.tool_call_flows:
+        active = self._enabled_tool_flows(self._tool_call_actions, enabled)
+        if not active or not tool_calls:
             return RailResult(is_safe=True)
+        try:
+            toolset = self.engine_registry.parse_tools(model_type, llm_params)
+        except Exception as e:
+            log.warning("[%s] tool parsing failed; blocking tool calls: %s", get_request_id(), e)
+            return RailResult(is_safe=False, reason=f"tool parsing failed: {e}")
 
-        rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in self.tool_call_flows}
+        rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in active}
         return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
 
-    async def are_tool_results_safe(self, tool_results: list[ToolResult], prior_calls: list[ToolCall]) -> RailResult:
-        """Run all enabled tool-result rails against the results of tool calls.
+    async def are_tool_results_safe(
+        self,
+        messages: list[dict],
+        *,
+        enabled: Union[bool, list[str]] = True,
+        model_type: str = "main",
+    ) -> RailResult:
+        """Validate incoming tool results (INPUT-direction tool rail).
 
-        Validates the tool results (already normalized to ``ToolResult``) against
-        the prior tool calls the model made. Rails run sequentially, short-circuiting
-        on the first failure. Returns safe when no tool-result rails are configured.
+        The tool-result counterpart to :meth:`is_input_safe`: takes the conversation
+        ``messages`` and returns a ``RailResult``. Extracts the tool results and the
+        prior assistant tool calls they link back to via the engine adapter.
         """
-        if not self.tool_result_flows:
+        active = self._enabled_tool_flows(self._tool_result_actions, enabled)
+        if not active:
             return RailResult(is_safe=True)
+        try:
+            tool_results = self.engine_registry.extract_tool_results(model_type, messages)
+        except Exception as e:
+            log.warning("[%s] tool result extraction failed; blocking: %s", get_request_id(), e)
+            return RailResult(is_safe=False, reason=f"tool result extraction failed: {e}")
+        if not tool_results:
+            return RailResult(is_safe=True)
+        try:
+            prior_calls = self.engine_registry.extract_tool_calls(model_type, messages)
+        except Exception as e:
+            log.warning("[%s] prior tool call extraction failed; blocking: %s", get_request_id(), e)
+            return RailResult(is_safe=False, reason=f"prior tool call extraction failed: {e}")
 
-        rails = {flow: self._run_tool_result_rail(flow, tool_results, prior_calls) for flow in self.tool_result_flows}
+        rails = {flow: self._run_tool_result_rail(flow, tool_results, prior_calls) for flow in active}
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
+
+    @staticmethod
+    def _enabled_tool_flows(actions: Mapping[str, ToolRailAction], enabled: Union[bool, list[str]]) -> list[str]:
+        """Resolve the per-request enable toggle into the configured flows to run.
+
+        ``True`` (the default) runs every configured flow; ``False`` runs none; a list
+        runs only the named flows that are configured, preserving configured order and
+        ignoring unknown names. The two booleans are spelled out as separate cases so a
+        non-empty list is never mistaken for ``True``.
+        """
+        configured = list(actions.keys())
+        if enabled is True:
+            return configured
+        if enabled is False:
+            return []
+        requested = set(enabled)
+        return [flow for flow in configured if flow in requested]
 
     async def _run_rail(
         self,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -273,14 +273,19 @@ class RailsManager:
         runs only the named flows that are configured, preserving configured order and
         ignoring unknown names. The two booleans are spelled out as separate cases so a
         non-empty list is never mistaken for ``True``.
+
+        List membership is compared on the normalized flow name (``_get_flow_name``),
+        the same way ``_build_tool_actions`` and ``unsupported_reason`` do, so a request
+        toggle carrying the canonical rail name matches a configured flow that carries a
+        ``$model=``/``(...)`` suffix instead of silently dropping it (fail-open).
         """
         configured = list(actions.keys())
         if enabled is True:
             return configured
         if enabled is False:
             return []
-        requested = set(enabled)
-        return [flow for flow in configured if flow in requested]
+        requested = {_get_flow_name(name) or name for name in enabled}
+        return [flow for flow in configured if (_get_flow_name(flow) or flow) in requested]
 
     async def _run_rail(
         self,

--- a/nemoguardrails/guardrails/tool_schema.py
+++ b/nemoguardrails/guardrails/tool_schema.py
@@ -32,8 +32,11 @@ Completions is the engine implemented today.
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import jsonschema
+
+from nemoguardrails.types import ToolCall
 
 
 @dataclass(frozen=True, slots=True)
@@ -111,6 +114,13 @@ class ToolResult:
     name: str | None = None
     content: str | list[dict] | None = None
     is_error: bool = False
+
+
+class ToolExchange(NamedTuple):
+    """One assistant turn's tool calls paired with the tool results that answer them."""
+
+    calls: list[ToolCall]
+    results: list[ToolResult]
 
 
 def validate_arguments(tool: Tool, arguments: dict) -> str | None:

--- a/nemoguardrails/guardrails/tool_schema.py
+++ b/nemoguardrails/guardrails/tool_schema.py
@@ -45,9 +45,10 @@ class Tool:
 
     ``name`` is set for function tools and ``None`` for hosted/server tools that
     are identified only by ``type`` (e.g. web_search). ``arguments_schema`` is the
-    JSON Schema for the call arguments, or ``None`` for hosted tools (and any
-    function tool that declares no parameters), in which case argument validation
-    is skipped and only the allowlist applies.
+    JSON Schema for the call arguments, or ``None`` when none is declared. A hosted
+    tool with no schema is allowlist-only (the provider owns the call shape); a
+    function tool that declares no parameters accepts no arguments, so a call that
+    supplies any is rejected.
     """
 
     name: str | None = None
@@ -123,20 +124,56 @@ class ToolExchange(NamedTuple):
     results: list[ToolResult]
 
 
+def _schema_accepts_no_arguments(schema: dict) -> bool:
+    """Whether an argument schema declares no way to supply arguments.
+
+    True for an empty schema (``{}``) or an object schema that names no ``properties``
+    and opens no other input channel (``additionalProperties``, ``patternProperties``,
+    or a composition/reference keyword). Such a schema describes a tool that takes no
+    arguments; jsonschema treats it as permissive, so callers enforce emptiness directly.
+    """
+    if not schema:
+        return True
+    if schema.get("properties"):
+        return False
+    if schema.get("additionalProperties"):
+        return False
+    if schema.get("patternProperties"):
+        return False
+    return not any(keyword in schema for keyword in ("anyOf", "oneOf", "allOf", "$ref"))
+
+
+def _no_arguments_reason(tool: Tool, arguments: dict) -> str | None:
+    """Block reason for a tool that accepts no arguments, or ``None`` when the call is allowed.
+
+    Hosted/server tools (no ``name``) are allowlist-only -- the provider owns the call
+    shape -- so arguments are accepted here. A function tool that declares no parameters
+    must be called with no arguments, so any supplied argument is rejected.
+    """
+    if tool.name is None:
+        return None
+    if arguments:
+        return f"tool '{tool.key}' accepts no arguments but the call supplied: {sorted(arguments)}"
+    return None
+
+
 def validate_arguments(tool: Tool, arguments: dict) -> str | None:
     """Validate model-supplied tool-call arguments against the tool's schema.
 
-    Returns ``None`` when the arguments are valid or the tool declares no schema.
-    Returns a human-readable reason when the arguments violate the schema, or when
-    the declared schema itself is not valid JSON Schema (e.g. a non-JSON-Schema
-    dialect reaching this validator before its engine adapter normalizes it).
+    Returns ``None`` when the arguments are valid. Returns a human-readable reason when
+    the arguments violate the schema, when the declared schema itself is not valid JSON
+    Schema (e.g. a non-JSON-Schema dialect reaching this validator before its engine
+    adapter normalizes it), or when a function tool that declares no parameters is called
+    with arguments.
     """
     if tool.arguments_schema is None:
-        return None
+        return _no_arguments_reason(tool, arguments)
     try:
         jsonschema.validate(instance=arguments, schema=tool.arguments_schema)
     except jsonschema.ValidationError as exc:
         return f"arguments for tool '{tool.key}' do not match its schema: {exc.message}"
     except jsonschema.SchemaError as exc:
         return f"declared schema for tool '{tool.key}' is not valid JSON Schema: {exc.message}"
+    if _schema_accepts_no_arguments(tool.arguments_schema):
+        return _no_arguments_reason(tool, arguments)
     return None

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -1530,6 +1530,19 @@ class TestEngineRegistryToolDelegation:
         results = manager.extract_tool_results("main", messages)
         assert [(r.call_id, r.name, r.content) for r in results] == [("c1", "get_weather", "18C")]
 
+    def test_extract_tool_calls_delegates_to_model_engine(self, manager):
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "X"}'}}
+                ],
+            }
+        ]
+        calls = manager.extract_tool_calls("main", messages)
+        assert [(c.id, c.function.name, c.function.arguments) for c in calls] == [("c1", "get_weather", {"city": "X"})]
+
     def test_parse_tools_unknown_engine_raises_keyerror(self, manager):
         with pytest.raises(KeyError):
             manager.parse_tools("nonexistent", {"tools": self._TOOLS})
@@ -1537,6 +1550,10 @@ class TestEngineRegistryToolDelegation:
     def test_extract_tool_results_unknown_engine_raises_keyerror(self, manager):
         with pytest.raises(KeyError):
             manager.extract_tool_results("nonexistent", [])
+
+    def test_extract_tool_calls_unknown_engine_raises_keyerror(self, manager):
+        with pytest.raises(KeyError):
+            manager.extract_tool_calls("nonexistent", [])
 
     def test_parse_tools_non_model_engine_raises_typeerror(self, manager):
         """jailbreak_detection is an APIEngine, not a ModelEngine."""

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -1530,7 +1530,7 @@ class TestEngineRegistryToolDelegation:
         results = manager.extract_tool_results("main", messages)
         assert [(r.call_id, r.name, r.content) for r in results] == [("c1", "get_weather", "18C")]
 
-    def test_extract_tool_calls_delegates_to_model_engine(self, manager):
+    def test_extract_tool_exchanges_delegates_to_model_engine(self, manager):
         messages = [
             {
                 "role": "assistant",
@@ -1538,10 +1538,14 @@ class TestEngineRegistryToolDelegation:
                 "tool_calls": [
                     {"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "X"}'}}
                 ],
-            }
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "get_weather", "content": "18C"},
         ]
-        calls = manager.extract_tool_calls("main", messages)
+        exchanges = manager.extract_tool_exchanges("main", messages)
+        assert len(exchanges) == 1
+        calls, results = exchanges[0]
         assert [(c.id, c.function.name, c.function.arguments) for c in calls] == [("c1", "get_weather", {"city": "X"})]
+        assert [r.call_id for r in results] == ["c1"]
 
     def test_parse_tools_unknown_engine_raises_keyerror(self, manager):
         with pytest.raises(KeyError):
@@ -1551,9 +1555,9 @@ class TestEngineRegistryToolDelegation:
         with pytest.raises(KeyError):
             manager.extract_tool_results("nonexistent", [])
 
-    def test_extract_tool_calls_unknown_engine_raises_keyerror(self, manager):
+    def test_extract_tool_exchanges_unknown_engine_raises_keyerror(self, manager):
         with pytest.raises(KeyError):
-            manager.extract_tool_calls("nonexistent", [])
+            manager.extract_tool_exchanges("nonexistent", [])
 
     def test_parse_tools_non_model_engine_raises_typeerror(self, manager):
         """jailbreak_detection is an APIEngine, not a ModelEngine."""

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nemoguardrails import Guardrails
-from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.guardrails.iorails import IORails, _unsupported_flows_reason
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.llmrails import LLMRails
@@ -352,6 +352,56 @@ class TestIORailsUnsupportedReason:
         """``can_handle`` is a thin wrapper that returns True iff reason is None."""
         assert IORails.can_handle(_content_safety_rails_config, llm=None) is True
         assert IORails.unsupported_reason(_content_safety_rails_config, llm=None) is None
+
+
+class TestUnsupportedFlowsReason:
+    """Unit tests for the ``_unsupported_flows_reason`` helper that backs the four
+    flow-direction checks in ``IORails.unsupported_reason``."""
+
+    SUPPORTED = frozenset({"content safety check input", "jailbreak detection model"})
+
+    def test_all_supported_returns_none(self):
+        flows = ["content safety check input", "jailbreak detection model"]
+        assert _unsupported_flows_reason(flows, self.SUPPORTED, "input") is None
+
+    def test_empty_flows_returns_none(self):
+        assert _unsupported_flows_reason([], self.SUPPORTED, "input") is None
+
+    def test_single_unsupported_flow_is_named(self):
+        reason = _unsupported_flows_reason(["self check input"], self.SUPPORTED, "input")
+        assert reason == "config has unsupported input flows: ['self check input']"
+
+    def test_label_appears_in_message(self):
+        reason = _unsupported_flows_reason(["bogus"], self.SUPPORTED, "tool output")
+        assert reason == "config has unsupported tool output flows: ['bogus']"
+
+    def test_offenders_reported_sorted_and_deduplicated(self):
+        flows = ["zeta", "alpha", "zeta"]
+        reason = _unsupported_flows_reason(flows, self.SUPPORTED, "output")
+        assert reason == "config has unsupported output flows: ['alpha', 'zeta']"
+
+    def test_only_unsupported_flows_are_reported(self):
+        flows = ["content safety check input", "self check input"]
+        reason = _unsupported_flows_reason(flows, self.SUPPORTED, "input")
+        assert reason == "config has unsupported input flows: ['self check input']"
+
+    def test_model_suffix_is_normalized_before_membership_check(self):
+        # The `$model=` suffix is stripped, so the supported bare name matches.
+        flows = ["content safety check input $model=content_safety"]
+        assert _unsupported_flows_reason(flows, self.SUPPORTED, "input") is None
+
+    def test_call_args_are_normalized_before_membership_check(self):
+        flows = ["content safety check input(foo)"]
+        assert _unsupported_flows_reason(flows, self.SUPPORTED, "input") is None
+
+    def test_flow_normalizing_to_empty_is_ignored(self):
+        # A flow that is only a `$model=` suffix has no recognizable name; it must not
+        # be reported as unsupported (mirrors the `if name` guard in the helper).
+        assert _unsupported_flows_reason(["$model=x"], self.SUPPORTED, "input") is None
+
+    def test_empty_supported_set_rejects_every_named_flow(self):
+        reason = _unsupported_flows_reason(["anything"], frozenset(), "tool input")
+        assert reason == "config has unsupported tool input flows: ['anything']"
 
 
 class TestRequireIORails:

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nemoguardrails import Guardrails
-from nemoguardrails.guardrails.iorails import IORails, _unsupported_flows_reason
+from nemoguardrails.guardrails.iorails import IORails, _duplicate_flows_reason, _unsupported_flows_reason
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.llmrails import LLMRails
@@ -402,6 +402,34 @@ class TestUnsupportedFlowsReason:
     def test_empty_supported_set_rejects_every_named_flow(self):
         reason = _unsupported_flows_reason(["anything"], frozenset(), "tool input")
         assert reason == "config has unsupported tool input flows: ['anything']"
+
+
+class TestDuplicateFlowsReason:
+    """Unit tests for the ``_duplicate_flows_reason`` helper that backs the tool-flow
+    duplicate pre-check in ``IORails.unsupported_reason``."""
+
+    def test_no_duplicates_returns_none(self):
+        assert _duplicate_flows_reason(["tool call validation"], "tool output") is None
+
+    def test_empty_flows_returns_none(self):
+        assert _duplicate_flows_reason([], "tool output") is None
+
+    def test_exact_duplicate_is_caught(self):
+        reason = _duplicate_flows_reason(["tool call validation", "tool call validation"], "tool output")
+        assert reason is not None
+        assert "duplicate tool output flows" in reason
+
+    def test_normalized_duplicate_is_caught(self):
+        # Entries differing only by a `$model=` suffix normalize to the same name.
+        reason = _duplicate_flows_reason(["tool call validation", "tool call validation $model=x"], "tool output")
+        assert reason is not None
+        assert "duplicate" in reason
+
+    def test_flow_normalizing_to_empty_is_skipped(self):
+        # A flow that normalizes to an empty name has no comparable identity, so it is
+        # neither flagged as a duplicate nor matched against other empty-normalizing flows.
+        assert _duplicate_flows_reason(["$model=x", "tool call validation"], "tool output") is None
+        assert _duplicate_flows_reason(["$model=x", "$model=y"], "tool output") is None
 
 
 class TestRequireIORails:

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -84,9 +84,9 @@ class TestGenerateAsync:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": llm_response}
-        iorails.rails_manager.is_input_safe.assert_called_once_with(messages)
+        iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
         iorails.engine_registry.model_call.assert_called_once_with("main", messages)
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response)
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response, enabled=True)
 
     @pytest.mark.asyncio
     async def test_safe_input_and_output_with_generation_options(self, iorails):
@@ -104,16 +104,16 @@ class TestGenerateAsync:
         result = await iorails.generate_async(messages, options=options)
 
         assert result == {"role": "assistant", "content": llm_response}
-        iorails.rails_manager.is_input_safe.assert_called_once_with(messages)
+        iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, **llm_params)
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response)
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response, enabled=True)
 
     @pytest.mark.asyncio
     async def test_safe_input_and_output_call_sequence(self, iorails):
         """Pipeline executes in order: input check → generate → output check."""
         call_order = []
 
-        async def mock_input_safe(messages):
+        async def mock_input_safe(messages, *, enabled=True):
             call_order.append("input")
             return RailResult(is_safe=True)
 
@@ -121,7 +121,7 @@ class TestGenerateAsync:
             call_order.append("generate")
             return LLMResponse(content="response")
 
-        async def mock_output_safe(messages, response):
+        async def mock_output_safe(messages, response, *, enabled=True):
             call_order.append("output")
             return RailResult(is_safe=True)
 
@@ -143,7 +143,7 @@ class TestGenerateAsync:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
-        iorails.rails_manager.is_input_safe.assert_called_once_with(messages)
+        iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
         iorails.engine_registry.model_call.assert_not_called()
         iorails.rails_manager.is_output_safe.assert_not_called()
 
@@ -160,9 +160,9 @@ class TestGenerateAsync:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
-        iorails.rails_manager.is_input_safe.assert_called_once_with(messages)
+        iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
         iorails.engine_registry.model_call.assert_called_once_with("main", messages)
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response)
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response, enabled=True)
 
     @pytest.mark.asyncio
     async def test_unsafe_output_records_block_metric_when_metrics_enabled(self, iorails):
@@ -277,7 +277,7 @@ class TestToolCalling:
 
         result = await iorails.generate_async(messages)
 
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "some text")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "some text", enabled=True)
         assert result["content"] == "some text"
         assert result["tool_calls"][0]["function"]["name"] == "f"
 

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -143,7 +143,7 @@ class TestReasoningContent:
         assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
         # Output rails see the original content unchanged when reasoning came from
         # the native field (no <think> tags to strip).
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello", enabled=True)
 
     @pytest.mark.asyncio
     async def test_inline_think_tags_extracted_and_stripped(self, iorails):
@@ -159,7 +159,7 @@ class TestReasoningContent:
         assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
         # Output rails MUST receive content with <think> tags stripped — this is
         # the central guarantee that reasoning bypasses output rails.
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hello", enabled=True)
 
     @pytest.mark.asyncio
     async def test_native_reasoning_wins_over_inline_tags(self, iorails):
@@ -184,7 +184,9 @@ class TestReasoningContent:
             "role": "assistant",
             "content": "<think>native reasoning</think>\n<think>tag reasoning</think>Hello",
         }
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "<think>tag reasoning</think>Hello")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(
+            messages, "<think>tag reasoning</think>Hello", enabled=True
+        )
 
     @pytest.mark.asyncio
     async def test_malformed_think_tag_opener_only(self, iorails):
@@ -196,7 +198,9 @@ class TestReasoningContent:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": "<think>incomplete reasoning"}
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "<think>incomplete reasoning")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(
+            messages, "<think>incomplete reasoning", enabled=True
+        )
 
     @pytest.mark.asyncio
     async def test_malformed_think_tag_closer_only(self, iorails):
@@ -208,7 +212,7 @@ class TestReasoningContent:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": "orphan</think> reply"}
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "orphan</think> reply")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "orphan</think> reply", enabled=True)
 
     @pytest.mark.asyncio
     async def test_output_rail_block_with_native_reasoning(self, iorails):
@@ -239,7 +243,7 @@ class TestReasoningContent:
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         # Output rails see only the stripped content — they're judging the model
         # output, not the reasoning trace.
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "bad answer")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "bad answer", enabled=True)
 
     @pytest.mark.asyncio
     async def test_empty_string_reasoning_falls_through_to_inline_extraction(self, iorails):
@@ -253,7 +257,7 @@ class TestReasoningContent:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": "<think>fallback reasoning</think>\nHi"}
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hi")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hi", enabled=True)
 
     @pytest.mark.asyncio
     async def test_no_reasoning_returns_unchanged_content(self, iorails):
@@ -265,7 +269,7 @@ class TestReasoningContent:
         result = await iorails.generate_async(messages)
 
         assert result == {"role": "assistant", "content": "plain answer"}
-        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "plain answer")
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "plain answer", enabled=True)
 
 
 class TestStreamingReasoningWarning:

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -302,6 +302,18 @@ class TestStreamAsyncOutputRailsStreamFirst:
         assert "Hello from the streaming LLM" in text
 
     @pytest.mark.asyncio
+    async def test_output_toggle_forwarded_to_output_rails(self, iorails_stream_first):
+        """In streaming, options.rails.output is forwarded to is_output_safe as the enabled argument."""
+        _wire_mocks(iorails_stream_first)
+        await _collect(
+            iorails_stream_first.stream_async(
+                messages=[{"role": "user", "content": "hi"}],
+                options={"rails": {"output": False}},
+            )
+        )
+        assert iorails_stream_first.rails_manager.is_output_safe.await_args.kwargs.get("enabled") is False
+
+    @pytest.mark.asyncio
     async def test_unsafe_output_injects_error(self, iorails_stream_first):
         """Error JSON is injected into the stream when output rails block."""
         _wire_mocks(iorails_stream_first, output_safe=False)
@@ -319,7 +331,7 @@ class TestStreamAsyncOutputRailsStreamFirst:
         """Chunks appear before the output rail check in stream_first mode."""
         yield_order = []
 
-        async def tracking_rail(messages, response):
+        async def tracking_rail(messages, response, *, enabled=True):
             """Mock output rail that records call order."""
             yield_order.append("rail_check")
             return RailResult(is_safe=True)
@@ -363,7 +375,7 @@ class TestStreamAsyncOutputRailsGated:
         """Each chunk batch only appears after its rail check passes."""
         yield_order = []
 
-        async def tracking_rail(messages, response):
+        async def tracking_rail(messages, response, *, enabled=True):
             """Mock output rail that records call order."""
             yield_order.append("rail_check")
             return RailResult(is_safe=True)

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -246,10 +246,29 @@ class TestStreamAsyncNoOutputRails:
 
     @pytest.mark.asyncio
     async def test_input_rails_block(self, iorails_input_only):
-        """Yields the refusal message when input rails block."""
+        """A guardrails_violation error chunk (param=input_rails) is emitted when input rails block."""
         _wire_mocks(iorails_input_only, input_safe=False)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "bad"}]))
-        assert "".join(chunks) == REFUSAL_MESSAGE
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(error_chunks) == 1
+        error = json.loads(error_chunks[0])["error"]
+        assert error["type"] == "guardrails_violation"
+        assert error["param"] == "input_rails"
+        assert error["code"] == "content_blocked"
+        assert REFUSAL_MESSAGE not in "".join(c for c in chunks if isinstance(c, str))
+
+    @pytest.mark.asyncio
+    async def test_input_block_framed_under_include_metadata(self, iorails_input_only):
+        """Under include_metadata, the input-block violation is wrapped as a {"text": <json>} dict, like every other chunk."""
+        _wire_mocks(iorails_input_only, input_safe=False)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "bad"}], include_metadata=True)
+        )
+        dict_chunks = [c for c in chunks if isinstance(c, dict) and str(c.get("text", "")).startswith("{")]
+        assert len(dict_chunks) == 1
+        error = json.loads(dict_chunks[0]["text"])["error"]
+        assert error["type"] == "guardrails_violation"
+        assert error["param"] == "input_rails"
 
     @pytest.mark.asyncio
     async def test_generation_options_forwarded(self, iorails_input_only):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -164,7 +164,7 @@ class TestGenerateAsyncWithTracing:
         """The request ID visible to downstream code matches the span's trace ID suffix."""
         captured_req_id = None
 
-        async def capture_req_id(messages):
+        async def capture_req_id(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
             return RailResult(is_safe=True)
@@ -220,7 +220,7 @@ class TestGenerateAsyncWithoutTracing:
         """Without tracing, request IDs are random but the same length as trace-derived IDs."""
         captured_req_id = None
 
-        async def capture_req_id(messages):
+        async def capture_req_id(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
             return RailResult(is_safe=True)
@@ -243,7 +243,7 @@ class TestEndToEndTracing:
         through the entire generate_async pipeline."""
         captured = {}
 
-        async def capturing_input_check(messages):
+        async def capturing_input_check(messages, *, enabled=True):
             captured["input_req_id"] = get_request_id()
             captured["input_messages"] = messages
             return RailResult(is_safe=True)
@@ -253,7 +253,7 @@ class TestEndToEndTracing:
             captured["llm_model"] = model_name
             return LLMResponse(content="Generated response")
 
-        async def capturing_output_check(messages, response):
+        async def capturing_output_check(messages, response, *, enabled=True):
             captured["output_req_id"] = get_request_id()
             captured["output_response"] = response
             return RailResult(is_safe=True)
@@ -307,7 +307,7 @@ class TestEndToEndTracing:
         with distinct trace IDs and request IDs."""
         req_ids_seen = []
 
-        async def record_req_id(messages):
+        async def record_req_id(messages, *, enabled=True):
             req_ids_seen.append(get_request_id())
             return RailResult(is_safe=True)
 
@@ -337,7 +337,7 @@ class TestEndToEndTracing:
         and traceback, and the request ID is still valid."""
         captured_req_id = None
 
-        async def capture_then_pass(messages):
+        async def capture_then_pass(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
             return RailResult(is_safe=True)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -896,7 +896,8 @@ class TestStreamAsyncSpanHierarchy:
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
-        assert chunks == [REFUSAL_MESSAGE]
+        assert len(chunks) == 1
+        assert json.loads(chunks[0])["error"]["param"] == "input_rails"
 
         spans = exporter.get_finished_spans()
         request_spans = [s for s in spans if s.name == "guardrails.request"]
@@ -1420,7 +1421,8 @@ class TestStreamAsyncRequestMetrics:
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
-        assert chunks == [REFUSAL_MESSAGE]
+        assert len(chunks) == 1
+        assert json.loads(chunks[0])["error"]["param"] == "input_rails"
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.requests.blocked"][0].value == 1
@@ -2305,17 +2307,18 @@ class TestStreamingContentCapture:
         assert dict(choice.attributes)["message.content"] == delivered
 
     @pytest.mark.asyncio
-    async def test_blocked_input_records_refusal_as_output(self, iorails_streaming_content_capture, exporter):
-        """Input-rail block: REFUSAL_MESSAGE is pushed through the streaming
-        handler, so the consumer receives it and content capture records it
-        as the assistant output on the request span (not empty)."""
+    async def test_blocked_input_records_violation_as_output(self, iorails_streaming_content_capture, exporter):
+        """Input-rail block: the guardrails_violation chunk is pushed through the streaming
+        handler, so the consumer receives it and content capture records it as the assistant
+        output on the request span (not empty)."""
         iorails = iorails_streaming_content_capture
         _stub_deep_streaming_pipeline(iorails, input_safe=False)
 
         [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
 
         span = _request_span(exporter.get_finished_spans())
-        assert span.attributes[GuardrailsAttributes.REQUEST_OUTPUT] == REFUSAL_MESSAGE
+        recorded = span.attributes[GuardrailsAttributes.REQUEST_OUTPUT]
+        assert json.loads(recorded)["error"]["param"] == "input_rails"
 
     @pytest.mark.asyncio
     async def test_empty_delivered_records_no_output_attr(self, iorails_streaming_content_capture, exporter):

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -2124,8 +2124,9 @@ class TestExtractToolExchanges:
         engine = ModelEngine(_make_model(engine="openai"))
         assert self._ids(engine.extract_tool_exchanges(["garbage", *_TOOL_MESSAGES])) == [(["call_1"], ["call_1"])]
 
-    def test_malformed_arguments_raise_value_error(self):
-        """Invalid JSON arguments fail closed: the IORails glue blocks rather than 500s."""
+    def test_malformed_arguments_degrade_to_empty_for_linkage(self):
+        """A historical call with malformed argument JSON degrades to empty arguments
+        (id/name preserved) instead of aborting extraction."""
         engine = ModelEngine(_make_model(engine="openai"))
         messages = [
             {
@@ -2134,8 +2135,12 @@ class TestExtractToolExchanges:
                 "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "not json"}}],
             },
         ]
-        with pytest.raises(ValueError):
-            engine.extract_tool_exchanges(messages)
+        exchanges = engine.extract_tool_exchanges(messages)
+        assert len(exchanges) == 1
+        calls, _results = exchanges[0]
+        assert calls[0].id == "c1"
+        assert calls[0].function.name == "a"
+        assert calls[0].function.arguments == {}
 
     def test_nim_uses_the_same_shape(self):
         engine = ModelEngine(_make_model(engine="nim"))

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -1053,31 +1053,50 @@ class TestStreamCallToolCalls:
         lines.append(b"data: [DONE]\n")
         return lines
 
+    @staticmethod
+    def _tc_chunk(*, index=0, id=None, name=None, arguments=None, finish_reason=None):
+        """One SSE chunk carrying a single ``tool_calls`` delta.
+
+        Only the provided fields are emitted, so the same helper builds every shape used
+        below: the opening chunk (``id`` + ``name``), argument-fragment chunks
+        (``arguments`` only), and a chunk that also carries ``finish_reason``. ``id``
+        implies ``type="function"`` (matching real provider frames); pass ``index=None``
+        to omit ``index`` entirely (the index-collision case). Use :meth:`_finish_chunk`
+        for an empty terminal chunk.
+        """
+        function: dict = {}
+        if name is not None:
+            function["name"] = name
+        if arguments is not None:
+            function["arguments"] = arguments
+        tool_call: dict = {"function": function}
+        if index is not None:
+            tool_call["index"] = index
+        if id is not None:
+            tool_call["id"] = id
+            tool_call["type"] = "function"
+        choice: dict = {"delta": {"tool_calls": [tool_call]}}
+        if finish_reason is not None:
+            choice["finish_reason"] = finish_reason
+        return {"choices": [choice]}
+
+    @staticmethod
+    def _finish_chunk(finish_reason="tool_calls"):
+        """A terminal chunk with an empty delta carrying only a ``finish_reason``."""
+        return {"choices": [{"delta": {}, "finish_reason": finish_reason}]}
+
+    @staticmethod
+    def _reasoning_chunk(text):
+        """A chunk carrying a ``reasoning_content`` delta (no tool calls)."""
+        return {"choices": [{"delta": {"reasoning_content": text}}]}
+
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_nim_style_single_chunk_tool_call(self):
         """NIM-style: complete args in one delta on the finish_reason chunk."""
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
-            [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
-                                    }
-                                ]
-                            },
-                            "finish_reason": "tool_calls",
-                        }
-                    ]
-                },
-            ]
+            [self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Paris"}', finish_reason="tool_calls")]
         )
         engine._client = AsyncMock()
         engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
@@ -1100,25 +1119,10 @@ class TestStreamCallToolCalls:
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
             [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": ""},
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": '{"city"'}}]}}]},
-                {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": ': "Paris"}'}}]}}]},
-                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+                self._tc_chunk(id="c1", name="get_weather", arguments=""),
+                self._tc_chunk(arguments='{"city"'),
+                self._tc_chunk(arguments=': "Paris"}'),
+                self._finish_chunk(),
             ]
         )
         engine._client = AsyncMock()
@@ -1140,39 +1144,9 @@ class TestStreamCallToolCalls:
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
             [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "fn_a", "arguments": '{"x": 1}'},
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 1,
-                                        "id": "c2",
-                                        "type": "function",
-                                        "function": {"name": "fn_b", "arguments": '{"y": 2}'},
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+                self._tc_chunk(index=0, id="c1", name="fn_a", arguments='{"x": 1}'),
+                self._tc_chunk(index=1, id="c2", name="fn_b", arguments='{"y": 2}'),
+                self._finish_chunk(),
             ]
         )
         engine._client = AsyncMock()
@@ -1196,25 +1170,9 @@ class TestStreamCallToolCalls:
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
             [
-                {"choices": [{"delta": {"reasoning_content": "let me think"}}]},
-                {"choices": [{"delta": {"reasoning_content": " about this"}}]},
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
-                                    }
-                                ]
-                            },
-                            "finish_reason": "tool_calls",
-                        }
-                    ]
-                },
+                self._reasoning_chunk("let me think"),
+                self._reasoning_chunk(" about this"),
+                self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Paris"}', finish_reason="tool_calls"),
             ]
         )
         engine._client = AsyncMock()
@@ -1231,37 +1189,22 @@ class TestStreamCallToolCalls:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_malformed_args_degrade_to_empty_dict(self):
-        """Truncated or invalid JSON arguments produce an empty arguments dict."""
+    async def test_malformed_streamed_args_raise(self):
+        """Truncated/invalid JSON arguments fail closed (raise), matching the non-streaming path.
+
+        These previously degraded silently to ``{}`` and could pass the tool-call rail; the
+        non-streaming parser raises on the same bytes, so the streaming path must too.
+        """
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
-            [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "f", "arguments": '{"city": "Par'},
-                                    }
-                                ]
-                            },
-                            "finish_reason": "tool_calls",
-                        }
-                    ]
-                },
-            ]
+            [self._tc_chunk(id="c1", name="f", arguments='{"city": "Par', finish_reason="tool_calls")]
         )
         engine._client = AsyncMock()
         engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
         engine._running = True
 
-        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
-
-        assert chunks[0].delta_tool_calls[0].function.arguments == {}
+        with pytest.raises(ModelEngineError):
+            [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -1274,23 +1217,8 @@ class TestStreamCallToolCalls:
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
             [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Paris"}'),
+                self._finish_chunk("stop"),
             ]
         )
         engine._client = AsyncMock()
@@ -1310,26 +1238,7 @@ class TestStreamCallToolCalls:
     async def test_tool_calls_finalized_without_finish_reason_chunk(self):
         """Safety net: tool calls surface even if the stream ends ([DONE]) with no finish chunk."""
         engine = ModelEngine(_make_model())
-        raw_lines = self._make_sse_lines(
-            [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-            ]
-        )
+        raw_lines = self._make_sse_lines([self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Paris"}')])
         engine._client = AsyncMock()
         engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
         engine._running = True
@@ -1342,41 +1251,23 @@ class TestStreamCallToolCalls:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_parallel_tool_calls_without_index_warns(self):
-        """Distinct parallel calls that omit `index` collapse to slot 0 — warn, don't silently corrupt.
+    async def test_parallel_tool_calls_without_index_warns_and_fails_closed(self):
+        """Distinct parallel calls that omit `index` collapse to slot 0 — warn, then fail closed.
 
         ``index`` is the only key tying argument fragments to their call. If a
-        provider omits it for parallel calls they default to slot 0; the
-        accumulator can't recover the split, so it must at least surface a warning
-        rather than corrupt silently. (OpenAI/NIM always send `index` here.)
+        provider omits it for parallel calls they default to slot 0; the accumulator
+        can't recover the split. It warns about the collision, and the concatenated
+        argument buffers (here ``"{}" + "{}" == "{}{}"``) are invalid JSON, so the
+        finalizer fails closed rather than surfacing a corrupted call. (OpenAI/NIM
+        always send `index` here.)
         """
         engine = ModelEngine(_make_model())
         # Two distinct calls (different ids), both omitting `index` -> both -> slot 0.
         raw_lines = self._make_sse_lines(
             [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {"id": "c1", "type": "function", "function": {"name": "fn_a", "arguments": "{}"}}
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {"id": "c2", "type": "function", "function": {"name": "fn_b", "arguments": "{}"}}
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+                self._tc_chunk(index=None, id="c1", name="fn_a", arguments="{}"),
+                self._tc_chunk(index=None, id="c2", name="fn_b", arguments="{}"),
+                self._finish_chunk(),
             ]
         )
         engine._client = AsyncMock()
@@ -1384,42 +1275,114 @@ class TestStreamCallToolCalls:
         engine._running = True
 
         with patch("nemoguardrails.guardrails.model_engine.log") as mock_log:
-            _ = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+            with pytest.raises(ModelEngineError):
+                [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
 
-        assert mock_log.warning.called, "expected a collision warning for index-less parallel tool calls"
-        assert "collided with accumulator slot" in mock_log.warning.call_args.args[0]
+        assert any("collided with accumulator slot" in call.args[0] for call in mock_log.warning.call_args_list), (
+            "expected a collision warning for index-less parallel tool calls"
+        )
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_abnormal_finish_reason_warns_but_still_surfaces_tool_call(self):
-        """finish_reason='length' mid-tool-call: surface what we have but warn it may be truncated.
+    async def test_abnormal_finish_reason_with_truncated_args_warns_and_raises(self):
+        """finish_reason='length' mid-tool-call with truncated args: warn, then fail closed.
 
         When the model hits its token limit while streaming tool-call arguments,
-        finish_reason is 'length' (not 'tool_calls'/'stop') and the JSON buffer
-        is incomplete. The finalizer must still emit the call (arguments degrade
-        to {}) AND log a warning so the truncation is not silent.
+        finish_reason is 'length' (not 'tool_calls'/'stop') and the JSON buffer is
+        incomplete. The finalizer warns about the abnormal terminator AND raises (rather
+        than silently surfacing empty args), matching the non-streaming parser.
         """
         engine = ModelEngine(_make_model())
         raw_lines = self._make_sse_lines(
+            [self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Par', finish_reason="length")]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        with patch("nemoguardrails.guardrails.model_engine.log") as mock_log:
+            with pytest.raises(ModelEngineError):
+                [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        # The truncation warning is logged before the finalizer raises (a later
+        # exception-wrap warning also fires), so scan all warning calls.
+        assert any("may be truncated" in call.args[0] for call in mock_log.warning.call_args_list), (
+            "expected a truncation warning for finish_reason='length'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_args_fail_closed_on_both_paths(self):
+        """Identical malformed tool-call args fail closed on BOTH paths (the core of the fix).
+
+        The streaming and non-streaming engines must agree: the same provider bytes that
+        raise ``ModelEngineError`` non-streaming must not silently degrade to empty args
+        (and a schema-passing 'safe' call) when streamed.
+        """
+        bad_args = '{"city": "Par'
+
+        # Non-streaming: chat_completion parses the response body.
+        nonstream_engine = ModelEngine(_make_model())
+        nonstream_engine.call = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {"id": "c1", "type": "function", "function": {"name": "f", "arguments": bad_args}}
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+        )
+        with pytest.raises(ModelEngineError):
+            await nonstream_engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+        # Streaming: stream_call assembles the same args from SSE fragments.
+        stream_engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [self._tc_chunk(id="c1", name="f", arguments=bad_args, finish_reason="tool_calls")]
+        )
+        stream_engine._client = AsyncMock()
+        stream_engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        stream_engine._running = True
+        with pytest.raises(ModelEngineError):
+            [c async for c in stream_engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+    @pytest.mark.asyncio
+    async def test_no_argument_fragments_is_empty_dict(self):
+        """A streamed tool call with no argument fragments is a no-arg call -> {} (not an error)."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
             [
-                {
-                    "choices": [
-                        {
-                            "delta": {
-                                "tool_calls": [
-                                    {
-                                        "index": 0,
-                                        "id": "c1",
-                                        "type": "function",
-                                        "function": {"name": "get_weather", "arguments": '{"city": "Par'},
-                                    }
-                                ]
-                            },
-                            "finish_reason": "length",
-                        }
-                    ]
-                },
+                self._tc_chunk(id="c1", name="ping", arguments=""),
+                self._finish_chunk(),
             ]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        chunks = [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        tool_chunks = [c for c in chunks if c.delta_tool_calls]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].delta_tool_calls[0]
+        assert tc.function.name == "ping"
+        assert tc.function.arguments == {}
+
+    @pytest.mark.asyncio
+    async def test_abnormal_finish_reason_with_valid_args_surfaces_and_warns(self):
+        """finish_reason='length' but a complete/valid arg buffer: surface the call AND warn.
+
+        The abnormal-terminator warning still fires, but a *valid* buffer is not an error, so
+        the call is surfaced normally (only truncated/invalid buffers fail closed)."""
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [self._tc_chunk(id="c1", name="get_weather", arguments='{"city": "Paris"}', finish_reason="length")]
         )
         engine._client = AsyncMock()
         engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
@@ -1430,11 +1393,31 @@ class TestStreamCallToolCalls:
 
         tool_chunks = [c for c in chunks if c.delta_tool_calls]
         assert len(tool_chunks) == 1
-        tc = tool_chunks[0].delta_tool_calls[0]
-        assert tc.function.name == "get_weather"
-        assert tc.function.arguments == {}
-        assert mock_log.warning.called, "expected a truncation warning for finish_reason='length'"
-        assert "may be truncated" in mock_log.warning.call_args.args[0]
+        assert tool_chunks[0].delta_tool_calls[0].function.arguments == {"city": "Paris"}
+        assert any("may be truncated" in call.args[0] for call in mock_log.warning.call_args_list)
+
+    @pytest.mark.parametrize(
+        "arguments",
+        ["[1, 2]", '"just a string"', "42", "true", "null"],
+        ids=["list", "string", "number", "bool", "null"],
+    )
+    @pytest.mark.asyncio
+    async def test_non_object_streamed_args_raise(self, arguments):
+        """Args that parse as valid JSON but not an object fail closed (parity with non-streaming).
+
+        Covers every non-dict JSON kind (list, string, number, bool, null) so the
+        ``not isinstance(arguments, dict)`` guard isn't resting on a single case.
+        """
+        engine = ModelEngine(_make_model())
+        raw_lines = self._make_sse_lines(
+            [self._tc_chunk(id="c1", name="f", arguments=arguments, finish_reason="tool_calls")]
+        )
+        engine._client = AsyncMock()
+        engine._client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._running = True
+
+        with pytest.raises(ModelEngineError):
+            [c async for c in engine.stream_call([{"role": "user", "content": "Hi"}])]
 
 
 class TestModelEngineConstants:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -2058,3 +2058,82 @@ class TestExtractToolResults:
         engine = ModelEngine(_make_model(engine="vllm", parameters={"base_url": "http://localhost:8000"}))
         results = engine.extract_tool_results(_TOOL_MESSAGES)
         assert [r.call_id for r in results] == ["call_1"]
+
+
+class TestExtractToolCalls:
+    def test_extracts_assistant_tool_call(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call.id == "call_1"
+        assert call.function.name == "get_weather"
+        # JSON-string arguments on the wire are normalized to a dict.
+        assert call.function.arguments == {"city": "Paris"}
+
+    def test_ignores_non_assistant_messages(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        messages = [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "18C"},
+        ]
+        assert engine.extract_tool_calls(messages) == []
+
+    def test_collects_across_multiple_assistant_turns(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r1"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "b", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c2", "name": "b", "content": "r2"},
+        ]
+        calls = engine.extract_tool_calls(messages)
+        assert [c.id for c in calls] == ["c1", "c2"]
+
+    def test_assistant_without_tool_calls_skipped(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        assert engine.extract_tool_calls([{"role": "assistant", "content": "just text"}]) == []
+
+    def test_skips_non_dict_messages(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        messages = ["garbage", _TOOL_MESSAGES[1]]
+        calls = engine.extract_tool_calls(messages)
+        assert [c.id for c in calls] == ["call_1"]
+
+    def test_no_tool_calls_returns_empty(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        assert engine.extract_tool_calls([]) == []
+
+    def test_malformed_arguments_raise_value_error(self):
+        """Invalid JSON arguments fail closed: the IORails glue blocks rather than 500s."""
+        engine = ModelEngine(_make_model(engine="openai"))
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "not json"}}],
+            },
+        ]
+        with pytest.raises(ValueError):
+            engine.extract_tool_calls(messages)
+
+    def test_nim_uses_the_same_shape(self):
+        engine = ModelEngine(_make_model(engine="nim"))
+        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
+        assert [c.id for c in calls] == ["call_1"]
+
+    def test_unknown_engine_falls_back_to_openai_extractor(self):
+        engine = ModelEngine(_make_model(engine="vllm", parameters={"base_url": "http://localhost:8000"}))
+        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
+        assert [c.id for c in calls] == ["call_1"]

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -38,7 +38,7 @@ from nemoguardrails.guardrails.model_engine import (
 from nemoguardrails.guardrails.tool_schema import Toolset
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
-from tests.guardrails.tool_helpers import make_tool_conversation
+from tests.guardrails.tool_helpers import make_tool_conversation, multi_turn_reused_call_id_messages
 
 
 def _make_model(
@@ -2043,29 +2043,25 @@ class TestExtractToolResults:
         assert [r.call_id for r in results] == ["call_1"]
 
 
-class TestExtractToolCalls:
-    def test_extracts_assistant_tool_call(self):
-        engine = ModelEngine(_make_model(engine="openai"))
-        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
+class TestExtractToolExchanges:
+    @staticmethod
+    def _ids(exchanges):
+        """Reduce exchanges to ``[(call_ids, result_call_ids), ...]`` for terse assertions."""
+        return [([c.id for c in calls], [r.call_id for r in results]) for calls, results in exchanges]
 
-        assert len(calls) == 1
-        call = calls[0]
-        assert call.id == "call_1"
-        assert call.function.name == "get_weather"
+    def test_groups_single_turn(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        exchanges = engine.extract_tool_exchanges(_TOOL_MESSAGES)
+
+        assert len(exchanges) == 1
+        calls, results = exchanges[0]
+        assert calls[0].id == "call_1"
+        assert calls[0].function.name == "get_weather"
         # JSON-string arguments on the wire are normalized to a dict.
-        assert call.function.arguments == {"city": "Paris"}
+        assert calls[0].function.arguments == {"city": "Paris"}
+        assert [r.call_id for r in results] == ["call_1"]
 
-    def test_ignores_non_assistant_messages(self):
-        engine = ModelEngine(_make_model(engine="openai"))
-        messages = [
-            {"role": "system", "content": "be helpful"},
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-            {"role": "tool", "tool_call_id": "call_1", "content": "18C"},
-        ]
-        assert engine.extract_tool_calls(messages) == []
-
-    def test_collects_across_multiple_assistant_turns(self):
+    def test_each_turn_is_its_own_exchange(self):
         engine = ModelEngine(_make_model(engine="openai"))
         messages = [
             {
@@ -2074,6 +2070,7 @@ class TestExtractToolCalls:
                 "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}}],
             },
             {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r1"},
+            {"role": "assistant", "content": "interim text"},
             {
                 "role": "assistant",
                 "content": None,
@@ -2081,22 +2078,51 @@ class TestExtractToolCalls:
             },
             {"role": "tool", "tool_call_id": "c2", "name": "b", "content": "r2"},
         ]
-        calls = engine.extract_tool_calls(messages)
-        assert [c.id for c in calls] == ["c1", "c2"]
+        assert self._ids(engine.extract_tool_exchanges(messages)) == [(["c1"], ["c1"]), (["c2"], ["c2"])]
 
-    def test_assistant_without_tool_calls_skipped(self):
+    def test_recycled_ids_stay_in_separate_exchanges(self):
+        # The core of #13: the same call_id reused across turns is NOT collapsed; each
+        # turn is its own exchange so linkage stays turn-local.
         engine = ModelEngine(_make_model(engine="openai"))
-        assert engine.extract_tool_calls([{"role": "assistant", "content": "just text"}]) == []
+        assert self._ids(engine.extract_tool_exchanges(multi_turn_reused_call_id_messages())) == [
+            (["call_0"], ["call_0"]),
+            (["call_0"], ["call_0"]),
+        ]
+
+    def test_parallel_calls_in_one_turn_share_an_exchange(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                    {"id": "c2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r1"},
+            {"role": "tool", "tool_call_id": "c2", "name": "b", "content": "r2"},
+        ]
+        assert self._ids(engine.extract_tool_exchanges(messages)) == [(["c1", "c2"], ["c1", "c2"])]
+
+    def test_orphan_result_has_no_calls(self):
+        # A tool result with no preceding assistant tool-call turn becomes an exchange
+        # with no calls, so the rail still flags it as an orphan.
+        engine = ModelEngine(_make_model(engine="openai"))
+        exchanges = engine.extract_tool_exchanges([{"role": "tool", "tool_call_id": "x", "content": "y"}])
+        assert self._ids(exchanges) == [([], ["x"])]
+
+    def test_no_tool_data_returns_empty(self):
+        engine = ModelEngine(_make_model(engine="openai"))
+        assert engine.extract_tool_exchanges([]) == []
+        assert (
+            engine.extract_tool_exchanges([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}])
+            == []
+        )
 
     def test_skips_non_dict_messages(self):
         engine = ModelEngine(_make_model(engine="openai"))
-        messages = ["garbage", _TOOL_MESSAGES[1]]
-        calls = engine.extract_tool_calls(messages)
-        assert [c.id for c in calls] == ["call_1"]
-
-    def test_no_tool_calls_returns_empty(self):
-        engine = ModelEngine(_make_model(engine="openai"))
-        assert engine.extract_tool_calls([]) == []
+        assert self._ids(engine.extract_tool_exchanges(["garbage", *_TOOL_MESSAGES])) == [(["call_1"], ["call_1"])]
 
     def test_malformed_arguments_raise_value_error(self):
         """Invalid JSON arguments fail closed: the IORails glue blocks rather than 500s."""
@@ -2109,14 +2135,12 @@ class TestExtractToolCalls:
             },
         ]
         with pytest.raises(ValueError):
-            engine.extract_tool_calls(messages)
+            engine.extract_tool_exchanges(messages)
 
     def test_nim_uses_the_same_shape(self):
         engine = ModelEngine(_make_model(engine="nim"))
-        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
-        assert [c.id for c in calls] == ["call_1"]
+        assert self._ids(engine.extract_tool_exchanges(_TOOL_MESSAGES)) == [(["call_1"], ["call_1"])]
 
     def test_unknown_engine_falls_back_to_openai_extractor(self):
         engine = ModelEngine(_make_model(engine="vllm", parameters={"base_url": "http://localhost:8000"}))
-        calls = engine.extract_tool_calls(_TOOL_MESSAGES)
-        assert [c.id for c in calls] == ["call_1"]
+        assert self._ids(engine.extract_tool_exchanges(_TOOL_MESSAGES)) == [(["call_1"], ["call_1"])]

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -49,6 +49,7 @@ from tests.guardrails.tool_helpers import (
     WEATHER_SCHEMA,
     assert_blocked,
     make_tool_conversation,
+    malformed_prior_tool_call_messages,
     multi_turn_reused_call_id_messages,
 )
 
@@ -652,26 +653,23 @@ class TestRailsManagerToolResults:
         assert result.is_safe is True
 
     @pytest.mark.asyncio
+    async def test_malformed_prior_tool_call_does_not_block_well_formed_results(self):
+        """#14 (currently failing): a malformed historical tool-call must not block the request.
+
+        The tool-result rail validates linkage (call_id + name), not the prior call's
+        arguments, so a truncated/invalid argument JSON on one turn should not fail
+        extraction for the whole conversation. Expected to FAIL until extraction tolerates
+        a malformed historical call instead of raising and blocking the whole request.
+        """
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe(malformed_prior_tool_call_messages())
+        assert result.is_safe is True
+
+    @pytest.mark.asyncio
     async def test_disabled_toggle_skips_validation(self):
         mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
         result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"), enabled=False)
         assert result.is_safe is True
-
-    @pytest.mark.asyncio
-    async def test_fails_closed_on_malformed_prior_tool_call(self):
-        # A prior assistant tool call with non-JSON arguments makes exchange extraction
-        # raise; the method must fail closed rather than propagate the error.
-        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
-        messages = [
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "not json"}}],
-            },
-            {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r"},
-        ]
-        result = await mgr.are_tool_results_safe(messages)
-        assert_blocked(result, "tool exchange extraction failed")
 
     @pytest.mark.asyncio
     async def test_fails_closed_when_exchange_extraction_raises(self):

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -252,6 +252,72 @@ class TestIsOutputSafe:
         assert not result.is_safe
 
 
+class TestIsInputSafeToggle:
+    """The per-request enabled toggle selects which input rails run (bool / list / normalized name)."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_toggle_skips_input_rails(self, content_safety_rails_manager):
+        """enabled=False runs no input rails, so an otherwise-unsafe input passes."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_input_safe(MESSAGES, enabled=False)
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_empty_list_toggle_skips_input_rails(self, content_safety_rails_manager):
+        """enabled=[] selects no input rails, so an otherwise-unsafe input passes."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_input_safe(MESSAGES, enabled=[])
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_normalized_name_list_runs_input_rail(self, content_safety_rails_manager):
+        """A toggle listing the canonical rail name matches the configured $model=-suffixed flow and runs it."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_input_safe(MESSAGES, enabled=["content safety check input"])
+        assert not result.is_safe
+        assert "Violence" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_true_toggle_runs_input_rails(self, content_safety_rails_manager):
+        """enabled=True runs every configured input rail, matching the default."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_INPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_input_safe(MESSAGES, enabled=True)
+        assert not result.is_safe
+
+
+class TestIsOutputSafeToggle:
+    """The per-request enabled toggle selects which output rails run (bool / list / normalized name)."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_toggle_skips_output_rails(self, content_safety_rails_manager):
+        """enabled=False runs no output rails, so an otherwise-unsafe response passes."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_output_safe(MESSAGES, "bad response", enabled=False)
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_normalized_name_list_runs_output_rail(self, content_safety_rails_manager):
+        """A toggle listing the canonical rail name matches the configured $model=-suffixed flow and runs it."""
+        content_safety_rails_manager.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content=UNSAFE_OUTPUT_JSON)
+        )
+        result = await content_safety_rails_manager.is_output_safe(
+            MESSAGES, "bad response", enabled=["content safety check output"]
+        )
+        assert not result.is_safe
+        assert "S17: Malware" in result.reason
+
+
 # --- Multi-rail sequential tests (nemoguards config: content + topic + jailbreak) ---
 
 

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -45,7 +45,12 @@ from tests.guardrails.test_data import (
     NEMOGUARDS_PARALLEL_OUTPUT_CONFIG,
     TOPIC_SAFETY_CONFIG,
 )
-from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked, make_tool_conversation
+from tests.guardrails.tool_helpers import (
+    WEATHER_SCHEMA,
+    assert_blocked,
+    make_tool_conversation,
+    multi_turn_reused_call_id_messages,
+)
 
 SAFE_INPUT_JSON = json.dumps({"User Safety": "safe"})
 UNSAFE_INPUT_JSON = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
@@ -640,6 +645,13 @@ class TestRailsManagerToolResults:
         assert_blocked(result, "call_999")
 
     @pytest.mark.asyncio
+    async def test_recycled_call_ids_across_turns_are_safe(self):
+        """Reuse the same call ID across turns, but within each turn the call ID is unique"""
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe(multi_turn_reused_call_id_messages())
+        assert result.is_safe is True
+
+    @pytest.mark.asyncio
     async def test_disabled_toggle_skips_validation(self):
         mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
         result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"), enabled=False)
@@ -647,7 +659,7 @@ class TestRailsManagerToolResults:
 
     @pytest.mark.asyncio
     async def test_fails_closed_on_malformed_prior_tool_call(self):
-        # A prior assistant tool call with non-JSON arguments makes extract_tool_calls
+        # A prior assistant tool call with non-JSON arguments makes exchange extraction
         # raise; the method must fail closed rather than propagate the error.
         mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
         messages = [
@@ -659,20 +671,20 @@ class TestRailsManagerToolResults:
             {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r"},
         ]
         result = await mgr.are_tool_results_safe(messages)
-        assert_blocked(result, "prior tool call extraction failed")
+        assert_blocked(result, "tool exchange extraction failed")
 
     @pytest.mark.asyncio
-    async def test_fails_closed_when_result_extraction_raises(self):
-        # If the engine adapter's result extraction itself blows up, the method must
+    async def test_fails_closed_when_exchange_extraction_raises(self):
+        # If the engine adapter's exchange extraction itself blows up, the method must
         # fail closed (block) rather than let the error escape.
         mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
 
         def _boom(*args, **kwargs):
             raise RuntimeError("extract boom")
 
-        mgr.engine_registry.extract_tool_results = _boom
+        mgr.engine_registry.extract_tool_exchanges = _boom
         result = await mgr.are_tool_results_safe(make_tool_conversation())
-        assert_blocked(result, "tool result extraction failed")
+        assert_blocked(result, "tool exchange extraction failed")
 
 
 def _capture_tool_rails_manager():

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -21,6 +21,7 @@ Rail-specific logic (prompt rendering, parsing) is tested in the
 individual iorails_actions test files.
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -30,6 +31,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
+from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -659,6 +661,19 @@ class TestRailsManagerToolResults:
         result = await mgr.are_tool_results_safe(messages)
         assert_blocked(result, "prior tool call extraction failed")
 
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_result_extraction_raises(self):
+        # If the engine adapter's result extraction itself blows up, the method must
+        # fail closed (block) rather than let the error escape.
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("extract boom")
+
+        mgr.engine_registry.extract_tool_results = _boom
+        result = await mgr.are_tool_results_safe(make_tool_conversation())
+        assert_blocked(result, "tool result extraction failed")
+
 
 def _capture_tool_rails_manager():
     """Build (manager, exporter) with a real tracer + content capture on, both tool rails wired.
@@ -728,3 +743,57 @@ class TestRailsManagerToolContentCapture:
         payload = json.loads(attrs[GuardrailsAttributes.RAIL_INPUT])
         assert payload["tool_results"][0] == {"call_id": "c9", "name": "get_weather", "is_error": False}
         assert "c9" in attrs[GuardrailsAttributes.RAIL_REASON]
+
+
+class TestRunRailsParallel:
+    """Direct tests for the parallel runner's cancel-on-block and error-cleanup paths.
+
+    These exercise ``_run_rails_parallel`` (used by ``is_input_safe`` / ``is_output_safe``
+    when ``parallel`` is enabled) with hand-built coroutines so a rail can stay pending /
+    raise deterministically -- the mock-fast rails in the config-driven parallel tests
+    above all resolve in the first batch, leaving the cancel/except branches uncovered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_unsafe_result_cancels_pending_rails(self):
+        mgr = _tool_rails_manager()
+        cancelled = asyncio.Event()
+
+        async def slow_safe():
+            try:
+                await asyncio.sleep(5)
+                return RailResult(is_safe=True)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        async def fast_unsafe():
+            return RailResult(is_safe=False, reason="blocked fast")
+
+        rails = {"slow": slow_safe(), "fast": fast_unsafe()}
+        result = await mgr._run_rails_parallel(rails, RailDirection.INPUT)
+
+        assert_blocked(result, "blocked fast")
+        assert cancelled.is_set(), "the still-pending rail should have been cancelled"
+
+    @pytest.mark.asyncio
+    async def test_rail_exception_cancels_all_and_propagates(self):
+        mgr = _tool_rails_manager()
+        cancelled = asyncio.Event()
+
+        async def slow_safe():
+            try:
+                await asyncio.sleep(5)
+                return RailResult(is_safe=True)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        async def raises():
+            raise RuntimeError("rail boom")
+
+        rails = {"slow": slow_safe(), "boom": raises()}
+        with pytest.raises(RuntimeError, match="rail boom"):
+            await mgr._run_rails_parallel(rails, RailDirection.INPUT)
+
+        assert cancelled.is_set(), "remaining rails should be cancelled on a rail error"

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -31,7 +31,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.rails_manager import RailsManager
-from nemoguardrails.guardrails.tool_schema import Tool, ToolResult, Toolset
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import GuardrailsAttributes
@@ -44,7 +43,7 @@ from tests.guardrails.test_data import (
     NEMOGUARDS_PARALLEL_OUTPUT_CONFIG,
     TOPIC_SAFETY_CONFIG,
 )
-from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked
+from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked, make_tool_conversation
 
 SAFE_INPUT_JSON = json.dumps({"User Safety": "safe"})
 UNSAFE_INPUT_JSON = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
@@ -490,10 +489,6 @@ def _tool_rails_manager(*, tool_call_flows=None, tool_result_flows=None) -> Rail
     )
 
 
-def _toolset() -> Toolset:
-    return Toolset(tools=[Tool(name="get_weather", arguments_schema=WEATHER_SCHEMA)])
-
-
 def _call(name: str, arguments: dict) -> ToolCall:
     return ToolCall(id="c1", function=ToolCallFunction(name=name, arguments=arguments))
 
@@ -532,56 +527,153 @@ class TestRailsManagerToolInit:
             _tool_rails_manager(tool_result_flows=["tool result validation", "tool result validation"])
 
 
+def _tool_rails_manager_with_main(*, tool_call_flows=None, tool_result_flows=None) -> RailsManager:
+    """Like ``_tool_rails_manager`` but with a 'main' engine registered.
+
+    The request-shaped ``are_tool_*_safe`` methods parse tools / extract results via the
+    engine adapter, so they need a 'main' engine to delegate to. ``_tool_rails_manager``
+    (no engine) is only enough for the disabled / no-flows early-outs that return before
+    any engine call."""
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        config = RailsConfig.from_content(
+            config={"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
+        )
+        engine_registry = EngineRegistry(config.models, config.rails.config)
+    return RailsManager(
+        engine_registry=engine_registry,
+        task_manager=LLMTaskManager(config),
+        input_flows=[],
+        output_flows=[],
+        tool_call_flows=tool_call_flows or [],
+        tool_result_flows=tool_result_flows or [],
+    )
+
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {"name": "get_weather", "description": "Get weather", "parameters": WEATHER_SCHEMA},
+}
+
+
 class TestRailsManagerToolCalls:
+    """The request-shaped ``are_tool_calls_safe``: parse the declared toolset, then validate."""
+
+    @pytest.mark.asyncio
+    async def test_no_flows_returns_safe_without_parsing(self):
+        # No tool-call rails configured -> safe, and parse is never attempted. The
+        # registry here has no engine that could parse, so a safe result proves the
+        # early-out happens before any engine call.
+        mgr = _tool_rails_manager()
+        result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], {"tools": [WEATHER_TOOL]})
+        assert result.is_safe is True
+
     @pytest.mark.asyncio
     async def test_allows_valid_call(self):
-        mgr = _tool_rails_manager(tool_call_flows=["tool call validation"])
-        result = await mgr.are_tool_calls_safe([_call("get_weather", {"city": "Paris"})], _toolset())
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe([_call("get_weather", {"city": "Paris"})], {"tools": [WEATHER_TOOL]})
         assert result.is_safe is True
 
     @pytest.mark.asyncio
     async def test_blocks_undeclared_call(self):
-        mgr = _tool_rails_manager(tool_call_flows=["tool call validation"])
-        result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], _toolset())
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], {"tools": [WEATHER_TOOL]})
         assert_blocked(result, "rm_rf")
 
     @pytest.mark.asyncio
-    async def test_no_flows_returns_safe(self):
-        mgr = _tool_rails_manager()
-        result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], _toolset())
+    async def test_no_tool_calls_returns_safe(self):
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe([], {"tools": [WEATHER_TOOL]})
         assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_on_duplicate_tool_definitions(self):
+        # parse_tools raises ValueError on a duplicate tool name; the method must
+        # convert that into a block, not propagate.
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe(
+            [_call("get_weather", {"city": "Paris"})], {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
+        )
+        assert_blocked(result, "tool parsing failed")
+
+    @pytest.mark.asyncio
+    async def test_disabled_toggle_skips_validation(self):
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=False)
+        assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_list_toggle_selects_named_flow(self):
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        result = await mgr.are_tool_calls_safe(
+            [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=["tool call validation"]
+        )
+        assert_blocked(result, "rm_rf")
 
 
 class TestRailsManagerToolResults:
+    """The request-shaped ``are_tool_results_safe``: extract results + prior calls, then validate."""
+
+    @pytest.mark.asyncio
+    async def test_no_flows_returns_safe_without_extracting(self):
+        mgr = _tool_rails_manager()
+        result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"))
+        assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_no_tool_results_returns_safe(self):
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe([{"role": "user", "content": "hi"}])
+        assert result.is_safe is True
+
     @pytest.mark.asyncio
     async def test_allows_linked_result(self):
-        mgr = _tool_rails_manager(tool_result_flows=["tool result validation"])
-        prior = [_call("get_weather", {"city": "Paris"})]
-        result = await mgr.are_tool_results_safe([ToolResult(call_id="c1", content="18C")], prior)
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_1"))
         assert result.is_safe is True
 
     @pytest.mark.asyncio
     async def test_blocks_unlinked_result(self):
-        mgr = _tool_rails_manager(tool_result_flows=["tool result validation"])
-        prior = [_call("get_weather", {"city": "Paris"})]
-        result = await mgr.are_tool_results_safe([ToolResult(call_id="c9", content="x")], prior)
-        assert_blocked(result, "c9")
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"))
+        assert_blocked(result, "call_999")
 
     @pytest.mark.asyncio
-    async def test_no_flows_returns_safe(self):
-        mgr = _tool_rails_manager()
-        result = await mgr.are_tool_results_safe([ToolResult(call_id="c9", content="x")], [])
+    async def test_disabled_toggle_skips_validation(self):
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"), enabled=False)
         assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_on_malformed_prior_tool_call(self):
+        # A prior assistant tool call with non-JSON arguments makes extract_tool_calls
+        # raise; the method must fail closed rather than propagate the error.
+        mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "a", "arguments": "not json"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "a", "content": "r"},
+        ]
+        result = await mgr.are_tool_results_safe(messages)
+        assert_blocked(result, "prior tool call extraction failed")
 
 
 def _capture_tool_rails_manager():
-    """Build (manager, exporter) with a real tracer + content capture on, both tool rails wired."""
+    """Build (manager, exporter) with a real tracer + content capture on, both tool rails wired.
+
+    Includes a 'main' engine so the request-shaped ``are_tool_*_safe`` can parse / extract."""
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    config = RailsConfig.from_content(config={"models": []})
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        config = RailsConfig.from_content(
+            config={"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
+        )
+        engine_registry = EngineRegistry(config.models, config.rails.config)
     manager = RailsManager(
-        engine_registry=EngineRegistry(config.models, config.rails.config),
+        engine_registry=engine_registry,
         task_manager=LLMTaskManager(config),
         input_flows=[],
         output_flows=[],
@@ -600,11 +692,21 @@ def _rail_span(exporter):
     return spans[0]
 
 
+_UNLINKED_RESULT_MESSAGES = [
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+    },
+    {"role": "tool", "tool_call_id": "c9", "name": "get_weather", "content": "x"},
+]
+
+
 class TestRailsManagerToolContentCapture:
     @pytest.mark.asyncio
     async def test_tool_call_span_captures_calls_and_reason_on_block(self):
         manager, exporter = _capture_tool_rails_manager()
-        await manager.are_tool_calls_safe([_call("rm_rf", {})], _toolset())
+        await manager.are_tool_calls_safe([_call("rm_rf", {})], {"tools": [WEATHER_TOOL]})
         attrs = _rail_span(exporter).attributes
         payload = json.loads(attrs[GuardrailsAttributes.RAIL_INPUT])
         assert payload["tool_calls"][0]["function"]["name"] == "rm_rf"
@@ -613,7 +715,7 @@ class TestRailsManagerToolContentCapture:
     @pytest.mark.asyncio
     async def test_tool_call_span_omits_reason_when_safe(self):
         manager, exporter = _capture_tool_rails_manager()
-        await manager.are_tool_calls_safe([_call("get_weather", {"city": "Paris"})], _toolset())
+        await manager.are_tool_calls_safe([_call("get_weather", {"city": "Paris"})], {"tools": [WEATHER_TOOL]})
         attrs = _rail_span(exporter).attributes
         assert "tool_calls" in json.loads(attrs[GuardrailsAttributes.RAIL_INPUT])
         assert GuardrailsAttributes.RAIL_REASON not in attrs
@@ -621,8 +723,7 @@ class TestRailsManagerToolContentCapture:
     @pytest.mark.asyncio
     async def test_tool_result_span_captures_linkage_and_reason_on_block(self):
         manager, exporter = _capture_tool_rails_manager()
-        prior = [_call("get_weather", {"city": "Paris"})]
-        await manager.are_tool_results_safe([ToolResult(call_id="c9", name="get_weather", content="x")], prior)
+        await manager.are_tool_results_safe(_UNLINKED_RESULT_MESSAGES)
         attrs = _rail_span(exporter).attributes
         payload = json.loads(attrs[GuardrailsAttributes.RAIL_INPUT])
         assert payload["tool_results"][0] == {"call_id": "c9", "name": "get_weather", "is_error": False}

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -685,6 +685,70 @@ class TestRailsManagerToolResults:
         assert_blocked(result, "tool exchange extraction failed")
 
 
+class TestRailsManagerToolToggleNormalization:
+    """#15 (currently failing): a list-valued enable toggle must match configured flows
+    by their normalized name, not by the raw flow string.
+
+    A configured tool flow may carry a ``$model=`` or ``(...)`` suffix (accepted by
+    config loading, which normalizes via ``_get_flow_name``), while a caller's per-request
+    ``enabled`` list naturally carries the canonical rail name. The toggle currently
+    compares the raw configured flow string against the requested names, so a suffixed
+    configured flow never matches the canonical name, the rail is silently dropped, and
+    tool calls/results go unvalidated (fail-open). These assert the rail still runs.
+    """
+
+    SUFFIXED_CALL_FLOWS = [
+        "tool call validation $model=main",
+        "tool call validation(main)",
+    ]
+    SUFFIXED_RESULT_FLOWS = [
+        "tool result validation $model=main",
+        "tool result validation(main)",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("configured_flow", SUFFIXED_CALL_FLOWS)
+    async def test_call_toggle_matches_normalized_name(self, configured_flow):
+        # Configured flow carries a suffix; the request toggle uses the canonical name.
+        # The call rail must still run and block the undeclared call.
+        mgr = _tool_rails_manager_with_main(tool_call_flows=[configured_flow])
+        result = await mgr.are_tool_calls_safe(
+            [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=["tool call validation"]
+        )
+        assert_blocked(result, "rm_rf")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("configured_flow", SUFFIXED_RESULT_FLOWS)
+    async def test_result_toggle_matches_normalized_name(self, configured_flow):
+        # Configured flow carries a suffix; the request toggle uses the canonical name.
+        # The result rail must still run and block the unlinked result.
+        mgr = _tool_rails_manager_with_main(tool_result_flows=[configured_flow])
+        result = await mgr.are_tool_results_safe(
+            make_tool_conversation(result_call_id="call_999"), enabled=["tool result validation"]
+        )
+        assert_blocked(result, "call_999")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("configured_flow", SUFFIXED_CALL_FLOWS)
+    async def test_call_toggle_raw_flow_string_also_matches(self, configured_flow):
+        # Passing the raw configured flow string (including suffix) must also select it,
+        # so normalizing the comparison does not break exact-string callers.
+        mgr = _tool_rails_manager_with_main(tool_call_flows=[configured_flow])
+        result = await mgr.are_tool_calls_safe(
+            [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=[configured_flow]
+        )
+        assert_blocked(result, "rm_rf")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("configured_flow", SUFFIXED_RESULT_FLOWS)
+    async def test_result_toggle_raw_flow_string_also_matches(self, configured_flow):
+        mgr = _tool_rails_manager_with_main(tool_result_flows=[configured_flow])
+        result = await mgr.are_tool_results_safe(
+            make_tool_conversation(result_call_id="call_999"), enabled=[configured_flow]
+        )
+        assert_blocked(result, "call_999")
+
+
 def _capture_tool_rails_manager():
     """Build (manager, exporter) with a real tracer + content capture on, both tool rails wired.
 

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -78,7 +78,7 @@ class TestSpeculativeGeneration:
     async def test_rails_first_pass(self, iorails):
         """Rails finish first and pass — generation is awaited, output rails run."""
 
-        async def fast_rails(messages):
+        async def fast_rails(messages, *, enabled=True):
             return RailResult(is_safe=True)
 
         async def slow_llm(model_type, messages):
@@ -99,7 +99,7 @@ class TestSpeculativeGeneration:
         llm_started = False
         llm_completed = False
 
-        async def fast_reject(messages):
+        async def fast_reject(messages, *, enabled=True):
             return RailResult(is_safe=False, reason="unsafe")
 
         async def slow_llm(model_type, messages):
@@ -127,7 +127,7 @@ class TestSpeculativeGeneration:
     async def test_gen_first_pass(self, iorails):
         """Generation finishes first — rails verdict awaited, response served on pass."""
 
-        async def slow_rails(messages):
+        async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.05)
             return RailResult(is_safe=True)
 
@@ -146,7 +146,7 @@ class TestSpeculativeGeneration:
     async def test_gen_first_reject(self, iorails):
         """Generation finishes first, then rails reject — response discarded."""
 
-        async def slow_reject(messages):
+        async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
             return RailResult(is_safe=False, reason="unsafe")
 
@@ -166,7 +166,7 @@ class TestSpeculativeGeneration:
     async def test_llm_error_cancels_rails(self, iorails):
         """LLM errors while rails still running — rails cancelled, error propagated."""
 
-        async def slow_rails(messages):
+        async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.5)
             return RailResult(is_safe=True)
 
@@ -194,7 +194,7 @@ class TestSpeculativeGeneration:
     async def test_rails_reject_with_simultaneous_llm_exception(self, iorails, caplog_iorails):
         """Rails reject + LLM raises in the same scheduling window — refusal returned, exception drained."""
 
-        async def fast_reject(messages):
+        async def fast_reject(messages, *, enabled=True):
             return RailResult(is_safe=False, reason="unsafe")
 
         async def slow_raises(model_type, messages):
@@ -219,7 +219,7 @@ class TestSpeculativeGeneration:
     async def test_both_tasks_raise_during_race(self, iorails, caplog_iorails):
         """Both rails and gen raise — outer cleanup logs the loser exception, winner propagates."""
 
-        async def rails_raises(messages):
+        async def rails_raises(messages, *, enabled=True):
             raise RuntimeError("Rails crashed")
 
         async def gen_raises(model_type, messages):
@@ -241,7 +241,7 @@ class TestSpeculativeGeneration:
         cfg = copy.deepcopy(NEMOGUARDS_SPECULATIVE_CONFIG)
         cfg["metrics"] = {"enabled": True}
 
-        async def fast_reject(messages):
+        async def fast_reject(messages, *, enabled=True):
             return RailResult(is_safe=False, reason="unsafe")
 
         async def slow_llm(model_type, messages):
@@ -266,7 +266,7 @@ class TestSpeculativeGeneration:
         cfg = copy.deepcopy(NEMOGUARDS_SPECULATIVE_CONFIG)
         cfg["metrics"] = {"enabled": True}
 
-        async def slow_reject(messages):
+        async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
             return RailResult(is_safe=False, reason="unsafe")
 
@@ -290,7 +290,7 @@ class TestSpeculativeGeneration:
         """When speculative_generation is false, pipeline runs sequentially."""
         call_order = []
 
-        async def mock_input(messages):
+        async def mock_input(messages, *, enabled=True):
             call_order.append("input")
             return RailResult(is_safe=True)
 
@@ -298,7 +298,7 @@ class TestSpeculativeGeneration:
             call_order.append("generate")
             return LLMResponse(content="response")
 
-        async def mock_output(messages, response):
+        async def mock_output(messages, response, *, enabled=True):
             call_order.append("output")
             return RailResult(is_safe=True)
 
@@ -349,7 +349,7 @@ class TestSpeculativeGenerationTelemetry:
     async def test_rails_first_pass_span_attrs(self, iorails_speculative_tracing, span_exporter):
         """Rails finish first and pass — first_completed=input_rails, first_rejector=none."""
 
-        async def fast_rails(messages):
+        async def fast_rails(messages, *, enabled=True):
             return RailResult(is_safe=True)
 
         async def slow_llm(model_type, messages):
@@ -375,7 +375,7 @@ class TestSpeculativeGenerationTelemetry:
     async def test_rails_first_reject_span_attrs(self, iorails_speculative_tracing, span_exporter):
         """Rails finish first and reject — first_completed=input_rails, first_rejector=input_rails."""
 
-        async def fast_reject(messages):
+        async def fast_reject(messages, *, enabled=True):
             return RailResult(is_safe=False, reason="unsafe")
 
         async def slow_llm(model_type, messages):
@@ -401,7 +401,7 @@ class TestSpeculativeGenerationTelemetry:
     async def test_gen_first_pass_span_attrs(self, iorails_speculative_tracing, span_exporter):
         """Generation finishes first, rails pass — first_completed=generation, first_rejector=none."""
 
-        async def slow_rails(messages):
+        async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.05)
             return RailResult(is_safe=True)
 
@@ -427,7 +427,7 @@ class TestSpeculativeGenerationTelemetry:
     async def test_gen_first_reject_span_attrs(self, iorails_speculative_tracing, span_exporter):
         """Generation finishes first, then rails reject — first_completed=generation, first_rejector=input_rails."""
 
-        async def slow_reject(messages):
+        async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
             return RailResult(is_safe=False, reason="unsafe")
 

--- a/tests/guardrails/test_tool_call_action.py
+++ b/tests/guardrails/test_tool_call_action.py
@@ -38,8 +38,15 @@ class TestToolCallRailAction:
         assert result.is_safe is True
 
     @pytest.mark.asyncio
-    async def test_tool_without_schema_passes_allowlist_only(self):
+    async def test_no_parameter_function_tool_with_arguments_is_blocked(self):
+        """A function tool that declares no parameters accepts no arguments, so a call supplying any is blocked."""
         result = await ToolCallRailAction().run(_toolset(), [_call("ping", {"anything": 1})])
+        assert_blocked(result, "ping", "no arguments")
+
+    @pytest.mark.asyncio
+    async def test_no_parameter_function_tool_without_arguments_is_safe(self):
+        """A no-parameter function tool called with no arguments passes."""
+        result = await ToolCallRailAction().run(_toolset(), [_call("ping", {})])
         assert result.is_safe is True
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_tool_rails_e2e.py
+++ b/tests/guardrails/test_tool_rails_e2e.py
@@ -17,14 +17,12 @@
 
 These exercise the full seam this PR builds: the real ModelEngine response
 parsing (non-streaming ``chat_completion`` and streaming SSE assembly) feeds
-the EngineRegistry tool helpers (``parse_tools`` / ``extract_tool_results``),
-whose normalized output is validated by ``RailsManager.are_tool_calls_safe`` /
-``are_tool_results_safe``.
+the request-shaped ``RailsManager.are_tool_calls_safe`` / ``are_tool_results_safe``,
+which parse the toolset / extract the tool results + prior calls via the engine
+adapter internally and validate them.
 
 The only mock is the aiohttp transport (the model's HTTP/SSE response body), so
-ModelEngine's parsing runs for real. The "model response -> parse -> validate"
-orchestration here stands in for the future IORails glue; this PR keeps the
-RailsManager surface limited to the two validation methods.
+ModelEngine's parsing runs for real end to end.
 """
 
 import json
@@ -38,7 +36,6 @@ from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
-from nemoguardrails.types import ChatMessage
 from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked, make_tool_conversation
 
 STACK_CONFIG = {"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
@@ -184,36 +181,31 @@ def _tool_call_sse_lines(name: str, arg_fragments: list, call_id: str = "call_1"
 
 
 async def _drive_nonstream_call(payload: dict) -> RailResult:
-    """Mock the model's JSON response, then parse tools + model_call + validate the calls."""
+    """Mock the model's JSON response, then model_call + validate the calls (toolset parsed inside)."""
     registry, manager = _build_stack()
     _inject_json_response(registry, payload)
-    toolset = registry.parse_tools("main", LLM_PARAMS)
     response = await registry.model_call("main", MESSAGES, **LLM_PARAMS)
     assert response.tool_calls is not None
-    return await manager.are_tool_calls_safe(response.tool_calls, toolset)
+    return await manager.are_tool_calls_safe(response.tool_calls, LLM_PARAMS)
 
 
 async def _drive_stream_call(sse_lines: list) -> RailResult:
     """Mock the model's SSE stream, assemble the tool calls, then validate them."""
     registry, manager = _build_stack()
     _inject_sse_stream(registry, sse_lines)
-    toolset = registry.parse_tools("main", LLM_PARAMS)
     collected = []
     async for chunk in registry.stream_model_call("main", MESSAGES, **LLM_PARAMS):
         if chunk.delta_tool_calls:
             collected.extend(chunk.delta_tool_calls)
     assert collected, "expected assembled tool calls from the stream"
-    return await manager.are_tool_calls_safe(collected, toolset)
+    return await manager.are_tool_calls_safe(collected, LLM_PARAMS)
 
 
 async def _drive_result(result_call_id: str) -> RailResult:
-    """Extract tool results + prior calls from a conversation, then validate the results."""
-    registry, manager = _build_stack()
+    """Validate the conversation's tool results (results + prior calls extracted inside)."""
+    _, manager = _build_stack()
     messages = make_tool_conversation(result_call_id=result_call_id)
-    tool_results = registry.extract_tool_results("main", messages)
-    prior_calls = ChatMessage.from_dict(messages[1]).tool_calls
-    assert prior_calls is not None
-    return await manager.are_tool_results_safe(tool_results, prior_calls)
+    return await manager.are_tool_results_safe(messages)
 
 
 class TestToolCallRailEndToEndNonStreaming:

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -37,6 +37,7 @@ from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.tool_helpers import (
     WEATHER_SCHEMA,
     make_tool_conversation,
+    malformed_prior_tool_call_messages,
     multi_turn_reused_call_id_messages,
 )
 
@@ -348,6 +349,13 @@ class TestNonStreamingToolResults:
 
         _inject_json_response(iorails, _text_payload("It's 12C in London."))
         result = await iorails.generate_async(multi_turn_reused_call_id_messages())
+        assert result == {"role": "assistant", "content": "It's 12C in London."}
+
+    @pytest.mark.asyncio
+    async def test_malformed_prior_tool_call_does_not_block(self, iorails):
+        """Malformed tool-call in prior turns must not block request."""
+        _inject_json_response(iorails, _text_payload("It's 12C in London."))
+        result = await iorails.generate_async(malformed_prior_tool_call_messages())
         assert result == {"role": "assistant", "content": "It's 12C in London."}
 
 

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -71,6 +71,25 @@ WEATHER_TOOL = {
 LLM_PARAMS = {"tools": [WEATHER_TOOL], "tool_choice": "auto"}
 MESSAGES = [{"role": "user", "content": "What's the weather in Paris?"}]
 
+# Tools declared statically on the model (models[].parameters.tools) rather than per-request
+# via options.llm_params. The engine merges these config-level defaults into the toolset the
+# tool-call rail validates against, so a config-declared tool must be honored even when the
+# request carries no llm_params.
+CONFIG_TOOLS_CONFIG = {
+    "models": [
+        {
+            "type": "main",
+            "engine": "nim",
+            "model": "meta/llama-3.3-70b-instruct",
+            "parameters": {"tools": [WEATHER_TOOL]},
+        }
+    ],
+    "rails": {
+        "tool_output": {"flows": ["tool call validation"]},
+        "tool_input": {"flows": ["tool result validation"]},
+    },
+}
+
 
 def _config(rails: dict) -> RailsConfig:
     """Build a RailsConfig with the given ``rails`` block, under a stubbed API key."""
@@ -334,6 +353,39 @@ class TestSpeculativeToolCalls:
         _inject_json_response(speculative_iorails, _text_payload("ok"))
         await speculative_iorails.generate_async(MESSAGES, options={"rails": {"input": False}})
         assert spy.await_args.kwargs.get("enabled") is False
+
+
+class TestConfigDeclaredTools:
+    """Tools declared on the model (models[].parameters.tools) are validated by the tool-call
+    rail end to end, even when the request carries no options.llm_params.tools."""
+
+    @pytest_asyncio.fixture
+    async def iorails_config_tools(self):
+        async with started_iorails(CONFIG_TOOLS_CONFIG) as engine:
+            yield engine
+
+    @pytest.mark.asyncio
+    async def test_config_declared_tool_call_passes(self, iorails_config_tools):
+        """A call to a config-declared tool passes the rail when the request carries no llm_params."""
+        _inject_json_response(iorails_config_tools, _tool_call_payload("get_weather", '{"city": "Paris"}'))
+        result = await iorails_config_tools.generate_async(MESSAGES)
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_tool_call_blocked_against_config_tools(self, iorails_config_tools):
+        """A call to a tool absent from the config toolset is blocked when the request carries no llm_params."""
+        _inject_json_response(iorails_config_tools, _tool_call_payload("rm_rf", "{}"))
+        result = await iorails_config_tools.generate_async(MESSAGES)
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_streamed_undeclared_tool_call_blocked_against_config_tools(self, iorails_config_tools):
+        """In streaming, a call to a tool absent from the config toolset is blocked with no llm_params."""
+        _inject_sse_stream(iorails_config_tools, _tool_call_sse_lines("rm_rf", ["{}"]))
+        chunks = await _collect(iorails_config_tools.stream_async(MESSAGES))
+        violations = _stream_violation_chunks(chunks)
+        assert len(violations) == 1
+        assert violations[0]["error"]["param"] == "tool_output_rails"
 
 
 class TestNonStreamingToolResults:

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -34,7 +34,11 @@ from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from tests.guardrails.async_helpers import started_iorails
-from tests.guardrails.tool_helpers import WEATHER_SCHEMA, make_tool_conversation
+from tests.guardrails.tool_helpers import (
+    WEATHER_SCHEMA,
+    make_tool_conversation,
+    multi_turn_reused_call_id_messages,
+)
 
 BASE_CONFIG = {"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
 
@@ -337,6 +341,14 @@ class TestNonStreamingToolResults:
         result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         forbidden_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recycled_call_ids_across_turns_not_blocked(self, iorails):
+        """Multi-turn conversation reusing the same call_id across turns is valid"""
+
+        _inject_json_response(iorails, _text_payload("It's 12C in London."))
+        result = await iorails.generate_async(multi_turn_reused_call_id_messages())
+        assert result == {"role": "assistant", "content": "It's 12C in London."}
 
 
 class TestStreamingToolCalls:

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -29,6 +29,7 @@ import pytest
 import pytest_asyncio
 
 from nemoguardrails import Guardrails
+from nemoguardrails.guardrails.guardrails_types import RailDirection
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -245,6 +246,13 @@ class TestRouting:
         with pytest.raises(RuntimeError):
             IORails(_config({"tool_output": {"flows": ["tool call validation", "tool call validation"]}}))
 
+    def test_tool_parallel_flag_warns_inert(self):
+        # tool_*.parallel is inert (tool rails run sequentially); construction warns
+        # rather than silently ignoring it.
+        config = _config({"tool_output": {"flows": ["tool call validation"], "parallel": True}})
+        with pytest.warns(UserWarning, match="not honored by IORails"):
+            IORails(config)
+
 
 class TestNonStreamingToolCalls:
     @pytest.mark.asyncio
@@ -360,3 +368,46 @@ class TestFailClosed:
         dup_params = {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
         result = await iorails.generate_async(MESSAGES, options={"llm_params": dup_params})
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+
+class TestToolRailBlockMetrics:
+    """When metrics are enabled, a tool-rail block records the directional block metric."""
+
+    @pytest.mark.asyncio
+    async def test_nonstream_tool_result_block_records_input_metric(self, iorails):
+        iorails._metrics_enabled = True
+        with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
+            result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        record_blocked.assert_called_once_with(RailDirection.INPUT)
+
+    @pytest.mark.asyncio
+    async def test_nonstream_tool_call_block_records_output_metric(self, iorails):
+        iorails._metrics_enabled = True
+        _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
+        with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
+            result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        record_blocked.assert_called_once_with(RailDirection.OUTPUT)
+
+    @pytest.mark.asyncio
+    async def test_streamed_tool_result_block_records_input_metric(self, iorails):
+        iorails._metrics_enabled = True
+        with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
+            chunks = await _collect(iorails.stream_async(make_tool_conversation(result_call_id="call_999")))
+        assert REFUSAL_MESSAGE in chunks
+        record_blocked.assert_called_once_with(RailDirection.INPUT)
+
+    @pytest.mark.asyncio
+    async def test_streamed_tool_call_block_records_metric_and_captures(self, iorails):
+        # Enable both metrics and content capture so the block records the OUTPUT metric
+        # and appends the violation payload to the captured output.
+        iorails._metrics_enabled = True
+        iorails._content_capture_enabled = True
+        _inject_sse_stream(iorails, _tool_call_sse_lines("rm_rf", ["{}"]))
+        with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
+            chunks = await _collect(iorails.stream_async(MESSAGES, options={"llm_params": LLM_PARAMS}))
+        violations = _stream_violation_chunks(chunks)
+        assert len(violations) == 1
+        assert violations[0]["error"]["param"] == "tool_output_rails"
+        record_blocked.assert_called_once_with(RailDirection.OUTPUT)

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -326,6 +326,15 @@ class TestSpeculativeToolCalls:
         result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result["tool_calls"][0]["function"]["name"] == "get_weather"
 
+    @pytest.mark.asyncio
+    async def test_input_toggle_forwarded_to_input_rails(self, speculative_iorails):
+        """On the speculative path, options.rails.input is forwarded to is_input_safe as the enabled argument."""
+        spy = AsyncMock(wraps=speculative_iorails.rails_manager.is_input_safe)
+        speculative_iorails.rails_manager.is_input_safe = spy
+        _inject_json_response(speculative_iorails, _text_payload("ok"))
+        await speculative_iorails.generate_async(MESSAGES, options={"rails": {"input": False}})
+        assert spy.await_args.kwargs.get("enabled") is False
+
 
 class TestNonStreamingToolResults:
     @pytest.mark.asyncio
@@ -421,6 +430,43 @@ class TestPerRequestToggles:
             options={"rails": {"tool_input": False}},
         )
         assert result == {"role": "assistant", "content": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_input_toggle_forwarded_to_input_rails(self, iorails):
+        """options.rails.input is forwarded to is_input_safe as the enabled argument."""
+        spy = AsyncMock(wraps=iorails.rails_manager.is_input_safe)
+        iorails.rails_manager.is_input_safe = spy
+        _inject_json_response(iorails, _text_payload("ok"))
+        await iorails.generate_async(MESSAGES, options={"rails": {"input": False}})
+        assert spy.await_args.kwargs.get("enabled") is False
+
+    @pytest.mark.asyncio
+    async def test_output_toggle_forwarded_to_output_rails(self, iorails):
+        """options.rails.output is forwarded to is_output_safe as the enabled argument."""
+        spy = AsyncMock(wraps=iorails.rails_manager.is_output_safe)
+        iorails.rails_manager.is_output_safe = spy
+        _inject_json_response(iorails, _text_payload("ok"))
+        await iorails.generate_async(MESSAGES, options={"rails": {"output": False}})
+        assert spy.await_args.kwargs.get("enabled") is False
+
+    @pytest.mark.asyncio
+    async def test_streamed_input_toggle_forwarded_to_input_rails(self, iorails):
+        """In streaming, options.rails.input is forwarded to is_input_safe as the enabled argument."""
+        spy = AsyncMock(wraps=iorails.rails_manager.is_input_safe)
+        iorails.rails_manager.is_input_safe = spy
+        text_lines = [
+            _sse(
+                {
+                    "id": "c1",
+                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": "ok"}, "finish_reason": None}],
+                }
+            ),
+            _sse({"id": "c1", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}),
+            b"data: [DONE]\n\n",
+        ]
+        _inject_sse_stream(iorails, text_lines)
+        await _collect(iorails.stream_async(MESSAGES, options={"rails": {"input": False}}))
+        assert spy.await_args.kwargs.get("enabled") is False
 
 
 class TestFailClosed:

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -360,6 +360,18 @@ class TestStreamingToolCalls:
         # The tool-call chunk is suppressed: no chunk carries the tool call.
         assert not any(isinstance(c, str) and '"tool_calls"' in c for c in chunks)
 
+    @pytest.mark.asyncio
+    async def test_truncated_streamed_tool_call_fails_closed(self, iorails):
+        # Truncated tool-call args must fail closed (parity with non-streaming): no tool-call
+        # chunk is surfaced with silently-empty args; a generation error is emitted instead.
+        _inject_sse_stream(iorails, _tool_call_sse_lines("get_weather", ['{"city": "Par']))
+        chunks = await _collect(iorails.stream_async(MESSAGES, options={"llm_params": LLM_PARAMS}))
+
+        assert not any(isinstance(c, str) and '"tool_calls"' in c for c in chunks)
+        error_chunks = [c for c in chunks if isinstance(c, str) and '"error"' in c]
+        assert error_chunks, f"expected a generation error chunk, got {chunks}"
+        assert json.loads(error_chunks[0])["error"]["code"] == "generation_failed"
+
 
 class TestStreamingToolResults:
     @pytest.mark.asyncio

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -405,10 +405,13 @@ class TestStreamingToolCalls:
 class TestStreamingToolResults:
     @pytest.mark.asyncio
     async def test_unlinked_tool_result_blocks_stream(self, iorails):
-        # As above, the streaming block must short-circuit before the model is called.
+        """A guardrails_violation error chunk (param=tool_input_rails) is emitted, and the model is never called."""
         forbidden_post = _inject_forbidden_transport(iorails)
         chunks = await _collect(iorails.stream_async(make_tool_conversation(result_call_id="call_999")))
-        assert REFUSAL_MESSAGE in chunks
+        violations = _stream_violation_chunks(chunks)
+        assert len(violations) == 1
+        assert violations[0]["error"]["param"] == "tool_input_rails"
+        assert REFUSAL_MESSAGE not in chunks
         forbidden_post.assert_not_called()
 
 
@@ -504,7 +507,7 @@ class TestToolRailBlockMetrics:
         iorails._metrics_enabled = True
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
             chunks = await _collect(iorails.stream_async(make_tool_conversation(result_call_id="call_999")))
-        assert REFUSAL_MESSAGE in chunks
+        assert _stream_violation_chunks(chunks)
         record_blocked.assert_called_once_with(RailDirection.INPUT)
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -115,6 +115,22 @@ def _inject_sse_stream(iorails: IORails, raw_lines: list) -> None:
     engine._running = True
 
 
+def _inject_forbidden_transport(iorails: IORails) -> MagicMock:
+    """Wire the 'main' engine with a transport whose ``post`` must never be called.
+
+    Returns the mock ``post`` so the test can assert it stayed untouched. Any actual
+    call raises immediately, so a regression that lets a blocked request reach the
+    provider fails loudly here instead of hitting the live network.
+    """
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(side_effect=AssertionError("provider must not be called when the request is blocked"))
+    mock_client.closed = False
+    engine = iorails.engine_registry._get_engine("main", ModelEngine)
+    engine._client = mock_client
+    engine._running = True
+    return mock_client.post
+
+
 def _tool_call_payload(name: str, arguments_json: str, call_id: str = "call_1") -> dict:
     """A non-streaming /v1/chat/completions response carrying a single tool call."""
     return {
@@ -240,6 +256,16 @@ class TestRouting:
         assert reason is not None
         assert "duplicate" in reason
 
+    def test_normalized_duplicate_tool_flow_falls_back(self):
+        # Two entries differing only by a `$model=` suffix normalize to the same tool
+        # flow (the tool rails ignore the suffix); they must be caught as a duplicate
+        # rather than slipping past and running twice.
+        reason = IORails.unsupported_reason(
+            _config({"tool_output": {"flows": ["tool call validation", "tool call validation $model=x"]}})
+        )
+        assert reason is not None
+        assert "duplicate" in reason
+
     def test_iorails_construction_raises_on_duplicate_flow(self):
         # Why unsupported_reason pre-validates duplicates: IORails.__init__ itself would
         # raise on a dup flow, so without the pre-check Guardrails could not fall back.
@@ -305,10 +331,12 @@ class TestNonStreamingToolResults:
 
     @pytest.mark.asyncio
     async def test_unlinked_tool_result_blocked_before_generation(self, iorails):
-        # No response is injected: a blocked tool result must short-circuit before
-        # the model is ever called.
+        # A blocked tool result must short-circuit before the model is ever called:
+        # wire a transport that fails if used, and assert it stayed untouched.
+        forbidden_post = _inject_forbidden_transport(iorails)
         result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        forbidden_post.assert_not_called()
 
 
 class TestStreamingToolCalls:
@@ -336,8 +364,11 @@ class TestStreamingToolCalls:
 class TestStreamingToolResults:
     @pytest.mark.asyncio
     async def test_unlinked_tool_result_blocks_stream(self, iorails):
+        # As above, the streaming block must short-circuit before the model is called.
+        forbidden_post = _inject_forbidden_transport(iorails)
         chunks = await _collect(iorails.stream_async(make_tool_conversation(result_call_id="call_999")))
         assert REFUSAL_MESSAGE in chunks
+        forbidden_post.assert_not_called()
 
 
 class TestPerRequestToggles:

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the tool rails wired into IORails.
+
+These drive the full top-level request path (``generate_async`` / ``stream_async``)
+with only the aiohttp transport mocked, so the real ModelEngine parsing
+(``parse_tools`` / ``extract_tool_results`` / ``extract_tool_calls``) and the
+RailsManager tool rails run end to end. They are the IORails-level companions to
+``test_tool_rails_e2e.py`` (which stops at the RailsManager surface).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from nemoguardrails import Guardrails
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.model_engine import ModelEngine
+from nemoguardrails.rails.llm.config import RailsConfig
+from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.tool_helpers import WEATHER_SCHEMA, make_tool_conversation
+
+BASE_CONFIG = {"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
+
+TOOL_CONFIG = {
+    **BASE_CONFIG,
+    "rails": {
+        "tool_output": {"flows": ["tool call validation"]},
+        "tool_input": {"flows": ["tool result validation"]},
+    },
+}
+
+SPECULATIVE_TOOL_CONFIG = {
+    **BASE_CONFIG,
+    "rails": {
+        "input": {"speculative_generation": True},
+        "tool_output": {"flows": ["tool call validation"]},
+        "tool_input": {"flows": ["tool result validation"]},
+    },
+}
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather for a city.",
+        "parameters": WEATHER_SCHEMA,
+    },
+}
+LLM_PARAMS = {"tools": [WEATHER_TOOL], "tool_choice": "auto"}
+MESSAGES = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+
+def _config(rails: dict) -> RailsConfig:
+    """Build a RailsConfig with the given ``rails`` block, under a stubbed API key."""
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        return RailsConfig.from_content(config={**BASE_CONFIG, "rails": rails})
+
+
+def _inject_json_response(iorails: IORails, payload: dict) -> None:
+    """Wire the 'main' engine's aiohttp client to return *payload* as JSON."""
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=payload)
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    mock_client.closed = False
+    engine = iorails.engine_registry._get_engine("main", ModelEngine)
+    engine._client = mock_client
+    engine._running = True
+
+
+def _inject_sse_stream(iorails: IORails, raw_lines: list) -> None:
+    """Wire the 'main' engine's aiohttp client to stream *raw_lines* via readline()."""
+    all_lines = []
+    for raw in raw_lines:
+        for part in raw.split(b"\n"):
+            if part:
+                all_lines.append(part + b"\n")
+    line_iter = iter(all_lines)
+
+    async def _readline():
+        return next(line_iter, b"")
+
+    mock_content = MagicMock()
+    mock_content.readline = _readline
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = 200
+    mock_response.content = mock_content
+
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    mock_client.closed = False
+    engine = iorails.engine_registry._get_engine("main", ModelEngine)
+    engine._client = mock_client
+    engine._running = True
+
+
+def _tool_call_payload(name: str, arguments_json: str, call_id: str = "call_1") -> dict:
+    """A non-streaming /v1/chat/completions response carrying a single tool call."""
+    return {
+        "id": "chatcmpl-1",
+        "model": "meta/llama-3.3-70b-instruct",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments_json}}
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+
+
+def _text_payload(text: str) -> dict:
+    """A non-streaming /v1/chat/completions response carrying plain assistant text."""
+    return {
+        "id": "chatcmpl-1",
+        "model": "meta/llama-3.3-70b-instruct",
+        "choices": [{"message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+    }
+
+
+def _sse(chunk: dict) -> bytes:
+    return ("data: " + json.dumps(chunk) + "\n\n").encode("utf-8")
+
+
+def _tool_call_sse_lines(name: str, arg_fragments: list, call_id: str = "call_1") -> list:
+    """SSE lines streaming a single tool call: id/name first, then argument fragments, then finish."""
+    chunks = [
+        {
+            "id": "chatcmpl-1",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {"index": 0, "id": call_id, "type": "function", "function": {"name": name, "arguments": ""}}
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+    ]
+    for fragment in arg_fragments:
+        chunks.append(
+            {
+                "id": "chatcmpl-1",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"tool_calls": [{"index": 0, "function": {"arguments": fragment}}]},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
+    chunks.append({"id": "chatcmpl-1", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]})
+    lines = [_sse(chunk) for chunk in chunks]
+    lines.append(b"data: [DONE]\n\n")
+    return lines
+
+
+async def _collect(stream) -> list:
+    return [chunk async for chunk in stream]
+
+
+def _stream_violation_chunks(chunks: list) -> list:
+    """The guardrails_violation error payloads among streamed string chunks."""
+    violations = []
+    for chunk in chunks:
+        if isinstance(chunk, str) and '"error"' in chunk:
+            try:
+                parsed = json.loads(chunk)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict) and parsed.get("error", {}).get("type") == "guardrails_violation":
+                violations.append(parsed)
+    return violations
+
+
+@pytest_asyncio.fixture
+async def iorails():
+    """A started IORails with both tool rails enabled (transport mocked per test)."""
+    async with started_iorails(TOOL_CONFIG) as engine:
+        yield engine
+
+
+class TestRouting:
+    """A config with tool rails routes to IORails; misconfigured tool flows fall back."""
+
+    def test_tool_rails_config_can_be_handled(self):
+        assert IORails.can_handle(_config(TOOL_CONFIG["rails"])) is True
+
+    def test_guardrails_dispatches_tool_rails_to_iorails(self):
+        guardrails = Guardrails(_config(TOOL_CONFIG["rails"]))
+        assert guardrails.use_iorails_engine is True
+        assert isinstance(guardrails.rails_engine, IORails)
+
+    def test_unknown_tool_output_flow_falls_back(self):
+        reason = IORails.unsupported_reason(_config({"tool_output": {"flows": ["make a sandwich"]}}))
+        assert reason is not None
+        assert "tool output" in reason
+
+    def test_misdirected_flow_falls_back(self):
+        # The tool-result validator under tool_output is the wrong direction.
+        reason = IORails.unsupported_reason(_config({"tool_output": {"flows": ["tool result validation"]}}))
+        assert reason is not None
+        assert "tool output" in reason
+
+    def test_duplicate_tool_flow_falls_back(self):
+        reason = IORails.unsupported_reason(
+            _config({"tool_output": {"flows": ["tool call validation", "tool call validation"]}})
+        )
+        assert reason is not None
+        assert "duplicate" in reason
+
+    def test_iorails_construction_raises_on_duplicate_flow(self):
+        # Why unsupported_reason pre-validates duplicates: IORails.__init__ itself would
+        # raise on a dup flow, so without the pre-check Guardrails could not fall back.
+        with pytest.raises(RuntimeError):
+            IORails(_config({"tool_output": {"flows": ["tool call validation", "tool call validation"]}}))
+
+
+class TestNonStreamingToolCalls:
+    @pytest.mark.asyncio
+    async def test_allowed_tool_call_passes(self, iorails):
+        _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
+        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_tool_call_blocked(self, iorails):
+        _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
+        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_invalid_arguments_blocked(self, iorails):
+        # Missing the required "city" argument violates the declared schema.
+        _inject_json_response(iorails, _tool_call_payload("get_weather", "{}"))
+        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+
+class TestSpeculativeToolCalls:
+    """The tool-call rail runs after generation on the speculative path too."""
+
+    @pytest_asyncio.fixture
+    async def speculative_iorails(self):
+        async with started_iorails(SPECULATIVE_TOOL_CONFIG) as engine:
+            yield engine
+
+    @pytest.mark.asyncio
+    async def test_undeclared_tool_call_blocked(self, speculative_iorails):
+        _inject_json_response(speculative_iorails, _tool_call_payload("rm_rf", "{}"))
+        result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_allowed_tool_call_passes(self, speculative_iorails):
+        _inject_json_response(speculative_iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
+        result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+class TestNonStreamingToolResults:
+    @pytest.mark.asyncio
+    async def test_linked_tool_result_passes(self, iorails):
+        _inject_json_response(iorails, _text_payload("It is sunny."))
+        result = await iorails.generate_async(make_tool_conversation(result_call_id="call_1"))
+        assert result == {"role": "assistant", "content": "It is sunny."}
+
+    @pytest.mark.asyncio
+    async def test_unlinked_tool_result_blocked_before_generation(self, iorails):
+        # No response is injected: a blocked tool result must short-circuit before
+        # the model is ever called.
+        result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+
+class TestStreamingToolCalls:
+    @pytest.mark.asyncio
+    async def test_allowed_streamed_tool_call_passes(self, iorails):
+        _inject_sse_stream(iorails, _tool_call_sse_lines("get_weather", ['{"city": ', '"Paris"}']))
+        chunks = await _collect(iorails.stream_async(MESSAGES, options={"llm_params": LLM_PARAMS}))
+
+        assert _stream_violation_chunks(chunks) == []
+        terminal = json.loads(chunks[-1])
+        assert terminal["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_streamed_tool_call_blocked(self, iorails):
+        _inject_sse_stream(iorails, _tool_call_sse_lines("rm_rf", ["{}"]))
+        chunks = await _collect(iorails.stream_async(MESSAGES, options={"llm_params": LLM_PARAMS}))
+
+        violations = _stream_violation_chunks(chunks)
+        assert len(violations) == 1
+        assert violations[0]["error"]["param"] == "tool_output_rails"
+        # The tool-call chunk is suppressed: no chunk carries the tool call.
+        assert not any(isinstance(c, str) and '"tool_calls"' in c for c in chunks)
+
+
+class TestStreamingToolResults:
+    @pytest.mark.asyncio
+    async def test_unlinked_tool_result_blocks_stream(self, iorails):
+        chunks = await _collect(iorails.stream_async(make_tool_conversation(result_call_id="call_999")))
+        assert REFUSAL_MESSAGE in chunks
+
+
+class TestPerRequestToggles:
+    @pytest.mark.asyncio
+    async def test_tool_output_disabled_skips_tool_call_rail(self, iorails):
+        # An undeclared tool call would normally block; disabling tool_output lets it through.
+        _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
+        options = {"llm_params": LLM_PARAMS, "rails": {"tool_output": False}}
+        result = await iorails.generate_async(MESSAGES, options=options)
+        assert result["tool_calls"][0]["function"]["name"] == "rm_rf"
+
+    @pytest.mark.asyncio
+    async def test_tool_input_disabled_skips_tool_result_rail(self, iorails):
+        # An unlinked tool result would normally block; disabling tool_input lets it through.
+        _inject_json_response(iorails, _text_payload("ok"))
+        result = await iorails.generate_async(
+            make_tool_conversation(result_call_id="call_999"),
+            options={"rails": {"tool_input": False}},
+        )
+        assert result == {"role": "assistant", "content": "ok"}
+
+
+class TestFailClosed:
+    @pytest.mark.asyncio
+    async def test_duplicate_tool_definitions_block(self, iorails):
+        # parse_tools raises on a duplicate tool name; the request must fail closed.
+        _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
+        dup_params = {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
+        result = await iorails.generate_async(MESSAGES, options={"llm_params": dup_params})
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}

--- a/tests/guardrails/test_tool_result_action.py
+++ b/tests/guardrails/test_tool_result_action.py
@@ -41,14 +41,15 @@ class TestToolResultRailAction:
         assert result.is_safe is True
 
     @pytest.mark.asyncio
-    async def test_result_without_name_links_on_call_id_only(self):
+    async def test_result_without_name_blocked_when_prior_name_known(self):
+        """When the prior call's name is known, a result without a name should be blocked"""
         result = await ToolResultRailAction().run([_result("c2")], _prior_calls())
-        assert result.is_safe is True
+        assert_blocked(result, "missing a name", "search")
 
     @pytest.mark.asyncio
     async def test_list_content_is_well_formed(self):
         result = await ToolResultRailAction().run(
-            [_result("c1", content=[{"type": "text", "text": "18C"}])], _prior_calls()
+            [_result("c1", name="get_weather", content=[{"type": "text", "text": "18C"}])], _prior_calls()
         )
         assert result.is_safe is True
 
@@ -75,7 +76,7 @@ class TestToolResultRailAction:
     @pytest.mark.asyncio
     async def test_malformed_content_is_blocked(self):
         result = await ToolResultRailAction().run(
-            [_result("c1", content={"unexpected": "shape"})],  # type: ignore[arg-type]
+            [_result("c1", name="get_weather", content={"unexpected": "shape"})],  # type: ignore[arg-type]
             _prior_calls(),
         )
         assert_blocked(result, "malformed content")
@@ -83,14 +84,14 @@ class TestToolResultRailAction:
     @pytest.mark.asyncio
     async def test_list_of_non_dicts_is_blocked(self):
         result = await ToolResultRailAction().run(
-            [_result("c1", content=[1, 2, 3])],  # type: ignore[arg-type]
+            [_result("c1", name="get_weather", content=[1, 2, 3])],  # type: ignore[arg-type]
             _prior_calls(),
         )
         assert_blocked(result, "malformed content")
 
     @pytest.mark.asyncio
     async def test_empty_content_list_is_well_formed(self):
-        result = await ToolResultRailAction().run([_result("c1", content=[])], _prior_calls())
+        result = await ToolResultRailAction().run([_result("c1", name="get_weather", content=[])], _prior_calls())
         assert result.is_safe is True
 
     @pytest.mark.asyncio
@@ -174,12 +175,23 @@ class TestValidateResultName:
     def test_matching_names_returns_none(self):
         assert self.action._validate_result_name(_result("c1", name="get_weather"), self.prior) is None
 
-    def test_result_without_name_returns_none(self):
-        assert self.action._validate_result_name(_result("c1"), self.prior) is None
+    def test_result_without_name_is_blocked_when_prior_name_known(self):
+        """When the prior call's name is known, a result without a name should be blocked"""
+        assert_blocked(
+            self.action._validate_result_name(_result("c1"), self.prior),
+            "missing a name",
+            "get_weather",
+            "c1",
+        )
 
     def test_prior_without_function_name_returns_none(self):
+        """If a prior call is missing a name, a matching result with a name is allowed through"""
         prior = ToolCall(id="c1", function=ToolCallFunction(name="", arguments={}))
         assert self.action._validate_result_name(_result("c1", name="get_weather"), prior) is None
+
+    def test_both_names_absent_returns_none(self):
+        prior = ToolCall(id="c1", function=ToolCallFunction(name="", arguments={}))
+        assert self.action._validate_result_name(_result("c1"), prior) is None
 
     def test_name_mismatch_is_blocked(self):
         assert_blocked(

--- a/tests/guardrails/test_tool_schema.py
+++ b/tests/guardrails/test_tool_schema.py
@@ -144,11 +144,62 @@ class TestValidateArguments:
         assert reason is not None
         assert "get_weather" in reason
 
-    def test_no_schema_skips_validation(self):
-        # A tool with no declared schema (hosted tool, or a function with no
-        # parameters) is allowlist-only: any arguments are accepted here.
+    def test_hosted_tool_without_schema_skips_validation(self):
+        """A hosted/server tool (name is None) declares no schema and the provider owns the call shape, so it stays allowlist-only: any arguments are accepted here."""
         hosted = Tool(name=None, type="web_search")
         assert validate_arguments(hosted, {"anything": [1, 2, 3]}) is None
+
+    def test_function_tool_without_parameters_allows_empty_arguments(self):
+        """A no-parameter function tool legitimately called with no arguments stays safe."""
+        tool = Tool(name="get_time", arguments_schema=None)
+        assert validate_arguments(tool, {}) is None
+
+    def test_function_tool_without_parameters_rejects_arguments(self):
+        """A function tool that declares no parameters accepts no arguments, so supplying any blocks instead of skipping."""
+        tool = Tool(name="get_time", arguments_schema=None)
+        reason = validate_arguments(tool, {"path": "/etc/shadow"})
+        assert reason is not None
+        assert "get_time" in reason
+        assert "no arguments" in reason
+
+    def test_function_tool_empty_dict_schema_rejects_arguments(self):
+        """An explicit empty schema ({}) declares no properties; jsonschema would accept anything, so it is treated as no-args."""
+        tool = Tool(name="ping", arguments_schema={})
+        reason = validate_arguments(tool, {"x": 1})
+        assert reason is not None
+        assert "ping" in reason
+        assert "no arguments" in reason
+
+    def test_function_tool_empty_properties_rejects_arguments(self):
+        """An object schema with empty properties and no additionalProperties:false defaults to permissive, so it is treated as no-args."""
+        tool = Tool(name="ping", arguments_schema={"type": "object", "properties": {}})
+        reason = validate_arguments(tool, {"x": 1})
+        assert reason is not None
+        assert "ping" in reason
+        assert "no arguments" in reason
+
+    def test_function_tool_object_schema_without_properties_rejects_arguments(self):
+        """An object schema with no properties key at all declares no inputs, so it is treated as no-args."""
+        tool = Tool(name="ping", arguments_schema={"type": "object"})
+        reason = validate_arguments(tool, {"x": 1})
+        assert reason is not None
+        assert "ping" in reason
+        assert "no arguments" in reason
+
+    def test_function_tool_additional_properties_schema_accepts_arguments(self):
+        """A schema that opens additionalProperties declares an input channel, so it is not treated as no-args and free-form arguments pass."""
+        tool = Tool(name="kv", arguments_schema={"type": "object", "additionalProperties": {"type": "string"}})
+        assert validate_arguments(tool, {"foo": "bar"}) is None
+
+    def test_function_tool_pattern_properties_schema_accepts_arguments(self):
+        """A schema that opens patternProperties declares an input channel, so it is not treated as no-args and matching arguments pass."""
+        tool = Tool(name="kv", arguments_schema={"type": "object", "patternProperties": {"^x": {"type": "integer"}}})
+        assert validate_arguments(tool, {"x1": 1}) is None
+
+    def test_function_tool_composition_schema_accepts_arguments(self):
+        """A schema using a composition keyword declares an input channel, so it is not treated as no-args and conforming arguments pass."""
+        tool = Tool(name="kv", arguments_schema={"anyOf": [{"type": "object"}]})
+        assert validate_arguments(tool, {"x": 1}) is None
 
     def test_malformed_schema_is_reported_not_raised(self):
         # A declared schema that is not valid JSON Schema degrades to a reason

--- a/tests/guardrails/tool_helpers.py
+++ b/tests/guardrails/tool_helpers.py
@@ -57,3 +57,38 @@ def make_tool_conversation(result_call_id: str = "call_1") -> list:
         },
         {"role": "tool", "tool_call_id": result_call_id, "name": "get_weather", "content": "18C"},
     ]
+
+
+def multi_turn_reused_call_id_messages(call_id: str = "call_0") -> list:
+    """Two ``get_weather`` turns that reuse the same tool-call id across turns.
+    This is valid according to the OpenAI chat completions spec"""
+
+    return [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "name": "get_weather", "content": "18C"},
+        {"role": "assistant", "content": "It's 18C in Paris."},
+        {"role": "user", "content": "And in London?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "London"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "name": "get_weather", "content": "12C"},
+    ]

--- a/tests/guardrails/tool_helpers.py
+++ b/tests/guardrails/tool_helpers.py
@@ -92,3 +92,32 @@ def multi_turn_reused_call_id_messages(call_id: str = "call_0") -> list:
         },
         {"role": "tool", "tool_call_id": call_id, "name": "get_weather", "content": "12C"},
     ]
+
+
+def malformed_prior_tool_call_messages() -> list:
+    """Two turns where the FIRST turn's tool-call arguments are malformed (truncated JSON)."""
+    return [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_0", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Par'}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_0", "name": "get_weather", "content": "18C"},
+        {"role": "assistant", "content": "It's 18C in Paris."},
+        {"role": "user", "content": "And in London?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "London"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "get_weather", "content": "12C"},
+    ]


### PR DESCRIPTION
## Description

**Stacked PR** connecting up the tool-calling rails from the previous PR #2030 at IORails-level. Adds validation of tool-calling arguments and schema, and results of tool execution by the agent harness.

### PR Stack

* **Merged** #2016 : Non-streaming tool-calling connected to main LLM for inference and back to the client with the response. No canonicalization.
* **Merged** #2024  : Streaming tool-calling implementation. Just propagating tool calls to the Main LLM and back again without canonicalization.
* (#2030) : **Applies to RailsManager and ModelRegistry only**. Add canonical internal dataclasses for tool-calling. Implement tool-calling rails to check the LLM-generated function call matches the provided tool signature and schema , and that the response from the function execution is from a previous tool call.
* **This PR** (#2058) : Connect up RailsManager tool-calling at the IORails level, test end-to-end integration.
* **TODO** : Docs PR describing the feature as implemented.

## Related Issue(s)

Stacked PR on top of #2030 (which added tool-calling argument and results rails).

## Verification

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE poetry run pytest -n auto --dist worksteal
================================================================ test session starts =================================================================
platform darwin -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-tool-calling-api
configfile: pytest.ini
testpaths: tests, benchmark/tests
plugins: anyio-4.12.1, langsmith-0.7.12, xdist-3.8.0, httpx-0.35.0, asyncio-0.26.0, profiling-1.8.1, cov-7.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [5079 items]
.............................................................................................................................................. [  2%]
...............ss.ss.......................................................................................................................... [  5%]
....................................................................................................................s......................... [  8%]
.........................................................s.................................................................s.................. [ 11%]
...........................................................................................................s..ss.ssss..................sss.sss [ 13%]
ss............................................................................................................................................ [ 16%]
..............................................................................................................................s............... [ 19%]
.............................................................................................................................................. [ 22%]
..........................................................................................................................s..ssssss.s......... [ 25%]
.............................................................................................................................................. [ 27%]
.................................................................sssss........................................................................ [ 30%]
....................................s........ss.....................s.s..................................................................s..s. [ 33%]
.s...s....s....s......s....................................................................................................................... [ 36%]
.............................................................................................................................................. [ 39%]
...............................................................................................s.............................................. [ 41%]
.............................................................................................................................................. [ 44%]
........................................................................................sssss.......s.ssss.ss.s..s.ssss.ss..sss............... [ 47%]
.............................................................................................................................................. [ 50%]
.........................ssss.ssss..........sssss.s...ss...s......................ssssssss.................................................... [ 53%]
.................................................................................................................s............................ [ 55%]
........................................................................................................................................ss.... [ 58%]
....................................................sssssss..............s.ssss............................................................... [ 61%]
.............................................................................................................................................. [ 64%]
.............................................................................s................................................................ [ 67%]
.............................................................................................................................................. [ 69%]
.............................................................ss.....................s......................................................... [ 72%]
.............................s..s.................................................................ss...........s......ss...................... [ 75%]
sssssssssssss...............................................................................................................................s. [ 78%]
.....s...................................................................................................ss.................................s. [ 81%]
.....................................................................s.....................................................s.................. [ 83%]
.......................................................................................s..........s........................................... [ 86%]
...................................................................................................................ssssssss................... [ 89%]
............sss..sss.s..ss...sssssssssssss......s........................................ss................................................... [ 92%]
.............................................................................................................................................. [ 95%]
........................................................................................................................................s..... [ 97%]
............................s................................................................................                                  [100%]
========================================================= 4899 passed, 180 skipped in 32.54s =========================================================
```


### Integration test with Chat

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-06-22 16:08:08 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-22 16:08:08 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-06-22 16:08:08 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-06-22 16:08:08 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-22 16:08:08 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-06-22 16:08:11 INFO: [b49f905e82d10f01] generate_async called
2026-06-22 16:08:11 INFO: [b49f905e82d10f01] Running input rails
2026-06-22 16:08:11 INFO: [b49f905e82d10f01] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-22 16:08:12 INFO: [b49f905e82d10f01] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-06-22 16:08:12 INFO: [b49f905e82d10f01] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-22 16:08:12 INFO: [b49f905e82d10f01] Calling main LLM
2026-06-22 16:08:12 INFO: [b49f905e82d10f01] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-22 16:08:14 INFO: [b49f905e82d10f01] Running output rails
2026-06-22 16:08:14 INFO: [b49f905e82d10f01] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-22 16:08:14 INFO: [b49f905e82d10f01] generate_async completed time=2996.9ms
Hello. How can I help you today?

> How can I burn a house down?
2026-06-22 16:08:18 INFO: [6e1d375cffca00cd] generate_async called
2026-06-22 16:08:18 INFO: [6e1d375cffca00cd] Running input rails
2026-06-22 16:08:18 INFO: [6e1d375cffca00cd] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-22 16:08:19 INFO: [6e1d375cffca00cd] Input flow content safety check input $model=content_safety blocked
2026-06-22 16:08:19 INFO: [6e1d375cffca00cd] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-06-22 16:08:19 INFO: [6e1d375cffca00cd] generate_async completed time=753.7ms
I'm sorry, I can't respond to that.
```


### Integration test with Prod endpoint  (using [e2e_tool_rail_validation.py](https://gist.github.com/tgasser-nv/6db1490ef69dd314a99567f469517925)

#### Non-streaming

```
$ poetry run python ~/utils/toolcalling/e2e_tool_rail_validation.py
=== IORails tool-rail e2e - model=gpt-4o-mini, mode=non-streaming ===
2026-06-22 16:49:45 INFO: Registered model engine: type=main, model=gpt-4o-mini, base_url=https://api.openai.com
2026-06-22 16:49:45 INFO: RailsManager initialized: input_flows=[], output_flows=[], tool_call_flows=['tool call validation'], tool_result_flows=['tool result validation'], input_parallel=False, output_parallel=False

[1/2] ToolCallRail: asking the model to call get_weather ...
2026-06-22 16:49:45 INFO: [cb705e54599023a5] generate_async called
2026-06-22 16:49:45 INFO: [cb705e54599023a5] Running tool result rails
2026-06-22 16:49:45 INFO: [cb705e54599023a5] Running input rails
2026-06-22 16:49:45 INFO: [cb705e54599023a5] Calling main LLM
2026-06-22 16:49:45 INFO: [cb705e54599023a5] HTTP POST https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-22 16:49:47 INFO: [cb705e54599023a5] generate_async completed time=1231.1ms
  ok  model emitted: get_weather({"city": "Paris"}) [id=call_5gkDEcEHodlEm278eYhvhJHm]
  ok  ToolCallRail passed (the call was surfaced, not blocked)

[2/2] ToolResultRail: feeding the tool result back ...
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] generate_async called
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] Running tool result rails
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] Running input rails
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] Calling main LLM
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] HTTP POST https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] Running output rails
2026-06-22 16:49:47 INFO: [c959cffa7f4fcc2c] generate_async completed time=648.4ms
  ok  ToolResultRail passed (the result was accepted, not blocked)
  ok  final answer: 'The current weather in Paris is 18 degrees Celsius and sunny.'

RESULT: PASS
```


#### Streaming

```
$ poetry run python ~/utils/toolcalling/e2e_tool_rail_validation.py --stream
=== IORails tool-rail e2e - model=gpt-4o-mini, mode=streaming ===
2026-06-22 16:46:54 INFO: Registered model engine: type=main, model=gpt-4o-mini, base_url=https://api.openai.com
2026-06-22 16:46:54 INFO: RailsManager initialized: input_flows=[], output_flows=[], tool_call_flows=['tool call validation'], tool_result_flows=['tool result validation'], input_parallel=False, output_parallel=False

[1/2] ToolCallRail: asking the model to call get_weather ...
2026-06-22 16:46:54 INFO: [ab39187f82a878da] stream_async called
2026-06-22 16:46:54 INFO: [ab39187f82a878da] Running tool result rails
2026-06-22 16:46:54 INFO: [ab39187f82a878da] Running input rails
2026-06-22 16:46:54 INFO: [ab39187f82a878da] Streaming main LLM
2026-06-22 16:46:54 INFO: [ab39187f82a878da] HTTP POST (stream) https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-22 16:46:55 INFO: [ab39187f82a878da] Tool-call-only stream: output rails skipped
2026-06-22 16:46:55 INFO: [ab39187f82a878da] generation task completed time=902.9ms
2026-06-22 16:46:55 INFO: [ab39187f82a878da] stream_async completed time=905.7ms
  ok  model emitted: get_weather({"city": "Paris"}) [id=call_ugSW28pkqELGLfrcHMEohjZz]
  ok  ToolCallRail passed (the call was surfaced, not blocked)

[2/2] ToolResultRail: feeding the tool result back ...
2026-06-22 16:46:55 INFO: [e29eb502a5a5ff1a] stream_async called
2026-06-22 16:46:55 INFO: [e29eb502a5a5ff1a] Running tool result rails
2026-06-22 16:46:55 INFO: [e29eb502a5a5ff1a] Running input rails
2026-06-22 16:46:55 INFO: [e29eb502a5a5ff1a] Streaming main LLM
2026-06-22 16:46:55 INFO: [e29eb502a5a5ff1a] HTTP POST (stream) https://api.openai.com/v1/chat/completions model='gpt-4o-mini'
2026-06-22 16:46:57 INFO: [e29eb502a5a5ff1a] generation task completed time=1313.1ms
2026-06-22 16:46:57 INFO: [e29eb502a5a5ff1a] stream_async completed time=1313.8ms
  ok  ToolResultRail passed (the result was accepted, not blocked)
  ok  final answer: 'The current weather in Paris is 18 degrees Celsius and sunny.'

RESULT: PASS
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool input/output safety validation is now supported. Tool calls and results can be validated against configured guardrails before execution and processing.

* **Tests**
  * Added comprehensive test coverage for tool call extraction, validation, and end-to-end tool rails behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->