### PR TITLE
chore: exclude agent files from packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ include = [
   "nemoguardrails/**/*.json",
   "nemoguardrails/**/*.lark",
 ]
+exclude = [
+  "nemoguardrails/AGENTS.md",
+  "nemoguardrails/CLAUDE.md",
+]
 
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Description

Exclude repository agent instruction files from Poetry source and wheel packages.

## Verification

- `poetry check`
- `poetry build`
- Confirmed `AGENTS.md` and `CLAUDE.md` are absent from the wheel and source distribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging to exclude a couple of documentation files from distributed package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->