### PR TITLE
docs(iorails): Guardrails engine feature table

### DIFF
--- a/docs/configure-rails/yaml-schema/guardrails-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/guardrails-configuration.mdx
@@ -206,31 +206,32 @@ You can configure input and output rails to run in parallel. This can improve la
 
 ### IORails Engine
 
-The IORails engine is an optimized execution engine that runs NemoGuard input and output rails in
-parallel with dedicated model management. The IORails engine is an opt-in feature. By default, the
-NeMo Guardrails library uses the LLMRails engine.
+The IORails engine is an optimized execution engine for supported input, output, and tool rails.
+It runs supported NeMoGuard safety flows with dedicated model management, parallel rail execution, admission control, metrics, and optional speculative generation.
 
 <Note>
-    IORails is an early-release feature and currently does not support
-    streaming, reasoning models, and telemetry as in LLMRails.
+    This section covers `config.yml` settings that affect IORails and shared
+    rail parallelism. For a complete comparison of `LLMRails` and `IORails`
+    capabilities, see [Engine Feature Support](/reference/engine-feature-support).
 </Note>
 
 #### Supported Flows
 
-The IORails engine supports the following flows:
+In `config.yml`, the IORails engine supports the following built-in safety flows:
 
 - `content safety check input` / `content safety check output`
 - `topic safety check input`
 - `jailbreak detection model`
 
-When IORails is enabled and the configuration uses only these flows, the engine runs them in parallel.
+When IORails is enabled and the configuration uses only supported flows, the engine runs them in parallel.
 Configurations that include custom flows, dialog rails, or other unsupported flows
-silently fall back to the LLMRails engine and emit a warning. Pass `require_iorails=True`
+fall back to the LLMRails engine and emit a warning. Pass `require_iorails=True`
 to `Guardrails(...)` to raise a `ValueError` at initialization instead.
 
 #### Enabling IORails
 
-To enable the IORails engine, set the `NEMO_GUARDRAILS_IORAILS_ENGINE` environment variable to `1`:
+To enable the IORails engine for command-line workflows that instantiate `LLMRails`, set the
+`NEMO_GUARDRAILS_IORAILS_ENGINE` environment variable to `1`:
 
 ```bash
 NEMO_GUARDRAILS_IORAILS_ENGINE=1 nemoguardrails chat --config examples/configs/content_safety

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -562,6 +562,9 @@ navigation:
       - page: Use Case Diagrams
         path: reference/use-case-diagrams.mdx
         slug: use-case-diagrams
+      - page: Engine Feature Support
+        path: reference/engine-feature-support.mdx
+        slug: engine-feature-support
       - folder: _static/python-sdk-reference/guardrails-python-sdk
         title: Python SDK Reference
         collapsed: true

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -71,77 +71,21 @@ rails = Guardrails(config, require_iorails=True)
 Otherwise the facade falls back to `LLMRails` and logs the reason.
 You can inspect that decision directly with `IORails.unsupported_reason(config, llm)`, which returns the human-readable fallback reason, or `None` when `IORails` can handle the config.
 
-## Feature support matrix
+## Feature support
 
-The following matrix lists supported features per engine.
-Category names link to the matching description in [Feature details](#feature-details).
+Each section below covers one capability area, with a support table followed by a comparison of the two engines.
 
-Legend: ✓ supported · ✗ not supported · ◐ partial (see the note).
+Legend: ✓ supported · ✗ not supported · ◐ partial (see notes).
+
+### Rail types
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
-| **[Rail types](#rail-types)** | | | |
 | Input rails | ✓ | ✓ | |
 | Output rails | ✓ | ✓ | |
 | Dialog rails | ✓ | ✗ | Require the Colang runtime, which IORails does not run |
 | Retrieval (RAG and knowledge base) rails | ✓ | ✗ | LLMRails only |
 | Execution rails (custom actions) | ✓ | ✗ | LLMRails only |
-| **[Colang language support](#colang-language-support)** | | | |
-| Colang 1.0 configurations | ✓ | ✓ | |
-| Colang 2.x configurations | ✓ | ✗ | IORails accepts Colang 1.0 only |
-| **[Built-in NeMoGuard safety rails](#built-in-nemoguard-safety-rails)** | | | |
-| Content safety | ✓ | ✓ | Only output rail IORails supports |
-| Topic control | ✓ | ✓ | IORails: input only |
-| Jailbreak detection (NIM) | ✓ | ✓ | IORails: input only |
-| **[Tool calling](#tool-calling)** | | | |
-| Tool-call passthrough | ✓ | ✓ | |
-| Tool-call validation rail | ✓ | ✓ | IORails flow: `tool call validation` |
-| Tool-result validation rail | ✓ | ✓ | IORails flow: `tool result validation` |
-| **[Generation and validation API](#generation-and-validation-api)** | | | |
-| `generate` / `generate_async` | ✓ | ✓ | |
-| `stream_async` | ✓ | ✓ | |
-| Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
-| `check` / `check_async` (rails-only validation) | ✓ | ✗ | LLMRails only |
-| `GenerationOptions` | ✓ | ◐ | IORails uses `llm_params` and rail toggles; no `log` or `output_data` |
-| `GenerationResponse` (structured response object) | ✓ | ✗ | IORails returns an OpenAI-style message dict |
-| `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
-| **[Streaming](#streaming)** | | | |
-| Output-rail streaming | ✓ | ✓ | |
-| Streaming usage and metadata | ✓ | ✓ | IORails: `include_metadata=True` |
-| Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
-| **[Parallelism and concurrency](#parallelism-and-concurrency)** | | | |
-| Parallel rail execution | ✓ | ✓ | `rails.input.parallel` / `rails.output.parallel` |
-| Speculative generation | ✗ | ✓ | Input rails race generation; non-streaming only |
-| Admission control and concurrency limits | ✗ | ✓ | `AsyncWorkQueue` plus a streaming semaphore |
-| **[Reasoning-model support](#reasoning-model-support)** | | | |
-| Reasoning trace handling (`<think>` tags or reasoning field) | ✓ | ✓ | |
-| `reasoning_content` in a structured response | ✓ | ✗ | Requires `GenerationResponse` |
-| **[Multimodal](#multimodal)** | | | |
-| Multimodal (vision) input and output rails | ✓ | ✗ | LLMRails only |
-| **[Observability](#observability)** | | | |
-| Tracing (OpenTelemetry spans) | ✓ | ✓ | |
-| Metrics (OpenTelemetry token and duration) | ✗ | ✓ | LLMRails surfaces token statistics through logging |
-| Prometheus export | ✗ | ✓ | Through the OpenTelemetry metrics exporter |
-| Logging (verbose and call statistics) | ✓ | ✓ | |
-| Content capture (span content) | ✓ | ✓ | |
-| **[LLM frameworks and providers](#llm-frameworks-and-providers)** | | | |
-| Default framework (OpenAI-compatible) | ✓ | ✓ | |
-| LangChain integration (opt-in) | ✓ | ✗ | Passing a LangChain LLM routes to LLMRails |
-| Custom LLM injection (`llm=` / `update_llm`) | ✓ | ✗ | A custom `llm` forces LLMRails |
-| **[Knowledge base and embeddings](#knowledge-base-and-embeddings)** | | | |
-| Knowledge base, embeddings, and custom providers | ✓ | ✗ | LLMRails only |
-| **[Community and third-party rail catalog](#community-and-third-party-rail-catalog)** | | | |
-| Community integrations (PII, AlignScore, ActiveFence, and others) | ✓ | ✗ | Run as LLMRails actions and flows |
-| **[Server and deployment](#server-and-deployment)** | | | |
-| Guardrails server (OpenAI-compatible REST API) | ✓ | ✗ | Bundled server runs LLMRails; use IORails through the Python API |
-| Server-side threads and multi-config | ✓ | ✗ | LLMRails only |
-| **[Configuration and operations](#configuration-and-operations)** | | | |
-| Configuration serialization and conversation state | ✓ | ✗ | IORails is stateless |
-| `.railsignore` and multi-config loading | ✓ | ✓ | Shared configuration-loading layer |
-
-## Feature details
-
-### Rail types
 
 `LLMRails` runs every rail direction through the Colang runtime: input, output, dialog, retrieval, and execution (custom action) rails.
 Input and output rails wrap the model call, dialog rails drive multi-turn conversation flows, retrieval rails guard a knowledge base, and execution rails run custom Python actions.
@@ -152,12 +96,23 @@ Dialog, retrieval, and execution rails are not available on `IORails`; configura
 
 ### Colang language support
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Colang 1.0 configurations | ✓ | ✓ | |
+| Colang 2.x configurations | ✓ | ✗ | IORails accepts Colang 1.0 only |
+
 `LLMRails` runs both the Colang 1.0 and Colang 2.x runtimes, selecting the runtime from `config.colang_version`.
 
 `IORails` accepts Colang 1.0 configurations only and runs no dialog flows.
 A Colang 2.x configuration is a fallback condition: `Guardrails` routes it to `LLMRails`.
 
 ### Built-in NeMoGuard safety rails
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Content safety | ✓ | ✓ | Only output rail IORails supports |
+| Topic control | ✓ | ✓ | IORails: input only |
+| Jailbreak detection (NIM) | ✓ | ✓ | IORails: input only |
 
 Both engines support the built-in NeMoGuard safety models: content safety, topic control, and jailbreak detection.
 On `LLMRails` these run as Colang flows and can be placed on input or output as the configuration allows.
@@ -168,6 +123,12 @@ A topic-control or jailbreak flow on the output rail is a fallback condition.
 
 ### Tool calling
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Tool-call passthrough | ✓ | ✓ | |
+| Tool-call validation rail | ✓ | ✓ | IORails flow: `tool call validation` |
+| Tool-result validation rail | ✓ | ✓ | IORails flow: `tool result validation` |
+
 Both engines support passing model tool calls through to the caller and validating tool calls and tool results.
 `LLMRails` handles these through the Colang runtime and tool rails.
 
@@ -175,6 +136,16 @@ Both engines support passing model tool calls through to the caller and validati
 Tool calls are returned in the OpenAI-style `tool_calls` field of the response message.
 
 ### Generation and validation API
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| `generate` / `generate_async` | ✓ | ✓ | |
+| `stream_async` | ✓ | ✓ | |
+| Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
+| `check` / `check_async` (rails-only validation) | ✓ | ✗ | LLMRails only |
+| `GenerationOptions` | ✓ | ◐ | IORails uses `llm_params` and rail toggles; no `log` or `output_data` |
+| `GenerationResponse` (structured response object) | ✓ | ✗ | IORails returns an OpenAI-style message dict |
+| `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
 
 Both engines expose `generate`, `generate_async`, and `stream_async`.
 `LLMRails` can return a rich `GenerationResponse` and processes the full `GenerationOptions` object, including rail toggles, `llm_params`, logging options, and `output_data`.
@@ -186,6 +157,12 @@ The event-based API, `check` and `check_async`, and `explain()` are not availabl
 
 ### Streaming
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Output-rail streaming | ✓ | ✓ | |
+| Streaming usage and metadata | ✓ | ✓ | IORails: `include_metadata=True` |
+| Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
+
 Both engines stream responses through `stream_async` and support streaming output rails.
 Both can include usage and metadata; on `IORails`, pass `include_metadata=True` to receive `{"text": ..., "metadata": ...}` chunks instead of plain strings.
 
@@ -193,6 +170,12 @@ Parallel streaming output rails, where the output rail validates streamed chunks
 `IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.
 
 ### Parallelism and concurrency
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Parallel rail execution | ✓ | ✓ | `rails.input.parallel` / `rails.output.parallel` |
+| Speculative generation | ✗ | ✓ | Input rails race generation; non-streaming only |
+| Admission control and concurrency limits | ✗ | ✓ | `AsyncWorkQueue` plus a streaming semaphore |
 
 Both engines run multiple rails on the same direction concurrently when `rails.input.parallel` or `rails.output.parallel` is set; the first rail to block short-circuits the result.
 
@@ -202,6 +185,11 @@ Admission control through an `AsyncWorkQueue` (and a separate semaphore for stre
 
 ### Reasoning-model support
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Reasoning trace handling (`<think>` tags or reasoning field) | ✓ | ✓ | |
+| `reasoning_content` in a structured response | ✓ | ✗ | Requires `GenerationResponse` |
+
 Both engines preserve model reasoning traces, whether the model returns them in a dedicated reasoning field or inline within `<think>` tags, and both keep reasoning out of the prompt history sent back to the model.
 
 `LLMRails` can expose reasoning in the structured response through `reasoning_content`.
@@ -209,11 +197,23 @@ Because `IORails` returns a message dictionary rather than a `GenerationResponse
 
 ### Multimodal
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Multimodal (vision) input and output rails | ✓ | ✗ | LLMRails only |
+
 Multimodal (vision) input and output rails, which run safety checks over image content alongside text, are supported by `LLMRails`.
 
 `IORails` does not run multimodal safety rails over image content on its input and output rails; multimodal configurations route to `LLMRails`.
 
 ### Observability
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Tracing (OpenTelemetry spans) | ✓ | ✓ | |
+| Metrics (OpenTelemetry token and duration) | ✗ | ✓ | LLMRails surfaces token statistics through logging |
+| Prometheus export | ✗ | ✓ | Through the OpenTelemetry metrics exporter |
+| Logging (verbose and call statistics) | ✓ | ✓ | |
+| Content capture (span content) | ✓ | ✓ | |
 
 Both engines support OpenTelemetry tracing and content capture on spans, and both emit logs.
 `LLMRails` surfaces token usage and timing through its logging and statistics output and verbose mode.
@@ -223,6 +223,12 @@ For more information, see the [Observability](/observability) documentation.
 
 ### LLM frameworks and providers
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Default framework (OpenAI-compatible) | ✓ | ✓ | |
+| LangChain integration (opt-in) | ✓ | ✗ | Passing a LangChain LLM routes to LLMRails |
+| Custom LLM injection (`llm=` / `update_llm`) | ✓ | ✗ | A custom `llm` forces LLMRails |
+
 Both engines use the default OpenAI-compatible framework to call models defined in the configuration.
 
 The LangChain integration is opt-in and available on `LLMRails`.
@@ -230,11 +236,19 @@ Passing a custom `llm` to the constructor, including a LangChain model, forces `
 
 ### Knowledge base and embeddings
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Knowledge base, embeddings, and custom providers | ✓ | ✗ | LLMRails only |
+
 The knowledge base, embedding providers, and custom embedding or embedding-search providers are part of the Colang retrieval pipeline and are supported by `LLMRails`.
 
 `IORails` does not initialize a knowledge base or embeddings; configurations that rely on retrieval route to `LLMRails`.
 
 ### Community and third-party rail catalog
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Community integrations (PII, AlignScore, ActiveFence, and others) | ✓ | ✗ | Run as LLMRails actions and flows |
 
 The community and third-party integrations in the [Guardrail Catalog](/configure-guardrails/guardrail-catalog) (for example, PII detection, AlignScore, ActiveFence, Fiddler, Pangea, and others) run as `LLMRails` actions and flows.
 
@@ -242,12 +256,22 @@ The community and third-party integrations in the [Guardrail Catalog](/configure
 
 ### Server and deployment
 
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Guardrails server (OpenAI-compatible REST API) | ✓ | ✗ | Bundled server runs LLMRails; use IORails through the Python API |
+| Server-side threads and multi-config | ✓ | ✗ | LLMRails only |
+
 The bundled Guardrails server exposes an OpenAI-compatible REST API and runs on `LLMRails`.
 Server-side threads and multi-config serving are provided through that server.
 
 `IORails` is consumed through the in-process `Guardrails` Python API rather than the bundled server.
 
 ### Configuration and operations
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| Configuration serialization and conversation state | ✓ | ✗ | IORails is stateless |
+| `.railsignore` and multi-config loading | ✓ | ✓ | Shared configuration-loading layer |
 
 `LLMRails` supports configuration serialization and maintains conversation state across turns, which the event-based and `process_events` APIs build on.
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -40,7 +40,8 @@ rails = LLMRails(config)
 It runs the built-in NeMoGuard safety models (content safety, topic control, and jailbreak detection) and tool validation directly against the model endpoints, with parallel rail execution, admission control through an `AsyncWorkQueue`, OpenTelemetry token metrics, and optional speculative generation.
 It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
 
-`IORails` requires a `start()` and `stop()` lifecycle for non-streaming generation.
+`IORails` has a `start()` / `stop()` lifecycle that initializes and releases the engine's model clients and work queue.
+Both `generate_async()` and `stream_async()` call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to pre-warm the clients and `stop()` at shutdown to release them.
 When you use the `Guardrails` facade described below, that lifecycle is managed for you through `startup()` and `shutdown()` (or by using `Guardrails` as an async context manager).
 
 ### Choosing an engine

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -89,6 +89,7 @@ Legend: ✓ supported · ✗ not supported · ◐ partial (see notes).
 
 `LLMRails` runs every rail direction through the Colang runtime: input, output, dialog, retrieval, and execution (custom action) rails.
 Input and output rails wrap the model call, dialog rails drive multi-turn conversation flows, retrieval rails guard a knowledge base, and execution rails run custom Python actions.
+Execution rails govern those custom actions; validating the model's own tool calls and tool results is covered separately under [Tool calling](#tool-calling).
 
 `IORails` runs input, output, and tool rails only, and it does so without the Colang runtime.
 Input rails run before the model call and output rails run after it, using a fixed set of built-in flows.

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -17,7 +17,8 @@ This page explains what each engine is optimized for, how to select one, and whi
 Both engines read the same `RailsConfig` object, but they support different feature sets.
 
 LLMRails is designed for flexibility, and it supports all rail types with Colang 1.0 and 2.x so that you can define custom dialog flows.
-IORails is optimized for low-latency input, output, and tool rails, and the `Guardrails` facade can select it automatically when the configuration uses supported flows.
+IORails is optimized for low-latency input, output, and tool rails.
+The `Guardrails` facade selects the optimal engine to use, based on the Guardrails configuration.
 
 ### LLMRails
 
@@ -37,7 +38,8 @@ rails = LLMRails(config)
 ### IORails
 
 `IORails` is optimized for accelerated input and output rail inference.
-It runs the built-in NeMoGuard safety models (content safety, topic control, and jailbreak detection) and tool validation directly against the model endpoints, with parallel rail execution, admission control through an `AsyncWorkQueue`, OpenTelemetry token metrics, and optional speculative generation.
+It includes tool-calling rails.
+It runs the built-in NeMoGuard safety models (content safety, topic control, and jailbreak detection) and tool validation directly against the model endpoints, with optional parallel rail execution, admission control through an `AsyncWorkQueue`, OpenTelemetry token metrics, and optional speculative generation.
 It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
 
 `IORails` has a `start()` and `stop()` lifecycle that initializes and releases the engine's model clients and work queue.

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -9,7 +9,7 @@ content:
   type: "reference"
 ---
 
-The NVIDIA NeMo Guardrails library support two engines: `LLMRails` and `IORails`.
+The NVIDIA NeMo Guardrails library supports two engines: `LLMRails` and `IORails`.
 This page explains what each engine is optimized for, how to select one, and which features each engine supports.
 
 ## The LLMRails and IORails engines
@@ -17,7 +17,7 @@ This page explains what each engine is optimized for, how to select one, and whi
 Both engines use the same `RailsConfig` object to configure their operation interchangeably.
 
 LLMRails is designed for flexibility, supporting all rail-types with Colang 1 and 2 to allow users to define custom dialog flows.
-IORails is optimized for low-latency input and output-rails only.
+IORails is optimized for low-latency input, output, and tool rails.
 
 ### LLMRails
 
@@ -86,6 +86,7 @@ Legend: ✓ supported · ✗ not supported · ◐ partial (see notes).
 | Dialog rails | ✓ | ✗ | Require the Colang runtime, which IORails does not run |
 | Retrieval (RAG and knowledge base) rails | ✓ | ✗ | LLMRails only |
 | Execution rails (custom actions) | ✓ | ✗ | LLMRails only |
+| Tool rails | ✓ | ✓ | IORails: tool-call and tool-result validation; see [Tool calling](#tool-calling) |
 
 `LLMRails` runs every rail direction through the Colang runtime: input, output, dialog, retrieval, and execution (custom action) rails.
 Input and output rails wrap the model call, dialog rails drive multi-turn conversation flows, retrieval rails guard a knowledge base, and execution rails run custom Python actions.
@@ -111,7 +112,7 @@ A Colang 2.x configuration is a fallback condition: `Guardrails` routes it to `L
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
-| Content safety | ✓ | ✓ | Only output rail IORails supports |
+| Content safety | ✓ | ✓ | IORails: input and output |
 | Topic control | ✓ | ✓ | IORails: input only |
 | Jailbreak detection (NIM) | ✓ | ✓ | IORails: input only |
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -1,0 +1,255 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Engine Feature Support"
+sidebar-title: "Engine Feature Support"
+description: "Compare which NeMo Guardrails features are supported by the LLMRails and IORails engines."
+keywords: ["llmrails", "iorails", "guardrails engines", "feature support", "engine comparison"]
+content:
+  type: "reference"
+---
+
+The NVIDIA NeMo Guardrails library support two engines: `LLMRails` and `IORails`.
+This page explains what each engine is optimized for, how to select one, and which features each engine supports.
+
+## The LLMRails and IORails engines
+
+Both engines use the same `RailsConfig` object to configure their operation interchangeably.
+
+LLMRails is designed for flexibility, supporting all rail-types with Colang 1 and 2 to allow users to define custom dialog flows.
+IORails is optimized for low-latency input and output-rails only.
+
+### LLMRails
+
+`LLMRails` is the full-featured, event-driven engine.
+It runs the complete Colang 1.0 and 2.x runtime, including dialog rails, input and output rails, retrieval (RAG and knowledge base) rails, execution rails (custom Python actions), tool rails, and embeddings.
+It is optimized for flexibility and complete conversational guardrailing, and it is the engine behind every capability that depends on the Colang runtime, custom actions, embeddings, or a custom LLM.
+
+Instantiate it directly:
+
+```python
+from nemoguardrails import LLMRails, RailsConfig
+
+config = RailsConfig.from_path("path/to/config")
+rails = LLMRails(config)
+```
+
+### IORails
+
+`IORails` is optimized for accelerated input and output rail inference.
+It runs the built-in NeMoGuard safety models (content safety, topic control, and jailbreak detection) and tool validation directly against the model endpoints, with parallel rail execution, admission control through an `AsyncWorkQueue`, OpenTelemetry token metrics, and optional speculative generation.
+It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
+
+`IORails` requires a `start()` and `stop()` lifecycle for non-streaming generation.
+When you use the `Guardrails` facade described below, that lifecycle is managed for you through `startup()` and `shutdown()` (or by using `Guardrails` as an async context manager).
+
+### Choosing an engine
+
+The recommended entry point is the `Guardrails` facade, which routes a configuration to the appropriate engine automatically.
+
+```python
+from nemoguardrails import Guardrails, RailsConfig
+
+config = RailsConfig.from_path("path/to/config")
+
+# Auto-route: use IORails when the config is supported, otherwise fall back to LLMRails.
+rails = Guardrails(config)
+
+# Always use LLMRails.
+rails = Guardrails(config, use_iorails=False)
+
+# Require IORails and raise if the config is not supported.
+rails = Guardrails(config, require_iorails=True)
+```
+
+`Guardrails(config)` selects `IORails` when all of the following hold:
+
+- No custom `llm` is passed to the constructor.
+- The configuration is Colang 1.0.
+- Only supported rail types and flows are configured (see [Built-in NeMoGuard safety rails](#built-in-nemoguard-safety-rails) and [Tool calling](#tool-calling)).
+
+Otherwise the facade falls back to `LLMRails` and logs the reason.
+You can inspect that decision directly with `IORails.unsupported_reason(config, llm)`, which returns the human-readable fallback reason, or `None` when `IORails` can handle the config.
+
+## Feature support matrix
+
+The following matrix lists supported features per engine.
+Category names link to the matching description in [Feature details](#feature-details).
+
+Legend: ✓ supported · ✗ not supported · ◐ partial (see the note).
+
+| Feature | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| **[Rail types](#rail-types)** | | | |
+| Input rails | ✓ | ✓ | |
+| Output rails | ✓ | ✓ | |
+| Dialog rails | ✓ | ✗ | Require the Colang runtime, which IORails does not run |
+| Retrieval (RAG and knowledge base) rails | ✓ | ✗ | LLMRails only |
+| Execution rails (custom actions) | ✓ | ✗ | LLMRails only |
+| **[Colang language support](#colang-language-support)** | | | |
+| Colang 1.0 configurations | ✓ | ✓ | |
+| Colang 2.x configurations | ✓ | ✗ | IORails accepts Colang 1.0 only |
+| **[Built-in NeMoGuard safety rails](#built-in-nemoguard-safety-rails)** | | | |
+| Content safety | ✓ | ✓ | Only output rail IORails supports |
+| Topic control | ✓ | ✓ | IORails: input only |
+| Jailbreak detection (NIM) | ✓ | ✓ | IORails: input only |
+| **[Tool calling](#tool-calling)** | | | |
+| Tool-call passthrough | ✓ | ✓ | |
+| Tool-call validation rail | ✓ | ✓ | IORails flow: `tool call validation` |
+| Tool-result validation rail | ✓ | ✓ | IORails flow: `tool result validation` |
+| **[Generation and validation API](#generation-and-validation-api)** | | | |
+| `generate` / `generate_async` | ✓ | ✓ | |
+| `stream_async` | ✓ | ✓ | |
+| Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
+| `check` / `check_async` (rails-only validation) | ✓ | ✗ | LLMRails only |
+| `GenerationOptions` | ✓ | ◐ | IORails uses `llm_params` and rail toggles; no `log` or `output_data` |
+| `GenerationResponse` (structured response object) | ✓ | ✗ | IORails returns an OpenAI-style message dict |
+| `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
+| **[Streaming](#streaming)** | | | |
+| Output-rail streaming | ✓ | ✓ | |
+| Streaming usage and metadata | ✓ | ✓ | IORails: `include_metadata=True` |
+| Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
+| **[Parallelism and concurrency](#parallelism-and-concurrency)** | | | |
+| Parallel rail execution | ✓ | ✓ | `rails.input.parallel` / `rails.output.parallel` |
+| Speculative generation | ✗ | ✓ | Input rails race generation; non-streaming only |
+| Admission control and concurrency limits | ✗ | ✓ | `AsyncWorkQueue` plus a streaming semaphore |
+| **[Reasoning-model support](#reasoning-model-support)** | | | |
+| Reasoning trace handling (`<think>` tags or reasoning field) | ✓ | ✓ | |
+| `reasoning_content` in a structured response | ✓ | ✗ | Requires `GenerationResponse` |
+| **[Multimodal](#multimodal)** | | | |
+| Multimodal (vision) input and output rails | ✓ | ✗ | LLMRails only |
+| **[Observability](#observability)** | | | |
+| Tracing (OpenTelemetry spans) | ✓ | ✓ | |
+| Metrics (OpenTelemetry token and duration) | ✗ | ✓ | LLMRails surfaces token statistics through logging |
+| Prometheus export | ✗ | ✓ | Through the OpenTelemetry metrics exporter |
+| Logging (verbose and call statistics) | ✓ | ✓ | |
+| Content capture (span content) | ✓ | ✓ | |
+| **[LLM frameworks and providers](#llm-frameworks-and-providers)** | | | |
+| Default framework (OpenAI-compatible) | ✓ | ✓ | |
+| LangChain integration (opt-in) | ✓ | ✗ | Passing a LangChain LLM routes to LLMRails |
+| Custom LLM injection (`llm=` / `update_llm`) | ✓ | ✗ | A custom `llm` forces LLMRails |
+| **[Knowledge base and embeddings](#knowledge-base-and-embeddings)** | | | |
+| Knowledge base, embeddings, and custom providers | ✓ | ✗ | LLMRails only |
+| **[Community and third-party rail catalog](#community-and-third-party-rail-catalog)** | | | |
+| Community integrations (PII, AlignScore, ActiveFence, and others) | ✓ | ✗ | Run as LLMRails actions and flows |
+| **[Server and deployment](#server-and-deployment)** | | | |
+| Guardrails server (OpenAI-compatible REST API) | ✓ | ✗ | Bundled server runs LLMRails; use IORails through the Python API |
+| Server-side threads and multi-config | ✓ | ✗ | LLMRails only |
+| **[Configuration and operations](#configuration-and-operations)** | | | |
+| Configuration serialization and conversation state | ✓ | ✗ | IORails is stateless |
+| `.railsignore` and multi-config loading | ✓ | ✓ | Shared configuration-loading layer |
+
+## Feature details
+
+### Rail types
+
+`LLMRails` runs every rail direction through the Colang runtime: input, output, dialog, retrieval, and execution (custom action) rails.
+Input and output rails wrap the model call, dialog rails drive multi-turn conversation flows, retrieval rails guard a knowledge base, and execution rails run custom Python actions.
+
+`IORails` runs input, output, and tool rails only, and it does so without the Colang runtime.
+Input rails run before the model call and output rails run after it, using a fixed set of built-in flows.
+Dialog, retrieval, and execution rails are not available on `IORails`; configurations that use them fall back to `LLMRails`.
+
+### Colang language support
+
+`LLMRails` runs both the Colang 1.0 and Colang 2.x runtimes, selecting the runtime from `config.colang_version`.
+
+`IORails` accepts Colang 1.0 configurations only and runs no dialog flows.
+A Colang 2.x configuration is a fallback condition: `Guardrails` routes it to `LLMRails`.
+
+### Built-in NeMoGuard safety rails
+
+Both engines support the built-in NeMoGuard safety models: content safety, topic control, and jailbreak detection.
+On `LLMRails` these run as Colang flows and can be placed on input or output as the configuration allows.
+
+`IORails` supports a fixed set of these flows per direction.
+On input it supports content safety, topic control, and jailbreak detection; on output it supports content safety only.
+A topic-control or jailbreak flow on the output rail is a fallback condition.
+
+### Tool calling
+
+Both engines support passing model tool calls through to the caller and validating tool calls and tool results.
+`LLMRails` handles these through the Colang runtime and tool rails.
+
+`IORails` validates tool calls and tool results through directional flows: `tool call validation` on the tool-output rail and `tool result validation` on the tool-input rail.
+Tool calls are returned in the OpenAI-style `tool_calls` field of the response message.
+
+### Generation and validation API
+
+Both engines expose `generate`, `generate_async`, and `stream_async`.
+`LLMRails` can return a rich `GenerationResponse` and processes the full `GenerationOptions` object, including rail toggles, `llm_params`, logging options, and `output_data`.
+It also exposes the event-based API (`generate_events` and `process_events`), the rails-only validation methods (`check` and `check_async`), and `explain()` for debugging.
+
+`IORails` returns an OpenAI-style message dictionary with `role`, `content`, and optional `tool_calls`, rather than a `GenerationResponse`.
+It accepts `GenerationOptions` but uses only `llm_params` and rail toggles.
+The event-based API, `check` and `check_async`, and `explain()` are not available; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
+
+### Streaming
+
+Both engines stream responses through `stream_async` and support streaming output rails.
+Both can include usage and metadata; on `IORails`, pass `include_metadata=True` to receive `{"text": ..., "metadata": ...}` chunks instead of plain strings.
+
+Parallel streaming output rails, where the output rail validates streamed chunks using the streaming buffer, is an `LLMRails` feature.
+`IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.
+
+### Parallelism and concurrency
+
+Both engines run multiple rails on the same direction concurrently when `rails.input.parallel` or `rails.output.parallel` is set; the first rail to block short-circuits the result.
+
+`IORails` adds two concurrency capabilities that `LLMRails` does not provide.
+Speculative generation (`rails.input.speculative_generation`) runs input rails concurrently with model generation and discards the generation if an input rail blocks, reducing latency on the safe path; it applies to non-streaming generation only.
+Admission control through an `AsyncWorkQueue` (and a separate semaphore for streaming) bounds the number of in-flight requests and rejects work when the queue is full.
+
+### Reasoning-model support
+
+Both engines preserve model reasoning traces, whether the model returns them in a dedicated reasoning field or inline within `<think>` tags, and both keep reasoning out of the prompt history sent back to the model.
+
+`LLMRails` can expose reasoning in the structured response through `reasoning_content`.
+Because `IORails` returns a message dictionary rather than a `GenerationResponse`, the structured `reasoning_content` field is an `LLMRails` capability.
+
+### Multimodal
+
+Multimodal (vision) input and output rails, which run safety checks over image content alongside text, are supported by `LLMRails`.
+
+`IORails` does not run multimodal safety rails over image content on its input and output rails; multimodal configurations route to `LLMRails`.
+
+### Observability
+
+Both engines support OpenTelemetry tracing and content capture on spans, and both emit logs.
+`LLMRails` surfaces token usage and timing through its logging and statistics output and verbose mode.
+
+OpenTelemetry token and duration metrics (for example, `gen_ai.client.token.usage` and `gen_ai.client.operation.duration`) are an `IORails` capability, and those metrics can be exported to Prometheus through an OpenTelemetry metrics exporter.
+For more information, see the [Observability](/observability) documentation.
+
+### LLM frameworks and providers
+
+Both engines use the default OpenAI-compatible framework to call models defined in the configuration.
+
+The LangChain integration is opt-in and available on `LLMRails`.
+Passing a custom `llm` to the constructor, including a LangChain model, forces `LLMRails`, because `IORails` resolves its models from the configuration rather than from an injected LLM and does not support `update_llm`.
+
+### Knowledge base and embeddings
+
+The knowledge base, embedding providers, and custom embedding or embedding-search providers are part of the Colang retrieval pipeline and are supported by `LLMRails`.
+
+`IORails` does not initialize a knowledge base or embeddings; configurations that rely on retrieval route to `LLMRails`.
+
+### Community and third-party rail catalog
+
+The community and third-party integrations in the [Guardrail Catalog](/configure-guardrails/guardrail-catalog) (for example, PII detection, AlignScore, ActiveFence, Fiddler, Pangea, and others) run as `LLMRails` actions and flows.
+
+`IORails` ships only the built-in NeMoGuard safety models and tool validation, so catalog integrations route to `LLMRails`.
+
+### Server and deployment
+
+The bundled Guardrails server exposes an OpenAI-compatible REST API and runs on `LLMRails`.
+Server-side threads and multi-config serving are provided through that server.
+
+`IORails` is consumed through the in-process `Guardrails` Python API rather than the bundled server.
+
+### Configuration and operations
+
+`LLMRails` supports configuration serialization and maintains conversation state across turns, which the event-based and `process_events` APIs build on.
+
+`IORails` is stateless and does not serialize conversation state.
+Configuration loading, including `.railsignore` and multi-config loading, is handled by a shared layer and behaves the same for both engines.

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Engine Feature Support"
 sidebar-title: "Engine Feature Support"
-description: "Compare which NeMo Guardrails features are supported by the LLMRails and IORails engines."
+description: "Compare feature support between the LLMRails and IORails engines in the NVIDIA NeMo Guardrails library."
 keywords: ["llmrails", "iorails", "guardrails engines", "feature support", "engine comparison"]
 content:
   type: "reference"
@@ -12,12 +12,12 @@ content:
 The NVIDIA NeMo Guardrails library supports two engines: `LLMRails` and `IORails`.
 This page explains what each engine is optimized for, how to select one, and which features each engine supports.
 
-## The LLMRails and IORails engines
+## The LLMRails and IORails Engines
 
-Both engines use the same `RailsConfig` object to configure their operation interchangeably.
+Both engines read the same `RailsConfig` object, but they support different feature sets.
 
-LLMRails is designed for flexibility, supporting all rail-types with Colang 1 and 2 to allow users to define custom dialog flows.
-IORails is optimized for low-latency input, output, and tool rails.
+LLMRails is designed for flexibility, and it supports all rail types with Colang 1.0 and 2.x so that you can define custom dialog flows.
+IORails is optimized for low-latency input, output, and tool rails, and the `Guardrails` facade can select it automatically when the configuration uses supported flows.
 
 ### LLMRails
 
@@ -40,11 +40,11 @@ rails = LLMRails(config)
 It runs the built-in NeMoGuard safety models (content safety, topic control, and jailbreak detection) and tool validation directly against the model endpoints, with parallel rail execution, admission control through an `AsyncWorkQueue`, OpenTelemetry token metrics, and optional speculative generation.
 It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
 
-`IORails` has a `start()` / `stop()` lifecycle that initializes and releases the engine's model clients and work queue.
-Both `generate_async()` and `stream_async()` call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to pre-warm the clients and `stop()` at shutdown to release them.
+`IORails` has a `start()` and `stop()` lifecycle that initializes and releases the engine's model clients and work queue.
+Both `generate_async()` and `stream_async()` call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to warm the clients and `stop()` at shutdown to release them.
 When you use the `Guardrails` facade described below, that lifecycle is managed for you through `startup()` and `shutdown()` (or by using `Guardrails` as an async context manager).
 
-### Choosing an engine
+### Choosing an Engine
 
 The recommended entry point is the `Guardrails` facade, which routes a configuration to the appropriate engine automatically.
 
@@ -72,13 +72,13 @@ rails = Guardrails(config, require_iorails=True)
 Otherwise the facade falls back to `LLMRails` and logs the reason.
 You can inspect that decision directly with `IORails.unsupported_reason(config, llm)`, which returns the human-readable fallback reason, or `None` when `IORails` can handle the config.
 
-## Feature support
+## Feature Support
 
 Each section below covers one capability area, with a support table followed by a comparison of the two engines.
 
 Legend: ✓ supported · ✗ not supported · ◐ partial (see notes).
 
-### Rail types
+### Rail Types
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -97,7 +97,7 @@ Execution rails govern those custom actions; validating the model's own tool cal
 Input rails run before the model call and output rails run after it, using a fixed set of built-in flows.
 Dialog, retrieval, and execution rails are not available on `IORails`; configurations that use them fall back to `LLMRails`.
 
-### Colang language support
+### Colang Language Support
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -109,7 +109,7 @@ Dialog, retrieval, and execution rails are not available on `IORails`; configura
 `IORails` accepts Colang 1.0 configurations only and runs no dialog flows.
 A Colang 2.x configuration is a fallback condition: `Guardrails` routes it to `LLMRails`.
 
-### Built-in NeMoGuard safety rails
+### Built-In NeMoGuard Safety Rails
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -124,7 +124,7 @@ On `LLMRails` these run as Colang flows and can be placed on input or output as 
 On input it supports content safety, topic control, and jailbreak detection; on output it supports content safety only.
 A topic-control or jailbreak flow on the output rail is a fallback condition.
 
-### Tool calling
+### Tool Calling
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -138,7 +138,7 @@ Both engines support passing model tool calls through to the caller and validati
 `IORails` validates tool calls and tool results through directional flows: `tool call validation` on the tool-output rail and `tool result validation` on the tool-input rail.
 Tool calls are returned in the OpenAI-style `tool_calls` field of the response message.
 
-### Generation and validation API
+### Generation and Validation API
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -167,12 +167,13 @@ The event-based API, `check` and `check_async`, and `explain()` are not availabl
 | Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
 
 Both engines stream responses through `stream_async` and support streaming output rails.
-Both can include usage and metadata; on `IORails`, pass `include_metadata=True` to receive `{"text": ..., "metadata": ...}` chunks instead of plain strings.
+Both can include streaming metadata; on `IORails`, pass `include_metadata=True` to receive dictionary-framed chunks such as `{"text": ...}` instead of plain strings.
+`IORails` does not add a separate `metadata` field to each streamed text chunk.
 
 Parallel streaming output rails, where the output rail validates streamed chunks using the streaming buffer, is an `LLMRails` feature.
 `IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.
 
-### Parallelism and concurrency
+### Parallelism and Concurrency
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -180,13 +181,15 @@ Parallel streaming output rails, where the output rail validates streamed chunks
 | Speculative generation | ✗ | ✓ | Input rails race generation; non-streaming only |
 | Admission control and concurrency limits | ✗ | ✓ | `AsyncWorkQueue` plus a streaming semaphore |
 
-Both engines run multiple rails on the same direction concurrently when `rails.input.parallel` or `rails.output.parallel` is set; the first rail to block short-circuits the result.
+Both engines run multiple rails in the same direction concurrently when `rails.input.parallel` or `rails.output.parallel` is set; the first rail to block short-circuits the result.
+For YAML examples, see [Parallel Execution of Input and Output Rails](/configure-guardrails/yaml-schema/guardrails-configuration#parallel-execution-of-input-and-output-rails).
 
 `IORails` adds two concurrency capabilities that `LLMRails` does not provide.
 Speculative generation (`rails.input.speculative_generation`) runs input rails concurrently with model generation and discards the generation if an input rail blocks, reducing latency on the safe path; it applies to non-streaming generation only.
+For a configuration example, see [Speculative Generation](/configure-guardrails/yaml-schema/guardrails-configuration#speculative-generation).
 Admission control through an `AsyncWorkQueue` (and a separate semaphore for streaming) bounds the number of in-flight requests and rejects work when the queue is full.
 
-### Reasoning-model support
+### Reasoning-Model Support
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -224,7 +227,7 @@ Both engines support OpenTelemetry tracing and content capture on spans, and bot
 OpenTelemetry token and duration metrics (for example, `gen_ai.client.token.usage` and `gen_ai.client.operation.duration`) are an `IORails` capability, and those metrics can be exported to Prometheus through an OpenTelemetry metrics exporter.
 For more information, see the [Observability](/observability) documentation.
 
-### LLM frameworks and providers
+### LLM Frameworks and Providers
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -237,7 +240,7 @@ Both engines use the default OpenAI-compatible framework to call models defined 
 The LangChain integration is opt-in and available on `LLMRails`.
 Passing a custom `llm` to the constructor, including a LangChain model, forces `LLMRails`, because `IORails` resolves its models from the configuration rather than from an injected LLM and does not support `update_llm`.
 
-### Knowledge base and embeddings
+### Knowledge Base and Embeddings
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -247,7 +250,7 @@ The knowledge base, embedding providers, and custom embedding or embedding-searc
 
 `IORails` does not initialize a knowledge base or embeddings; configurations that rely on retrieval route to `LLMRails`.
 
-### Community and third-party rail catalog
+### Community and Third-Party Rail Catalog
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -257,7 +260,7 @@ The community and third-party integrations in the [Guardrail Catalog](/configure
 
 `IORails` ships only the built-in NeMoGuard safety models and tool validation, so catalog integrations route to `LLMRails`.
 
-### Server and deployment
+### Server and Deployment
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
@@ -269,7 +272,7 @@ Server-side threads and multi-config serving are provided through that server.
 
 `IORails` is consumed through the in-process `Guardrails` Python API rather than the bundled server.
 
-### Configuration and operations
+### Configuration and Operations
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|


### PR DESCRIPTION
## Description

Adds the Engine Feature Support page under References to give a summary of which features are supported in LLMRails, which are in IORails, and a brief description of the two and how they differ. It also includes the standard RailsConfig configuration object and how engines can be hard-coded or whether the most appropriate one will be used.

Direct page link (from the staged Fern build): https://nvidia-preview-pr-2100.docs.buildwithfern.com/nemo/guardrails/reference/engine-feature-support


## Related Issue(s)

## Verification

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 285 pages at /Users/tgasser/projects/nemo_guardrails_worktree/docs/iorails-feature-table/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries
                                             ╭──────────────────────────────────╮
                                             │                                  │
                                             │        Upgrades available        │
                                             │                                  │
                                             │      Fern 5.50.5 → 5.57.0        │
                                             │   (Run fern upgrade to update)   │
                                             │                                  │
                                             ╰──────────────────────────────────╯

node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" check
All checks passed
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new reference page covering engine feature support and how the two engines differ.
  * Expanded the docs navigation to surface the new page under the Reference section.
  * Included comparison tables and guidance on supported rails, streaming, multimodal use, observability, deployment, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->