### PR TITLE
Fix batched embedding failures leaving waiters blocked

### DIFF
--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -92,6 +92,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         # Data structures for batching embedding requests
         self._req_queue: Dict[int, str] = {}
         self._req_results: Dict[int, List[float]] = {}
+        self._req_errors: Dict[int, Exception] = {}
         self._req_idx: int = 0
         self._current_batch_finished_event: Optional[asyncio.Event] = None
         self._current_batch_full_event: Optional[asyncio.Event] = None
@@ -252,13 +253,23 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
         # print(f"Running batch of length {len(batch)}")
 
-        # Compute the embeddings
-        embeddings = await self._get_embeddings(batch)
-        for i in range(len(embeddings)):
-            self._req_results[batch_ids[i]] = embeddings[i]
+        try:
+            embeddings = await self._get_embeddings(batch)
+            if len(embeddings) != len(batch_ids):
+                raise RuntimeError(
+                    f"Embedding batch returned {len(embeddings)} result(s) for {len(batch_ids)} request(s)."
+                )
 
-        # Signal that the batch has finished processing
-        batch_event.set()
+            for req_id, embedding in zip(batch_ids, embeddings):
+                self._req_results[req_id] = embedding
+        except Exception as exc:
+            log.exception("Failed to compute embeddings batch of size %d.", len(batch))
+            for req_id in batch_ids:
+                self._req_results.pop(req_id, None)
+                self._req_errors[req_id] = exc
+        finally:
+            # Signal that the batch has finished processing even if the provider failed.
+            batch_event.set()
 
     async def _batch_get_embeddings(self, text: str) -> List[float]:
         # As long as the queue is full, we wait for the next batch
@@ -280,11 +291,20 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._current_batch_full_event.set()
 
         # Wait for the batch to finish
-        await self._current_batch_finished_event.wait()
+        batch_event = self._current_batch_finished_event
+        if batch_event is None:
+            raise RuntimeError("Batch event not initialized. This should not happen.")
+
+        await batch_event.wait()
+
+        error = self._req_errors.pop(req_id, None)
+        if error is not None:
+            raise RuntimeError("Failed to compute embeddings for batched request.") from error
 
         # Remove the result and return it
-        result = self._req_results[req_id]
-        del self._req_results[req_id]
+        result = self._req_results.pop(req_id, None)
+        if result is None:
+            raise RuntimeError("Embedding batch finished without a result for the request.")
 
         return result
 

--- a/tests/test_batch_embeddings.py
+++ b/tests/test_batch_embeddings.py
@@ -85,3 +85,67 @@ async def test_search_speed():
     print(f"Completed {completed_requests} requests in {total_time:.2f} seconds.")
     print(f"Average latency: {total_time / completed_requests if completed_requests else 0:.2f} seconds.")
     print(f"Maximum concurrency: {concurrency}")
+
+
+@pytest.mark.asyncio
+async def test_batch_get_embeddings_raises_for_all_waiters_if_provider_fails(monkeypatch):
+    embeddings_index = BasicEmbeddingsIndex(use_batching=True, max_batch_size=2, max_batch_hold=1.0)
+
+    async def _fail(_texts):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(embeddings_index, "_get_embeddings", _fail)
+
+    results = await asyncio.wait_for(
+        asyncio.gather(
+            embeddings_index._batch_get_embeddings("first"),
+            embeddings_index._batch_get_embeddings("second"),
+            return_exceptions=True,
+        ),
+        timeout=0.2,
+    )
+
+    assert len(results) == 2
+    for result in results:
+        assert isinstance(result, RuntimeError)
+        assert str(result) == "Failed to compute embeddings for batched request."
+        assert isinstance(result.__cause__, RuntimeError)
+        assert str(result.__cause__) == "provider down"
+
+
+@pytest.mark.asyncio
+async def test_batch_get_embeddings_recovers_after_failed_batch(monkeypatch):
+    embeddings_index = BasicEmbeddingsIndex(use_batching=True, max_batch_size=2, max_batch_hold=1.0)
+    call_count = 0
+
+    async def _maybe_fail(texts):
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            raise RuntimeError("provider down")
+
+        return [[float(len(text))] for text in texts]
+
+    monkeypatch.setattr(embeddings_index, "_get_embeddings", _maybe_fail)
+
+    failed_results = await asyncio.wait_for(
+        asyncio.gather(
+            embeddings_index._batch_get_embeddings("first"),
+            embeddings_index._batch_get_embeddings("second"),
+            return_exceptions=True,
+        ),
+        timeout=0.2,
+    )
+
+    assert all(isinstance(result, RuntimeError) for result in failed_results)
+
+    recovered_results = await asyncio.wait_for(
+        asyncio.gather(
+            embeddings_index._batch_get_embeddings("ok"),
+            embeddings_index._batch_get_embeddings("great"),
+        ),
+        timeout=0.2,
+    )
+
+    assert recovered_results == [[2.0], [5.0]]


### PR DESCRIPTION
## Summary
This fixes a reliability bug in batched embedding lookups where a provider failure could leave every caller in that batch waiting forever.

## Root cause
`BasicEmbeddingsIndex._run_batch()` only set the batch completion event after `_get_embeddings()` returned successfully. When the provider raised, the background task exited before signaling the shared event, so every waiter on that batch blocked indefinitely.

## What changed
- store batch failures per request and always signal batch completion in a `finally` block
- re-raise a clear batched-embedding error from waiters while preserving the original provider exception as the cause
- guard against partial or mismatched batch results with a clearer runtime error
- add async regression tests for failure fan-out and recovery after a failed batch

## Validation
- `./.venv/bin/python -m pytest tests/test_batch_embeddings.py tests/test_basic_embeddings_index_numpy.py`
