### PR TITLE
fix(streaming): avoid duplicate usage metadata chunk

### DIFF
--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -249,6 +249,8 @@ class StreamingHandler(AsyncIterator):
                         elif self.current_metadata:
                             chunk_dict["metadata"] = self.current_metadata.copy()
                         await self.queue.put(chunk_dict)
+                        if chunk is not END_OF_STREAM and "usage" in chunk_dict.get("metadata", {}):
+                            self.current_metadata.pop("usage", None)
                     else:
                         await self.queue.put(chunk)
 

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -733,6 +733,29 @@ async def test_metadata_accumulation_across_chunks():
 
 
 @pytest.mark.asyncio
+async def test_raw_usage_metadata_chunk_is_not_repeated_on_final_chunk():
+    streaming_handler = StreamingHandler(include_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+    usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+    try:
+        await streaming_handler.push_chunk("Hello")
+        await streaming_handler.push_chunk("", metadata={"usage": usage})
+        await streaming_handler.push_chunk(None)
+
+        chunks = await streaming_consumer.get_chunks()
+        usage_chunks = [chunk for chunk in chunks if chunk.get("metadata", {}).get("usage")]
+
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0]["metadata"]["usage"] == usage
+        assert "usage" not in chunks[-1]["metadata"]
+        assert chunks[-1]["metadata"]["response_metadata"] is None
+        assert chunks[-1]["metadata"]["usage_metadata"] is None
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
 async def test_metadata_defaults_when_provider_returns_no_metadata():
     """Test that the final chunk includes metadata with None values when include_metadata=True
     but the provider does not return any metadata."""


### PR DESCRIPTION
## Description

avoid duplicate usage metadata chunk. addressing https://github.com/NVIDIA-NeMo/Guardrails/pull/1977#discussion_r3475922419

## Related Issue(s)

https://github.com/NVIDIA-NeMo/Guardrails/pull/1977#discussion_r3475922419

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming metadata so usage information is only included once and does not repeat in the final streamed chunk.
  * Improved handling of streamed metadata when metadata display is enabled, preventing stale usage data from carrying over to later chunks.

* **Tests**
  * Added coverage to confirm raw usage metadata appears a single time and is not duplicated at stream completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->