### PR TITLE
chore(deps): add jsonschema to core deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -9250,4 +9250,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "9f24db0c0cf507d836776b3efbbd4f44977fe74158945f458d9426442104dcd3"
+content-hash = "05fc5e457ae4deadcbcd7c4211b7e2c16a6913b992eb418e3f8aaf423eb93d7b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ onnxruntime = [
 ]
 httpx = ">=0.24.1"
 jinja2 = ">=3.1.6"
+jsonschema = "^4.26.0"
 lark = ">=1.1.7"
 nest-asyncio = ">=1.5.6,"
 # NOTE:
@@ -173,7 +174,6 @@ starlette = ">=0.49.1"
 watchdog = ">=3.0.0"
 pyright = "^1.1.405"
 ruff = "0.14.6"
-jsonschema = "^4.26.0"
 chainlit = "^2.11.0"
 # LangChain integration is now opt-in at runtime (DefaultFramework replaces it for chat).
 # These dev deps keep the LangChain-specific tests and the NIM embeddings test path working.


### PR DESCRIPTION

## Description
fixes https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/28070188602/job/83102998951
jsonschema is an optional, dev-only dependency, but tool_schema.py imported it at module top level. 

Adding it to the core.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency handling for tool argument validation, so missing optional validation support now produces a clearer install message instead of failing at startup.
  * Kept existing argument validation behavior unchanged once the dependency is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->