### PR TITLE
build: stop bundling examples and repo files in the wheel (10x smaller)

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -5,14 +5,15 @@ set -e
 
 # Define variables for paths
 PACKAGE_DIR="nemoguardrails"
-EXAMPLES_SRC="examples"
-EXAMPLES_DST="$PACKAGE_DIR/examples"
+EXAMPLES_SRC="examples/bots"
+EXAMPLES_DST="$PACKAGE_DIR/examples/bots"
 
 # Copy the directories into the package directory
+mkdir -p "$PACKAGE_DIR/examples"
 cp -r "$EXAMPLES_SRC" "$EXAMPLES_DST"
 
 # Build the wheel using Poetry
 poetry build
 
 # Remove the copied directories after building
-rm -rf "$EXAMPLES_DST"
+rm -rf "$PACKAGE_DIR/examples"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,11 @@ include = [
   "LICENSE.md",
   "LICENSE-Apache-2.0.txt",
   "LICENCES-3rd-party.txt",
-  "examples/**/*",
-  "eval/data/**/*",
-  "**/*.yml",
-  "**/*.co",
-  "**/*.txt",
-  "**/*.json",
-  "**/*.lark",
+  "nemoguardrails/**/*.yml",
+  "nemoguardrails/**/*.co",
+  "nemoguardrails/**/*.txt",
+  "nemoguardrails/**/*.json",
+  "nemoguardrails/**/*.lark",
 ]
 
 classifiers = [


### PR DESCRIPTION
## Description

The published wheel shipped far more than the package: `examples/` was bundled
twice (top-level `include` glob + a `build.sh` copy into the package), and the
root-relative data globs (`**/*.yml`, `**/*.co`, ...) also swept in `tests/`,
`qa/`, `.github/`, `.venv/`, and other repo dirs. Only `examples/bots` is needed
at runtime (the server's default `rails_config_path`).

This PR copies just `examples/bots` in `build.sh`, scopes the data globs to
`nemoguardrails/**`, and drops a dead `eval/data` glob. No runtime code changes.

| Metric | 0.22.0 (PyPI) | After | Reduction |
| --- | --- | --- | --- |
| Wheel download (compressed) | 8.99 MB | 0.87 MB | **-90%** |
| Installed (uncompressed) | 27.32 MB | 2.76 MB | **-90%** |


## Verification

- Compared the rebuilt wheel against the real `0.22.0` PyPI wheel; all package
  data under `nemoguardrails/` is preserved and only `examples/bots` remains.
- Confirmed the server default config still resolves from the installed wheel.
- CI green, including `test-wheel` (install + server smoke test) on Python
  3.10-3.13.
- Note: this also stops shipping `tests/`, `qa/`, `.github/`, etc. in the wheel (broader than "drop examples")

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.