### PR TITLE
docs(iorails): Telemetry - Content Capture docs

### DIFF
--- a/docs/configure-rails/yaml-schema/tracing-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/tracing-configuration.mdx
@@ -36,6 +36,23 @@ tracing:
 |--------|-------------|---------|
 | `enabled` | Enable or disable tracing | `false` |
 | `adapters` | List of tracing adapters | `[]` |
+| `span_format` | Span structure for the LLMRails post-hoc tracing path: `opentelemetry` (recommended) or `legacy` (deprecated) | `opentelemetry` |
+| `enable_content_capture` | Capture prompt and response content on spans. May include PII. See [Content Capture](/observability/tracing/content-capture) | `false` |
+
+## Content Capture
+
+By default, traces record metadata about each request but not the prompt or response content.
+Set `enable_content_capture: true` to additionally record message content on spans:
+
+```yaml
+tracing:
+  enabled: true
+  enable_content_capture: false  # default; see privacy considerations
+```
+
+This captures user inputs and model outputs, which may include sensitive information (PII).
+The behavior, environment-variable overrides, and output format differ between the IORails and LLMRails engines.
+See [Content Capture](/observability/tracing/content-capture) for the full contract.
 
 ## Tracing Adapters
 

--- a/docs/configure-rails/yaml-schema/tracing-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/tracing-configuration.mdx
@@ -36,7 +36,7 @@ tracing:
 |--------|-------------|---------|
 | `enabled` | Enable or disable tracing | `false` |
 | `adapters` | List of tracing adapters | `[]` |
-| `span_format` | Span structure for the LLMRails post-hoc tracing path: `opentelemetry` (recommended) or `legacy` (deprecated) | `opentelemetry` |
+| `span_format` | Span structure for LLMRails tracing path: `opentelemetry` (recommended) or `legacy` (deprecated) | `opentelemetry` |
 | `enable_content_capture` | Capture prompt and response content on spans. May include PII. See [Content Capture](/observability/tracing/content-capture) | `false` |
 
 ## Content Capture

--- a/docs/configure-rails/yaml-schema/tracing-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/tracing-configuration.mdx
@@ -47,7 +47,7 @@ Set `enable_content_capture: true` to additionally record message content on spa
 ```yaml
 tracing:
   enabled: true
-  enable_content_capture: false  # default; see privacy considerations
+  enable_content_capture: true  # caution: may capture PII; see privacy considerations
 ```
 
 This captures user inputs and model outputs, which may include sensitive information (PII).

--- a/docs/configure-rails/yaml-schema/tracing-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/tracing-configuration.mdx
@@ -1,15 +1,14 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "Tracing Configuration for NeMo Guardrails"
+title: "Tracing Configuration for the NVIDIA NeMo Guardrails Library"
 sidebar-title: "Tracing"
 description: "Configure FileSystem and OpenTelemetry tracing adapters to monitor guardrails."
 content:
-  type: "reference"
+    type: "reference"
 ---
 
-<a id="tracing-configuration"></a>
-# Tracing Configuration
+<a id="tracing-configuration"></a># Tracing Configuration
 
 This section describes how to configure tracing and monitoring in the `config.yml` file.
 
@@ -24,20 +23,20 @@ Configure tracing in `config.yml`:
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: FileSystem
-      filepath: "./logs/traces.jsonl"
+    enabled: true
+    adapters:
+        - name: FileSystem
+          filepath: "./logs/traces.jsonl"
 ```
 
 ## Configuration Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `enabled` | Enable or disable tracing | `false` |
-| `adapters` | List of tracing adapters | `[]` |
-| `span_format` | Span structure for LLMRails tracing path: `opentelemetry` (recommended) or `legacy` (deprecated) | `opentelemetry` |
-| `enable_content_capture` | Capture prompt and response content on spans. May include PII. See [Content Capture](/observability/tracing/content-capture) | `false` |
+| Option                   | Description                                                                                                                  | Default         |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `enabled`                | Enable or disable tracing                                                                                                    | `false`         |
+| `adapters`               | List of tracing adapters                                                                                                     | `[]`            |
+| `span_format`            | Span structure for LLMRails tracing path: `opentelemetry` (recommended) or `legacy` (deprecated)                             | `opentelemetry` |
+| `enable_content_capture` | Capture prompt and response content on spans. May include PII. See [Content Capture](/observability/tracing/content-capture) | `false`         |
 
 ## Content Capture
 
@@ -46,12 +45,12 @@ Set `enable_content_capture: true` to additionally record message content on spa
 
 ```yaml
 tracing:
-  enabled: true
-  enable_content_capture: true  # caution: may capture PII; see privacy considerations
+    enabled: true
+    enable_content_capture: true # caution: may capture PII; see privacy considerations
 ```
 
-This captures user inputs and model outputs, which may include sensitive information (PII).
-The behavior, environment-variable overrides, and output format differ between the IORails and LLMRails engines.
+Content capture records user inputs and model outputs, which can include sensitive information (PII).
+The behavior, environment variable overrides, and output format differ between the IORails and LLMRails engines.
 See [Content Capture](/observability/tracing/content-capture) for the full contract.
 
 ## Tracing Adapters
@@ -62,14 +61,14 @@ Log traces to local JSON files (recommended for development):
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: FileSystem
-      filepath: "./logs/traces.jsonl"
+    enabled: true
+    adapters:
+        - name: FileSystem
+          filepath: "./logs/traces.jsonl"
 ```
 
-| Option | Description |
-|--------|-------------|
+| Option     | Description                   |
+| ---------- | ----------------------------- |
 | `filepath` | Path to the trace output file |
 
 ### OpenTelemetry Adapter
@@ -78,9 +77,9 @@ Integrate with observability platforms (recommended for production):
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: OpenTelemetry
+    enabled: true
+    adapters:
+        - name: OpenTelemetry
 ```
 
 <Info>
@@ -93,15 +92,15 @@ To use OpenTelemetry tracing, install the tracing dependencies:
 <Note>
 
 OpenTelemetry integration requires configuring the OpenTelemetry SDK in your application code.
-NeMo Guardrails follows OpenTelemetry best practices where libraries use only the API and applications configure the SDK.
+The NeMo Guardrails library follows OpenTelemetry best practices where libraries use only the API and applications configure the SDK.
 
 </Note>
 
 ## Adapter Comparison
 
-| Adapter | Use Case | Configuration |
-|---------|----------|---------------|
-| FileSystem | Development, debugging, simple logging | `filepath: "./logs/traces.jsonl"` |
+| Adapter       | Use Case                                              | Configuration                                |
+| ------------- | ----------------------------------------------------- | -------------------------------------------- |
+| FileSystem    | Development, debugging, simple logging                | `filepath: "./logs/traces.jsonl"`            |
 | OpenTelemetry | Production, monitoring platforms, distributed systems | Requires application-level SDK configuration |
 
 ## Multiple Adapters
@@ -110,25 +109,25 @@ Configure multiple adapters simultaneously:
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: FileSystem
-      filepath: "./logs/traces.jsonl"
-    - name: OpenTelemetry
+    enabled: true
+    adapters:
+        - name: FileSystem
+          filepath: "./logs/traces.jsonl"
+        - name: OpenTelemetry
 ```
 
 ## Trace Information
 
 Traces capture the following information:
 
-| Data | Description |
-|------|-------------|
-| **Rail Activation** | Which rails get triggered during the conversation |
-| **LLM Calls** | LLM invocations, prompts, and responses |
-| **Flow Execution** | Colang flow execution paths and timing |
-| **Actions** | Custom action invocations and results |
-| **Errors** | Error conditions and debugging information |
-| **Timing** | Duration of each operation |
+| Data                | Description                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
+| **Rail Activation** | Which rails get triggered during the conversation                                                   |
+| **LLM Calls**       | LLM invocations, parameters, token usage, and prompts and responses when content capture is enabled |
+| **Flow Execution**  | Colang flow execution paths and timing                                                              |
+| **Actions**         | Custom action invocations and results                                                               |
+| **Errors**          | Error conditions and debugging information                                                          |
+| **Timing**          | Duration of each operation                                                                          |
 
 ## Example Configurations
 
@@ -136,32 +135,32 @@ Traces capture the following information:
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: FileSystem
-      filepath: "./logs/traces.jsonl"
+    enabled: true
+    adapters:
+        - name: FileSystem
+          filepath: "./logs/traces.jsonl"
 ```
 
 ### Production Configuration
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    - name: OpenTelemetry
+    enabled: true
+    adapters:
+        - name: OpenTelemetry
 ```
 
 ### Comprehensive Configuration
 
 ```yaml
 tracing:
-  enabled: true
-  adapters:
-    # Local logs for debugging
-    - name: FileSystem
-      filepath: "./logs/traces.jsonl"
-    # Export to observability platform
-    - name: OpenTelemetry
+    enabled: true
+    adapters:
+        # Local logs for debugging
+        - name: FileSystem
+          filepath: "./logs/traces.jsonl"
+        # Export to observability platform
+        - name: OpenTelemetry
 ```
 
 ## OpenTelemetry Setup

--- a/docs/configure-rails/yaml-schema/tracing-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/tracing-configuration.mdx
@@ -8,8 +8,6 @@ content:
     type: "reference"
 ---
 
-<a id="tracing-configuration"></a># Tracing Configuration
-
 This section describes how to configure tracing and monitoring in the `config.yml` file.
 
 ## Overview

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -494,6 +494,9 @@ navigation:
           - page: Span Reference
             path: observability/tracing/span-reference.mdx
             slug: span-reference
+          - page: Content Capture
+            path: observability/tracing/content-capture.mdx
+            slug: content-capture
           - page: Troubleshooting
             path: observability/tracing/troubleshooting.mdx
             slug: troubleshooting

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -8,63 +8,63 @@ content:
   type: "how_to"
 ---
 
-By default, traces record *metadata* about each request, such as span timing, model and provider names, sampling parameters, token usage, and rail decisions. They never record the prompt or response *content* itself.
-Content capture is an opt-in feature that additionally records the user, system, assistant, and tool message text onto spans so you can inspect exactly what was sent to and returned from the model.
+By default, traces record metadata about each request, such as span timing, model and provider names, sampling parameters, token usage, and rail decisions. They do not record prompt or response content.
+Content capture is an opt-in feature that also records user, system, assistant, and tool message text on spans so you can inspect what the application sent to the model and what the model returned.
 
 <Warning title="Experimental Feature">
 The `tracing.enable_content_capture` config flag works on both the IORails and `LLMRails` engines.
-The *environment-variable controls* and *inline-span behavior* described on this page are specific to the opt-in IORails engine.
-Enable IORails either by constructing `Guardrails(config, use_iorails=True)` (the form used in this guide) or by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1`, which aliases the top-level `LLMRails` import to `Guardrails`.
+The environment variable controls and inline span behavior described on this page are specific to the opt-in IORails engine.
+Enable IORails by constructing `Guardrails(config, use_iorails=True)` (the form used in this guide) or by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1`, which aliases the top-level `LLMRails` import to `Guardrails`.
 IORails is an early-release feature, and span names and attributes can change as the OpenTelemetry GenAI semantic conventions evolve.
-The legacy `LLMRails` engine supports a narrower form of content capture; see [Differences on the LLMRails engine](#differences-on-the-llmrails-engine) below.
+The legacy `LLMRails` engine supports a narrower form of content capture. For more information, refer to [Differences on the LLMRails Engine](#differences-on-the-llmrails-engine).
 </Warning>
 
 <Warning title="Privacy">
-Captured content includes the full text of prompts and responses, which may contain personally identifiable information (PII) or other sensitive data.
+Captured content includes the full text of prompts and responses and can contain personally identifiable information (PII) or other sensitive data.
 Only enable content capture when you need it, and ensure your telemetry backend and its retention policy comply with your data-protection obligations.
-See [Privacy considerations](#privacy-considerations) below.
+For more information, refer to [Privacy Considerations](#privacy-considerations).
 </Warning>
 
-## What gets captured
+## What Gets Captured
 
-When content capture is enabled, IORails records content onto three kinds of span:
+When content capture is enabled, IORails records content on three types of spans:
 
-| Span (kind) | Attribute or event | When recorded |
+| Span (Kind) | Attribute or Event | When Recorded |
 |-------------|--------------------|---------------|
 | `guardrails.request` (SERVER) | `guardrails.request.input`: JSON-encoded list of the caller's input messages | Always, while capturing |
 | `guardrails.request` (SERVER) | `guardrails.request.output`: the text actually returned to the caller | When output is produced (a blocked request records the refusal message; an empty stream records nothing) |
-| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call: the main generation call and every rail-action LLM call. On the streaming path, recorded at stream end; see [Streaming](#streaming) |
+| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call: the main generation call and every rail-action LLM call. On the streaming path, recorded when the stream ends; see [Streaming](#streaming) |
 | `guardrails.rail` (INTERNAL) | `guardrails.rail.input`: JSON-encoded `{"messages": ..., "bot_response": ...}` snapshot | Every rail execution, while capturing |
 | `guardrails.rail` (INTERNAL) | `guardrails.rail.reason`: the human-readable block reason | Only when the rail blocks the request |
 
 The SERVER span and the CLIENT span deliberately use different attribute names.
-On a blocked request the CLIENT span records the raw model response while the SERVER span records the refusal message the caller actually received, so the two values are kept under distinct names to avoid confusing backends that correlate them.
+On a blocked request, the CLIENT span records the raw model response while the SERVER span records the refusal message the caller received. Distinct names help avoid confusing backends that correlate these values.
 
-Sampling parameters (`gen_ai.request.temperature`, `max_tokens`, and so on) and token-usage attributes are *not* content, so they are recorded on the CLIENT span whenever tracing is enabled, regardless of the content-capture setting.
+Sampling parameters (`gen_ai.request.temperature`, `max_tokens`, and so on) and token-usage attributes are not content, so IORails records them on the CLIENT span whenever tracing is enabled, regardless of the content-capture setting.
 
-## Enabling content capture
+## Enabling Content Capture
 
-Content capture is active only when **all** of the following hold:
+Content capture is active only when all of the following conditions are true:
 
 1. The `opentelemetry-api` package is installed (`pip install "nemoguardrails[tracing]"`).
 2. Tracing is enabled (`tracing.enabled: true`).
 3. Content capture is requested, either through the config field or the environment variable below.
 
-The `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable is the primary control and overrides the config field in both directions, so a single OTEL-standard variable can flip capture across all services regardless of what each deployed config says.
+The `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable is the primary control. It overrides the config field in both directions, so one OTEL-standard variable can control capture across services regardless of what each deployed config says.
 
 | Source | Value | Effect |
 |--------|-------|--------|
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `true` or `1` | Force on, overriding the config field |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `false` or `0` | Force off, overriding the config field |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset or any other value | Fall through to the config field |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `true` or `1` | Forces capture on, overriding the config field |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `false` or `0` | Forces capture off, overriding the config field |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset or any other value | Falls through to the config field |
 | `tracing.enable_content_capture` | `true` | On (when the environment variable is not decisive) |
 | `tracing.enable_content_capture` | `false` (default) | Off |
 
-Environment-variable values are matched case-insensitively with surrounding whitespace stripped.
+The library strips surrounding whitespace and matches environment variable values case-insensitively.
 
 ## Quickstart
 
-This example enables content capture, runs a single request, and prints the resulting spans to the console so you can see the captured content before wiring up a production exporter.
+This example enables content capture, runs a single request, and prints the resulting spans to the console so you can review the captured content before you configure a production exporter.
 
 1. Install the NVIDIA NeMo Guardrails library and the OpenTelemetry SDK.
 
@@ -132,7 +132,7 @@ This example enables content capture, runs a single request, and prints the resu
     python content_capture_example.py
     ```
 
-    The `chat gpt-4o-mini` CLIENT span carries the captured prompt and response as span events (the default format), and the `guardrails.request` SERVER span carries the caller-facing input and output. Trimmed for clarity:
+    The `chat gpt-4o-mini` CLIENT span carries the captured prompt and response as span events (the default format), and the `guardrails.request` SERVER span carries the caller-facing input and output. The following output is trimmed for clarity:
 
     ```json
     {
@@ -160,16 +160,16 @@ This example enables content capture, runs a single request, and prints the resu
 
 <Info>
 The host application is responsible for configuring a `TracerProvider`.
-If you enable tracing and content capture but no `TracerProvider` is set, the OpenTelemetry API returns a no-op tracer and every span, along with the captured content on it, is silently discarded.
+If you enable tracing and content capture but do not set a `TracerProvider`, the OpenTelemetry API returns a no-op tracer and silently discards every span and its captured content.
 Always set the `TracerProvider` before constructing `Guardrails`.
 </Info>
 
-## Output format
+## Output Format
 
 The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable selects how LLM-call content is encoded on the CLIENT span.
-It holds a comma-separated list of opt-in tokens, and is read fresh on each call so changes take effect immediately.
+It holds a comma-separated list of opt-in tokens, and the library reads it on each call so changes take effect immediately.
 
-| `OTEL_SEMCONV_STABILITY_OPT_IN` | Form | What is emitted |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` | Form | What Is Emitted |
 |---------------------------------|------|-----------------|
 | Contains `gen_ai_latest_experimental` | JSON span **attributes** | `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions` (JSON-encoded) |
 | Token absent (default) | Legacy span **events** | `gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.tool.message`, and `gen_ai.choice` |
@@ -182,13 +182,13 @@ This selector is distinct from the `tracing.span_format` config field.
 `span_format` chooses the span *structure* produced by the LLMRails post-hoc tracing adapter; `OTEL_SEMCONV_STABILITY_OPT_IN` chooses the *encoding* of captured content on the inline IORails CLIENT spans.
 </Note>
 
-To emit the JSON-attribute form instead of the default events, set the variable before running:
+To emit the JSON-attribute form instead of the default events, set the variable before you run the application:
 
 ```bash
 export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
 ```
 
-With this set, the `chat gpt-4o-mini` span carries JSON-encoded attributes instead of events:
+When you set this variable, the `chat gpt-4o-mini` span carries JSON-encoded attributes instead of events:
 
 ```json
 {
@@ -202,47 +202,47 @@ With this set, the `chat gpt-4o-mini` span carries JSON-encoded attributes inste
 }
 ```
 
-System messages are captured separately as `gen_ai.system_instructions`, a flat list of parts with no role wrapper, per the GenAI specification.
-Attributes are only set when non-empty, so a backend can distinguish "no system instructions" from an empty string.
+The library captures system messages separately as `gen_ai.system_instructions`, a flat list of parts with no role wrapper, per the GenAI specification.
+The library sets attributes only when they are non-empty, so a backend can distinguish "no system instructions" from an empty string.
 
 ## Streaming
 
 On the streaming path, both the `guardrails.request` SERVER span and the `chat <model>` CLIENT span accumulate streamed chunks and record content once, when the stream ends, rather than per chunk.
-They differ in *what* they record and in their behavior when the stream exits abnormally.
+They differ in what they record and how they behave when the stream exits abnormally.
 
 **`guardrails.request` SERVER span.** Accumulates the chunks the consumer actually receives and records them as `guardrails.request.output`, so the captured value is exactly what reached the caller, including any output-rail error payload injected on a block.
-Capture runs in a `finally`, so it executes even when the stream exits early through a provider error or consumer cancellation, and an interrupted stream still records whatever was delivered.
+Capture runs in a `finally` block, so it executes even when the stream exits early through a provider error or consumer cancellation, and an interrupted stream still records whatever was delivered.
 
 **`chat <model>` CLIENT span.** Accumulates the model's response deltas and records the LLM input plus the accumulated response in the [selected format](#output-format).
-This capture runs only on natural completion of the stream: if the stream is cancelled by the consumer or the provider raises, the partial model output is intentionally **not** recorded on the CLIENT span.
+The CLIENT span captures content only when the stream completes naturally. If the consumer cancels the stream or the provider raises an error, IORails intentionally does not record the partial model output on the CLIENT span.
 
-In both cases, if no content was produced the output is omitted rather than recorded as an empty string.
+In both cases, if no content was produced, IORails omits the output rather than recording an empty string.
 
-## Privacy considerations
+## Privacy Considerations
 
 - Content capture is **off by default**. Prompts and responses are never written to spans unless you explicitly enable it.
-- Captured content may include PII or other sensitive data. Treat your tracing backend as a system that now holds user content, and apply the same access controls and retention limits you would to any store of conversation data.
-- Use `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` to force capture off across every service from the environment, regardless of what individual configs request. This is useful as a deployment-wide guardrail in regulated environments.
-- The [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) recommend against capturing message content by default for exactly these privacy reasons.
+- Captured content can include PII or other sensitive data. Treat your tracing backend as a system that stores user content, and apply the same access controls and retention limits you would apply to any store of conversation data.
+- Use `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` to force capture off across every service from the environment, regardless of what individual configs request. This is useful as a deployment-wide guardrail for regulated environments.
+- The [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) recommend against capturing message content by default because of these privacy risks.
 
-## Differences on the LLMRails engine
+## Differences on the LLMRails Engine
 
 The legacy `LLMRails` engine also honors `tracing.enable_content_capture`, but through a different mechanism with a narrower contract.
-Rather than instrumenting live spans, it captures content after the request completes, when its tracing adapter extracts spans from the interaction log.
+Instead of instrumenting live spans, it captures content after the request completes, when its tracing adapter extracts spans from the interaction log.
 
 | Dimension | IORails (this page) | LLMRails |
 |-----------|---------------------|----------|
 | Mechanism | Inline live spans during execution | Post-hoc extraction from the interaction log via the tracing adapter |
 | Enable control | `enable_content_capture` **and** the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable | `enable_content_capture` config field only |
-| Format selector | `OTEL_SEMCONV_STABILITY_OPT_IN` (JSON attributes vs. current legacy events) | None (one fixed form) |
+| Format selector | `OTEL_SEMCONV_STABILITY_OPT_IN` (JSON attributes or current legacy events) | None (one fixed form) |
 | LLM content form | `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions`, or the current `gen_ai.user.message` / `gen_ai.assistant.message` / `gen_ai.system.message` / `gen_ai.choice` events | **Deprecated** `gen_ai.content.prompt` and `gen_ai.content.completion` events |
 | Request and rail content | `guardrails.request.input` / `.output`, `guardrails.rail.input` / `.reason` | No equivalent; instead emits guardrails-internal `guardrails.user_message` and `guardrails.utterance.*` events |
 | Streaming | Accumulates and records the delivered text at stream end | Not applicable (post-hoc from the log) |
 
 Neither `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` nor `OTEL_SEMCONV_STABILITY_OPT_IN` is consulted on the LLMRails path; the config field is the only control there.
 
-## Related topics
+## Related Topics
 
-- [Tracing Configuration](/configure-guardrails/yaml-schema/tracing-configuration) - the `tracing` config schema, including the `enable_content_capture` field.
-- [Quick Start](/observability/tracing/quick-start) - minimal setup to enable tracing.
-- [OpenTelemetry](/observability/tracing/opentelemetry-integration) - production-ready exporter setup.
+- [Tracing Configuration](/configure-guardrails/yaml-schema/tracing-configuration): The `tracing` config schema, including the `enable_content_capture` field.
+- [Quick Start](/observability/tracing/quick-start): Minimal setup to enable tracing.
+- [OpenTelemetry](/observability/tracing/opentelemetry-integration): Production-ready exporter setup.

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -1,0 +1,242 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Capturing Prompt and Response Content"
+sidebar-title: "Content Capture"
+description: "Record prompt and response content on tracing spans, including the environment variables that control capture and output format."
+content:
+  type: "how_to"
+---
+
+By default, NeMo Guardrails traces record *metadata* about each request — span timing, model and provider names, sampling parameters, token usage, and rail decisions — but never the prompt or response *content* itself.
+Content capture is an opt-in feature that additionally records the user, system, assistant, and tool message text onto spans so you can inspect exactly what was sent to and returned from the model.
+
+<Warning title="Experimental Feature">
+Inline content capture with the environment-variable controls described on this page requires the opt-in IORails engine.
+Enable it either by constructing `Guardrails(config, use_iorails=True)` (the form used in this guide) or by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1`, which aliases the top-level `LLMRails` import to `Guardrails`.
+IORails is an early-release feature, and span names and attributes can change as the OpenTelemetry GenAI semantic conventions evolve.
+The legacy `LLMRails` engine supports a narrower form of content capture; see [Differences on the LLMRails engine](#differences-on-the-llmrails-engine) below.
+</Warning>
+
+<Warning title="Privacy">
+Captured content includes the full text of prompts and responses, which may contain personally identifiable information (PII) or other sensitive data.
+Only enable content capture when you need it, and ensure your telemetry backend and its retention policy comply with your data-protection obligations.
+See [Privacy considerations](#privacy-considerations) below.
+</Warning>
+
+## What gets captured
+
+When content capture is enabled, IORails records content onto three kinds of span:
+
+| Span (kind) | Attribute or event | When recorded |
+|-------------|--------------------|---------------|
+| `guardrails.request` (SERVER) | `guardrails.request.input` — JSON-encoded list of the caller's input messages | Always, while capturing |
+| `guardrails.request` (SERVER) | `guardrails.request.output` — the text actually returned to the caller | When output is produced (a blocked request records the refusal message; an empty stream records nothing) |
+| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call — the main generation call and every rail-action LLM call |
+| `guardrails.rail` (INTERNAL) | `guardrails.rail.input` — JSON-encoded `{"messages": ..., "bot_response": ...}` snapshot | Every rail execution, while capturing |
+| `guardrails.rail` (INTERNAL) | `guardrails.rail.reason` — the human-readable block reason | Only when the rail blocks the request |
+
+The SERVER span and the CLIENT span deliberately use different attribute names.
+On a blocked request the CLIENT span records the raw model response while the SERVER span records the refusal message the caller actually received, so the two values are kept under distinct names to avoid confusing backends that correlate them.
+
+Sampling parameters (`gen_ai.request.temperature`, `max_tokens`, and so on) and token-usage attributes are *not* content, so they are recorded on the CLIENT span whenever tracing is enabled, regardless of the content-capture setting.
+
+## Enabling content capture
+
+Content capture is active only when **all** of the following hold:
+
+1. The `opentelemetry-api` package is installed (`pip install "nemoguardrails[tracing]"`).
+2. Tracing is enabled (`tracing.enabled: true`).
+3. Content capture is requested, either through the config field or the environment variable below.
+
+The `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable is the primary control and overrides the config field in both directions, so a single OTEL-standard variable can flip capture across all services regardless of what each deployed config says.
+
+| Source | Value | Effect |
+|--------|-------|--------|
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `true` or `1` | Force on, overriding the config field |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `false` or `0` | Force off, overriding the config field |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset or any other value | Fall through to the config field |
+| `tracing.enable_content_capture` | `true` | On (when the environment variable is not decisive) |
+| `tracing.enable_content_capture` | `false` (default) | Off |
+
+Environment-variable values are matched case-insensitively with surrounding whitespace stripped.
+
+## Quickstart
+
+This example enables content capture, runs a single request, and prints the resulting spans to the console so you can see the captured content before wiring up a production exporter.
+
+1. Install the NeMo Guardrails library and the OpenTelemetry SDK.
+
+    ```bash
+    pip install "nemoguardrails[tracing]" opentelemetry-sdk
+    ```
+
+    The `[tracing]` extra installs `opentelemetry-api`, which is the only OpenTelemetry dependency the library itself takes.
+
+2. Save the following to `content_capture_example.py`.
+
+    ```python
+    # content_capture_example.py
+    import asyncio
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+    from nemoguardrails import Guardrails, RailsConfig
+
+    # Configure the OpenTelemetry TracerProvider BEFORE constructing Guardrails so
+    # the engine resolves a real tracer when it creates spans.
+    resource = Resource.create({"service.name": "guardrails-content-capture"})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    # Tracing must be enabled for content capture to take effect. The inline
+    # IORails path does not use the `adapters` list (that is the LLMRails
+    # post-hoc path); it exports through the TracerProvider configured above.
+    config_yaml = """
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o-mini
+
+    tracing:
+      enabled: true
+      enable_content_capture: true
+    """
+
+    config = RailsConfig.from_content(yaml_content=config_yaml)
+
+    async def main() -> None:
+        # use_iorails=True selects the IORails engine. require_iorails=True raises
+        # a ValueError if the config is incompatible with IORails.
+        async with Guardrails(config, use_iorails=True, require_iorails=True) as rails:
+            response = await rails.generate_async(
+                messages=[{"role": "user", "content": "Hello!"}],
+            )
+            print(f"Response: {response}")
+
+    try:
+        asyncio.run(main())
+    finally:
+        # Flush buffered spans to the console exporter before the process exits.
+        provider.shutdown()
+    ```
+
+3. Run the script.
+
+    ```bash
+    python content_capture_example.py
+    ```
+
+    The `chat gpt-4o-mini` CLIENT span carries the captured prompt and response as span events (the default format), and the `guardrails.request` SERVER span carries the caller-facing input and output. Trimmed for clarity:
+
+    ```json
+    {
+      "name": "chat gpt-4o-mini",
+      "kind": "SpanKind.CLIENT",
+      "attributes": {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "gpt-4o-mini"
+      },
+      "events": [
+        {"name": "gen_ai.user.message", "attributes": {"role": "user", "content": "Hello!"}},
+        {"name": "gen_ai.choice", "attributes": {"index": 0, "message.role": "assistant", "message.content": "Hello! How can I help you today?"}}
+      ]
+    }
+    {
+      "name": "guardrails.request",
+      "kind": "SpanKind.SERVER",
+      "attributes": {
+        "gen_ai.operation.name": "guardrails",
+        "guardrails.request.input": "[{\"role\": \"user\", \"content\": \"Hello!\"}]",
+        "guardrails.request.output": "Hello! How can I help you today?"
+      }
+    }
+    ```
+
+<Info>
+The host application is responsible for configuring a `TracerProvider`.
+If you enable tracing and content capture but no `TracerProvider` is set, the OpenTelemetry API returns a no-op tracer and every span — and the captured content on it — is silently discarded.
+Always set the `TracerProvider` before constructing `Guardrails`.
+</Info>
+
+## Output format
+
+The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable selects how LLM-call content is encoded on the CLIENT span.
+It holds a comma-separated list of opt-in tokens, and is read fresh on each call so changes take effect immediately.
+
+| `OTEL_SEMCONV_STABILITY_OPT_IN` | Form | What is emitted |
+|---------------------------------|------|-----------------|
+| Contains `gen_ai_latest_experimental` | JSON span **attributes** | `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions` (JSON-encoded) |
+| Token absent (default) | Legacy span **events** | `gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.tool.message`, and `gen_ai.choice` |
+
+This selector applies only to the `gen_ai.*` CLIENT spans.
+The `guardrails.request.*` and `guardrails.rail.*` attributes are always JSON-encoded regardless of the selector, because no GenAI semantic convention covers them.
+
+<Note>
+This selector is distinct from the `tracing.span_format` config field.
+`span_format` chooses the span *structure* produced by the LLMRails post-hoc tracing adapter; `OTEL_SEMCONV_STABILITY_OPT_IN` chooses the *encoding* of captured content on the inline IORails CLIENT spans.
+</Note>
+
+To emit the JSON-attribute form instead of the default events, set the variable before running:
+
+```bash
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
+
+With this set, the `chat gpt-4o-mini` span carries JSON-encoded attributes instead of events:
+
+```json
+{
+  "name": "chat gpt-4o-mini",
+  "kind": "SpanKind.CLIENT",
+  "attributes": {
+    "gen_ai.request.model": "gpt-4o-mini",
+    "gen_ai.input.messages": "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Hello!\"}]}]",
+    "gen_ai.output.messages": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"Hello! How can I help you today?\"}]}]"
+  }
+}
+```
+
+System messages are captured separately as `gen_ai.system_instructions`, a flat list of parts with no role wrapper, per the GenAI specification.
+Attributes are only set when non-empty, so a backend can distinguish "no system instructions" from an empty string.
+
+## Streaming
+
+On the streaming path, content capture accumulates the chunks the consumer actually receives and records them once, when the stream ends, on the `guardrails.request` span.
+The captured `guardrails.request.output` is therefore exactly what reached the caller — including any output-rail error payload injected on a block.
+
+Capture runs even when the stream exits early through an error or consumer cancellation, so an interrupted stream still records whatever was delivered.
+If the stream produced no content at all, the output attribute is omitted rather than recorded as an empty string.
+
+## Privacy considerations
+
+- Content capture is **off by default**. Prompts and responses are never written to spans unless you explicitly enable it.
+- Captured content may include PII or other sensitive data. Treat your tracing backend as a system that now holds user content, and apply the same access controls and retention limits you would to any store of conversation data.
+- Use `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` to force capture off across every service from the environment, regardless of what individual configs request — useful as a deployment-wide guardrail in regulated environments.
+- The [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) recommend against capturing message content by default for exactly these privacy reasons.
+
+## Differences on the LLMRails engine
+
+The legacy `LLMRails` engine also honors `tracing.enable_content_capture`, but through a different mechanism with a narrower contract.
+Rather than instrumenting live spans, it captures content after the request completes, when its tracing adapter extracts spans from the interaction log.
+
+| Dimension | IORails (this page) | LLMRails |
+|-----------|---------------------|----------|
+| Mechanism | Inline live spans during execution | Post-hoc extraction from the interaction log via the tracing adapter |
+| Enable control | `enable_content_capture` **and** the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable | `enable_content_capture` config field only |
+| Format selector | `OTEL_SEMCONV_STABILITY_OPT_IN` (JSON attributes vs. current legacy events) | None — one fixed form |
+| LLM content form | `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions`, or the current `gen_ai.user.message` / `gen_ai.assistant.message` / `gen_ai.system.message` / `gen_ai.choice` events | **Deprecated** `gen_ai.content.prompt` and `gen_ai.content.completion` events |
+| Request and rail content | `guardrails.request.input` / `.output`, `guardrails.rail.input` / `.reason` | No equivalent; instead emits guardrails-internal `guardrails.user_message` and `guardrails.utterance.*` events |
+| Streaming | Accumulates and records the delivered text at stream end | Not applicable (post-hoc from the log) |
+
+Neither `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` nor `OTEL_SEMCONV_STABILITY_OPT_IN` is consulted on the LLMRails path; the config field is the only control there.
+
+## Related topics
+
+- [Tracing Configuration](/configure-rails/yaml-schema/tracing-configuration) — the `tracing` config schema, including the `enable_content_capture` field.
+- [Quick Start](/observability/tracing/quick-start) — minimal setup to enable tracing.
+- [OpenTelemetry](/observability/tracing/opentelemetry-integration) — production-ready exporter setup.

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -8,7 +8,7 @@ content:
   type: "how_to"
 ---
 
-By default, NeMo Guardrails traces record *metadata* about each request — span timing, model and provider names, sampling parameters, token usage, and rail decisions — but never the prompt or response *content* itself.
+By default, traces record *metadata* about each request, such as span timing, model and provider names, sampling parameters, token usage, and rail decisions. They never record the prompt or response *content* itself.
 Content capture is an opt-in feature that additionally records the user, system, assistant, and tool message text onto spans so you can inspect exactly what was sent to and returned from the model.
 
 <Warning title="Experimental Feature">
@@ -31,11 +31,11 @@ When content capture is enabled, IORails records content onto three kinds of spa
 
 | Span (kind) | Attribute or event | When recorded |
 |-------------|--------------------|---------------|
-| `guardrails.request` (SERVER) | `guardrails.request.input` — JSON-encoded list of the caller's input messages | Always, while capturing |
-| `guardrails.request` (SERVER) | `guardrails.request.output` — the text actually returned to the caller | When output is produced (a blocked request records the refusal message; an empty stream records nothing) |
-| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call — the main generation call and every rail-action LLM call. On the streaming path, recorded at stream end; see [Streaming](#streaming) |
-| `guardrails.rail` (INTERNAL) | `guardrails.rail.input` — JSON-encoded `{"messages": ..., "bot_response": ...}` snapshot | Every rail execution, while capturing |
-| `guardrails.rail` (INTERNAL) | `guardrails.rail.reason` — the human-readable block reason | Only when the rail blocks the request |
+| `guardrails.request` (SERVER) | `guardrails.request.input`: JSON-encoded list of the caller's input messages | Always, while capturing |
+| `guardrails.request` (SERVER) | `guardrails.request.output`: the text actually returned to the caller | When output is produced (a blocked request records the refusal message; an empty stream records nothing) |
+| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call: the main generation call and every rail-action LLM call. On the streaming path, recorded at stream end; see [Streaming](#streaming) |
+| `guardrails.rail` (INTERNAL) | `guardrails.rail.input`: JSON-encoded `{"messages": ..., "bot_response": ...}` snapshot | Every rail execution, while capturing |
+| `guardrails.rail` (INTERNAL) | `guardrails.rail.reason`: the human-readable block reason | Only when the rail blocks the request |
 
 The SERVER span and the CLIENT span deliberately use different attribute names.
 On a blocked request the CLIENT span records the raw model response while the SERVER span records the refusal message the caller actually received, so the two values are kept under distinct names to avoid confusing backends that correlate them.
@@ -66,7 +66,7 @@ Environment-variable values are matched case-insensitively with surrounding whit
 
 This example enables content capture, runs a single request, and prints the resulting spans to the console so you can see the captured content before wiring up a production exporter.
 
-1. Install the NeMo Guardrails library and the OpenTelemetry SDK.
+1. Install the NVIDIA NeMo Guardrails library and the OpenTelemetry SDK.
 
     ```bash
     pip install "nemoguardrails[tracing]" opentelemetry-sdk
@@ -160,7 +160,7 @@ This example enables content capture, runs a single request, and prints the resu
 
 <Info>
 The host application is responsible for configuring a `TracerProvider`.
-If you enable tracing and content capture but no `TracerProvider` is set, the OpenTelemetry API returns a no-op tracer and every span — and the captured content on it — is silently discarded.
+If you enable tracing and content capture but no `TracerProvider` is set, the OpenTelemetry API returns a no-op tracer and every span, along with the captured content on it, is silently discarded.
 Always set the `TracerProvider` before constructing `Guardrails`.
 </Info>
 
@@ -210,7 +210,7 @@ Attributes are only set when non-empty, so a backend can distinguish "no system 
 On the streaming path, both the `guardrails.request` SERVER span and the `chat <model>` CLIENT span accumulate streamed chunks and record content once, when the stream ends, rather than per chunk.
 They differ in *what* they record and in their behavior when the stream exits abnormally.
 
-**`guardrails.request` SERVER span.** Accumulates the chunks the consumer actually receives and records them as `guardrails.request.output`, so the captured value is exactly what reached the caller — including any output-rail error payload injected on a block.
+**`guardrails.request` SERVER span.** Accumulates the chunks the consumer actually receives and records them as `guardrails.request.output`, so the captured value is exactly what reached the caller, including any output-rail error payload injected on a block.
 Capture runs in a `finally`, so it executes even when the stream exits early through a provider error or consumer cancellation, and an interrupted stream still records whatever was delivered.
 
 **`chat <model>` CLIENT span.** Accumulates the model's response deltas and records the LLM input plus the accumulated response in the [selected format](#output-format).
@@ -222,7 +222,7 @@ In both cases, if no content was produced the output is omitted rather than reco
 
 - Content capture is **off by default**. Prompts and responses are never written to spans unless you explicitly enable it.
 - Captured content may include PII or other sensitive data. Treat your tracing backend as a system that now holds user content, and apply the same access controls and retention limits you would to any store of conversation data.
-- Use `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` to force capture off across every service from the environment, regardless of what individual configs request — useful as a deployment-wide guardrail in regulated environments.
+- Use `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false` to force capture off across every service from the environment, regardless of what individual configs request. This is useful as a deployment-wide guardrail in regulated environments.
 - The [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) recommend against capturing message content by default for exactly these privacy reasons.
 
 ## Differences on the LLMRails engine
@@ -234,7 +234,7 @@ Rather than instrumenting live spans, it captures content after the request comp
 |-----------|---------------------|----------|
 | Mechanism | Inline live spans during execution | Post-hoc extraction from the interaction log via the tracing adapter |
 | Enable control | `enable_content_capture` **and** the `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` environment variable | `enable_content_capture` config field only |
-| Format selector | `OTEL_SEMCONV_STABILITY_OPT_IN` (JSON attributes vs. current legacy events) | None — one fixed form |
+| Format selector | `OTEL_SEMCONV_STABILITY_OPT_IN` (JSON attributes vs. current legacy events) | None (one fixed form) |
 | LLM content form | `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions`, or the current `gen_ai.user.message` / `gen_ai.assistant.message` / `gen_ai.system.message` / `gen_ai.choice` events | **Deprecated** `gen_ai.content.prompt` and `gen_ai.content.completion` events |
 | Request and rail content | `guardrails.request.input` / `.output`, `guardrails.rail.input` / `.reason` | No equivalent; instead emits guardrails-internal `guardrails.user_message` and `guardrails.utterance.*` events |
 | Streaming | Accumulates and records the delivered text at stream end | Not applicable (post-hoc from the log) |
@@ -243,6 +243,6 @@ Neither `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` nor `OTEL_SEMCONV_S
 
 ## Related topics
 
-- [Tracing Configuration](/configure-rails/yaml-schema/tracing-configuration) — the `tracing` config schema, including the `enable_content_capture` field.
-- [Quick Start](/observability/tracing/quick-start) — minimal setup to enable tracing.
-- [OpenTelemetry](/observability/tracing/opentelemetry-integration) — production-ready exporter setup.
+- [Tracing Configuration](/configure-guardrails/yaml-schema/tracing-configuration) - the `tracing` config schema, including the `enable_content_capture` field.
+- [Quick Start](/observability/tracing/quick-start) - minimal setup to enable tracing.
+- [OpenTelemetry](/observability/tracing/opentelemetry-integration) - production-ready exporter setup.

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -12,8 +12,9 @@ By default, NeMo Guardrails traces record *metadata* about each request — span
 Content capture is an opt-in feature that additionally records the user, system, assistant, and tool message text onto spans so you can inspect exactly what was sent to and returned from the model.
 
 <Warning title="Experimental Feature">
-Inline content capture with the environment-variable controls described on this page requires the opt-in IORails engine.
-Enable it either by constructing `Guardrails(config, use_iorails=True)` (the form used in this guide) or by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1`, which aliases the top-level `LLMRails` import to `Guardrails`.
+The `tracing.enable_content_capture` config flag works on both the IORails and `LLMRails` engines.
+The *environment-variable controls* and *inline-span behavior* described on this page are specific to the opt-in IORails engine.
+Enable IORails either by constructing `Guardrails(config, use_iorails=True)` (the form used in this guide) or by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1`, which aliases the top-level `LLMRails` import to `Guardrails`.
 IORails is an early-release feature, and span names and attributes can change as the OpenTelemetry GenAI semantic conventions evolve.
 The legacy `LLMRails` engine supports a narrower form of content capture; see [Differences on the LLMRails engine](#differences-on-the-llmrails-engine) below.
 </Warning>

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -33,7 +33,7 @@ When content capture is enabled, IORails records content onto three kinds of spa
 |-------------|--------------------|---------------|
 | `guardrails.request` (SERVER) | `guardrails.request.input` — JSON-encoded list of the caller's input messages | Always, while capturing |
 | `guardrails.request` (SERVER) | `guardrails.request.output` — the text actually returned to the caller | When output is produced (a blocked request records the refusal message; an empty stream records nothing) |
-| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call — the main generation call and every rail-action LLM call |
+| `chat <model>` (CLIENT) | LLM input and output, in the [selected format](#output-format) | Once per LLM call — the main generation call and every rail-action LLM call. On the streaming path, recorded at stream end; see [Streaming](#streaming) |
 | `guardrails.rail` (INTERNAL) | `guardrails.rail.input` — JSON-encoded `{"messages": ..., "bot_response": ...}` snapshot | Every rail execution, while capturing |
 | `guardrails.rail` (INTERNAL) | `guardrails.rail.reason` — the human-readable block reason | Only when the rail blocks the request |
 
@@ -207,11 +207,16 @@ Attributes are only set when non-empty, so a backend can distinguish "no system 
 
 ## Streaming
 
-On the streaming path, content capture accumulates the chunks the consumer actually receives and records them once, when the stream ends, on the `guardrails.request` span.
-The captured `guardrails.request.output` is therefore exactly what reached the caller — including any output-rail error payload injected on a block.
+On the streaming path, both the `guardrails.request` SERVER span and the `chat <model>` CLIENT span accumulate streamed chunks and record content once, when the stream ends, rather than per chunk.
+They differ in *what* they record and in their behavior when the stream exits abnormally.
 
-Capture runs even when the stream exits early through an error or consumer cancellation, so an interrupted stream still records whatever was delivered.
-If the stream produced no content at all, the output attribute is omitted rather than recorded as an empty string.
+**`guardrails.request` SERVER span.** Accumulates the chunks the consumer actually receives and records them as `guardrails.request.output`, so the captured value is exactly what reached the caller — including any output-rail error payload injected on a block.
+Capture runs in a `finally`, so it executes even when the stream exits early through a provider error or consumer cancellation, and an interrupted stream still records whatever was delivered.
+
+**`chat <model>` CLIENT span.** Accumulates the model's response deltas and records the LLM input plus the accumulated response in the [selected format](#output-format).
+This capture runs only on natural completion of the stream: if the stream is cancelled by the consumer or the provider raises, the partial model output is intentionally **not** recorded on the CLIENT span.
+
+In both cases, if no content was produced the output is omitted rather than recorded as an empty string.
 
 ## Privacy considerations
 

--- a/docs/observability/tracing/index.mdx
+++ b/docs/observability/tracing/index.mdx
@@ -71,7 +71,7 @@ The following are the key differences between the supported span formats.
 **Development Status**: The [OpenTelemetry semantic conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are currently in development and may undergo changes. Consider the following risks:
 
 - **Evolving Standards**: Conventions may change as they mature, potentially affecting existing implementations
-- **Data Privacy**: The `enable_content_capture` option captures user inputs and model outputs, which may include sensitive information (PII). Only enable when necessary and ensure compliance with data protection regulations. See [GenAI Events documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) for details
+- **Data Privacy**: The `enable_content_capture` option captures user inputs and model outputs, which may include sensitive information (PII). Only enable when necessary and ensure compliance with data protection regulations. See [Content Capture](/observability/tracing/content-capture) for the full contract and the [GenAI Events documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) for details
 - **Performance Impact**: Extensive telemetry collection may impact system performance, especially with large inputs/outputs
 
 ### Migration Path
@@ -90,6 +90,7 @@ Existing configurations will continue to work. However, it is strongly recommend
 - [OpenTelemetry](/observability/tracing/opentelemetry-integration) - Production-ready OpenTelemetry setup and ecosystem compatibility
 - [OpenTelemetry Logs](/observability/tracing/opentelemetry-logs) - Forward guardrails Python logs to OpenTelemetry with trace correlation
 - [Span Reference](/observability/tracing/span-reference) - Every span and attribute the LLMRails and IORails engines emit, including the token-level GenAI attributes on the LLM span
+- [Content Capture](/observability/tracing/content-capture) - Record prompt and response content on spans, with the environment variables that control capture and format
 - [Troubleshooting](/observability/tracing/troubleshooting) - Common issues and solutions
 
 ## Jupyter Notebooks

--- a/docs/observability/tracing/index.mdx
+++ b/docs/observability/tracing/index.mdx
@@ -5,13 +5,12 @@ title: "Tracing Guardrails"
 sidebar-title: "Tracing"
 description: "Enable distributed tracing with OpenTelemetry to monitor guardrails execution and LLM calls."
 content:
-  type: "how_to"
+    type: "how_to"
 ---
 
-<a id="tracing"></a>
-# Tracing Guardrails
+<a id="tracing"></a># Tracing Guardrails
 
-Tracing enhances the observability of guardrails execution. This section explains the configuration process for implementing tracing with the NeMo Guardrails library.
+Tracing enhances the observability of guardrails execution. This section explains how to configure tracing with the NVIDIA NeMo Guardrails library.
 
 With tracing, you can:
 
@@ -22,7 +21,7 @@ With tracing, you can:
 
 ## Span Formats
 
-Starting with the NeMo Guardrails library v0.16.0, the tracing system has transitioned to OpenTelemetry semantic conventions for Generative AI (GenAI), moving away from the legacy span format. This change enhances observability standardization and improves monitoring capabilities for AI workloads.
+Starting with v0.16.0, the NeMo Guardrails library uses OpenTelemetry semantic conventions for Generative AI (GenAI) instead of the legacy span format. This change standardizes observability and improves monitoring for AI workloads.
 
 **Reference Documentation:**
 
@@ -43,9 +42,9 @@ You can control the span format through the tracing configuration:
 
 ```yaml
 tracing:
-  enabled: true
-  span_format: "opentelemetry"  # default
-  enable_content_capture: false  # default, see privacy considerations below
+    enabled: true
+    span_format: "opentelemetry" # default
+    enable_content_capture: false # default, see privacy considerations below
 ```
 
 ### Key Differences
@@ -71,7 +70,7 @@ The following are the key differences between the supported span formats.
 **Development Status**: The [OpenTelemetry semantic conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are currently in development and may undergo changes. Consider the following risks:
 
 - **Evolving Standards**: Conventions may change as they mature, potentially affecting existing implementations
-- **Data Privacy**: The `enable_content_capture` option captures user inputs and model outputs, which may include sensitive information (PII). Only enable when necessary and ensure compliance with data protection regulations. See [Content Capture](/observability/tracing/content-capture) for the full contract and the [GenAI Events documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) for details
+- **Data Privacy**: The `enable_content_capture` option captures user inputs and model outputs, which can include sensitive information (PII). Only enable it when necessary, and ensure compliance with data protection regulations. See [Content Capture](/observability/tracing/content-capture) for the full contract and the [GenAI Events documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) for details
 - **Performance Impact**: Extensive telemetry collection may impact system performance, especially with large inputs/outputs
 
 ### Migration Path


### PR DESCRIPTION
## Description

Add docs for the OTEL content-capture span tracing feature in IORails. Separate out the LLMRails implementation and IORails.

## Related Issue(s)

#1972 - PR adding content-capture feature

## Verification

TODO


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded tracing configuration docs with new options for span formatting and optional content capture.
  * Added a new “Content Capture” guide explaining what is recorded, how to enable it, and privacy considerations.
  * Updated tracing navigation and references to surface the new guide more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->