### PR TITLE
fix(streaming): pass user content to output rails

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1811,13 +1811,13 @@ class LLMRails(BaseGuardrails):
 
         def _get_latest_user_message(
             messages: Optional[List[dict]] = None,
-        ) -> dict:
+        ) -> str:
             if messages is None:
-                return {}
+                return ""
             for message in reversed(messages):
                 if message.get("role") == "user":
-                    return message
-            return {}
+                    return message.get("content", "")
+            return ""
 
         def _prepare_context_for_parallel_rails(
             chunk_str: str,

--- a/tests/test_streaming_output_rails.py
+++ b/tests/test_streaming_output_rails.py
@@ -290,6 +290,98 @@ async def test_external_generator_with_output_rails_allowed():
 
 
 @pytest.mark.asyncio
+async def test_external_generator_output_rails_receive_user_content():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    "flows": ["self check output"],
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                        "context_size": 2,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "streaming": True,
+            "prompts": [{"task": "self_check_output", "content": "Check: {{ bot_response }}"}],
+        },
+        colang_content="""
+        define flow self check output
+          execute self_check_output
+        """,
+    )
+    rails = LLMRails(config)
+    observed_user_messages = []
+
+    @action(name="self_check_output")
+    async def self_check_output(**kwargs):
+        observed_user_messages.append(kwargs.get("context", {}).get("user_message"))
+        return True
+
+    rails.register_action(self_check_output, "self_check_output")
+
+    tokens = []
+    async for token in rails.stream_async(
+        generator=simple_token_generator(),
+        messages=[{"role": "user", "content": "Hello"}],
+    ):
+        tokens.append(token)
+
+    assert tokens == ["Hello", " ", "world", "!"]
+    assert observed_user_messages
+    assert set(observed_user_messages) == {"Hello"}
+
+
+@pytest.mark.asyncio
+async def test_external_generator_output_rails_use_empty_user_content_without_user_message():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    "flows": ["self check output"],
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                        "context_size": 2,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "streaming": True,
+            "prompts": [{"task": "self_check_output", "content": "Check: {{ bot_response }}"}],
+        },
+        colang_content="""
+        define flow self check output
+          execute self_check_output
+        """,
+    )
+    rails = LLMRails(config)
+    observed_user_messages = []
+
+    @action(name="self_check_output")
+    async def self_check_output(**kwargs):
+        observed_user_messages.append(kwargs.get("context", {}).get("user_message"))
+        return True
+
+    rails.register_action(self_check_output, "self_check_output")
+
+    tokens = []
+    async for token in rails.stream_async(
+        generator=simple_token_generator(),
+        messages=[{"role": "assistant", "content": "Earlier assistant message"}],
+    ):
+        tokens.append(token)
+
+    assert tokens == ["Hello", " ", "world", "!"]
+    assert observed_user_messages
+    assert set(observed_user_messages) == {""}
+
+
+@pytest.mark.asyncio
 async def test_external_generator_with_output_rails_blocked():
     """Test that external generator content can be blocked by output rails."""
     config = RailsConfig.from_content(


### PR DESCRIPTION
## Description

pass user content to output rails, fixes a bug that discovered in #1978 , addresses https://github.com/NVIDIA-NeMo/Guardrails/pull/1978#discussion_r3476871842.

### Root cause
streaming output rails received the wrong shape for `context["user_message"]`. The
nested helper `_get_latest_user_message()` returned the whole message dict, so for
`stream_async(messages=[...])` calls the output-rail context (and the `$user_message`
action param) got `{"role": "user", "content": "hello"}` instead of `"hello"`. That
malformed value reaches runtime execution: both `content safety` and `self check output`
template `user_message` into their provider prompts, and custom actions reading
`context["user_message"]` get a dict. Rails whose decision depends only on `bot_message`
still behaved correctly, which is why it stayed latent.

Fix: return `message["content"]` (or `""` when there is no user message).

scope: streaming output rails with `messages=[...]` only. `stream_async(prompt="...")`
short-circuits to the string and was unaffected; non-streaming rails resolve
`$user_message` via the Colang runtime, a different path.


## Related Issue(s)

<!-- TODO: link the triaged issue before opening. -->
- Fixes #<issue_number>
- Issue assignee: @Pouyanpi



## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming output rails so the latest user message is passed as plain text, improving compatibility with downstream context handling.
  * Ensured output rails can access the incoming user message during streaming from an external token generator.

* **Tests**
  * Added coverage for streaming output rails to confirm token output remains unchanged and the user message is available as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->