### PR TITLE
fix(iorails): Add no-op events_history_cache when IORails is used

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -296,14 +296,16 @@ class Guardrails(BaseGuardrails):
 
     @property
     def events_history_cache(self) -> dict:
-        """Per-session events history cache. Only supported for LLMRails.
+        """Per-session events history cache.
 
         Used by the server to persist conversation state across requests.
-        Stored by reference; assigning replaces the dict object, not its
-        contents.
+        For LLMRails this is stored by reference; assigning replaces the dict
+        object, not its contents.
+
+        IORails is stateless, return empty cache and drop cache-store writes
         """
         if isinstance(self.rails_engine, IORails):
-            raise NotImplementedError("IORails doesn't support events_history_cache attribute access")
+            return {}
 
         llmrails = cast(LLMRails, self.rails_engine)
         return llmrails.events_history_cache
@@ -311,7 +313,7 @@ class Guardrails(BaseGuardrails):
     @events_history_cache.setter
     def events_history_cache(self, value: dict) -> None:
         if isinstance(self.rails_engine, IORails):
-            raise NotImplementedError("IORails doesn't support events_history_cache attribute access")
+            return
 
         llmrails = cast(LLMRails, self.rails_engine)
         llmrails.events_history_cache = value

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -241,6 +241,9 @@ class IORails(BaseGuardrails):
         if llm is not None:
             return "an `llm` argument was provided; IORails does not accept a custom LLM"
 
+        if config.colang_version != "1.0":
+            return f"IORails supports Colang 1.0 only; config uses Colang {config.colang_version}"
+
         unsupported_rails = sorted(config.rails.model_fields_set - cls.SUPPORTED_RAILS)
         if unsupported_rails:
             return f"config has rails outside the IORails-supported set: {unsupported_rails}"

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -348,6 +348,19 @@ class TestIORailsUnsupportedReason:
         reason = IORails.unsupported_reason(config, llm=MagicMock())
         assert reason == "an `llm` argument was provided; IORails does not accept a custom LLM"
 
+    def test_colang_2x_config_is_unsupported(self):
+        """A Colang 2.x config is rejected: IORails has no Colang runtime, so 2.x falls back to LLMRails."""
+        config = RailsConfig.from_content(config={"colang_version": "2.x"})
+        reason = IORails.unsupported_reason(config, llm=None)
+        assert reason == "IORails supports Colang 1.0 only; config uses Colang 2.x"
+        assert IORails.can_handle(config, llm=None) is False
+
+    def test_llm_takes_precedence_over_colang_version(self):
+        """When both an llm is provided and the config is Colang 2.x, the llm reason is reported first."""
+        config = RailsConfig.from_content(config={"colang_version": "2.x"})
+        reason = IORails.unsupported_reason(config, llm=MagicMock())
+        assert reason == "an `llm` argument was provided; IORails does not accept a custom LLM"
+
     def test_can_handle_matches_reason_none(self, _content_safety_rails_config):
         """``can_handle`` is a thin wrapper that returns True iff reason is None."""
         assert IORails.can_handle(_content_safety_rails_config, llm=None) is True

--- a/tests/guardrails/test_public_api_deprecations.py
+++ b/tests/guardrails/test_public_api_deprecations.py
@@ -22,8 +22,10 @@ attributes were reclassified as private:
   default_embedding_{model,engine,params}, llm_generation_actions).
 * Deprecated read/write alias on LLMRails for explain_info.
 * First-class passthrough_fn property/setter on LLMRails (no warning).
-* Guardrails-facade proxies for explain_info (deprecated), passthrough_fn,
-  and events_history_cache — including the IORails-engine raise paths.
+* Guardrails-facade proxies for explain_info (deprecated) and passthrough_fn,
+  including the IORails-engine raise paths.
+* Guardrails-facade proxy for events_history_cache: delegates under LLMRails,
+  inert under IORails (reads return {}, writes are dropped).
 """
 
 from unittest.mock import MagicMock, patch
@@ -224,7 +226,7 @@ class TestGuardrailsFacadePassthroughFn:
 
 
 class TestGuardrailsFacadeEventsHistoryCache:
-    """Facade proxy for events_history_cache: plain getter+setter under LLMRails, raises under IORails."""
+    """Facade proxy for events_history_cache: plain getter+setter under LLMRails, inert under IORails."""
 
     def test_read_delegates_to_llmrails(self, llmrails_guardrails):
         """Reading guardrails.events_history_cache returns the wrapped LLMRails's plain attribute."""
@@ -239,12 +241,15 @@ class TestGuardrailsFacadeEventsHistoryCache:
         llmrails_guardrails.events_history_cache = sentinel
         assert llmrails_guardrails.rails_engine.events_history_cache is sentinel
 
-    def test_read_raises_under_iorails(self, iorails_guardrails):
-        """Reading guardrails.events_history_cache on an IORails-backed facade raises NotImplementedError."""
-        with pytest.raises(NotImplementedError, match=r"IORails doesn't support events_history_cache"):
-            _ = iorails_guardrails.events_history_cache
+    def test_read_returns_empty_dict_under_iorails(self, iorails_guardrails):
+        """Reading guardrails.events_history_cache on an IORails-backed facade returns an empty dict."""
+        assert iorails_guardrails.events_history_cache == {}
 
-    def test_write_raises_under_iorails(self, iorails_guardrails):
-        """Writing guardrails.events_history_cache on an IORails-backed facade raises NotImplementedError."""
-        with pytest.raises(NotImplementedError, match=r"IORails doesn't support events_history_cache"):
-            iorails_guardrails.events_history_cache = {}
+    def test_write_is_dropped_under_iorails(self, iorails_guardrails):
+        """Writing guardrails.events_history_cache on an IORails-backed facade is silently dropped.
+
+        IORails is stateless, so a write followed by a read still yields {} —
+        the value is never stored and never consulted during generation.
+        """
+        iorails_guardrails.events_history_cache = {"b": 2}
+        assert iorails_guardrails.events_history_cache == {}

--- a/tests/server/test_iorails_engine_compat.py
+++ b/tests/server/test_iorails_engine_compat.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Server compatibility when NEMO_GUARDRAILS_IORAILS_ENGINE aliases LLMRails to Guardrails.
+
+Under that env var, ``nemoguardrails.server.api`` builds a ``Guardrails`` wrapper that
+selects the stateless IORails engine for IORails-compatible configs. These tests
+reproduce the reported 500: ``_get_rails`` assigns ``events_history_cache``, which used
+to raise ``NotImplementedError`` on an IORails-backed wrapper. The alias is simulated by
+patching ``api.LLMRails`` to ``Guardrails`` and ``RailsConfig.from_path`` to return an
+IORails-compatible content-safety config, so the test does not depend on the global
+import-time env var.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nemoguardrails import Guardrails, RailsConfig
+from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.server import api
+from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG
+
+
+@pytest.fixture
+def iorails_compatible_config():
+    """An IORails-compatible Colang 1.0 content-safety config loaded once for the test."""
+    return RailsConfig.from_content(config=CONTENT_SAFETY_CONFIG)
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    """Clear the per-config rails caches and force multi-config mode around each test."""
+    original_single_config_mode = api.app.single_config_mode
+    api.app.single_config_mode = False
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    yield
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    api.app.single_config_mode = original_single_config_mode
+
+
+@pytest.fixture
+def iorails_alias(monkeypatch, iorails_compatible_config):
+    """Simulate NEMO_GUARDRAILS_IORAILS_ENGINE: alias LLMRails->Guardrails and serve the IORails config."""
+    monkeypatch.setattr(api, "LLMRails", Guardrails)
+    monkeypatch.setattr(api.RailsConfig, "from_path", staticmethod(lambda full_path: iorails_compatible_config))
+    yield
+
+
+@pytest.mark.asyncio
+async def test_get_rails_does_not_raise_under_iorails_alias(iorails_alias):
+    """_get_rails returns an IORails-backed Guardrails with an inert events_history_cache instead of raising.
+
+    This is the exact crash site from the report: the events_history_cache assignment at
+    the end of _get_rails. Under IORails it must round-trip inertly (read -> {}) rather
+    than raise NotImplementedError.
+    """
+    rails = await api._get_rails(["content_safety"])
+
+    assert isinstance(rails, Guardrails)
+    assert isinstance(rails.rails_engine, IORails)
+    assert rails.events_history_cache == {}
+
+
+def test_chat_completion_returns_200_under_iorails_alias(iorails_alias, monkeypatch):
+    """POST /v1/chat/completions returns 200 when the server runs on the IORails engine.
+
+    Generation is stubbed at the IORails boundary (start + generate_async) so the test
+    exercises the server plumbing and the _get_rails cache assignment without any network
+    or provider credentials; the response shape is asserted to be OpenAI-compatible.
+    """
+
+    async def _fake_start(self):
+        self._running = True
+
+    async def _fake_generate_async(self, messages, **kwargs):
+        return {"role": "assistant", "content": "hello from iorails"}
+
+    monkeypatch.setattr(IORails, "start", _fake_start)
+    monkeypatch.setattr(IORails, "generate_async", _fake_generate_async)
+
+    client = TestClient(api.app, raise_server_exceptions=False)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "guardrails": {"config_id": "content_safety"},
+        },
+    )
+
+    assert response.status_code == 200
+    res = response.json()
+    assert res["object"] == "chat.completion"
+    assert res["choices"][0]["message"]["role"] == "assistant"
+    assert res["choices"][0]["message"]["content"] == "hello from iorails"


### PR DESCRIPTION
## Description

The #1933 commit cleaned up the Guardrails facade by adding support for every method and attribute in LLMRails at the top-level. These methods and attributes were delegated to LLMRails if that engine was selected. If IORails was selected, support methods were delegated to IORails through Guardrails. Unsupported methods and attributes raised NotImplementedError to give an early indication that something was wrong and fail noisily.

This causes an issue in the Server code, since it depends on an Colang-implementation-specific dict to cache server events called `events_history_cache`. The Server code is tightly coupled with the LLMRails implementation, since it expects this to exist, and will restore the value to prevent prior conversation turns being provided. This is moot when using /chat/completions since all inference requests contain all prior steps.

This is a point-fix PR to address the issue by always silently dropping sets to `events_history_cache`, and returning an empty dict on gets to `events_history_cache`. Addressing the lack of public interface and Colang implementation-specific details on Guardrails/LLMRails/IORails is out-of-scope and will be handled in a future PR.

It also adds a check for Colang 2 configurations since those aren't supported by IORails either.

## Related Issue(s)

* [NGUARD-839: IORails engine returns HTTP 500 on every server request - events_history_cache getter raises NotImplementedError](https://jirasw.nvidia.com/browse/NGUARD-839).
* [NVBug-6288130](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6288130)
* #1933 - Added the NotImplementedError to explicitly catch access to unsupported methods/attributes when IORails is selected.

## Verification

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test

================================================================ test session starts =================================================================
platform darwin -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-server-compat
configfile: pytest.ini
testpaths: tests, benchmark/tests
plugins: anyio-4.12.1, langsmith-0.7.12, xdist-3.8.0, httpx-0.35.0, asyncio-0.26.0, profiling-1.8.1, cov-7.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [5167 items]
.................................................................................................................s...s........................ [  2%]
.............................................................................s.....s......s...s..sss.ss....s...s.............................. [  5%]
.............................................................................................................................................. [  8%]
...........................................s.......................................................................................s.......... [ 10%]
.............................................................................................................................................. [ 13%]
............................................................................................................s................................. [ 16%]
........................................................................................s..................................................... [ 19%]
.............................................................................................................................................. [ 21%]
.............................................................................................................................................. [ 24%]
.............................................................................................................................................. [ 27%]
............................................................................ssssss.s.s.......................................sss..ssss........ [ 30%]
.................sss...sss.s.s................................................................................................................ [ 32%]
...............................................s....................................................................................ss........ [ 35%]
................................................................................................................................ss............ [ 38%]
.............................................................................................................................................. [ 41%]
.......................................................................................ss................................ss................... [ 43%]
....s........................................................................sss.ss........................................................... [ 46%]
........sssss.......ssssssssssssssssss................................................s....................................................... [ 49%]
...............................................s.............................................................................................. [ 52%]
..................................................................sssssss..................................................................... [ 54%]
.............................................................................................................................................. [ 57%]
......................................s.ssss................s.sss.ssss....................ssss.ss........s.s.......s.......................... [ 60%]
.......................sssss.sss.............................................................................................................. [ 63%]
...........................................................................................................................ss................. [ 65%]
.............................................................................................................................................. [ 68%]
............................................s................................................................................................. [ 71%]
.............................................................................................................................................. [ 74%]
.............................................................................................................................................. [ 76%]
.............................................................................................................................................. [ 79%]
................................................................................................................ss.....ss..................... [ 82%]
..............................................................................................s................ss.ss.sssssssss................ [ 85%]
...................................s.................................s......s.....................................................ss.......... [ 87%]
.......s.......s....................................................s...............................................ssssssss.................. [ 90%]
................sssss.ssssssssss.........s.....................sss.....................................................s...................... [ 93%]
...........................................................................ssss............................................................... [ 96%]
.............................s..................................................................s............................................. [ 98%]
.......................................................                                                                                        [100%]
========================================================= 4987 passed, 180 skipped in 31.41s =========================================================
```



### Steps to reproduce (on latest develop branch SHA 9102c63563e7a5483a3cc7d8146dc651cf1e49f2)

#### Server

```
$ export NVIDIA_API_KEY="..."
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 MAIN_MODEL_ENGINE=nim MAIN_MODEL_BASE_URL=https://integrate.api.nvidia.com  NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails server --config examples/configs --default-config-id nemoguards

INFO:     Started server process [41414]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:nemoguardrails.server.api:Got request for config None
2026-06-24 13:52:27 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-06-24 13:52:27 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-06-24 13:52:27 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-06-24 13:52:27 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-24 13:52:27 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False
INFO:     127.0.0.1:54804 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/applications.py", line 1160, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/applications.py", line 107, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/routing.py", line 290, in handle
    await self.app(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/routing.py", line 130, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/routing.py", line 116, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/routing.py", line 670, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-gKpfxRkg-py3.13/lib/python3.13/site-packages/fastapi/routing.py", line 324, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tgasser/projects/nemo_guardrails_worktree/Guardrails/nemoguardrails/server/api.py", line 517, in chat_completion
    llm_rails = await _get_rails(config_ids, model_name=body.model)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tgasser/projects/nemo_guardrails_worktree/Guardrails/nemoguardrails/server/api.py", line 400, in _get_rails
    llm_rails.events_history_cache = llm_rails_events_history_cache.get(configs_cache_key, {})
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tgasser/projects/nemo_guardrails_worktree/Guardrails/nemoguardrails/guardrails/guardrails.py", line 314, in events_history_cache
    raise NotImplementedError("IORails doesn't support events_history_cache attribute access")
NotImplementedError: IORails doesn't support events_history_cache attribute access

```

#### Client

```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "stream": false,
          "max_completion_tokens": 55

  }'
Internal Server Error%

```

### With the current PR

#### Server (INFO logsonly)
```
$ export NVIDIA_API_KEY="..."
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 MAIN_MODEL_ENGINE=nim MAIN_MODEL_BASE_URL=https://integrate.api.nvidia.com  NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails server --config examples/configs --default-config-id nemoguards

INFO:nemoguardrails.server.api:Got request for config None
2026-06-24 13:57:21 INFO: [1ec1259c4da78c12] generate_async called
2026-06-24 13:57:21 INFO: [1ec1259c4da78c12] Running tool result rails
2026-06-24 13:57:21 INFO: [1ec1259c4da78c12] Running input rails
2026-06-24 13:57:21 INFO: [1ec1259c4da78c12] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-24 13:57:39 INFO: [1ec1259c4da78c12] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-06-24 13:57:40 INFO: [1ec1259c4da78c12] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-06-24 13:57:40 INFO: [1ec1259c4da78c12] Calling main LLM
2026-06-24 13:57:40 INFO: [1ec1259c4da78c12] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-06-24 13:57:42 INFO: [1ec1259c4da78c12] Running output rails
2026-06-24 13:57:42 INFO: [1ec1259c4da78c12] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-06-24 13:57:42 INFO: [1ec1259c4da78c12] generate_async completed time=21350.9ms
```

#### Client

```
$curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "stream": false,
          "max_completion_tokens": 55

  }'
{"id":"chatcmpl-ce744e43-8ded-4615-9dd4-d04e31d39b2a","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello. I'm just a language model, so I don't have feelings or emotions like humans do, but I'm functioning properly and ready to help you with any questions or tasks you may have. How about you? How's your day going so far?","role":"assistant"}}],"created":1782327462,"model":"meta/llama-3.3-70b-instruct","object":"chat.completion","guardrails":{"config_id":"nemoguards"}}%
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior for I/O-based guardrails so cache access no longer errors; reads now return an empty cache and writes are ignored.
  * Tightened configuration validation so unsupported version settings are clearly rejected with a helpful message.
  * Improved server compatibility for I/O-based setups, helping chat requests complete successfully and return standard API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->