### PR TITLE
fix(langchain): OpenAI Responses API and Harmony response format support

### DIFF
--- a/docs/configure-rails/yaml-schema/model-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/model-configuration.mdx
@@ -69,9 +69,9 @@ models:
 
 ## Configuration Examples
 
-### OpenAI
+### OpenAI Chat Completions
 
-The following example shows how to configure the OpenAI model as the main application LLM:
+The following example shows how to configure the OpenAI model as the main application LLM using the chat completions endpoint:
 
 ```yaml
 models:
@@ -79,6 +79,44 @@ models:
     engine: openai
     model: gpt-4o
 ```
+
+### OpenAI Responses API
+
+To route an OpenAI model through the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) instead of Chat Completions, set `use_responses_api: true` in the model's `parameters` block:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o
+    parameters:
+      use_responses_api: true
+```
+
+<Note>
+
+The Responses API is supported **only** under the LangChain framework. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-openai`. The default framework's built-in client only calls `/v1/chat/completions`; under it, `use_responses_api` is silently forwarded as an unknown request field and has no effect. For background, refer to [Migrating to 0.22](/reference/0-22#using-langchain).
+
+</Note>
+
+Some OpenAI models (e.g. `gpt-5.x-pro`) only support Responses API format, while some options such as setting a `reasoning_effort` are also supported only when using Responses API for most recent OpenAI models.
+
+Function (custom) tool calls work over the Responses API in both streaming and non-streaming modes. Built-in/hosted Responses-API tools (`web_search`, `file_search`, `code_interpreter`, `computer_use`) are not surfaced as tool calls; only function-tool passthrough is supported.
+
+Self-hosted servers that expose an OpenAI-compatible `/v1/responses` endpoint (for example, vLLM) work with the same flag plus a `base_url`. Models that use the [Harmony response format](https://github.com/openai/harmony), such as `gpt-oss` or `gpt-oss-safeguard` models should use the Responses API. This still requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, since `use_responses_api` lives in the LangChain `ChatOpenAI` class:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: openai/gpt-oss-120b
+    api_key_env_var: THIS_CAN_BE_ANY_KEY
+    parameters:
+      base_url: http://localhost:8000/v1
+      use_responses_api: true
+```
+
+A complete example is available in [`examples/configs/llm/openai-responses-api`](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/examples/configs/llm/openai-responses-api).
 
 ### Azure OpenAI
 

--- a/docs/configure-rails/yaml-schema/model-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/model-configuration.mdx
@@ -99,7 +99,7 @@ The Responses API is supported **only** under the LangChain framework. Set `NEMO
 
 </Note>
 
-Some OpenAI models (e.g. `gpt-5.x-pro`) only support Responses API format, while some options such as setting a `reasoning_effort` are also supported only when using Responses API for most recent OpenAI models.
+Some OpenAI models (e.g. `gpt-5-pro`) only support Responses API format, while some options such as setting a `reasoning_effort` are also supported only when using Responses API for most recent OpenAI models.
 
 Function (custom) tool calls work over the Responses API in both streaming and non-streaming modes. Built-in/hosted Responses-API tools (`web_search`, `file_search`, `code_interpreter`, `computer_use`) are not surfaced as tool calls; only function-tool passthrough is supported.
 

--- a/examples/configs/llm/openai-responses-api/README.md
+++ b/examples/configs/llm/openai-responses-api/README.md
@@ -1,0 +1,40 @@
+# OpenAI Responses API Example
+
+> This example requires NeMo Guardrails' **LangChain framework**. The Responses API is **not** supported by the built-in DefaultFramework, whose OpenAI-compatible client only calls `/v1/chat/completions`. The `use_responses_api` parameter is honored only by `langchain_openai.ChatOpenAI`.
+
+This configuration shows how to route an OpenAI model through the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) instead of Chat Completions, by setting `use_responses_api: true` in the model's `parameters` block.
+
+## Requirements
+
+Set the framework and install the LangChain packages:
+
+```bash
+export NEMOGUARDRAILS_LLM_FRAMEWORK=langchain
+pip install langchain langchain-openai
+export OPENAI_API_KEY=sk-...
+```
+
+Without `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, the `use_responses_api` parameter is silently forwarded as an unknown field to `/v1/chat/completions` and has no effect (OpenAI rejects or ignores it) — the call does **not** switch to the Responses API.
+
+## Self-hosted models (vLLM and other OpenAI-compatible servers)
+
+Some inference servers — for example [vLLM](https://docs.vllm.ai/) — expose an OpenAI-compatible `/v1/responses` endpoint in addition to `/v1/chat/completions`. To target such a deployment, keep `engine: openai`, set `use_responses_api: true`, and point `base_url` at your server:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: openai/gpt-oss-20b
+    api_key_env_var: ANY_KEY_CAN_BE_USED_HERE
+    parameters:
+      base_url: http://localhost:8000/v1
+      use_responses_api: true
+```
+
+This still requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, because the `use_responses_api` switch lives in `langchain_openai.ChatOpenAI`. Confirm your server actually implements `/v1/responses` before enabling the flag; not all OpenAI-compatible servers do.
+
+## Tool calling (passthrough only)
+
+Function (custom) tool calls work over the Responses API in both streaming and non-streaming modes: the assistant's tool calls are surfaced on `LLMResponse.tool_calls` / `LLMResponseChunk.delta_tool_calls`, and `finish_reason` is reported as `tool_calls`.
+
+Built-in/hosted Responses-API tools (`web_search`, `file_search`, `code_interpreter`, `computer_use`, MCP, image generation) are **not** surfaced as tool calls. They are returned by the API as response output items rather than function calls, so the adapter does not expose them. Only function-tool passthrough is supported.

--- a/examples/configs/llm/openai-responses-api/config.yml
+++ b/examples/configs/llm/openai-responses-api/config.yml
@@ -1,0 +1,9 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-5-pro
+    parameters:
+      # Route calls to OpenAI's /v1/responses endpoint instead of
+      # /v1/chat/completions. Honored only under the LangChain framework
+      # (NEMOGUARDRAILS_LLM_FRAMEWORK=langchain); see README.md.
+      use_responses_api: true

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -316,10 +316,10 @@ _INCOMPLETE_REASON_MAP: Dict[str, FinishReason] = {
 }
 
 # Terminal finish reasons under which accumulated streaming tool-call fragments
-# should be finalized. Chat completions ends a tool-call turn with "tool_calls";
-# the Responses API ends it with status "completed" (-> "stop"); "length" covers
-# a tool call truncated by the token limit.
-_TOOL_CALL_TERMINAL_REASONS: frozenset = frozenset({"tool_calls", "stop", "length"})
+# should be finalized as a *complete* tool call. Chat completions ends a clean
+# tool-call turn with "tool_calls"; the Responses API ends it with status
+# "completed" (-> "stop").
+_TOOL_CALL_TERMINAL_REASONS: frozenset = frozenset({"tool_calls", "stop"})
 
 
 def _finish_reason_from_status(response_metadata: Dict[str, Any]) -> Optional[FinishReason]:

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -214,8 +214,13 @@ class LangChainLLMAdapter:
 
             response_chunk = _langchain_chunk_to_llm_response_chunk(chunk)
 
-            if response_chunk.finish_reason == "tool_calls" and tool_call_acc:
+            # On the terminal chunk, finalize any accumulated tool-call fragments.
+            # Chat completions signals this with finish_reason "tool_calls"; the
+            # Responses API reports status "completed" (-> "stop"), so accept the
+            # terminal reasons under which a tool call can legitimately close.
+            if tool_call_acc and response_chunk.finish_reason in _TOOL_CALL_TERMINAL_REASONS:
                 response_chunk.delta_tool_calls = _finalize_tool_call_acc(tool_call_acc)
+                response_chunk.finish_reason = "tool_calls"
 
             yield response_chunk
 
@@ -292,6 +297,45 @@ def _map_finish_reason(raw: Optional[str]) -> Optional[FinishReason]:
     if raw is None:
         return None
     return _FINISH_REASON_MAP.get(raw, "other")
+
+
+# The OpenAI Responses API does not report a per-choice ``finish_reason`` the way
+# chat completions does. Terminal state lives in the top-level ``status`` field
+# (and ``incomplete_details.reason`` when truncated), so we map that to the
+# internal FinishReason vocabulary as a fallback.
+_RESPONSES_STATUS_MAP: Dict[str, FinishReason] = {
+    "completed": "stop",
+    "failed": "error",
+    "cancelled": "other",
+}
+
+_INCOMPLETE_REASON_MAP: Dict[str, FinishReason] = {
+    "max_output_tokens": "length",
+    "max_tokens": "length",
+    "content_filter": "content_filter",
+}
+
+# Terminal finish reasons under which accumulated streaming tool-call fragments
+# should be finalized. Chat completions ends a tool-call turn with "tool_calls";
+# the Responses API ends it with status "completed" (-> "stop"); "length" covers
+# a tool call truncated by the token limit.
+_TOOL_CALL_TERMINAL_REASONS: frozenset = frozenset({"tool_calls", "stop", "length"})
+
+
+def _finish_reason_from_status(response_metadata: Dict[str, Any]) -> Optional[FinishReason]:
+    """Derive a finish reason from the Responses API ``status`` field.
+
+    Returns ``None`` for non-terminal statuses (e.g. ``in_progress``,
+    ``queued``) so a finish reason is only reported once the turn is complete.
+    """
+    status = response_metadata.get("status")
+    if not status:
+        return None
+    if status == "incomplete":
+        details = response_metadata.get("incomplete_details")
+        reason = details.get("reason") if isinstance(details, dict) else None
+        return _INCOMPLETE_REASON_MAP.get(reason, "other")
+    return _RESPONSES_STATUS_MAP.get(status)
 
 
 def _build_usage_info(raw: Any) -> Optional[UsageInfo]:
@@ -420,6 +464,8 @@ def _extract_model_info(response_metadata: Dict[str, Any]) -> _ModelInfo:
     model = response_metadata.get("model_name") or response_metadata.get("model")
     raw_finish = response_metadata.get("finish_reason") or response_metadata.get("stop_reason")
     finish_reason = _map_finish_reason(raw_finish)
+    if finish_reason is None:
+        finish_reason = _finish_reason_from_status(response_metadata)
     stop_sequence = response_metadata.get("stop_sequence")
     request_id = response_metadata.get("id") or response_metadata.get("request_id")
     return _ModelInfo(model, finish_reason, stop_sequence, request_id)
@@ -446,10 +492,16 @@ def _langchain_response_to_llm_response(response: Any) -> LLMResponse:
     additional_kwargs = getattr(response, "additional_kwargs", None) or {}
     model, finish_reason, stop_sequence, request_id = _extract_model_info(response_metadata)
 
+    tool_calls = _extract_tool_calls(response)
+    # The Responses API reports a tool-call turn as status "completed" (-> "stop")
+    # rather than "tool_calls". Reconcile so consumers can rely on finish_reason.
+    if tool_calls and finish_reason in (None, "stop"):
+        finish_reason = "tool_calls"
+
     return LLMResponse(
         content=content,
         reasoning=_extract_reasoning(response),
-        tool_calls=_extract_tool_calls(response),
+        tool_calls=tool_calls,
         model=model,
         finish_reason=finish_reason,
         stop_sequence=stop_sequence,

--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -218,6 +218,34 @@ class TestLangChainLLMAdapter:
         assert terminal.delta_tool_calls[0].function.arguments == {"q": "weather"}
 
     @pytest.mark.asyncio
+    async def test_stream_truncated_tool_call_preserves_length_finish_reason(self):
+        # A tool call cut off by the token limit ends with finish_reason "length"
+        # and incomplete JSON args. It must NOT be relabeled "tool_calls" (which
+        # would mask the truncation behind an empty-args call). finish_reason stays
+        # "length" and no tool calls are surfaced.
+        chunks = [
+            AIMessageChunk(
+                content="",
+                tool_call_chunks=[{"name": "search", "args": '{"q": "wea', "id": "tc_1", "index": 0}],
+            ),
+            AIMessageChunk(content="", response_metadata={"finish_reason": "length"}),
+        ]
+
+        async def mock_astream(*args, **kwargs):
+            for c in chunks:
+                yield c
+
+        mock_llm = MagicMock()
+        mock_llm.astream = mock_astream
+        adapter = LangChainLLMAdapter(mock_llm)
+
+        results = [chunk async for chunk in adapter.stream_async("find weather")]
+
+        terminal = results[-1]
+        assert terminal.finish_reason == "length"
+        assert terminal.delta_tool_calls is None
+
+    @pytest.mark.asyncio
     async def test_generate_passes_kwargs_via_bind(self):
         mock_llm = MagicMock()
         bound_llm = AsyncMock()

--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -184,6 +184,40 @@ class TestLangChainLLMAdapter:
         assert results[1].delta_content == "lo"
 
     @pytest.mark.asyncio
+    async def test_stream_finalizes_tool_calls_on_responses_api_completed(self):
+        # Responses-API streaming closes a tool-call turn with status "completed"
+        # (-> finish_reason "stop"), not "tool_calls". The terminal chunk must
+        # still finalize the accumulated fragments and report "tool_calls".
+        chunks = [
+            AIMessageChunk(
+                content="",
+                tool_call_chunks=[{"name": "search", "args": '{"q": "wea', "id": "tc_1", "index": 0}],
+            ),
+            AIMessageChunk(
+                content="",
+                tool_call_chunks=[{"name": None, "args": 'ther"}', "id": None, "index": 0}],
+            ),
+            AIMessageChunk(content="", response_metadata={"status": "completed", "id": "resp_x"}),
+        ]
+
+        async def mock_astream(*args, **kwargs):
+            for c in chunks:
+                yield c
+
+        mock_llm = MagicMock()
+        mock_llm.astream = mock_astream
+        adapter = LangChainLLMAdapter(mock_llm)
+
+        results = [chunk async for chunk in adapter.stream_async("find weather")]
+
+        terminal = results[-1]
+        assert terminal.finish_reason == "tool_calls"
+        assert terminal.delta_tool_calls is not None
+        assert len(terminal.delta_tool_calls) == 1
+        assert terminal.delta_tool_calls[0].function.name == "search"
+        assert terminal.delta_tool_calls[0].function.arguments == {"q": "weather"}
+
+    @pytest.mark.asyncio
     async def test_generate_passes_kwargs_via_bind(self):
         mock_llm = MagicMock()
         bound_llm = AsyncMock()
@@ -511,6 +545,113 @@ class TestConversionHelpers:
 
         assert isinstance(result, LLMResponseChunk)
         assert result.delta_content == "raw string"
+
+
+class TestResponsesApiFinishReason:
+    """The OpenAI Responses API reports terminal state via ``status`` /
+    ``incomplete_details`` rather than a per-choice ``finish_reason``."""
+
+    def test_response_completed_status_maps_to_stop(self):
+        response = AIMessage(
+            content=[{"type": "text", "text": "pong"}],
+            response_metadata={
+                "id": "resp_abc",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt-4o-mini-2024-07-18",
+            },
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "stop"
+        assert result.request_id == "resp_abc"
+        assert result.model == "gpt-4o-mini-2024-07-18"
+
+    def test_response_incomplete_max_tokens_maps_to_length(self):
+        response = AIMessage(
+            content=[{"type": "text", "text": "The ocean"}],
+            response_metadata={
+                "id": "resp_def",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "model": "gpt-4o-mini-2024-07-18",
+            },
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "length"
+
+    def test_response_incomplete_content_filter(self):
+        response = AIMessage(
+            content="",
+            response_metadata={
+                "status": "incomplete",
+                "incomplete_details": {"reason": "content_filter"},
+            },
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "content_filter"
+
+    def test_response_failed_status_maps_to_error(self):
+        response = AIMessage(content="", response_metadata={"status": "failed"})
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "error"
+
+    def test_response_incomplete_unknown_reason_maps_to_other(self):
+        response = AIMessage(
+            content="",
+            response_metadata={"status": "incomplete", "incomplete_details": {"reason": "mystery"}},
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "other"
+
+    def test_explicit_finish_reason_takes_precedence_over_status(self):
+        # Chat completions still wins: a real finish_reason is never overridden
+        # by status-derived inference.
+        response = AIMessage(
+            content="",
+            response_metadata={"finish_reason": "stop", "status": "completed"},
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "stop"
+
+    def test_response_tool_call_with_completed_status_maps_to_tool_calls(self):
+        # A Responses-API tool-call turn reports status "completed"; finish_reason
+        # must still surface as "tool_calls" so consumers can branch on it.
+        response = AIMessage(
+            content="",
+            tool_calls=[{"name": "fn", "args": {"x": 1}, "id": "tc1", "type": "tool_call"}],
+            response_metadata={"status": "completed", "model": "gpt-4o-mini"},
+        )
+        result = _langchain_response_to_llm_response(response)
+
+        assert result.finish_reason == "tool_calls"
+        assert result.tool_calls is not None and len(result.tool_calls) == 1
+
+    def test_chunk_completed_status_maps_to_stop(self):
+        chunk = AIMessageChunk(
+            content="",
+            response_metadata={
+                "id": "resp_stream",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt-4o-mini-2024-07-18",
+            },
+        )
+        result = _langchain_chunk_to_llm_response_chunk(chunk)
+
+        assert result.finish_reason == "stop"
+        assert result.request_id == "resp_stream"
+
+    def test_chunk_non_terminal_status_yields_no_finish_reason(self):
+        chunk = AIMessageChunk(content="pon", response_metadata={"status": "in_progress"})
+        result = _langchain_chunk_to_llm_response_chunk(chunk)
+
+        assert result.finish_reason is None
 
 
 class TestChatMessageToLangChain:


### PR DESCRIPTION
## Description

Addresses NGUARD-760.
Provides support to OpenAI Responses API and Harmony response format via the Langchain LLM framework. The support is provided both for OpenAI closed models and for open models that use Harmony response format (such as `gpt-oss` or `gpt-oss-safeguard`) served using OpenAI compatible endpoints. 

Documentation and an example are also added. 

## Related Issue(s)

Fixes NGUARD-760

## Verification

Run OpenAI models that require Responses API (do not support Chat Completions endpoint). 
Sample `config.yml`:

```
models:
  - type: main
    engine: openai
    model: gpt-5-pro
    parameters:
      use_responses_api: true


  - type: content_safety
    engine: nim
    model: nvidia/llama-3.1-nemotron-safety-guard-8b-v3

rails:
  input:
    flows:
      - content safety check input $model=content_safety
  output:
    flows:
      - content safety check output $model=content_safety
```


## AI Assistance

- [ ] No AI tools were used.
- [X] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [X] This PR links to a triaged issue assigned to me.
- [X] My PR title follows the project commit convention.
- [X] I've updated the documentation if applicable.
- [X] I've added tests if applicable.
- [X] I've noted any verification beyond CI and any checks I couldn't run.
- [X] I did not update generated changelog files manually.
- [X] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [X] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenAI configuration by separating Chat Completions vs Responses API guidance.
  * Added detailed instructions for enabling the OpenAI Responses API, including compatibility notes, tool-calling behavior, and self-hosted `/v1/responses` setup.
* **Examples**
  * Added an end-to-end OpenAI Responses API example configuration.
* **Bug Fixes**
  * Improved LangChain adapter handling for Responses API finish reasons and streaming tool-call finalization/normalization.
* **Tests**
  * Added and extended coverage for finish-reason mapping and streaming tool-call behavior (including truncation cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->