### PR TITLE
fix(eval): Use safe dumper and yaml load

### DIFF
--- a/nemoguardrails/eval/utils.py
+++ b/nemoguardrails/eval/utils.py
@@ -19,15 +19,12 @@ from typing import Any, Dict, List, Union
 
 import yaml
 
-# We try to load the efficient version of the Dumper for YAML.
-# Untrusted input is parsed with yaml.safe_load (see load_dict_from_file) to
-# avoid arbitrary object construction (CWE-502).
-# https://pyyaml.org/wiki/PyYAMLDocumentation
-# https://stackoverflow.com/questions/27743711/can-i-speedup-yaml
+# Use SafeDumper which refuses to emit !!python/... tags), maintain round-trip
+# compatibility with yaml.safe_load
 try:
-    from yaml import CDumper as Dumper
+    from yaml import CSafeDumper as Dumper
 except ImportError:
-    from yaml import Dumper
+    from yaml import SafeDumper as Dumper
 
 
 def load_dict_from_file(file_path: str) -> Dict[str, Any]:

--- a/nemoguardrails/eval/utils.py
+++ b/nemoguardrails/eval/utils.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Union
 
 import yaml
 
-# Use SafeDumper which refuses to emit !!python/... tags), maintain round-trip
+# Use SafeDumper which refuses to emit !!python/... tags, maintain round-trip
 # compatibility with yaml.safe_load
 try:
     from yaml import CSafeDumper as Dumper

--- a/nemoguardrails/eval/utils.py
+++ b/nemoguardrails/eval/utils.py
@@ -19,14 +19,15 @@ from typing import Any, Dict, List, Union
 
 import yaml
 
-# We try to load the efficient versions of the Loader and Dumper for YAML.
+# We try to load the efficient version of the Dumper for YAML.
+# Untrusted input is parsed with yaml.safe_load (see load_dict_from_file) to
+# avoid arbitrary object construction (CWE-502).
 # https://pyyaml.org/wiki/PyYAMLDocumentation
 # https://stackoverflow.com/questions/27743711/can-i-speedup-yaml
 try:
     from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import Dumper
 
 
 def load_dict_from_file(file_path: str) -> Dict[str, Any]:
@@ -36,7 +37,7 @@ def load_dict_from_file(file_path: str) -> Dict[str, Any]:
     _obj = {}
     if file_extension == ".yaml" or file_extension == ".yml":
         with open(file_path) as f:
-            _obj = yaml.load(f, Loader=Loader)
+            _obj = yaml.safe_load(f)
     elif file_extension == ".json":
         with open(file_path) as f:
             _obj = json.load(f)

--- a/tests/eval/test_utils_safe_yaml.py
+++ b/tests/eval/test_utils_safe_yaml.py
@@ -39,7 +39,7 @@ def test_load_dict_from_file_rejects_python_object_tags(tmp_path):
     call it encodes must never run."""
     sentinel = tmp_path / "pwned"
     config_file = tmp_path / "config.yaml"
-    config_file.write_text(f'models:\n- !!python/object/apply:os.makedirs ["{sentinel}"]\n')
+    config_file.write_text(f"models:\n- !!python/object/apply:os.makedirs [{json.dumps(str(sentinel))}]\n")
 
     with pytest.raises(yaml.constructor.ConstructorError):
         load_dict_from_file(str(config_file))
@@ -51,7 +51,9 @@ def test_load_dict_from_path_rejects_python_object_tags(tmp_path):
     """The recursive directory loader must also reject !!python/object tags in
     any file it walks rather than executing them at load time."""
     sentinel = tmp_path / "pwned"
-    (tmp_path / "config.yaml").write_text(f'models:\n- !!python/object/apply:os.makedirs ["{sentinel}"]\n')
+    (tmp_path / "config.yaml").write_text(
+        f"models:\n- !!python/object/apply:os.makedirs [{json.dumps(str(sentinel))}]\n"
+    )
 
     with pytest.raises(yaml.constructor.ConstructorError):
         load_dict_from_path(str(tmp_path))

--- a/tests/eval/test_utils_safe_yaml.py
+++ b/tests/eval/test_utils_safe_yaml.py
@@ -14,9 +14,13 @@
 # limitations under the License.
 
 
+import importlib
+import json
+
 import pytest
 import yaml
 
+import nemoguardrails.eval.utils as eval_utils
 from nemoguardrails.eval.utils import (
     load_dict_from_file,
     load_dict_from_path,
@@ -63,6 +67,28 @@ def test_load_dict_from_file_loads_benign_yaml(tmp_path):
     result = load_dict_from_file(str(config_file))
 
     assert result == {"models": [{"name": "main", "engine": "openai"}], "key": "value"}
+
+
+def test_load_dict_from_file_loads_json(tmp_path):
+    """A .json file must be parsed through the json branch of load_dict_from_file."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"models": [{"name": "main"}], "key": "value"}))
+
+    result = load_dict_from_file(str(config_file))
+
+    assert result == {"models": [{"name": "main"}], "key": "value"}
+
+
+def test_dumper_falls_back_to_safe_dumper_without_libyaml(monkeypatch):
+    """When the optional libyaml CSafeDumper is unavailable, the import must
+    fall back to the pure-Python SafeDumper, never the unsafe Dumper."""
+    monkeypatch.delattr(yaml, "CSafeDumper", raising=False)
+    try:
+        importlib.reload(eval_utils)
+        assert eval_utils.Dumper is yaml.SafeDumper
+    finally:
+        monkeypatch.undo()
+        importlib.reload(eval_utils)
 
 
 def test_save_dict_to_file_refuses_python_object_tags(tmp_path):

--- a/tests/eval/test_utils_safe_yaml.py
+++ b/tests/eval/test_utils_safe_yaml.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import yaml
+
+from nemoguardrails.eval.utils import load_dict_from_file, load_dict_from_path
+
+
+def test_load_dict_from_file_rejects_python_object_tags(tmp_path):
+    """A YAML file with a !!python/object/apply tag must be rejected by the
+    safe loader instead of instantiating the object, and the side-effecting
+    call it encodes must never run."""
+    sentinel = tmp_path / "pwned"
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f'models:\n- !!python/object/apply:os.makedirs ["{sentinel}"]\n')
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        load_dict_from_file(str(config_file))
+
+    assert not sentinel.exists()
+
+
+def test_load_dict_from_path_rejects_python_object_tags(tmp_path):
+    """The recursive directory loader must also reject !!python/object tags in
+    any file it walks rather than executing them at load time."""
+    sentinel = tmp_path / "pwned"
+    (tmp_path / "config.yaml").write_text(f'models:\n- !!python/object/apply:os.makedirs ["{sentinel}"]\n')
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        load_dict_from_path(str(tmp_path))
+
+    assert not sentinel.exists()
+
+
+def test_load_dict_from_file_loads_benign_yaml(tmp_path):
+    """The safe loader must still parse ordinary YAML content unchanged."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("models:\n- name: main\n  engine: openai\nkey: value\n")
+
+    result = load_dict_from_file(str(config_file))
+
+    assert result == {"models": [{"name": "main", "engine": "openai"}], "key": "value"}

--- a/tests/eval/test_utils_safe_yaml.py
+++ b/tests/eval/test_utils_safe_yaml.py
@@ -17,7 +17,16 @@
 import pytest
 import yaml
 
-from nemoguardrails.eval.utils import load_dict_from_file, load_dict_from_path
+from nemoguardrails.eval.utils import (
+    load_dict_from_file,
+    load_dict_from_path,
+    save_dict_to_file,
+)
+
+
+# Create an arbitrary object and make sure we don't serialize it for security
+class _CustomObject:
+    pass
 
 
 def test_load_dict_from_file_rejects_python_object_tags(tmp_path):
@@ -54,3 +63,21 @@ def test_load_dict_from_file_loads_benign_yaml(tmp_path):
     result = load_dict_from_file(str(config_file))
 
     assert result == {"models": [{"name": "main", "engine": "openai"}], "key": "value"}
+
+
+def test_save_dict_to_file_refuses_python_object_tags(tmp_path):
+    """The dumper must refuse to serialize arbitrary Python objects"""
+    output = tmp_path / "out.yaml"
+
+    with pytest.raises(yaml.representer.RepresenterError):
+        save_dict_to_file({"value": _CustomObject()}, str(output))
+
+
+def test_save_dict_to_file_roundtrips_benign_data(tmp_path):
+    """Ordinary primitive data must still serialize and load back unchanged."""
+    data = {"results": [{"id": "a", "score": 1}], "logs": ["ok"]}
+    output = tmp_path / "out.yaml"
+
+    save_dict_to_file(data, str(output))
+
+    assert load_dict_from_file(str(output)) == data


### PR DESCRIPTION
## Description

The nemoguardrails `eval` tool deserializes and serializes data using the `load_dict_from_file()` and `save_dict_to_file()` functions respectively. Prior to this PR, unsafe libraries were used to save and load files. This PR changes them to use the safe equivalent (which can't deserialize and execute arbitrary python code), and adds unit-tests to make sure this isn't possible.

Changes made are:
* Deserialization: `yaml.load()` -> `yaml.safe_load()`
* Serialization: `CDumper/Dumper` -> `CSafeDumper/SafeDumper`.

No functional changes were made.

## Related Issue(s)

* https://jirasw.nvidia.com/browse/NGUARD-844

## Verification

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ make test
=================================================== test session starts ===================================================platform darwin -- Python 3.13.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/safe-yaml
configfile: pytest.ini
testpaths: tests, benchmark/tests
plugins: anyio-4.12.1, inline-snapshot-0.33.0, recording-0.13.4, langsmith-0.7.12, xdist-3.8.0, httpx-0.35.0, asyncio-0.26.0, profiling-1.8.1, cov-7.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [5207 items]
...s............................................................................................................... [  2%]
....................................................................................................s.sss.s..s..s.. [  4%]
.s..s......ss............................................................s......................................... [  6%]
................................................................................................................... [  8%]
................................................................s.................................................. [ 11%]
........................................................................................................s.......... [ 13%]
................................................................................................................... [ 15%]
..........................................................................................................s........ [ 17%]
................................................................................................................... [ 19%]
................................................................................................................... [ 22%]
................................................................................................................... [ 24%]
................................................................................................................... [ 26%]
................................................................................................................... [ 28%]
................................................................................................................... [ 30%]
................................................................................................................... [ 33%]
.......s...........................................s.s.....................s....................................... [ 35%]
.....ssss..s.......s..s........................ss.ss..ssss......................s...............................s.. [ 37%]
................................................................................................................... [ 39%]
................................................................................................................... [ 41%]
.........................................................................................................ssssssss.. [ 44%]
.sssss................................................................................................ss........... [ 46%]
................................................................................................................... [ 48%]
........s.......................................................................................................... [ 50%]
................................................................................................................... [ 53%]
........................................ss.sss.......sssssss.sssssssss.ss.......................................... [ 55%]
................................................................................................................... [ 57%]
..............s..............................................................s.s.s.sssss......ssssss...ss.......... [ 59%]
s........................................ssssssss.................................................................. [ 61%]
................................................................................................................... [ 64%]
................................................................................................................... [ 66%]
................................................................................................................... [ 68%]
................................................................................................................... [ 70%]
......................sssss...........................................................s....sssssss................. [ 72%]
................................................................................................................... [ 75%]
................................................................................................................... [ 77%]
...........................................................s............ss......................................... [ 79%]
.....................................ss...ss............................s....ss...............................s.... [ 81%]
......................................sssssssssssss............ss.................................................. [ 83%]
...................................................................................s............................... [ 86%]
....................s...........s......ss............................................s............................. [ 88%]
.........ss.ssss.................................sss............................................................... [ 90%]
.................................................................................sssssssss.ssssss.ssss............. [ 92%]
......................................................................s............................................ [ 94%]
............................................................................s...................................... [ 97%]
.................................................s................................................................. [ 99%]
................................                                                                                    [100%]

═════════════════════════════════════════════════════ inline-snapshot ═════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but
snapshot(x) will only return x and inline-snapshot will not be able to fix snapshots or generate reports.


=========================================== 5029 passed, 178 skipped in 32.24s ============================================

```



## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML file handling to use safer parsing and writing defaults.
  * YAML inputs with unsafe Python object tags are now rejected, preventing unintended side effects.
  * Ordinary YAML and JSON files continue to load normally, and basic data now round-trips correctly when saved and reloaded.
  * If the faster YAML dumper isn’t available, the app now falls back to a safe alternative automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->