### PR TITLE
docs(iorails): Tool calling docs

### DIFF
--- a/docs/configure-rails/configuration-reference.mdx
+++ b/docs/configure-rails/configuration-reference.mdx
@@ -4,10 +4,17 @@
 title: "Configuration YAML Schema Reference"
 sidebar-title: "YAML Schema Reference"
 description: "Reference for all config.yml options including models, rails, prompts, and advanced settings."
-keywords: ["nemo guardrails config.yml", "guardrails yaml schema", "LLM configuration reference", "rails configuration"]
+keywords:
+    [
+        "nemo guardrails config.yml",
+        "guardrails yaml schema",
+        "LLM configuration reference",
+        "rails configuration",
+    ]
 content:
-  type: "reference"
+    type: "reference"
 ---
+
 This reference documents all configuration options for `config.yml`, derived from the authoritative Pydantic schema in [`nemoguardrails/rails/llm/config.py`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/config.py).
 
 ---
@@ -20,30 +27,30 @@ The `models` key defines LLM providers and models used by the NVIDIA NeMo Guardr
 
 ```yaml
 models:
-  - type: main                    # Required: Model type
-    engine: openai                # Required: LLM provider
-    model: gpt-4                  # Required: Model name
-    mode: chat                    # Optional: "chat" or "text" (default: "chat")
-    api_key_env_var: OPENAI_KEY   # Optional: Environment variable for API key
-    parameters:                   # Optional: Provider-specific parameters
-      temperature: 0.7
-      max_tokens: 1000
-    cache:                        # Optional: Caching configuration
-      enabled: false
-      maxsize: 50000
+    - type: main # Required: Model type
+      engine: openai # Required: LLM provider
+      model: gpt-4 # Required: Model name
+      mode: chat # Optional: "chat" or "text" (default: "chat")
+      api_key_env_var: OPENAI_KEY # Optional: Environment variable for API key
+      parameters: # Optional: Provider-specific parameters
+          temperature: 0.7
+          max_tokens: 1000
+      cache: # Optional: Caching configuration
+          enabled: false
+          maxsize: 50000
 ```
 
 ### Model Attributes
 
-| Attribute | Type | Required | Description |
-| --- | --- | --- | --- |
-| `models.api_key_env_var` | string | | Environment variable containing API key |
-| `models.cache` | object | | Cache configuration for this model |
-| `models.engine` | string | ✓ | LLM provider (see [Engines](#engines)) |
-| `models.mode` | string | | Completion mode: `chat` or `text` (default: `chat`) |
-| `models.model` | string | ✓ | Model name (can also be in `parameters.model_name`) |
-| `models.parameters` | object | | Provider-specific parameters. For engines served by the built-in client, such as any OpenAI-compatible endpoint, the runtime forwards `parameters` to the OpenAI-compatible HTTP request. Examples include `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, and `default_headers`. For engines served by LangChain, opt in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`; the runtime forwards `parameters` to the underlying LangChain class. For the engine-by-engine matrix, refer to [Inference Providers](/about-nemo-guardrails-library/supported-llms#inference-providers). |
-| `models.type` | string | ✓ | Model identifier (see [Model Types](#model-types)) |
+| Attribute                | Type   | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `models.api_key_env_var` | string |          | Environment variable containing API key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `models.cache`           | object |          | Cache configuration for this model                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `models.engine`          | string | ✓        | LLM provider (see [Engines](#engines))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `models.mode`            | string |          | Completion mode: `chat` or `text` (default: `chat`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `models.model`           | string | ✓        | Model name (can also be in `parameters.model_name`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `models.parameters`      | object |          | Provider-specific parameters. For engines served by the built-in client, such as any OpenAI-compatible endpoint, the runtime forwards `parameters` to the OpenAI-compatible HTTP request. Examples include `temperature`, `max_tokens`, `base_url`, `api_key`, `default_query`, and `default_headers`. For engines served by LangChain, opt in with `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`; the runtime forwards `parameters` to the underlying LangChain class. For the engine-by-engine matrix, refer to [Inference Providers](/about-nemo-guardrails-library/supported-llms#inference-providers). |
+| `models.type`            | string | ✓        | Model identifier (see [Model Types](#model-types))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ### Model Types
 
@@ -53,21 +60,21 @@ The `type` field is a free-form string identifier. Certain types have special ha
 
 These types have special handling in the runtime:
 
-| Type | Description |
-| --- | --- |
-| `embeddings` | Embedding model for knowledge base and similarity search |
-| `jailbreak_detection` | Jailbreak detection model (used with NIM) |
-| `main` | Primary application LLM for conversation |
+| Type                  | Description                                              |
+| --------------------- | -------------------------------------------------------- |
+| `embeddings`          | Embedding model for knowledge base and similarity search |
+| `jailbreak_detection` | Jailbreak detection model (used with NIM)                |
+| `main`                | Primary application LLM for conversation                 |
 
 #### Commonly-Used Types
 
 The following types are commonly used with guardrails:
 
-| Type | Description | Usage Example in Flows |
-| --- | --- | --- |
-| `content_safety` | Content safety model | `content safety check input $model=content_safety` |
-| `llama_guard` | Llama Guard content moderation | `llama guard check input $model=llama_guard` |
-| `topic_control` | Topic control model | `topic safety check input $model=topic_control` |
+| Type             | Description                    | Usage Example in Flows                             |
+| ---------------- | ------------------------------ | -------------------------------------------------- |
+| `content_safety` | Content safety model           | `content safety check input $model=content_safety` |
+| `llama_guard`    | Llama Guard content moderation | `llama guard check input $model=llama_guard`       |
+| `topic_control`  | Topic control model            | `topic safety check input $model=topic_control`    |
 
 #### Custom Types
 
@@ -75,14 +82,14 @@ You can define any custom type and reference it in flows. For example:
 
 ```yaml
 models:
-  - type: my_safety_model
-    engine: self-hosted
-    model: my-org/custom-safety-model
+    - type: my_safety_model
+      engine: self-hosted
+      model: my-org/custom-safety-model
 
 rails:
-  input:
-    flows:
-      - content safety check input $model=my_safety_model
+    input:
+        flows:
+            - content safety check input $model=my_safety_model
 ```
 
 The runtime validates that any `$model=<type>` reference in flows has a matching model defined in the configuration.
@@ -95,13 +102,13 @@ Starting with v0.22, the library serves engines through either the built-in Open
 
 These engines work with `pip install nemoguardrails` and do not require extra provider packages. Pass `parameters.base_url` to point at a self-hosted or alternative endpoint.
 
-| Engine | Description |
-| --- | --- |
+| Engine                  | Description                                                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `azure`, `azure_openai` | Azure OpenAI models with key-based authentication (`azure_endpoint` or `base_url`, `azure_deployment`, and `api_version`) |
-| `nim` | NVIDIA NIM microservices |
-| `nvidia_ai_endpoints` | Alias for `nim` |
-| `ollama` | Ollama OpenAI-compatible endpoint at `http://localhost:11434/v1` |
-| `openai` | OpenAI public API or any OpenAI-compatible endpoint using `parameters.base_url` |
+| `nim`                   | NVIDIA NIM microservices                                                                                                  |
+| `nvidia_ai_endpoints`   | Alias for `nim`                                                                                                           |
+| `ollama`                | Ollama OpenAI-compatible endpoint at `http://localhost:11434/v1`                                                          |
+| `openai`                | OpenAI public API or any OpenAI-compatible endpoint using `parameters.base_url`                                           |
 
 For OpenAI-compatible providers without a dedicated engine entry (vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp server, and similar), use `engine: openai` with `parameters.base_url` and `parameters.api_key`.
 
@@ -109,48 +116,48 @@ For OpenAI-compatible providers without a dedicated engine entry (vLLM, TGI, Ope
 
 To use one of these engines, set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install the matching `langchain-*` provider package.
 
-| Engine | Description |
-| --- | --- |
-| `anthropic` | Anthropic Claude models |
-| `cohere` | Cohere models |
-| `google_genai` | Google Generative AI through LangChain (requires `langchain-google-genai`) |
+| Engine                 | Description                                                                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `anthropic`            | Anthropic Claude models                                                                                                                                                        |
+| `cohere`               | Cohere models                                                                                                                                                                  |
+| `google_genai`         | Google Generative AI through LangChain (requires `langchain-google-genai`)                                                                                                     |
 | `huggingface_endpoint` | Hugging Face Inference Endpoints (default text-generation schema; if your endpoint exposes `/v1/chat/completions`, prefer `engine: openai` with `parameters.base_url` instead) |
-| `huggingface_hub` | Hugging Face Hub models |
-| `huggingface_pipeline` | In-process Hugging Face pipeline |
-| `self_hosted` | Generic self-hosted LangChain wrapper |
-| `trt_llm` | TensorRT-LLM in-process |
-| `vertexai` | Google Vertex AI through LangChain (requires `langchain-google-vertexai`) |
-| `vllm_openai` | Legacy LangChain wrapper for vLLM. For new configurations, prefer `engine: openai` with `parameters.base_url` |
+| `huggingface_hub`      | Hugging Face Hub models                                                                                                                                                        |
+| `huggingface_pipeline` | In-process Hugging Face pipeline                                                                                                                                               |
+| `self_hosted`          | Generic self-hosted LangChain wrapper                                                                                                                                          |
+| `trt_llm`              | TensorRT-LLM in-process                                                                                                                                                        |
+| `vertexai`             | Google Vertex AI through LangChain (requires `langchain-google-vertexai`)                                                                                                      |
+| `vllm_openai`          | Legacy LangChain wrapper for vLLM. For new configurations, prefer `engine: openai` with `parameters.base_url`                                                                  |
 
 #### Embedding Engines
 
-| Engine | Description |
-| --- | --- |
-| `FastEmbed` | FastEmbed (default) |
-| `nim` | NVIDIA NIM embeddings |
-| `openai` | OpenAI embeddings |
+| Engine      | Description           |
+| ----------- | --------------------- |
+| `FastEmbed` | FastEmbed (default)   |
+| `nim`       | NVIDIA NIM embeddings |
+| `openai`    | OpenAI embeddings     |
 
 ### Model Cache Configuration
 
 ```yaml
 models:
-  - type: content_safety
-    engine: nim
-    model: nvidia/llama-3.1-nemotron-safety-guard-8b-v3
-    cache:
-      enabled: true
-      maxsize: 50000
-      stats:
-        enabled: false
-        log_interval: null
+    - type: content_safety
+      engine: nim
+      model: nvidia/llama-3.1-nemotron-safety-guard-8b-v3
+      cache:
+          enabled: true
+          maxsize: 50000
+          stats:
+              enabled: false
+              log_interval: null
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `models.cache.enabled` | boolean | `false` | Enable caching for this model |
-| `models.cache.maxsize` | integer | `50000` | Maximum cache entries |
-| `models.cache.stats.enabled` | boolean | `false` | Enable cache statistics tracking |
-| `models.cache.stats.log_interval` | float | `null` | Seconds between stats logging |
+| Attribute                         | Type    | Default | Description                      |
+| --------------------------------- | ------- | ------- | -------------------------------- |
+| `models.cache.enabled`            | boolean | `false` | Enable caching for this model    |
+| `models.cache.maxsize`            | integer | `50000` | Maximum cache entries            |
+| `models.cache.stats.enabled`      | boolean | `false` | Enable cache statistics tracking |
+| `models.cache.stats.log_interval` | float   | `null`  | Seconds between stats logging    |
 
 ---
 
@@ -162,59 +169,59 @@ The `rails` key configures guardrails that control LLM behavior.
 
 ```yaml
 rails:
-  input:
-    parallel: false
-    flows:
-      - self check input
-      - check jailbreak
+    input:
+        parallel: false
+        flows:
+            - self check input
+            - check jailbreak
 
-  output:
-    parallel: false
-    flows:
-      - self check output
-    streaming:
-      enabled: false
-      chunk_size: 200
-      context_size: 50
-      stream_first: true
+    output:
+        parallel: false
+        flows:
+            - self check output
+        streaming:
+            enabled: false
+            chunk_size: 200
+            context_size: 50
+            stream_first: true
 
-  retrieval:
-    flows:
-      - check retrieval sensitive data
+    retrieval:
+        flows:
+            - check retrieval sensitive data
 
-  dialog:
-    single_call:
-      enabled: false
-      fallback_to_multiple_calls: true
-    user_messages:
-      embeddings_only: false
+    dialog:
+        single_call:
+            enabled: false
+            fallback_to_multiple_calls: true
+        user_messages:
+            embeddings_only: false
 
-  actions:
-    instant_actions: []
+    actions:
+        instant_actions: []
 
-  tool_output:
-    flows: []
-    parallel: false
+    tool_output:
+        flows: []
+        parallel: false
 
-  tool_input:
-    flows: []
-    parallel: false
+    tool_input:
+        flows: []
+        parallel: false
 
-  config:
-    # Rail-specific configurations
+    config:
+        # Rail-specific configurations
 ```
 
 ### Rail Types
 
 The following table summarizes the available rail types and their trigger points.
 
-| Rail Type | Trigger Point | Purpose |
-| --- | --- | --- |
-| **Dialog rails** | After canonical form is computed | Control conversation flow |
-| **Execution rails** | Before/after action execution | Control tool and action calls |
-| **Input rails** | When user input is received | Validate, filter, or modify user input |
-| **Output rails** | When LLM generates output | Validate, filter, or modify bot responses |
-| **Retrieval rails** | After RAG retrieval completes | Process retrieved chunks |
+| Rail Type           | Trigger Point                    | Purpose                                   |
+| ------------------- | -------------------------------- | ----------------------------------------- |
+| **Dialog rails**    | After canonical form is computed | Control conversation flow                 |
+| **Execution rails** | Before/after action execution    | Control tool and action calls             |
+| **Input rails**     | When user input is received      | Validate, filter, or modify user input    |
+| **Output rails**    | When LLM generates output        | Validate, filter, or modify bot responses |
+| **Retrieval rails** | After RAG retrieval completes    | Process retrieved chunks                  |
 
 The following diagram shows the guardrails process described in the table above in detail.
 
@@ -226,31 +233,31 @@ Process user messages before they reach the LLM.
 
 ```yaml
 rails:
-  input:
-    parallel: false      # Execute flows in parallel
-    flows:
-      - self check input
-      - check jailbreak
-      - mask sensitive data on input
+    input:
+        parallel: false # Execute flows in parallel
+        flows:
+            - self check input
+            - check jailbreak
+            - mask sensitive data on input
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.input.flows` | list | `[]` | Names of flows that implement input rails |
-| `rails.input.parallel` | boolean | `false` | Execute input rails in parallel |
+| Attribute              | Type    | Default | Description                               |
+| ---------------------- | ------- | ------- | ----------------------------------------- |
+| `rails.input.flows`    | list    | `[]`    | Names of flows that implement input rails |
+| `rails.input.parallel` | boolean | `false` | Execute input rails in parallel           |
 
 #### Built-in Input Flows
 
-| Flow | Description |
-| --- | --- |
-| `content safety check input` | NVIDIA content safety model |
-| `detect sensitive data on input` | Detect and block PII |
-| `jailbreak detection heuristics` | Jailbreak detection heuristics |
-| `jailbreak detection model` | NIM-based jailbreak detection |
-| `llama guard check input` | LlamaGuard content moderation |
-| `mask sensitive data on input` | Mask PII in user input |
-| `self check input` | LLM-based policy compliance check |
-| `topic safety check input` | Topic control model |
+| Flow                             | Description                       |
+| -------------------------------- | --------------------------------- |
+| `content safety check input`     | NVIDIA content safety model       |
+| `detect sensitive data on input` | Detect and block PII              |
+| `jailbreak detection heuristics` | Jailbreak detection heuristics    |
+| `jailbreak detection model`      | NIM-based jailbreak detection     |
+| `llama guard check input`        | LlamaGuard content moderation     |
+| `mask sensitive data on input`   | Mask PII in user input            |
+| `self check input`               | LLM-based policy compliance check |
+| `topic safety check input`       | Topic control model               |
 
 ### Output Rails
 
@@ -258,44 +265,44 @@ Process LLM responses before returning to users.
 
 ```yaml
 rails:
-  output:
-    parallel: false
-    flows:
-      - self check output
-      - self check facts
-    streaming:
-      enabled: false
-      chunk_size: 200
-      context_size: 50
-      stream_first: true
+    output:
+        parallel: false
+        flows:
+            - self check output
+            - self check facts
+        streaming:
+            enabled: false
+            chunk_size: 200
+            context_size: 50
+            stream_first: true
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.output.flows` | list | `[]` | Names of flows that implement output rails |
-| `rails.output.parallel` | boolean | `false` | Execute output rails in parallel |
-| `rails.output.streaming` | object | | Streaming output configuration |
+| Attribute                | Type    | Default | Description                                |
+| ------------------------ | ------- | ------- | ------------------------------------------ |
+| `rails.output.flows`     | list    | `[]`    | Names of flows that implement output rails |
+| `rails.output.parallel`  | boolean | `false` | Execute output rails in parallel           |
+| `rails.output.streaming` | object  |         | Streaming output configuration             |
 
 #### Output Streaming Configuration
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.output.streaming.chunk_size` | integer | `200` | Tokens per processing chunk |
-| `rails.output.streaming.context_size` | integer | `50` | Tokens carried from previous chunk |
-| `rails.output.streaming.enabled` | boolean | `false` | Enable streaming mode |
-| `rails.output.streaming.stream_first` | boolean | `true` | Stream before applying output rails |
+| Attribute                             | Type    | Default | Description                         |
+| ------------------------------------- | ------- | ------- | ----------------------------------- |
+| `rails.output.streaming.chunk_size`   | integer | `200`   | Tokens per processing chunk         |
+| `rails.output.streaming.context_size` | integer | `50`    | Tokens carried from previous chunk  |
+| `rails.output.streaming.enabled`      | boolean | `false` | Enable streaming mode               |
+| `rails.output.streaming.stream_first` | boolean | `true`  | Stream before applying output rails |
 
 #### Built-in Output Flows
 
-| Flow | Description |
-| --- | --- |
-| `content safety check output` | NVIDIA content safety model |
-| `injection detection` | Injection detection (SQL, XSS, code, template) |
-| `llama guard check output` | LlamaGuard content moderation |
-| `mask sensitive data on output` | Mask PII in output |
-| `self check facts` | Fact verification |
-| `self check hallucination` | Hallucination detection |
-| `self check output` | LLM-based policy compliance check |
+| Flow                            | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `content safety check output`   | NVIDIA content safety model                    |
+| `injection detection`           | Injection detection (SQL, XSS, code, template) |
+| `llama guard check output`      | LlamaGuard content moderation                  |
+| `mask sensitive data on output` | Mask PII in output                             |
+| `self check facts`              | Fact verification                              |
+| `self check hallucination`      | Hallucination detection                        |
+| `self check output`             | LLM-based policy compliance check              |
 
 ### Retrieval Rails
 
@@ -303,9 +310,9 @@ Process chunks retrieved from knowledge base.
 
 ```yaml
 rails:
-  retrieval:
-    flows:
-      - check retrieval sensitive data
+    retrieval:
+        flows:
+            - check retrieval sensitive data
 ```
 
 ### Dialog Rails
@@ -314,21 +321,21 @@ Control conversation flow after user intent is determined.
 
 ```yaml
 rails:
-  dialog:
-    single_call:
-      enabled: false
-      fallback_to_multiple_calls: true
-    user_messages:
-      embeddings_only: false
-      embeddings_only_similarity_threshold: null
-      embeddings_only_fallback_intent: null
+    dialog:
+        single_call:
+            enabled: false
+            fallback_to_multiple_calls: true
+        user_messages:
+            embeddings_only: false
+            embeddings_only_similarity_threshold: null
+            embeddings_only_fallback_intent: null
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.dialog.single_call.enabled` | boolean | `false` | Use single LLM call for intent + response |
-| `rails.dialog.single_call.fallback_to_multiple_calls` | boolean | `true` | Fall back if single call fails |
-| `rails.dialog.user_messages.embeddings_only` | boolean | `false` | Use only embeddings for intent matching |
+| Attribute                                             | Type    | Default | Description                               |
+| ----------------------------------------------------- | ------- | ------- | ----------------------------------------- |
+| `rails.dialog.single_call.enabled`                    | boolean | `false` | Use single LLM call for intent + response |
+| `rails.dialog.single_call.fallback_to_multiple_calls` | boolean | `true`  | Fall back if single call fails            |
+| `rails.dialog.user_messages.embeddings_only`          | boolean | `false` | Use only embeddings for intent matching   |
 
 ### Execution Rails
 
@@ -340,10 +347,10 @@ Control custom action and tool invocations.
 
 ```yaml
 rails:
-  actions:
-    instant_actions:
-      - action_name_1
-      - action_name_2
+    actions:
+        instant_actions:
+            - action_name_1
+            - action_name_2
 ```
 
 #### Tool Rails
@@ -353,16 +360,16 @@ The `tool_output` rails check the tool calls a model emits, and the `tool_input`
 
 ```yaml
 rails:
-  tool_output:
-    flows:
-      - tool call validation
-  tool_input:
-    flows:
-      - tool result validation
+    tool_output:
+        flows:
+            - tool call validation
+    tool_input:
+        flows:
+            - tool result validation
 ```
 
 Each section accepts only its own flow name: `tool_output` accepts `tool call validation`, and `tool_input` accepts `tool result validation`.
-These rails run only on the IORails engine, and the `parallel` field is accepted for symmetry with other rails but is not honored for tool rails.
+These rails run only on the IORails engine, which accepts the `parallel` field for symmetry with other rails but does not honor it for tool rails.
 For configuration details and behavior, see [Tool Calling](/configure-guardrails/guardrail-catalog/tool-calling).
 
 ### Rails Config Section
@@ -373,119 +380,119 @@ The `rails.config` section contains configuration for specific built-in rails.
 
 ```yaml
 rails:
-  config:
-    jailbreak_detection:
-      # Heuristics-based detection
-      server_endpoint: null
-      length_per_perplexity_threshold: 89.79
-      prefix_suffix_perplexity_threshold: 1845.65
+    config:
+        jailbreak_detection:
+            # Heuristics-based detection
+            server_endpoint: null
+            length_per_perplexity_threshold: 89.79
+            prefix_suffix_perplexity_threshold: 1845.65
 
-      # NIM-based detection
-      nim_base_url: "http://localhost:8000/v1/"
-      nim_server_endpoint: "classify"
-      api_key_env_var: "JAILBREAK_KEY"
+            # NIM-based detection
+            nim_base_url: "http://localhost:8000/v1/"
+            nim_server_endpoint: "classify"
+            api_key_env_var: "JAILBREAK_KEY"
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.config.jailbreak_detection.api_key` | string | `null` | API key (not recommended) |
-| `rails.config.jailbreak_detection.api_key_env_var` | string | `null` | Environment variable for API key |
-| `rails.config.jailbreak_detection.length_per_perplexity_threshold` | float | `89.79` | Length/perplexity threshold |
-| `rails.config.jailbreak_detection.nim_base_url` | string | `null` | NIM base URL (e.g., `http://localhost:8000/v1`) |
-| `rails.config.jailbreak_detection.nim_server_endpoint` | string | `"classify"` | NIM endpoint path |
-| `rails.config.jailbreak_detection.prefix_suffix_perplexity_threshold` | float | `1845.65` | Prefix/suffix perplexity threshold |
-| `rails.config.jailbreak_detection.server_endpoint` | string | `null` | Heuristics model endpoint |
+| Attribute                                                             | Type   | Default      | Description                                     |
+| --------------------------------------------------------------------- | ------ | ------------ | ----------------------------------------------- |
+| `rails.config.jailbreak_detection.api_key`                            | string | `null`       | API key (not recommended)                       |
+| `rails.config.jailbreak_detection.api_key_env_var`                    | string | `null`       | Environment variable for API key                |
+| `rails.config.jailbreak_detection.length_per_perplexity_threshold`    | float  | `89.79`      | Length/perplexity threshold                     |
+| `rails.config.jailbreak_detection.nim_base_url`                       | string | `null`       | NIM base URL (e.g., `http://localhost:8000/v1`) |
+| `rails.config.jailbreak_detection.nim_server_endpoint`                | string | `"classify"` | NIM endpoint path                               |
+| `rails.config.jailbreak_detection.prefix_suffix_perplexity_threshold` | float  | `1845.65`    | Prefix/suffix perplexity threshold              |
+| `rails.config.jailbreak_detection.server_endpoint`                    | string | `null`       | Heuristics model endpoint                       |
 
 #### Sensitive Data Detection (Presidio)
 
 ```yaml
 rails:
-  config:
-    sensitive_data_detection:
-      recognizers: []
-      input:
-        entities:
-          - PERSON
-          - EMAIL_ADDRESS
-          - PHONE_NUMBER
-          - CREDIT_CARD
-        mask_token: "*"
-        score_threshold: 0.2
-      output:
-        entities:
-          - PERSON
-          - EMAIL_ADDRESS
-      retrieval:
-        entities: []
+    config:
+        sensitive_data_detection:
+            recognizers: []
+            input:
+                entities:
+                    - PERSON
+                    - EMAIL_ADDRESS
+                    - PHONE_NUMBER
+                    - CREDIT_CARD
+                mask_token: "*"
+                score_threshold: 0.2
+            output:
+                entities:
+                    - PERSON
+                    - EMAIL_ADDRESS
+            retrieval:
+                entities: []
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.config.sensitive_data_detection.input/output/retrieval.entities` | list | `[]` | Entity types to detect |
-| `rails.config.sensitive_data_detection.input/output/retrieval.mask_token` | string | `"*"` | Token for masking |
-| `rails.config.sensitive_data_detection.input/output/retrieval.score_threshold` | float | `0.2` | Detection confidence threshold |
-| `rails.config.sensitive_data_detection.recognizers` | list | `[]` | Custom Presidio recognizers |
+| Attribute                                                                      | Type   | Default | Description                    |
+| ------------------------------------------------------------------------------ | ------ | ------- | ------------------------------ |
+| `rails.config.sensitive_data_detection.input/output/retrieval.entities`        | list   | `[]`    | Entity types to detect         |
+| `rails.config.sensitive_data_detection.input/output/retrieval.mask_token`      | string | `"*"`   | Token for masking              |
+| `rails.config.sensitive_data_detection.input/output/retrieval.score_threshold` | float  | `0.2`   | Detection confidence threshold |
+| `rails.config.sensitive_data_detection.recognizers`                            | list   | `[]`    | Custom Presidio recognizers    |
 
 #### Injection Detection
 
 ```yaml
 rails:
-  config:
-    injection_detection:
-      injections:
-        - sqli
-        - template
-        - code
-        - xss
-      action: reject    # "reject" or "omit"
-      yara_path: ""
-      yara_rules: {}
+    config:
+        injection_detection:
+            injections:
+                - sqli
+                - template
+                - code
+                - xss
+            action: reject # "reject" or "omit"
+            yara_path: ""
+            yara_rules: {}
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rails.config.injection_detection.action` | string | `"reject"` | Action: `reject` or `omit` |
-| `rails.config.injection_detection.injections` | list | `[]` | Injection types: `sqli`, `template`, `code`, `xss` |
-| `rails.config.injection_detection.yara_path` | string | `""` | Custom YARA rules path |
-| `rails.config.injection_detection.yara_rules` | object | `{}` | Inline YARA rules |
+| Attribute                                     | Type   | Default    | Description                                        |
+| --------------------------------------------- | ------ | ---------- | -------------------------------------------------- |
+| `rails.config.injection_detection.action`     | string | `"reject"` | Action: `reject` or `omit`                         |
+| `rails.config.injection_detection.injections` | list   | `[]`       | Injection types: `sqli`, `template`, `code`, `xss` |
+| `rails.config.injection_detection.yara_path`  | string | `""`       | Custom YARA rules path                             |
+| `rails.config.injection_detection.yara_rules` | object | `{}`       | Inline YARA rules                                  |
 
 #### Fact Checking
 
 ```yaml
 rails:
-  config:
-    fact_checking:
-      parameters:
-        endpoint: "http://localhost:5000"
-      fallback_to_self_check: false
+    config:
+        fact_checking:
+            parameters:
+                endpoint: "http://localhost:5000"
+            fallback_to_self_check: false
 ```
 
 #### Content Safety
 
 ```yaml
 rails:
-  config:
-    content_safety:
-      multilingual:
-        enabled: false
-        refusal_messages:
-          en: "Sorry, I cannot help with that."
-          es: "Lo siento, no puedo ayudar con eso."
+    config:
+        content_safety:
+            multilingual:
+                enabled: false
+                refusal_messages:
+                    en: "Sorry, I cannot help with that."
+                    es: "Lo siento, no puedo ayudar con eso."
 ```
 
 The multilingual feature supports the following languages:
 
 | Language | Code |
-| --- | --- |
-| Arabic | `ar` |
-| Chinese | `zh` |
-| English | `en` |
-| French | `fr` |
-| German | `de` |
-| Hindi | `hi` |
+| -------- | ---- |
+| Arabic   | `ar` |
+| Chinese  | `zh` |
+| English  | `en` |
+| French   | `fr` |
+| German   | `de` |
+| Hindi    | `hi` |
 | Japanese | `ja` |
-| Spanish | `es` |
-| Thai | `th` |
+| Spanish  | `es` |
+| Thai     | `th` |
 
 If the detected language is not in this list, English is used as the fallback. For more information, refer to [Multilingual Content Safety](/configure-guardrails/guardrail-catalog/content-safety#multilingual-refusal-messages).
 
@@ -495,13 +502,13 @@ If the detected language is not in this list, English is used as the fallback. F
 
 ```yaml
 rails:
-  config:
-    autoalign:
-      parameters: {}
-      input:
-        guardrails_config: {}
-      output:
-        guardrails_config: {}
+    config:
+        autoalign:
+            parameters: {}
+            input:
+                guardrails_config: {}
+            output:
+                guardrails_config: {}
 ```
 
 For more information, refer to [AutoAlign Integration](/configure-guardrails/guardrail-catalog/third-party/auto-align).
@@ -510,16 +517,16 @@ For more information, refer to [AutoAlign Integration](/configure-guardrails/gua
 
 ```yaml
 rails:
-  config:
-    patronus:
-      input:
-        evaluate_config:
-          success_strategy: all_pass  # or any_pass
-          params: {}
-      output:
-        evaluate_config:
-          success_strategy: all_pass
-          params: {}
+    config:
+        patronus:
+            input:
+                evaluate_config:
+                    success_strategy: all_pass # or any_pass
+                    params: {}
+            output:
+                evaluate_config:
+                    success_strategy: all_pass
+                    params: {}
 ```
 
 For more information, refer to [Patronus Evaluate API Integration](/configure-guardrails/guardrail-catalog/third-party/patronus-evaluate-api).
@@ -528,17 +535,17 @@ For more information, refer to [Patronus Evaluate API Integration](/configure-gu
 
 ```yaml
 rails:
-  config:
-    clavata:
-      server_endpoint: "https://gateway.app.clavata.ai:8443"
-      policies: {}
-      label_match_logic: ANY  # or ALL
-      input:
-        policy: "policy_alias"
-        labels: []
-      output:
-        policy: "policy_alias"
-        labels: []
+    config:
+        clavata:
+            server_endpoint: "https://gateway.app.clavata.ai:8443"
+            policies: {}
+            label_match_logic: ANY # or ALL
+            input:
+                policy: "policy_alias"
+                labels: []
+            output:
+                policy: "policy_alias"
+                labels: []
 ```
 
 For more information, refer to [Clavata Integration](/configure-guardrails/guardrail-catalog/third-party/clavata).
@@ -547,12 +554,12 @@ For more information, refer to [Clavata Integration](/configure-guardrails/guard
 
 ```yaml
 rails:
-  config:
-    pangea:
-      input:
-        recipe: "recipe_key"
-      output:
-        recipe: "recipe_key"
+    config:
+        pangea:
+            input:
+                recipe: "recipe_key"
+            output:
+                recipe: "recipe_key"
 ```
 
 For more information, refer to [Pangea AI Guard Integration](/configure-guardrails/guardrail-catalog/third-party/pangea).
@@ -561,10 +568,10 @@ For more information, refer to [Pangea AI Guard Integration](/configure-guardrai
 
 ```yaml
 rails:
-  config:
-    trend_micro:
-      v1_url: "https://api.xdr.trendmicro.com/beta/aiSecurity/guard"
-      api_key_env_var: "TREND_MICRO_API_KEY"
+    config:
+        trend_micro:
+            v1_url: "https://api.xdr.trendmicro.com/beta/aiSecurity/guard"
+            api_key_env_var: "TREND_MICRO_API_KEY"
 ```
 
 For more information, refer to [Trend Micro Integration](/configure-guardrails/guardrail-catalog/third-party/trend-micro).
@@ -573,10 +580,10 @@ For more information, refer to [Trend Micro Integration](/configure-guardrails/g
 
 ```yaml
 rails:
-  config:
-    ai_defense:
-      timeout: 30.0
-      fail_open: false
+    config:
+        ai_defense:
+            timeout: 30.0
+            fail_open: false
 ```
 
 For more information, refer to [Cisco AI Defense Integration](/configure-guardrails/guardrail-catalog/third-party/ai-defense).
@@ -585,15 +592,15 @@ For more information, refer to [Cisco AI Defense Integration](/configure-guardra
 
 ```yaml
 rails:
-  config:
-    private_ai_detection:
-      server_endpoint: "http://localhost:8080/process/text"
-      input:
-        entities: []
-      output:
-        entities: []
-      retrieval:
-        entities: []
+    config:
+        private_ai_detection:
+            server_endpoint: "http://localhost:8080/process/text"
+            input:
+                entities: []
+            output:
+                entities: []
+            retrieval:
+                entities: []
 ```
 
 For more information, refer to [Private AI Integration](/configure-guardrails/guardrail-catalog/third-party/privateai).
@@ -602,11 +609,11 @@ For more information, refer to [Private AI Integration](/configure-guardrails/gu
 
 ```yaml
 rails:
-  config:
-    fiddler:
-      fiddler_endpoint: "http://localhost:8080/process/text"
-      safety_threshold: 0.1
-      faithfulness_threshold: 0.05
+    config:
+        fiddler:
+            fiddler_endpoint: "http://localhost:8080/process/text"
+            safety_threshold: 0.1
+            faithfulness_threshold: 0.05
 ```
 
 For more information, refer to [Fiddler Guardrails Integration](/configure-guardrails/guardrail-catalog/third-party/fiddler).
@@ -615,18 +622,18 @@ For more information, refer to [Fiddler Guardrails Integration](/configure-guard
 
 ```yaml
 rails:
-  config:
-    guardrails_ai:
-      input:
-        validators:
-          - name: toxic_language
-            parameters:
-              threshold: 0.5
-            metadata: {}
-      output:
-        validators:
-          - name: pii
-            parameters: {}
+    config:
+        guardrails_ai:
+            input:
+                validators:
+                    - name: toxic_language
+                      parameters:
+                          threshold: 0.5
+                      metadata: {}
+            output:
+                validators:
+                    - name: pii
+                      parameters: {}
 ```
 
 For more information, refer to [Guardrails AI Integration](/configure-guardrails/guardrail-catalog/third-party/guardrails-ai).
@@ -639,56 +646,56 @@ Define prompts for LLM tasks.
 
 ```yaml
 prompts:
-  - task: self_check_input
-    content: |
-      Your task is to check if the user input is safe.
-      User input: {{ user_input }}
-      Answer [Yes/No]:
-    output_parser: null
-    max_length: 16000
-    max_tokens: null
-    mode: standard
-    stop: null
-    models: null    # Restrict to specific engines/models
+    - task: self_check_input
+      content: |
+          Your task is to check if the user input is safe.
+          User input: {{ user_input }}
+          Answer [Yes/No]:
+      output_parser: null
+      max_length: 16000
+      max_tokens: null
+      mode: standard
+      stop: null
+      models: null # Restrict to specific engines/models
 ```
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `prompts.content` | string | | Prompt template (mutually exclusive with `messages`) |
-| `prompts.max_length` | integer | `16000` | Maximum prompt length (characters) |
-| `prompts.max_tokens` | integer | `null` | Maximum response tokens |
-| `prompts.messages` | list | | Chat messages (mutually exclusive with `content`) |
-| `prompts.mode` | string | `"standard"` | Prompting mode |
-| `prompts.models` | list | `null` | Restrict to engines/models (e.g., `["openai", "nim/llama-3.1"]`) |
-| `prompts.output_parser` | string | `null` | Output parser name |
-| `prompts.stop` | list | `null` | Stop tokens |
-| `prompts.task` | string | ✓ | Task identifier |
+| Attribute               | Type    | Default      | Description                                                      |
+| ----------------------- | ------- | ------------ | ---------------------------------------------------------------- |
+| `prompts.content`       | string  |              | Prompt template (mutually exclusive with `messages`)             |
+| `prompts.max_length`    | integer | `16000`      | Maximum prompt length (characters)                               |
+| `prompts.max_tokens`    | integer | `null`       | Maximum response tokens                                          |
+| `prompts.messages`      | list    |              | Chat messages (mutually exclusive with `content`)                |
+| `prompts.mode`          | string  | `"standard"` | Prompting mode                                                   |
+| `prompts.models`        | list    | `null`       | Restrict to engines/models (e.g., `["openai", "nim/llama-3.1"]`) |
+| `prompts.output_parser` | string  | `null`       | Output parser name                                               |
+| `prompts.stop`          | list    | `null`       | Stop tokens                                                      |
+| `prompts.task`          | string  | ✓            | Task identifier                                                  |
 
 ### Available Tasks
 
 The following table lists all available tasks you can specify to `prompts.task`.
 
-| Task | Description |
-| --- | --- |
-| `general` | General response generation (no dialog rails) |
-| `generate_bot_message` | Generate bot response |
-| `generate_next_steps` | Determine next conversation step |
-| `generate_user_intent` | Generate canonical user intent |
-| `self_check_facts` | Verify factual accuracy of responses |
-| `self_check_hallucination` | Detect hallucinations in responses |
-| `self_check_input` | Check if user input complies with policy |
-| `self_check_output` | Check if bot output complies with policy |
+| Task                       | Description                                   |
+| -------------------------- | --------------------------------------------- |
+| `general`                  | General response generation (no dialog rails) |
+| `generate_bot_message`     | Generate bot response                         |
+| `generate_next_steps`      | Determine next conversation step              |
+| `generate_user_intent`     | Generate canonical user intent                |
+| `self_check_facts`         | Verify factual accuracy of responses          |
+| `self_check_hallucination` | Detect hallucinations in responses            |
+| `self_check_input`         | Check if user input complies with policy      |
+| `self_check_output`        | Check if bot output complies with policy      |
 
 ### Available Prompt Message Types
 
 The following table lists all available message types you can specify to `prompts.messages.type`.
 
-| Type | Description |
-| --- | --- |
+| Type        | Description                   |
+| ----------- | ----------------------------- |
 | `assistant` | Assistant/bot message content |
-| `bot` | Alias for `assistant` |
-| `system` | System-level instructions |
-| `user` | User message content |
+| `bot`       | Alias for `assistant`         |
+| `system`    | System-level instructions     |
+| `user`      | User message content          |
 
 ---
 
@@ -698,55 +705,55 @@ The following table lists all available message types you can specify to `prompt
 
 ```yaml
 instructions:
-  - type: general
-    content: |
-      You are a helpful assistant.
+    - type: general
+      content: |
+          You are a helpful assistant.
 ```
 
 ### Sample Conversation
 
 ```yaml
 sample_conversation: |
-  user "Hello there!"
-    express greeting
-  bot express greeting
-    "Hello! How can I assist you today?"
-  user "What can you do for me?"
-    ask about capabilities
-  bot respond about capabilities
-    "As an AI assistant, I can help you with a wide range of tasks."
+    user "Hello there!"
+      express greeting
+    bot express greeting
+      "Hello! How can I assist you today?"
+    user "What can you do for me?"
+      ask about capabilities
+    bot respond about capabilities
+      "As an AI assistant, I can help you with a wide range of tasks."
 ```
 
 ### Knowledge Base
 
 ```yaml
 knowledge_base:
-  folder: kb
-  embedding_search_provider:
-    name: default
-    parameters: {}
-    cache:
-      enabled: false
+    folder: kb
+    embedding_search_provider:
+        name: default
+        parameters: {}
+        cache:
+            enabled: false
 ```
 
 ### Core Settings
 
 ```yaml
 core:
-  embedding_search_provider:
-    name: default
-    parameters: {}
+    embedding_search_provider:
+        name: default
+        parameters: {}
 ```
 
 ### Tracing
 
 ```yaml
 tracing:
-  enabled: false
-  adapters:
-    - name: FileSystem
-  span_format: opentelemetry
-  enable_content_capture: false
+    enabled: false
+    adapters:
+        - name: FileSystem
+    span_format: opentelemetry
+    enable_content_capture: false
 ```
 
 ### Streaming
@@ -763,7 +770,7 @@ streaming: false
 
 ```yaml
 import_paths:
-  - path/to/shared/config
+    - path/to/shared/config
 ```
 
 ---
@@ -774,52 +781,52 @@ The following YAML example demonstrates a complete `config.yml` file that wires 
 
 ```yaml
 models:
-  # Main application LLM
-  - type: main
-    engine: nim
-    model: meta/llama-3.1-70b-instruct
-    parameters:
-      temperature: 0.7
+    # Main application LLM
+    - type: main
+      engine: nim
+      model: meta/llama-3.1-70b-instruct
+      parameters:
+          temperature: 0.7
 
-  # Content safety model
-  - type: content_safety
-    engine: nim
-    parameters:
-      base_url: "http://localhost:8000/v1"
-      model_name: "nvidia/llama-3.1-nemotron-safety-guard-8b-v3"
+    # Content safety model
+    - type: content_safety
+      engine: nim
+      parameters:
+          base_url: "http://localhost:8000/v1"
+          model_name: "nvidia/llama-3.1-nemotron-safety-guard-8b-v3"
 
-  # Embeddings
-  - type: embeddings
-    engine: FastEmbed
-    model: all-MiniLM-L6-v2
+    # Embeddings
+    - type: embeddings
+      engine: FastEmbed
+      model: all-MiniLM-L6-v2
 
 rails:
-  input:
-    flows:
-      - content safety check input $model=content_safety
+    input:
+        flows:
+            - content safety check input $model=content_safety
 
-  output:
-    flows:
-      - content safety check output $model=content_safety
-    streaming:
-      enabled: true
+    output:
+        flows:
+            - content safety check output $model=content_safety
+        streaming:
+            enabled: true
 
-  config:
-    jailbreak_detection:
-      nim_base_url: "http://localhost:8001/v1/"
+    config:
+        jailbreak_detection:
+            nim_base_url: "http://localhost:8001/v1/"
 
 prompts:
-  - task: content_safety_check_input $model=content_safety
-    content: |
-      Check if this content is safe: {{ user_input }}
-    output_parser: nemoguard_parse_prompt_safety
-    max_tokens: 50
+    - task: content_safety_check_input $model=content_safety
+      content: |
+          Check if this content is safe: {{ user_input }}
+      output_parser: nemoguard_parse_prompt_safety
+      max_tokens: 50
 
 instructions:
-  - type: general
-    content: |
-      You are a helpful, harmless, and honest assistant.
+    - type: general
+      content: |
+          You are a helpful, harmless, and honest assistant.
 
 streaming:
-  enabled: true
+    enabled: true
 ```

--- a/docs/configure-rails/configuration-reference.mdx
+++ b/docs/configure-rails/configuration-reference.mdx
@@ -348,20 +348,22 @@ rails:
 
 #### Tool Rails
 
-Control tool input/output processing.
+Validate tool calls and tool results when you use the IORails engine.
+The `tool_output` rails check the tool calls a model emits, and the `tool_input` rails check the tool results returned to the model.
 
 ```yaml
 rails:
   tool_output:
     flows:
-      - validate tool parameters
-    parallel: false
-
+      - tool call validation
   tool_input:
     flows:
-      - filter tool results
-    parallel: false
+      - tool result validation
 ```
+
+Each section accepts only its own flow name: `tool_output` accepts `tool call validation`, and `tool_input` accepts `tool result validation`.
+These rails run only on the IORails engine, and the `parallel` field is accepted for symmetry with other rails but is not honored for tool rails.
+For configuration details and behavior, see [Tool Calling](/configure-guardrails/guardrail-catalog/tool-calling).
 
 ### Rails Config Section
 

--- a/docs/configure-rails/guardrail-catalog/index.mdx
+++ b/docs/configure-rails/guardrail-catalog/index.mdx
@@ -51,6 +51,13 @@ Reference for agentic security guardrails that protect LLM-based agents using to
 <Badge intent="tip" minimal outlined>Reference</Badge>
 </Card>
 
+<Card title="Tool Calling" href="/configure-guardrails/guardrail-catalog/tool-calling">
+
+Reference for the IORails tool-calling rails that validate the tool calls a model emits and the tool results returned to it.
+
+<Badge intent="tip" minimal outlined>Reference</Badge>
+</Card>
+
 <Card title="Hallucinations & Fact-Checking" href="/configure-guardrails/guardrail-catalog/fact-checking">
 
 Reference for fact-checking and hallucination detection guardrails that ensure LLM output is grounded in evidence.

--- a/docs/configure-rails/guardrail-catalog/index.mdx
+++ b/docs/configure-rails/guardrail-catalog/index.mdx
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Guardrail Catalog"
 sidebar-title: "Guardrail Catalog"
-description: "Reference for pre-built guardrails including content safety, jailbreak detection, topic control, PII handling, agentic security, and third party APIs."
+description: "Reference for pre-built guardrails including content safety, jailbreak detection, topic control, PII handling, agentic security, and third-party APIs."
 content:
-  type: "Reference"
+    type: "Reference"
 ---
 
 The NeMo Guardrails library ships with a catalog of pre-built guardrails that you can activate out of the box. These guardrails span the most common safety and security concerns in LLM-powered applications from blocking harmful content and detecting jailbreak attempts to masking personally identifiable information and grounding responses in evidence.
@@ -53,7 +53,7 @@ Reference for agentic security guardrails that protect LLM-based agents using to
 
 <Card title="Tool Calling" href="/configure-guardrails/guardrail-catalog/tool-calling">
 
-Reference for the IORails tool-calling rails that validate the tool calls a model emits and the tool results returned to it.
+Reference for IORails tool-calling rails that validate model-emitted tool calls and application-returned tool results.
 
 <Badge intent="tip" minimal outlined>Reference</Badge>
 </Card>

--- a/docs/configure-rails/guardrail-catalog/tool-calling.mdx
+++ b/docs/configure-rails/guardrail-catalog/tool-calling.mdx
@@ -148,11 +148,13 @@ rails:
 You can enable either rail independently.
 To validate only the model's tool calls, configure `rails.tool_output` and leave `rails.tool_input` empty.
 
-<Note>
+<Warning>
 The flow names are fixed and direction-specific.
 `rails.tool_output` accepts only `tool call validation`, and `rails.tool_input` accepts only `tool result validation`.
-A misdirected, unknown, or duplicated tool flow makes the configuration ineligible for IORails, so the `Guardrails` facade routes it to `LLMRails` instead.
-</Note>
+A misdirected, unknown, or duplicated tool flow name makes the configuration ineligible for IORails: the `Guardrails` facade silently falls back to `LLMRails`, and none of the IORails tool rails run.
+A typo in a flow name therefore disables the tool rails you configured, with only a log warning to signal it.
+Pass `require_iorails=True` to the `Guardrails` constructor to raise instead of falling back silently.
+</Warning>
 
 <Note>
 The `parallel` field is accepted on the `tool_output` and `tool_input` sections for symmetry with other rails, but IORails does not honor it for tool rails and emits a warning if you set it to `true`.
@@ -203,6 +205,39 @@ When the model requests a tool, `generate_async` returns an assistant message th
     ],
 }
 ```
+
+After your application executes the tool, send the result back to the model.
+Resend the conversation with the original user message, the assistant turn that carried the tool call, and a `role: "tool"` message for each `tool_call_id`, then call `generate_async` again:
+
+```python
+messages = [
+    {"role": "user", "content": "What's the weather in Paris?"},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"},
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "get_weather",
+        "content": "{\"temperature_c\": 18, \"condition\": \"cloudy\"}",
+    },
+]
+
+response = await rails.generate_async(
+    messages=messages,
+    options={"llm_params": {"tools": tools}},
+)
+```
+
+The `tool result validation` rail runs on this request before the model sees the result, and the model then returns a final text answer or more tool calls.
 
 You can also declare tools statically on the model in `config.yml`.
 IORails merges these into the set of tools the rails validate against, so a config-declared tool is honored even when a request carries no `llm_params`:
@@ -299,9 +334,9 @@ IORails streams the text response as it arrives, accumulates the tool-call fragm
 
 ## Related tool features
 
-The NeMo Guardrails library includes other tool-related capabilities that are distinct from the IORails tool-calling rails described here:
+The NVIDIA NeMo Guardrails library includes other tool-related capabilities that are distinct from the IORails tool-calling rails described here:
 
-- [Tools Integration](/integration/tools-integration) covers LangChain tool passthrough and output-rail validation on the `LLMRails` engine.
-- [Rail types](/about/rail-types) describes Colang execution rails, which run actions before and after execution within the `LLMRails` event-driven pipeline.
+- [Tools Integration](/integration-with-third-party-libraries/tools-integration) covers LangChain tool passthrough and output-rail validation on the `LLMRails` engine.
+- [Rail types](/about-nemo-guardrails-library/rail-types) describes Colang execution rails, which run actions before and after execution within the `LLMRails` event-driven pipeline.
 
 The rails on this page operate at the request and response boundary of the IORails engine and do not execute tools.

--- a/docs/configure-rails/guardrail-catalog/tool-calling.mdx
+++ b/docs/configure-rails/guardrail-catalog/tool-calling.mdx
@@ -1,0 +1,307 @@
+---
+title: "Tool Calling"
+sidebar-title: "Tool Calling"
+description: "Validate the tool calls a model emits and the tool results returned to it with the IORails tool-calling rails."
+content:
+  type: "Reference"
+---
+
+The IORails engine can sit in front of a tool-using chat model and validate the tool traffic in both directions.
+It forwards your tool definitions to the model unchanged, then applies two structural rails:
+
+- **Tool call validation** checks every tool call the model emits against the tools you declared.
+  A call must name an allowed tool and supply arguments that satisfy that tool's JSON Schema.
+- **Tool result validation** checks the tool results your application returns to the model.
+  Each result must link to a tool call the model previously made, name a consistent tool, and carry well-formed content.
+
+Both rails are local checks.
+They make no extra LLM or API call, run on every request, and fail closed: a violation, a parsing error, or a malformed payload blocks the request rather than passing it through.
+
+<Note>
+The IORails engine does not execute tools.
+Your application or agent harness executes a tool after the model requests it, then sends the result back on the next request.
+These rails validate the request and response boundary; they do not call tools themselves.
+</Note>
+
+<Warning>
+Tool-calling rails run only on the IORails engine, which is opt-in and experimental.
+They are not available on the default `LLMRails` engine.
+See [Enable the IORails engine](#enable-the-iorails-engine) below.
+This feature currently supports the OpenAI Chat Completions wire format only (the `openai` and `nim` engines).
+</Warning>
+
+## How function calling works
+
+Function calling is a multi-step loop between your application and the model, and your application, not the model, runs the actual function.
+The flow follows the [OpenAI function-calling guide](https://developers.openai.com/api/docs/guides/function-calling), with the IORails rails validating the tool traffic at two points along the way.
+
+A *function* is a tool you define with a JSON Schema, and *tool* is the broader category that also covers built-in and custom tools.
+When the model decides to use a tool, it returns a *tool call* identified by a `tool_call_id`, and your application answers it with a *tool result* that carries the same `tool_call_id`.
+
+The end-to-end flow has five steps:
+
+1. **Make a request to the model with tools it could call.**
+   You send the conversation along with your tool definitions.
+2. **Receive a tool call from the model.**
+   The model responds with one or more tool calls instead of, or alongside, a text answer.
+   IORails runs **tool call validation** here, before the tool calls reach your application.
+3. **Execute code on the application side with input from the tool call.**
+   Your application runs the function and produces a result.
+4. **Make a second request to the model with the tool output.**
+   You resend the conversation, including the assistant turn that made the calls and one tool result for each `tool_call_id`.
+   IORails runs **tool result validation** here, before the model sees the results.
+5. **Receive a final response from the model (or more tool calls).**
+   The model returns a final text answer, or more tool calls that repeat the loop from step 2.
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'background': 'transparent' }}}%%
+
+sequenceDiagram
+    participant App as Application
+    participant GR as IORails
+    participant LLM as Model
+
+    App->>GR: 1. Request with tool definitions
+    GR->>LLM: Forward request
+    LLM-->>GR: 2. Tool calls
+    Note over GR: tool call validation
+    GR-->>App: Validated tool calls
+    App->>App: 3. Execute the function
+    App->>GR: 4. Request with tool results
+    Note over GR: tool result validation
+    GR->>LLM: Forward request
+    LLM-->>GR: 5. Final response or more tool calls
+    GR-->>App: Final response
+```
+
+## How tool-calling rails fit the pipeline
+
+Tool-calling rails mirror the input and output rails, with one rail per direction:
+
+| Rail | Config section | Flow name | Direction | What it checks |
+| --- | --- | --- | --- | --- |
+| Tool call validation | `rails.tool_output` | `tool call validation` | Model output | Tool calls the model emits: allowed name plus schema-valid arguments. |
+| Tool result validation | `rails.tool_input` | `tool result validation` | Request input | Tool results sent back to the model: linkage to a prior call, name consistency, well-formed content. |
+
+On a request, IORails runs the rails in this order:
+
+1. **Tool result validation** on the incoming messages (alongside input rails).
+2. **Input rails**, then the **main LLM** call.
+3. **Tool call validation** on the tool calls the model returned.
+4. **Output rails** on the text response.
+   A response that contains only tool calls and no text skips the text output rails.
+
+When any rail blocks, IORails returns the refusal message `I'm sorry, I can't respond to that.` for a non-streaming request, and a `guardrails_violation` error payload for a streaming request.
+
+## Enable the IORails engine
+
+Tool-calling rails require the IORails engine.
+Enable it in one of two ways.
+
+Set the `NEMO_GUARDRAILS_IORAILS_ENGINE` environment variable so the top-level `LLMRails` import resolves to the IORails-backed engine.
+This is the least invasive option for an existing application or the server:
+
+```console
+$ export NEMO_GUARDRAILS_IORAILS_ENGINE=1
+```
+
+```python
+from nemoguardrails import LLMRails, RailsConfig
+
+config = RailsConfig.from_path("./config")
+rails = LLMRails(config)
+```
+
+Or construct the `Guardrails` facade directly, which uses the IORails engine by default:
+
+```python
+from nemoguardrails import Guardrails, RailsConfig
+
+config = RailsConfig.from_path("./config")
+rails = Guardrails(config)
+```
+
+If the configuration is not IORails-compatible, the `Guardrails` facade falls back to `LLMRails` and logs a warning.
+Pass `require_iorails=True` to raise instead of falling back.
+A configuration is IORails-compatible only when it uses Colang version `1.0`, declares no custom `llm` argument, and uses only IORails-supported rails and flows.
+
+## Configure the rails
+
+Add the tool-calling flows to your `config.yml`.
+Each `tool_*` section accepts only its own flow name:
+
+```yaml
+models:
+  - type: main
+    engine: nim
+    model: meta/llama-3.3-70b-instruct
+
+rails:
+  tool_output:
+    flows:
+      - tool call validation
+  tool_input:
+    flows:
+      - tool result validation
+```
+
+You can enable either rail independently.
+To validate only the model's tool calls, configure `rails.tool_output` and leave `rails.tool_input` empty.
+
+<Note>
+The flow names are fixed and direction-specific.
+`rails.tool_output` accepts only `tool call validation`, and `rails.tool_input` accepts only `tool result validation`.
+A misdirected, unknown, or duplicated tool flow makes the configuration ineligible for IORails, so the `Guardrails` facade routes it to `LLMRails` instead.
+</Note>
+
+<Note>
+The `parallel` field is accepted on the `tool_output` and `tool_input` sections for symmetry with other rails, but IORails does not honor it for tool rails and emits a warning if you set it to `true`.
+Tool rails are local checks with no I/O to overlap, so they always run sequentially.
+</Note>
+
+## Declare tools
+
+The rails validate against the tools you declare on the request.
+Tool definitions use the provider-native OpenAI Chat Completions shape and are forwarded to the model unchanged.
+
+Declare tools per request in `options.llm_params`:
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    },
+]
+
+response = await rails.generate_async(
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    options={"llm_params": {"tools": tools, "tool_choice": "auto"}},
+)
+```
+
+When the model requests a tool, `generate_async` returns an assistant message that carries the tool calls in OpenAI shape:
+
+```python
+{
+    "role": "assistant",
+    "content": None,
+    "tool_calls": [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"},
+        }
+    ],
+}
+```
+
+You can also declare tools statically on the model in `config.yml`.
+IORails merges these into the set of tools the rails validate against, so a config-declared tool is honored even when a request carries no `llm_params`:
+
+```yaml
+models:
+  - type: main
+    engine: nim
+    model: meta/llama-3.3-70b-instruct
+    parameters:
+      tools:
+        - type: function
+          function:
+            name: get_weather
+            description: Get the weather for a city.
+            parameters:
+              type: object
+              properties:
+                city:
+                  type: string
+              required:
+                - city
+```
+
+## Tool call validation
+
+The `tool call validation` rail inspects every tool call in the model's response and blocks the request on the first violation.
+
+- **Allowlist.** The call must name a tool you declared.
+  A call to a tool that is not in the declared set is blocked, for example `tool call 'delete_database' is not an allowed tool`.
+- **Argument schema.** The call's arguments must validate against the tool's declared JSON Schema (the `function.parameters` block).
+  Arguments that violate the schema are blocked, for example `arguments for tool 'get_weather' do not match its schema: 'city' is a required property`.
+- **No-argument tools.** A function tool that declares no parameters must be called with no arguments.
+  Any supplied argument is blocked.
+- **Hosted tools.** A hosted or server-side tool that is identified only by `type` (for example a built-in web search) is allowlisted by type, and its arguments are not schema-validated because the provider owns the call shape.
+
+If the declared schema itself is not valid JSON Schema, the rail blocks the request rather than letting an unvalidated call through.
+
+## Tool result validation
+
+The `tool result validation` rail checks the tool results your application sends back to the model.
+Because the OpenAI Chat Completions API is stateless, your application resends the conversation history, including the assistant turn that made the tool calls and the `role: "tool"` messages that answer them.
+The rail validates each turn's results against that same turn's calls.
+
+The rail blocks the request when a tool result:
+
+- Is missing a `tool_call_id`, or that id does not correspond to a tool call earlier in the conversation.
+- Reuses a `tool_call_id` that another result in the same turn already used.
+  Each call must have exactly one result.
+- Names a different tool than the call it links to, or omits a name when the call's tool name is known.
+- Carries content that is not a string or a list of content-block objects.
+
+<Note>
+This rail validates structural well-formedness only.
+It confirms that the results are internally consistent with the calls in the request.
+It does not yet enforce a declared response schema, and it does not run a content-safety check on the tool result.
+Because the client resends the conversation, the linkage check verifies intra-request consistency, not server-verified provenance.
+</Note>
+
+## Control rails per request
+
+Use `options.rails` to enable or disable each tool rail for a single request.
+Each toggle accepts `true`, `false`, or a list of flow names, and defaults to `true`:
+
+```python
+response = await rails.generate_async(
+    messages=messages,
+    options={
+        "llm_params": {"tools": tools},
+        "rails": {"tool_output": True, "tool_input": False},
+    },
+)
+```
+
+## Streaming
+
+Tool-calling rails work with `stream_async`.
+IORails streams the text response as it arrives, accumulates the tool-call fragments, and runs `tool call validation` once the stream completes:
+
+- On a clean stream, IORails emits the assembled tool calls as a final chunk after the text and output rails finish.
+- When the rail blocks, IORails emits a `guardrails_violation` error payload and suppresses the tool-call chunk, so a consumer never receives a tool call after a block.
+- A stream that contains only tool calls and no text skips the output rails.
+
+## Limitations
+
+- **Wire format.** Only the OpenAI Chat Completions shape is supported, through the `openai` and `nim` engines.
+  The OpenAI Responses API, Anthropic, Gemini, and Bedrock are not yet supported.
+- **Structural result validation.** Tool result validation checks structure and linkage only.
+  It does not enforce response schemas or apply content-safety checks to tool results.
+- **Intra-request consistency.** The linkage check verifies consistency within a single request, not cross-turn provenance.
+- **Schema dialect.** Argument validation uses JSON Schema.
+  Tool schemas written in a different dialect are not validated against that dialect.
+- **Engine requirement.** Tool-calling rails require the IORails engine and a Colang `1.0` configuration.
+
+## Related tool features
+
+The NeMo Guardrails library includes other tool-related capabilities that are distinct from the IORails tool-calling rails described here:
+
+- [Tools Integration](/integration/tools-integration) covers LangChain tool passthrough and output-rail validation on the `LLMRails` engine.
+- [Rail types](/about/rail-types) describes Colang execution rails, which run actions before and after execution within the `LLMRails` event-driven pipeline.
+
+The rails on this page operate at the request and response boundary of the IORails engine and do not execute tools.

--- a/docs/configure-rails/guardrail-catalog/tool-calling.mdx
+++ b/docs/configure-rails/guardrail-catalog/tool-calling.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Tool Calling"
 sidebar-title: "Tool Calling"
-description: "Validate the tool calls a model emits and the tool results returned to it with the IORails tool-calling rails."
+description: "Validate model-emitted tool calls and application-returned tool results with the IORails tool-calling rails."
 content:
-  type: "Reference"
+    type: "Reference"
 ---
 
-The IORails engine can sit in front of a tool-using chat model and validate the tool traffic in both directions.
-It forwards your tool definitions to the model unchanged, then applies two structural rails:
+The IORails engine can sit in front of a tool-using chat model and validate tool traffic in both directions.
+It forwards your tool definitions to the model unchanged and applies two structural rails:
 
 - **Tool call validation** checks every tool call the model emits against the tools you declared.
   A call must name an allowed tool and supply arguments that satisfy that tool's JSON Schema.
@@ -15,28 +15,33 @@ It forwards your tool definitions to the model unchanged, then applies two struc
   Each result must link to a tool call the model previously made, name a consistent tool, and carry well-formed content.
 
 Both rails are local checks.
-They make no extra LLM or API call, run on every request, and fail closed: a violation, a parsing error, or a malformed payload blocks the request rather than passing it through.
+They do not make extra LLM or API calls.
+They run on every request and fail closed: a violation, a parsing error, or a malformed payload blocks the request rather than passing it through.
 
 <Note>
-The IORails engine does not execute tools.
-Your application or agent harness executes a tool after the model requests it, then sends the result back on the next request.
-These rails validate the request and response boundary; they do not call tools themselves.
+    The IORails engine does not execute tools. Your application or agent harness
+    executes a tool after the model requests it, then sends the result back on
+    the next request. These rails validate the request and response boundary;
+    they do not call tools themselves.
 </Note>
 
 <Warning>
-Tool-calling rails run only on the IORails engine, which is opt-in and experimental.
-They are not available on the default `LLMRails` engine.
-See [Enable the IORails engine](#enable-the-iorails-engine) below.
-This feature currently supports the OpenAI Chat Completions wire format only (the `openai` and `nim` engines).
+    Tool-calling rails run only on the IORails engine, which is opt-in and
+    experimental. They are not available on the default `LLMRails` engine. See
+    [Enable the IORails engine](#enable-the-iorails-engine) below. This feature
+    supports only the OpenAI Chat Completions wire format (the `openai` and
+    `nim` engines).
 </Warning>
 
-## How function calling works
+## How Function Calling Works
 
-Function calling is a multi-step loop between your application and the model, and your application, not the model, runs the actual function.
-The flow follows the [OpenAI function-calling guide](https://developers.openai.com/api/docs/guides/function-calling), with the IORails rails validating the tool traffic at two points along the way.
+Your application and the model use function calling as a multi-step loop.
+Your application, not the model, runs the function.
+The flow follows the [OpenAI function-calling guide](https://developers.openai.com/api/docs/guides/function-calling).
+During that flow, the IORails rails validate the tool traffic at two points.
 
-A *function* is a tool you define with a JSON Schema, and *tool* is the broader category that also covers built-in and custom tools.
-When the model decides to use a tool, it returns a *tool call* identified by a `tool_call_id`, and your application answers it with a *tool result* that carries the same `tool_call_id`.
+A _function_ is a tool you define with a JSON Schema, and _tool_ names the broader category that also covers built-in and custom tools.
+When the model decides to use a tool, it returns a _tool call_ identified by a `tool_call_id`, and your application answers it with a _tool result_ that carries the same `tool_call_id`.
 
 The end-to-end flow has five steps:
 
@@ -74,16 +79,16 @@ sequenceDiagram
     GR-->>App: Final response
 ```
 
-## How tool-calling rails fit the pipeline
+## How Tool-Calling Rails Fit the Pipeline
 
 Tool-calling rails mirror the input and output rails, with one rail per direction:
 
-| Rail | Config section | Flow name | Direction | What it checks |
-| --- | --- | --- | --- | --- |
-| Tool call validation | `rails.tool_output` | `tool call validation` | Model output | Tool calls the model emits: allowed name plus schema-valid arguments. |
-| Tool result validation | `rails.tool_input` | `tool result validation` | Request input | Tool results sent back to the model: linkage to a prior call, name consistency, well-formed content. |
+| Rail                   | Config section      | Flow name                | Direction     | What it checks                                                                                       |
+| ---------------------- | ------------------- | ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------- |
+| Tool call validation   | `rails.tool_output` | `tool call validation`   | Model output  | Tool calls the model emits: allowed name plus schema-valid arguments.                                |
+| Tool result validation | `rails.tool_input`  | `tool result validation` | Request input | Tool results sent back to the model: linkage to a prior call, name consistency, well-formed content. |
 
-On a request, IORails runs the rails in this order:
+For each request, IORails runs the rails in the following order:
 
 1. **Tool result validation** on the incoming messages (alongside input rails).
 2. **Input rails**, then the **main LLM** call.
@@ -93,7 +98,7 @@ On a request, IORails runs the rails in this order:
 
 When any rail blocks, IORails returns the refusal message `I'm sorry, I can't respond to that.` for a non-streaming request, and a `guardrails_violation` error payload for a streaming request.
 
-## Enable the IORails engine
+## Enable the IORails Engine
 
 Tool-calling rails require the IORails engine.
 Enable it in one of two ways.
@@ -112,7 +117,7 @@ config = RailsConfig.from_path("./config")
 rails = LLMRails(config)
 ```
 
-Or construct the `Guardrails` facade directly, which uses the IORails engine by default:
+Alternatively, construct the `Guardrails` facade directly, which uses the IORails engine by default:
 
 ```python
 from nemoguardrails import Guardrails, RailsConfig
@@ -125,46 +130,51 @@ If the configuration is not IORails-compatible, the `Guardrails` facade falls ba
 Pass `require_iorails=True` to raise instead of falling back.
 A configuration is IORails-compatible only when it uses Colang version `1.0`, declares no custom `llm` argument, and uses only IORails-supported rails and flows.
 
-## Configure the rails
+## Configure the Rails
 
 Add the tool-calling flows to your `config.yml`.
 Each `tool_*` section accepts only its own flow name:
 
 ```yaml
 models:
-  - type: main
-    engine: nim
-    model: meta/llama-3.3-70b-instruct
+    - type: main
+      engine: nim
+      model: meta/llama-3.3-70b-instruct
 
 rails:
-  tool_output:
-    flows:
-      - tool call validation
-  tool_input:
-    flows:
-      - tool result validation
+    tool_output:
+        flows:
+            - tool call validation
+    tool_input:
+        flows:
+            - tool result validation
 ```
 
 You can enable either rail independently.
 To validate only the model's tool calls, configure `rails.tool_output` and leave `rails.tool_input` empty.
 
 <Warning>
-The flow names are fixed and direction-specific.
-`rails.tool_output` accepts only `tool call validation`, and `rails.tool_input` accepts only `tool result validation`.
-A misdirected, unknown, or duplicated tool flow name makes the configuration ineligible for IORails: the `Guardrails` facade silently falls back to `LLMRails`, and none of the IORails tool rails run.
-A typo in a flow name therefore disables the tool rails you configured, with only a log warning to signal it.
-Pass `require_iorails=True` to the `Guardrails` constructor to raise instead of falling back silently.
+    The flow names are fixed and direction-specific. `rails.tool_output` accepts
+    only `tool call validation`, and `rails.tool_input` accepts only `tool
+    result validation`. A misdirected, unknown, or duplicated tool flow name
+    makes the configuration ineligible for IORails: the `Guardrails` facade
+    silently falls back to `LLMRails`, and none of the IORails tool rails run. A
+    typo in a flow name disables the tool rails you configured, with only a log
+    warning to signal it. Pass `require_iorails=True` to the `Guardrails`
+    constructor to raise instead of falling back silently.
 </Warning>
 
 <Note>
-The `parallel` field is accepted on the `tool_output` and `tool_input` sections for symmetry with other rails, but IORails does not honor it for tool rails and emits a warning if you set it to `true`.
-Tool rails are local checks with no I/O to overlap, so they always run sequentially.
+    IORails accepts the `parallel` field on the `tool_output` and `tool_input`
+    sections for symmetry with other rails, but does not honor it for tool rails
+    and emits a warning if you set it to `true`. Tool rails are local checks
+    with no I/O to overlap, so they always run sequentially.
 </Note>
 
-## Declare tools
+## Declare Tools
 
 The rails validate against the tools you declare on the request.
-Tool definitions use the provider-native OpenAI Chat Completions shape and are forwarded to the model unchanged.
+Tool definitions use the provider-native OpenAI Chat Completions shape, and IORails forwards them to the model unchanged.
 
 Declare tools per request in `options.llm_params`:
 
@@ -240,43 +250,43 @@ response = await rails.generate_async(
 The `tool result validation` rail runs on this request before the model sees the result, and the model then returns a final text answer or more tool calls.
 
 You can also declare tools statically on the model in `config.yml`.
-IORails merges these into the set of tools the rails validate against, so a config-declared tool is honored even when a request carries no `llm_params`:
+IORails merges these into the set of tools the rails validate against, so the rails honor a config-declared tool even when a request carries no `llm_params`:
 
 ```yaml
 models:
-  - type: main
-    engine: nim
-    model: meta/llama-3.3-70b-instruct
-    parameters:
-      tools:
-        - type: function
-          function:
-            name: get_weather
-            description: Get the weather for a city.
-            parameters:
-              type: object
-              properties:
-                city:
-                  type: string
-              required:
-                - city
+    - type: main
+      engine: nim
+      model: meta/llama-3.3-70b-instruct
+      parameters:
+          tools:
+              - type: function
+                function:
+                    name: get_weather
+                    description: Get the weather for a city.
+                    parameters:
+                        type: object
+                        properties:
+                            city:
+                                type: string
+                        required:
+                            - city
 ```
 
-## Tool call validation
+## Tool Call Validation
 
 The `tool call validation` rail inspects every tool call in the model's response and blocks the request on the first violation.
 
 - **Allowlist.** The call must name a tool you declared.
-  A call to a tool that is not in the declared set is blocked, for example `tool call 'delete_database' is not an allowed tool`.
+  IORails blocks a call to a tool that is not in the declared set, for example `tool call 'delete_database' is not an allowed tool`.
 - **Argument schema.** The call's arguments must validate against the tool's declared JSON Schema (the `function.parameters` block).
-  Arguments that violate the schema are blocked, for example `arguments for tool 'get_weather' do not match its schema: 'city' is a required property`.
-- **No-argument tools.** A function tool that declares no parameters must be called with no arguments.
-  Any supplied argument is blocked.
-- **Hosted tools.** A hosted or server-side tool that is identified only by `type` (for example a built-in web search) is allowlisted by type, and its arguments are not schema-validated because the provider owns the call shape.
+  IORails blocks arguments that violate the schema, for example `arguments for tool 'get_weather' do not match its schema: 'city' is a required property`.
+- **No-argument tools.** A function tool that declares no parameters must receive no arguments.
+  IORails blocks any supplied argument.
+- **Hosted tools.** IORails allowlists a hosted or server-side tool that only `type` identifies (for example a built-in web search) by type, and does not schema-validate its arguments because the provider owns the call shape.
 
 If the declared schema itself is not valid JSON Schema, the rail blocks the request rather than letting an unvalidated call through.
 
-## Tool result validation
+## Tool Result Validation
 
 The `tool result validation` rail checks the tool results your application sends back to the model.
 Because the OpenAI Chat Completions API is stateless, your application resends the conversation history, including the assistant turn that made the tool calls and the `role: "tool"` messages that answer them.
@@ -291,13 +301,15 @@ The rail blocks the request when a tool result:
 - Carries content that is not a string or a list of content-block objects.
 
 <Note>
-This rail validates structural well-formedness only.
-It confirms that the results are internally consistent with the calls in the request.
-It does not yet enforce a declared response schema, and it does not run a content-safety check on the tool result.
-Because the client resends the conversation, the linkage check verifies intra-request consistency, not server-verified provenance.
+    This rail validates structural well-formedness only. It confirms that the
+    results are internally consistent with the calls in the request. It does not
+    yet enforce a declared response schema, and it does not run a content-safety
+    check on the tool result. Because the client resends the conversation, the
+    linkage check verifies intra-request consistency, not server-verified
+    provenance.
 </Note>
 
-## Control rails per request
+## Control Rails per Request
 
 Use `options.rails` to enable or disable each tool rail for a single request.
 Each toggle accepts `true`, `false`, or a list of flow names, and defaults to `true`:
@@ -323,8 +335,8 @@ IORails streams the text response as it arrives, accumulates the tool-call fragm
 
 ## Limitations
 
-- **Wire format.** Only the OpenAI Chat Completions shape is supported, through the `openai` and `nim` engines.
-  The OpenAI Responses API, Anthropic, Gemini, and Bedrock are not yet supported.
+- **Wire format.** The tool-calling rails support only the OpenAI Chat Completions shape, through the `openai` and `nim` engines.
+  They do not yet support the OpenAI Responses API, Anthropic, Gemini, or Bedrock.
 - **Structural result validation.** Tool result validation checks structure and linkage only.
   It does not enforce response schemas or apply content-safety checks to tool results.
 - **Intra-request consistency.** The linkage check verifies consistency within a single request, not cross-turn provenance.
@@ -332,7 +344,7 @@ IORails streams the text response as it arrives, accumulates the tool-call fragm
   Tool schemas written in a different dialect are not validated against that dialect.
 - **Engine requirement.** Tool-calling rails require the IORails engine and a Colang `1.0` configuration.
 
-## Related tool features
+## Related Tool Features
 
 The NVIDIA NeMo Guardrails library includes other tool-related capabilities that are distinct from the IORails tool-calling rails described here:
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -121,6 +121,9 @@ navigation:
           - page: Agentic Security
             path: configure-rails/guardrail-catalog/agentic-security.mdx
             slug: agentic-security
+          - page: Tool Calling
+            path: configure-rails/guardrail-catalog/tool-calling.mdx
+            slug: tool-calling
           - page: Hallucinations & Fact-Checking
             path: configure-rails/guardrail-catalog/fact-checking.mdx
             slug: fact-checking


### PR DESCRIPTION
## Description

Add tool-calling page to Guardrail docs explaining at a high-level how tool-calling works over multiple inferences and the harness execution, where IORails' new tool calls fit into this flow. Includes configuration details on how to set it up.

Page is under Configure Guardrails / Guardrail Catalog / Tool Calling.
Direct link is: https://nvidia-preview-pr-2099.docs.buildwithfern.com/nemo/guardrails/configure-guardrails/guardrail-catalog/tool-calling

## Related Issue(s)

This docs PR stacks on top of the last PR in the stack below:

* #2016
* #2024
* #2030
* #2058

## Verification

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md
 generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 285 pages at /Users/tgasser/projects/nemo_guardrails_worktree/docs/iorails-tool-call
ing-docs/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries
                                             ╭──────────────────────────────────╮
                                             │                                  │
                                             │        Upgrades available        │
                                             │                                  │
                                             │      Fern 5.50.5 → 5.56.3        │
                                             │   (Run fern upgrade to update)   │
                                             │                                  │
                                             ╰──────────────────────────────────╯

node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" check
All checks passed
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Guardrail Catalog page for tool calling, including guidance on validating tool calls and tool results.
  * Expanded the Rails configuration reference with clearer setup notes and behavior details for tool-related validation.
  * Added navigation links so the new tool calling documentation is easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->