### PR TITLE
Serialize Redis embedding cache values

### DIFF
--- a/nemoguardrails/embeddings/cache.py
+++ b/nemoguardrails/embeddings/cache.py
@@ -204,10 +204,20 @@ class RedisCacheStore(CacheStore):
         self._redis = redis.Redis(host=host, port=port, db=db)
 
     def get(self, key):
-        return self._redis.get(key)
+        value = self._redis.get(key)
+        if value is None:
+            return None
+
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+
+        try:
+            return json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            return value
 
     def set(self, key, value):
-        self._redis.set(key, value)
+        self._redis.set(key, json.dumps(value))
 
     def clear(self):
         self._redis.flushall()

--- a/tests/test_cache_embeddings.py
+++ b/tests/test_cache_embeddings.py
@@ -102,14 +102,39 @@ def test_filesystem_cache_store():
 def test_redis_cache_store():
     pytest.importorskip("redis")
     mock_redis = MagicMock()
+    mock_redis.get.return_value = b"[0.1, 0.2, 0.3]"
     cache = RedisCacheStore()
     cache._redis = mock_redis
-    cache.set("key", "value")
-    mock_redis.set.assert_called_once_with("key", "value")
-    cache.get("key")
+    cache.set("key", [0.1, 0.2, 0.3])
+    mock_redis.set.assert_called_once_with("key", "[0.1, 0.2, 0.3]")
+    assert cache.get("key") == [0.1, 0.2, 0.3]
     mock_redis.get.assert_called_once_with("key")
     cache.clear()
     mock_redis.flushall.assert_called_once()
+
+
+def test_redis_cache_store_returns_legacy_non_json_strings():
+    pytest.importorskip("redis")
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = b"legacy-value"
+    cache = RedisCacheStore()
+    cache._redis = mock_redis
+
+    assert cache.get("key") == "legacy-value"
+
+
+def test_embeddings_cache_with_redis_store_round_trips_embeddings():
+    pytest.importorskip("redis")
+    mock_redis = MagicMock()
+    cache_store = RedisCacheStore()
+    cache_store._redis = mock_redis
+    embeddings_cache = EmbeddingsCache(key_generator=MD5KeyGenerator(), cache_store=cache_store)
+
+    embeddings_cache.set("text", [0.1, 0.2, 0.3])
+    stored_value = mock_redis.set.call_args.args[1]
+    mock_redis.get.return_value = stored_value.encode("utf-8")
+
+    assert embeddings_cache.get("text") == [0.1, 0.2, 0.3]
 
 
 class TestEmbeddingsCache(unittest.TestCase):


### PR DESCRIPTION
## Summary
This fixes the Redis-backed embeddings cache so embedding vectors are serialized before being written and deserialized when read back.

## Root cause
`RedisCacheStore.set()` passed Python values directly to `redis-py`, but embedding cache values are `list[float]` and `redis-py` rejects lists with `DataError`. Even if values were serialized elsewhere, `RedisCacheStore.get()` returned raw Redis bytes instead of decoded embedding vectors.

## What changed
- serialize Redis cache values with JSON on write
- deserialize JSON values on read so embedding cache callers receive normal Python values
- keep a small fallback for legacy non-JSON string values already present in Redis
- add focused tests for Redis cache serialization and embedding round-trips

## Validation
- `./.venv/bin/python -m pytest tests/test_cache_embeddings.py`
