### PR TITLE
test: remove flaky streaming timing diagnostic

### DIFF
--- a/tests/test_parallel_streaming_output_rails.py
+++ b/tests/test_parallel_streaming_output_rails.py
@@ -867,19 +867,13 @@ async def test_sequential_vs_parallel_streaming_output_rails_comparison():
     )
     parallel_chat.app.register_action(test_self_check_output)
 
-    import time
-
-    start_time = time.time()
     sequential_chunks = []
     async for chunk in sequential_chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]):
         sequential_chunks.append(chunk)
-    sequential_time = time.time() - start_time
 
-    start_time = time.time()
     parallel_chunks = []
     async for chunk in parallel_chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]):
         parallel_chunks.append(chunk)
-    parallel_time = time.time() - start_time
 
     # both should produce the same successful output
     sequential_response = "".join(sequential_chunks)
@@ -904,12 +898,6 @@ async def test_sequential_vs_parallel_streaming_output_rails_comparison():
         f"Sequential: {sequential_response}\n"
         f"Parallel: {parallel_response}"
     )
-
-    # log timing comparison (parallel should be faster or similar for single rail)
-    print("\nTiming Comparison:")
-    print(f"Sequential: {sequential_time:.4f}s")
-    print(f"Parallel: {parallel_time:.4f}s")
-    print(f"Speedup: {sequential_time / parallel_time:.2f}x")
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 


### PR DESCRIPTION
## Description

Removes timing-only reporting from `test_sequential_vs_parallel_streaming_output_rails_comparison`. On [Windows with Python 3.12](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/28384050082/job/84093953326), `time.time()` measured the fast parallel path as `0.0`, causing a division by zero after the functional assertions passed.

The functional test remains in regular CI. Parallel performance is already covered by the perf-only [`test_parallel_streaming_output_rails_performance_benefits`](https://github.com/NVIDIA-NeMo/Guardrails/blob/e80b0dfdc3485cd6fc68e09a3dedddc7034a179e/tests/test_parallel_streaming_output_rails.py#L455-L581) test.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified a streaming comparison test by removing timing measurements and related output.
  * The test still verifies that sequential and parallel streaming return identical, error-free results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->