### PR TITLE
docs: edit OpenAI Responses API guidance

### DIFF
--- a/docs/configure-rails/yaml-schema/model-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/model-configuration.mdx
@@ -82,7 +82,9 @@ models:
 
 ### OpenAI Responses API
 
-To route an OpenAI model through the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) instead of Chat Completions, set `use_responses_api: true` in the model's `parameters` block:
+Use the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) when an OpenAI model or option requires it. For example, some models, such as `gpt-5-pro`, require the Responses API, and recent OpenAI models support options such as `reasoning_effort` through the Responses API.
+
+The NVIDIA NeMo Guardrails library supports this option through the LangChain framework. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, install `langchain-openai`, and set `use_responses_api: true` in the model's `parameters` block:
 
 ```yaml
 models:
@@ -95,15 +97,15 @@ models:
 
 <Note>
 
-The Responses API is supported **only** under the LangChain framework. Set `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` and install `langchain-openai`. The default framework's built-in client only calls `/v1/chat/completions`; under it, `use_responses_api` is silently forwarded as an unknown request field and has no effect. For background, refer to [Migrating to 0.22](/reference/0-22#using-langchain).
+The built-in default framework does not support the Responses API. It calls `/v1/chat/completions` and forwards `use_responses_api` as an unknown request field, so the flag has no effect. For background, refer to [Migrating to 0.22](/reference/0-22#using-langchain).
 
 </Note>
 
-Some OpenAI models (e.g. `gpt-5-pro`) only support Responses API format, while some options such as setting a `reasoning_effort` are also supported only when using Responses API for most recent OpenAI models.
+Function tool calls work over the Responses API in streaming and non-streaming modes. The adapter surfaces function calls on `LLMResponse.tool_calls` and `LLMResponseChunk.delta_tool_calls`, and reports `finish_reason` as `tool_calls`.
 
-Function (custom) tool calls work over the Responses API in both streaming and non-streaming modes. Built-in/hosted Responses-API tools (`web_search`, `file_search`, `code_interpreter`, `computer_use`) are not surfaced as tool calls; only function-tool passthrough is supported.
+Built-in Responses API tools, such as `web_search`, `file_search`, `code_interpreter`, and `computer_use`, are not surfaced as tool calls. The API returns those tools as response output items, not function calls, so only function-tool passthrough is supported.
 
-Self-hosted servers that expose an OpenAI-compatible `/v1/responses` endpoint (for example, vLLM) work with the same flag plus a `base_url`. Models that use the [Harmony response format](https://github.com/openai/harmony), such as `gpt-oss` or `gpt-oss-safeguard` models should use the Responses API. This still requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, since `use_responses_api` lives in the LangChain `ChatOpenAI` class:
+Self-hosted servers that expose an OpenAI-compatible `/v1/responses` endpoint, such as vLLM, work with the same flag plus `parameters.base_url`. Confirm that your server implements `/v1/responses` before you enable the flag. Models that use the [Harmony response format](https://github.com/openai/harmony), such as `gpt-oss` or `gpt-oss-safeguard`, should use the Responses API.
 
 ```yaml
 models:

--- a/examples/configs/llm/openai-responses-api/README.md
+++ b/examples/configs/llm/openai-responses-api/README.md
@@ -1,8 +1,8 @@
 # OpenAI Responses API Example
 
-> This example requires NeMo Guardrails' **LangChain framework**. The Responses API is **not** supported by the built-in DefaultFramework, whose OpenAI-compatible client only calls `/v1/chat/completions`. The `use_responses_api` parameter is honored only by `langchain_openai.ChatOpenAI`.
+> This example requires the NVIDIA NeMo Guardrails library to use the LangChain framework. The built-in default framework does not support the Responses API because its OpenAI-compatible client only calls `/v1/chat/completions`. The `langchain_openai.ChatOpenAI` class honors the `use_responses_api` parameter.
 
-This configuration shows how to route an OpenAI model through the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) instead of Chat Completions, by setting `use_responses_api: true` in the model's `parameters` block.
+This configuration shows how to route an OpenAI model through the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`) instead of Chat Completions. Set `use_responses_api: true` in the model's `parameters` block.
 
 ## Requirements
 
@@ -14,11 +14,11 @@ pip install langchain langchain-openai
 export OPENAI_API_KEY=sk-...
 ```
 
-Without `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, the `use_responses_api` parameter is silently forwarded as an unknown field to `/v1/chat/completions` and has no effect (OpenAI rejects or ignores it) — the call does **not** switch to the Responses API.
+Without `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, the library forwards `use_responses_api` as an unknown field to `/v1/chat/completions`. The call does not switch to the Responses API.
 
 ## Self-hosted models (vLLM and other OpenAI-compatible servers)
 
-Some inference servers — for example [vLLM](https://docs.vllm.ai/) — expose an OpenAI-compatible `/v1/responses` endpoint in addition to `/v1/chat/completions`. To target such a deployment, keep `engine: openai`, set `use_responses_api: true`, and point `base_url` at your server:
+Some inference servers, such as [vLLM](https://docs.vllm.ai/), expose an OpenAI-compatible `/v1/responses` endpoint in addition to `/v1/chat/completions`. To target that deployment, keep `engine: openai`, set `use_responses_api: true`, and point `base_url` at your server:
 
 ```yaml
 models:
@@ -31,10 +31,10 @@ models:
       use_responses_api: true
 ```
 
-This still requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`, because the `use_responses_api` switch lives in `langchain_openai.ChatOpenAI`. Confirm your server actually implements `/v1/responses` before enabling the flag; not all OpenAI-compatible servers do.
+This configuration still requires `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` because `langchain_openai.ChatOpenAI` provides the `use_responses_api` switch. Confirm that your server implements `/v1/responses` before you enable the flag. Not all OpenAI-compatible servers support it.
 
 ## Tool calling (passthrough only)
 
-Function (custom) tool calls work over the Responses API in both streaming and non-streaming modes: the assistant's tool calls are surfaced on `LLMResponse.tool_calls` / `LLMResponseChunk.delta_tool_calls`, and `finish_reason` is reported as `tool_calls`.
+Function tool calls work over the Responses API in streaming and non-streaming modes. The adapter surfaces the assistant's tool calls on `LLMResponse.tool_calls` and `LLMResponseChunk.delta_tool_calls`, and reports `finish_reason` as `tool_calls`.
 
-Built-in/hosted Responses-API tools (`web_search`, `file_search`, `code_interpreter`, `computer_use`, MCP, image generation) are **not** surfaced as tool calls. They are returned by the API as response output items rather than function calls, so the adapter does not expose them. Only function-tool passthrough is supported.
+Built-in Responses API tools, such as `web_search`, `file_search`, `code_interpreter`, `computer_use`, MCP, and image generation, are not surfaced as tool calls. The API returns those tools as response output items, not function calls, so only function-tool passthrough is supported.


### PR DESCRIPTION
## Description

Follow-up edit pass for #2102. Tightens the OpenAI Responses API documentation so the LangChain requirement, self-hosted `/v1/responses` setup, and tool-calling limitations are easier to scan.

No behavior changes.

## Related Issue(s)

Follow-up to #2102 / NGUARD-760.

## Verification

- `/opt/homebrew/bin/pre-commit run --files docs/configure-rails/yaml-schema/model-configuration.mdx examples/configs/llm/openai-responses-api/README.md`
- Cursor diagnostics for edited files: no linter errors.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Cursor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use the OpenAI Responses API, including support for models that require it and self-hosted `/v1/responses` endpoints.
  * Updated guidance on framework behavior so it’s clear when the setting is passed through versus actually enabling Responses API support.
  * Expanded tool-handling notes to distinguish supported function-tool calls from built-in Responses API tools, with clearer streaming and non-streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->