### PR TITLE
fix(langchain): make RunnableRails.transform/atransform proper (async) iterators

### DIFF
--- a/nemoguardrails/integrations/langchain/runnable_rails.py
+++ b/nemoguardrails/integrations/langchain/runnable_rails.py
@@ -855,24 +855,39 @@ class RunnableRails(Runnable[Input, Output]):
 
     def transform(
         self,
-        input: Input,
+        input: Iterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Output:
-        """Transform the input.
+    ) -> Iterator[Output]:
+        """Transform an iterator of inputs into an iterator of outputs.
 
-        This is just an alias for invoke.
+        This follows the LangChain ``Runnable`` streaming protocol: ``transform``
+        consumes an *iterator* of inputs and yields an *iterator* of outputs. We
+        defer to the base-class implementation, which buffers the input stream and
+        delegates to :meth:`stream`, so guardrails are applied once over the fully
+        assembled input.
         """
-        return self.invoke(input, config, **kwargs)
+        yield from super().transform(input, config, **kwargs)
 
     async def atransform(
         self,
-        input: Input,
+        input: AsyncIterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Output:
-        """Transform the input asynchronously.
+    ) -> AsyncIterator[Output]:
+        """Transform an async iterator of inputs into an async iterator of outputs.
 
-        This is just an alias for ainvoke.
+        This follows the LangChain ``Runnable`` streaming protocol: ``atransform``
+        consumes an *async iterator* of inputs and must itself be an async iterator.
+        We defer to the base-class implementation, which buffers the input stream and
+        delegates to :meth:`astream`, so guardrails are applied once over the fully
+        assembled input.
+
+        The previous implementation aliased this to ``ainvoke`` and returned a
+        coroutine instead of an async iterator, which raised
+        ``TypeError: 'async for' requires an object with __aiter__ method`` whenever
+        ``RunnableRails`` was placed inside a ``RunnableSequence`` and streamed
+        (see issue #1692).
         """
-        return await self.ainvoke(input, config, **kwargs)
+        async for output in super().atransform(input, config, **kwargs):
+            yield output

--- a/tests/integrations/langchain/runnable_rails/test_streaming.py
+++ b/tests/integrations/langchain/runnable_rails/test_streaming.py
@@ -17,10 +17,12 @@
 Tests for streaming functionality in RunnableRails.
 """
 
+import asyncio
+
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langchain_core.prompt_values import StringPromptValue
-from langchain_core.runnables import RunnablePassthrough
+from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
@@ -489,3 +491,80 @@ def test_streaming_chunk_types():
 
     for chunk in chunks:
         assert chunk.__class__.__name__ == "AIMessageChunk"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the transform/atransform streaming protocol (issue #1692)
+# ---------------------------------------------------------------------------
+
+
+def _join_content(chunks):
+    return "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_atransform_in_runnable_sequence_streams():
+    """RunnableRails must be streamable when nested in a RunnableSequence.
+
+    Regression for #1692: placing RunnableRails in a sequence and calling
+    ``astream`` invokes ``atransform``, which previously aliased ``ainvoke`` and
+    returned a coroutine instead of an async iterator, raising
+    ``TypeError: 'async for' requires an object with __aiter__ method, got coroutine``.
+    """
+    llm = StreamingFakeLLM(responses=["Hello there! How can I help you?"])
+    config = RailsConfig.from_content(config={"models": []})
+    rails = RunnableRails(config, llm=llm)
+
+    pipeline = RunnableLambda(lambda x: x) | rails
+
+    chunks = [chunk async for chunk in pipeline.astream("Hi there")]
+
+    assert len(chunks) > 1
+    assert "Hello there!" in _join_content(chunks)
+
+
+@pytest.mark.asyncio
+async def test_atransform_returns_async_iterator():
+    """``atransform`` must be an async iterator, not a coroutine (#1692)."""
+    llm = StreamingFakeLLM(responses=["Async iterator response"])
+    config = RailsConfig.from_content(config={"models": []})
+    rails = RunnableRails(config, llm=llm)
+
+    async def _input_stream():
+        yield "Hi there"
+
+    result = rails.atransform(_input_stream())
+    assert not asyncio.iscoroutine(result)
+    assert hasattr(result, "__aiter__")
+
+    chunks = [chunk async for chunk in result]
+    assert len(chunks) > 1
+    assert "Async iterator response" in _join_content(chunks)
+
+
+def test_transform_returns_iterator():
+    """``transform`` must consume an iterator of inputs and yield outputs (#1692)."""
+    llm = StreamingFakeLLM(responses=["Sync iterator response"])
+    config = RailsConfig.from_content(config={"models": []})
+    rails = RunnableRails(config, llm=llm)
+
+    result = rails.transform(iter(["Hi there"]))
+    assert hasattr(result, "__next__")
+
+    chunks = list(result)
+    assert len(chunks) > 1
+    assert "Sync iterator response" in _join_content(chunks)
+
+
+def test_transform_in_runnable_sequence_streams():
+    """RunnableRails must be sync-streamable when nested in a RunnableSequence (#1692)."""
+    llm = StreamingFakeLLM(responses=["Sequence sync response"])
+    config = RailsConfig.from_content(config={"models": []})
+    rails = RunnableRails(config, llm=llm)
+
+    pipeline = RunnableLambda(lambda x: x) | rails
+
+    chunks = list(pipeline.stream("Hi there"))
+
+    assert len(chunks) > 1
+    assert "Sequence sync response" in _join_content(chunks)


### PR DESCRIPTION
## Summary

Fixes #1692.

`RunnableRails.transform` and `RunnableRails.atransform` were aliased to `invoke`/`ainvoke`, which violates the LangChain `Runnable` streaming protocol:

- `transform` must consume an **iterator** of inputs and return an **iterator** of outputs.
- `atransform` must consume an **async iterator** of inputs and must itself **be an async iterator**.

Because `atransform` was an `async def` that `return`ed a value, calling it produced a **coroutine** rather than an async iterator. As a result, placing `RunnableRails` inside a `RunnableSequence` and streaming it raised:

```
TypeError: 'async for' requires an object with __aiter__ method, got coroutine
```

### Reproduction (from the issue)

```python
import asyncio
from langchain_core.runnables import RunnableLambda
from nemoguardrails import RailsConfig
from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails

async def reproduce_bug():
    config = RailsConfig.from_content(yaml_content="models: []")
    rails = RunnableRails(config, passthrough=True)
    pipeline = RunnableLambda(lambda x: x) | rails
    async for _ in pipeline.astream("hello"):  # TypeError before this fix
        pass

asyncio.run(reproduce_bug())
```

## Fix

Defer to the base `Runnable.transform`/`atransform` implementations, which buffer the input stream and delegate to the already-correct `stream`/`astream` methods. Guardrails therefore run **once over the fully assembled input**, with no per-item re-invocation.

> Note: this intentionally avoids the per-item `invoke`/`ainvoke` approach that led the earlier attempts (#1702, #1763) to be closed — `stream`/`astream` already handle a single assembled input correctly.

## Tests

Added regression tests in `tests/integrations/langchain/runnable_rails/test_streaming.py`:

- `RunnableRails` nested in a `RunnableSequence` is streamable via `astream` (the exact issue scenario) and `stream`.
- `atransform` returns an async iterator (not a coroutine).
- `transform` consumes an iterator and yields outputs.

All four fail on the previous code and pass with this fix. Full `runnable_rails` suite: 165 passed, 2 skipped.