### PR TITLE
Fail cleanly when auto-reload watchdog is missing

### DIFF
--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -198,6 +198,11 @@ def server(
         setattr(api.app, "disable_chat_ui", True)
 
     if auto_reload:
+        try:
+            api.validate_auto_reload_dependencies()
+        except RuntimeError as exc:
+            typer.secho(str(exc), fg=typer.colors.RED)
+            raise typer.Exit(1)
         setattr(api.app, "auto_reload", True)
 
     if prefix:

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -115,6 +115,18 @@ def _validate_public_state_shape(state: Optional[dict]) -> None:
         _raise_invalid_state("Invalid state format: 'events' must be a list.")
 
 
+def validate_auto_reload_dependencies() -> None:
+    """Ensure auto-reload dependencies are installed before startup."""
+    try:
+        import watchdog.events  # noqa: F401
+        import watchdog.observers  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "The auto-reload feature requires `watchdog`. Install it with "
+            "`pip install watchdog` or `pip install nemoguardrails[server]`."
+        ) from exc
+
+
 api_description = """Guardrails Server API."""
 
 # The headers for each request
@@ -169,6 +181,7 @@ async def lifespan(app: GuardrailsApp):
                 config_module.init(app)
 
     if app.auto_reload:
+        validate_auto_reload_dependencies()
         app.loop = asyncio.get_running_loop()
         # Store the future directly as task
         app.task = app.loop.run_in_executor(None, start_auto_reload_monitoring)
@@ -775,58 +788,51 @@ def register_logger(logger: Callable):
 
 def start_auto_reload_monitoring():
     """Start a thread that monitors the config folder for changes."""
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    class Handler(FileSystemEventHandler):
+        def on_any_event(self, event):
+            if event.is_directory:
+                return None
+
+            elif event.event_type == "created" or event.event_type == "modified":
+                log.info(f"Watchdog received {event.event_type} event for file {event.src_path}")
+
+                # Compute the relative path
+                src_path_str = str(event.src_path)
+                rel_path = os.path.relpath(src_path_str, app.rails_config_path)
+
+                # The config_id is the first component
+                parts = rel_path.split(os.path.sep)
+                config_id = parts[0]
+
+                if (
+                    not parts[-1].startswith(".")
+                    and ".ipynb_checkpoints" not in parts
+                    and os.path.isfile(src_path_str)
+                ):
+                    # We just remove the config from the cache so that a new one is used next time
+                    if config_id in llm_rails_instances:
+                        instance = llm_rails_instances[config_id]
+                        del llm_rails_instances[config_id]
+                        if instance:
+                            val = instance.events_history_cache
+                            # We save the events history cache, to restore it on the new instance
+                            llm_rails_events_history_cache[config_id] = val
+
+                        log.info(f"Configuration {config_id} has changed. Clearing cache.")
+
+    observer = Observer()
+    event_handler = Handler()
+    observer.schedule(event_handler, app.rails_config_path, recursive=True)
+    observer.start()
     try:
-        from watchdog.events import FileSystemEventHandler
-        from watchdog.observers import Observer
-
-        class Handler(FileSystemEventHandler):
-            def on_any_event(self, event):
-                if event.is_directory:
-                    return None
-
-                elif event.event_type == "created" or event.event_type == "modified":
-                    log.info(f"Watchdog received {event.event_type} event for file {event.src_path}")
-
-                    # Compute the relative path
-                    src_path_str = str(event.src_path)
-                    rel_path = os.path.relpath(src_path_str, app.rails_config_path)
-
-                    # The config_id is the first component
-                    parts = rel_path.split(os.path.sep)
-                    config_id = parts[0]
-
-                    if (
-                        not parts[-1].startswith(".")
-                        and ".ipynb_checkpoints" not in parts
-                        and os.path.isfile(src_path_str)
-                    ):
-                        # We just remove the config from the cache so that a new one is used next time
-                        if config_id in llm_rails_instances:
-                            instance = llm_rails_instances[config_id]
-                            del llm_rails_instances[config_id]
-                            if instance:
-                                val = instance.events_history_cache
-                                # We save the events history cache, to restore it on the new instance
-                                llm_rails_events_history_cache[config_id] = val
-
-                            log.info(f"Configuration {config_id} has changed. Clearing cache.")
-
-        observer = Observer()
-        event_handler = Handler()
-        observer.schedule(event_handler, app.rails_config_path, recursive=True)
-        observer.start()
-        try:
-            while not app.stop_signal:
-                time.sleep(5)
-        finally:
-            observer.stop()
-            observer.join()
-
-    except ImportError:
-        # Since this is running in a separate thread, we just print the error.
-        print("The auto-reload feature requires `watchdog`. Please install using `pip install watchdog`.")
-        # Force close everything.
-        os._exit(-1)
+        while not app.stop_signal:
+            time.sleep(5)
+    finally:
+        observer.stop()
+        observer.join()
 
 
 def set_default_config_id(config_id: str):

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -206,6 +206,21 @@ class TestServerCommand:
 
     @patch("uvicorn.run")
     @patch("nemoguardrails.server.api.app")
+    @patch(
+        "nemoguardrails.server.api.validate_auto_reload_dependencies",
+        side_effect=RuntimeError("The auto-reload feature requires `watchdog`."),
+    )
+    def test_server_with_auto_reload_missing_watchdog_fails_cleanly(
+        self, _mock_validate, mock_app, mock_uvicorn
+    ):
+        result = runner.invoke(app, ["server", "--auto-reload"])
+        assert result.exit_code == 1
+        assert "The auto-reload feature requires `watchdog`." in result.stdout
+        assert getattr(mock_app, "auto_reload", False) is not True
+        mock_uvicorn.assert_not_called()
+
+    @patch("uvicorn.run")
+    @patch("nemoguardrails.server.api.app")
     @patch("nemoguardrails.server.api.set_default_config_id")
     def test_server_with_default_config_id(self, mock_set_default, mock_app, mock_uvicorn):
         result = runner.invoke(app, ["server", "--default-config-id=test_config"])

--- a/tests/telemetry/test_usage_reporting.py
+++ b/tests/telemetry/test_usage_reporting.py
@@ -595,6 +595,26 @@ class TestIntegration:
         usage_data = send_calls[0].kwargs["args"][0]
         assert usage_data.deployment_type == "api"
 
+    def test_server_lifespan_raises_when_auto_reload_dependency_is_missing(self, tmp_path):
+        from nemoguardrails.server.api import GuardrailsApp, lifespan
+
+        server_app = GuardrailsApp(lifespan=lifespan)
+        server_app.rails_config_path = str(tmp_path)
+        server_app.auto_reload = True
+
+        async def run_lifespan():
+            async with lifespan(server_app):
+                pass
+
+        with patch(
+            "nemoguardrails.server.api.validate_auto_reload_dependencies",
+            side_effect=RuntimeError("The auto-reload feature requires `watchdog`."),
+        ):
+            with pytest.raises(RuntimeError, match="requires `watchdog`"):
+                asyncio.run(run_lifespan())
+
+        assert server_app.task is None
+
     def test_report_skipped_when_disabled(self):
         with (
             patch.object(telemetry, "_is_usage_stats_enabled", return_value=False),


### PR DESCRIPTION
## Summary
This replaces the auto-reload watchdog failure path that could terminate the whole process with `os._exit(-1)`.

## Root cause
`start_auto_reload_monitoring()` imported `watchdog` inside a background helper thread. When `watchdog` was missing, that helper printed a message and called `os._exit(-1)`, bypassing normal startup failure handling and process cleanup.

## What changed
- added a shared `validate_auto_reload_dependencies()` check for the auto-reload dependency
- fail the CLI server command cleanly before `uvicorn.run(...)` when `--auto-reload` is requested without `watchdog`
- validate again in the app lifespan so programmatic auto-reload startup also fails normally
- removed the background helper path that called `os._exit(-1)`
- added regression coverage for both the CLI error path and the lifespan startup guard

## Validation
- `./.venv/bin/python -m pytest tests/cli/test_cli_main.py tests/telemetry/test_usage_reporting.py`
