### PR TITLE
ci: restore coverage upload on push to develop

### DIFF
--- a/.github/workflows/develop-coverage.yml
+++ b/.github/workflows/develop-coverage.yml
@@ -6,7 +6,6 @@ on:
       - develop
     paths-ignore:
       - "**/*.md"
-      - ".github/**"
 
 jobs:
   develop-coverage:

--- a/.github/workflows/develop-coverage.yml
+++ b/.github/workflows/develop-coverage.yml
@@ -1,0 +1,19 @@
+name: Develop Coverage
+
+on:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - "**/*.md"
+      - ".github/**"
+
+jobs:
+  develop-coverage:
+    uses: ./.github/workflows/_test.yml
+    secrets: inherit
+    with:
+      os: Ubuntu
+      image: ubuntu-latest
+      python-version: "3.11"
+      with-coverage: true


### PR DESCRIPTION

## Description

PR #1515 removed the push trigger from the coverage workflow and #1517 folded coverage into _test.yml gated by with-coverage, which is only set on pull_request runs. As a result no coverage was uploaded for develop commits, freezing Codecov's develop branch at #1351 (2025-11-26).

Add a develop-coverage workflow that runs on push to develop with coverage enabled. Scope the trigger to develop only so it does not reintroduce duplicate runs on every PR branch.


<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated coverage check for updates pushed to the `develop` branch.
  * Markdown-only changes and workflow file updates are excluded from this run to reduce unnecessary checks.
  * The new job runs in a Linux environment with Python 3.11 and includes coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->