### PR TITLE
fix(ci): update README version during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "New version (e.g. 0.15.1)"
+        description: "Stable release version (e.g. 0.23.0)"
         required: true
         type: string
       bump_type:
@@ -61,9 +61,11 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ -n "${INPUT_VERSION}" ]; then
+            VERSION="${INPUT_VERSION}"
           else
             # Use git-cliff to determine the next version based on commits
             VERSION=$(git cliff --bumped-version)
@@ -71,6 +73,10 @@ jobs:
 
           # Remove 'v' prefix if present
           VERSION=${VERSION#v}
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release version must use the stable X.Y.Z format."
+            exit 1
+          fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
 
@@ -103,10 +109,45 @@ jobs:
           poetry version ${{ steps.version.outputs.version }}
 
       - name: Update version in README.md
+        env:
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Update the version reference in README.md
-          sed -i "s/\[0\.[0-9]*\.[0-9]*\](https:\/\/github\.com\/NVIDIA\/NeMo-Guardrails\/tree\/v0\.[0-9]*\.[0-9]*)/[${{ steps.version.outputs.version }}](https:\/\/github.com\/NVIDIA\/NeMo-Guardrails\/tree\/v${{ steps.version.outputs.version }})/g" README.md
-          sed -i "s/version: \[0\.[0-9]*\.[0-9]*\]/version: [${{ steps.version.outputs.version }}]/g" README.md
+          poetry run python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("README.md")
+          lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+          marker = "> **LATEST RELEASE / DEVELOPMENT VERSION**:"
+          marker_lines = [index for index, line in enumerate(lines) if line.startswith(marker)]
+          if len(marker_lines) != 1:
+              raise SystemExit(
+                  f"Expected exactly one README release marker, found {len(marker_lines)}."
+              )
+
+          version = os.environ["VERSION"]
+          release_link = re.compile(
+              r"\[[0-9]+\.[0-9]+\.[0-9]+\]"
+              r"\(https://github\.com/[^/()]+/[^/()]+/tree/v"
+              r"[0-9]+\.[0-9]+\.[0-9]+\)"
+          )
+          repository = os.environ["REPOSITORY"]
+          replacement = (
+              f"[{version}]"
+              f"(https://github.com/{repository}/tree/v{version})"
+          )
+          index = marker_lines[0]
+          lines[index], replacements = release_link.subn(replacement, lines[index])
+          if replacements != 1:
+              raise SystemExit(
+                  "Expected exactly one stable release link on the README release marker, "
+                  f"found {replacements}."
+              )
+
+          path.write_text("".join(lines), encoding="utf-8")
+          PY
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Downloads](https://static.pepy.tech/badge/nemoguardrails)](https://pepy.tech/project/nemoguardrails)
 [![Downloads](https://static.pepy.tech/badge/nemoguardrails/month)](https://pepy.tech/project/nemoguardrails)
 
-> **LATEST RELEASE / DEVELOPMENT VERSION**: The [develop](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop) branch tracks the latest top of tree development. The latest released version is [0.21.0](https://github.com/NVIDIA-NeMo/Guardrails/tree/v0.21.0).
+> **LATEST RELEASE / DEVELOPMENT VERSION**: The [develop](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop) branch tracks the latest top of tree development. The latest released version is [0.22.0](https://github.com/NVIDIA-NeMo/Guardrails/tree/v0.22.0).
 
 ✨✨✨
 


### PR DESCRIPTION
## Description

Fix the release workflow so final releases update the README's stable-version
link after development and release-candidate versions. Fail clearly when the
release marker is missing, and correct the stale README version to 0.22.0.


## Verification

- `poetry run pre-commit run --files .github/workflows/release.yml README.md`
- Exercised the embedded updater against the current and former repository URLs.
- Verified that a missing README release marker fails the update.
- Verified that `.dev0` and `-rcN` inputs are rejected as final releases.
- proof of work in my fork: https://github.com/Pouyanpi/NeMo-Guardrails/pull/51
## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to show the latest stable release version.
  * Clarified the release version input format with an explicit example.

* **Bug Fixes**
  * Added stricter validation for release version formatting to prevent invalid version updates.
  * Improved the release update process to ensure the README release link is updated only when the expected release marker is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->