### PR TITLE
test: support aiohttp 3.14 in aioresponses mocks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import os
-from unittest.mock import patch
+from importlib.metadata import version
+from unittest.mock import Mock, patch
 
 import pytest
+from aiohttp import ClientResponse
+from packaging.version import Version
 
 from tests.testing.embeddings import (
     DeterministicEmbeddingSearchProvider,
@@ -35,6 +39,28 @@ _REAL_EMBEDDING_ENV_VARS = (
     "LIVE_TEST_MODE",
     "TEST_LIVE_MODE",
 )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def patch_aioresponses_client_response():
+    from aioresponses import core
+
+    if "stream_writer" not in inspect.signature(ClientResponse).parameters:
+        yield
+        return
+
+    if Version(version("aioresponses")) > Version("0.7.9"):
+        pytest.fail(
+            "aioresponses has advanced beyond 0.7.9; verify aiohttp compatibility and remove patch_aioresponses_client_response."
+        )
+
+    class CompatibleClientResponse(ClientResponse):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("stream_writer", Mock(output_size=0))
+            super().__init__(*args, **kwargs)
+
+    with patch.object(core, "ClientResponse", CompatibleClientResponse):
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

Adds a temporary test-only compatibility adapter for `aioresponses` 0.7.9 and `aiohttp` 3.14. `aiohttp` added a required `stream_writer` argument to `ClientResponse`, while `aioresponses` still constructs responses with the previous signature.

The adapter is inactive on older `aiohttp` versions. A version canary requires the workaround to be reviewed and removed when `aioresponses` advances beyond 0.7.9. Runtime dependencies and behavior are unchanged.

## Related Issue(s)

Failing run: https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/28303538719/job/83855828344

## Verification

- `make test`: 5,031 passed, 178 skipped with the CI-relevant dependency upgrades.
- All 92 `aioresponses` tests passed with both the locked dependencies and `aiohttp` 3.14.1 / `aioresponses` 0.7.9.
- `poetry run pre-commit run --files tests/conftest.py`
- fix evidence in #2092 
## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: OpenAI Codex).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment compatibility with newer HTTP client behavior.
  * Added a safeguard to fail early when an unsupported mock library version is detected.
  * Updated test setup to automatically apply a compatibility patch during the full test session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->