### PR TITLE
Hide reasoning traces from IORails output

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -552,10 +552,9 @@ class IORails(BaseGuardrails):
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
 
-        # Reasoning extraction prefers LLMResponse `reasoning` field if the provider
-        # supports it, falling back to extracting <think>...</think> tags otherwise.
-        # The fallback mutates response.content to remove reasoning content.
-        reasoning_content = response.reasoning or _extract_and_remove_think_tags(response)
+        # Keep reasoning traces out of user-visible content. If a model leaks
+        # reasoning through <think> tags, strip them from response.content.
+        _extract_and_remove_think_tags(response)
         response_text = response.content
 
         # Main LLM returns function calls to make based on available tools and conversation
@@ -570,9 +569,7 @@ class IORails(BaseGuardrails):
                     record_request_blocked(RailDirection.OUTPUT)
                 return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
-        # Output rails check the final answer, not reasoning traces.
-        # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
-        # rails, matching LLMRails.
+        # Output rails check the final user-visible answer content.
         # A tool-call-only response skips output rails (no text to check)
         # Tool calls have their own `ToolOutputRails` set of rails separate to `OutputRails`
         is_tool_call_only = bool(response.tool_calls) and not response_text
@@ -584,11 +581,6 @@ class IORails(BaseGuardrails):
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
                 return {"role": "assistant", "content": REFUSAL_MESSAGE}
-
-        # TODO: Support returning GenerationResponse `reasoning_content` to match LLMRails
-        # For now, embed the reasoning on the content with think-tags
-        if reasoning_content:
-            response_text = f"<think>{reasoning_content}</think>\n" + response_text
 
         return _build_assistant_message(response_text, response.tool_calls)
 

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -195,6 +195,38 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, **llm_params)
 
     @pytest.mark.asyncio
+    async def test_generate_async_does_not_expose_reasoning_field_in_content(self, iorails):
+        """Provider reasoning stays out of the returned assistant content."""
+        messages = [{"role": "user", "content": "hi"}]
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Final answer", reasoning="secret internal reasoning")
+        )
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "Final answer"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Final answer", enabled=True)
+
+    @pytest.mark.asyncio
+    async def test_generate_async_strips_think_tags_from_returned_content(self, iorails):
+        """Embedded <think> traces are removed before output rails and before returning to the caller."""
+        messages = [{"role": "user", "content": "hi"}]
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="<think>secret reasoning</think>\nFinal answer")
+        )
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        result = await iorails.generate_async(messages)
+
+        assert result == {"role": "assistant", "content": "Final answer"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Final answer", enabled=True)
+
+    @pytest.mark.asyncio
     async def test_generate_async_propagates_exception(self, iorails):
         """Exceptions from the LLM call propagate to the caller."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))


### PR DESCRIPTION
## Summary
This closes a safety gap in non-streaming `IORails` where reasoning traces could be reattached to the returned assistant message after output rails had already run.

## Root cause
`IORails.generate_async()` extracted reasoning, ran output rails on the stripped answer text, and then prepended the reasoning back into the returned `content` as `<think>...</think>`. That allowed reasoning traces to bypass output rails and still be returned to the caller.

## What changed
- stop reattaching reasoning traces into non-streaming `IORails` response content
- always strip leaked `<think>...</think>` blocks from returned content before output rails run
- add focused regressions for both provider-side reasoning fields and embedded think tags

## Why this approach
This is the smallest safety fix with the lowest review surface. It also aligns non-streaming `IORails` with the existing streaming behavior, which already drops reasoning from caller-visible output.

## Validation
- `./.venv/bin/python -m pytest tests/guardrails/test_iorails.py tests/guardrails/test_iorails_streaming.py`
