### PR TITLE
docs: add Guardrails 0.23.0 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,97 @@ For a complete record of changes in a release, refer to the
 
 ---
 
+<a id="v0-23-0"></a>
+## 0.23.0
+
+<a id="v0-23-0-features"></a>
+### Key Features
+
+- `IORails` adds tool-calling rails for OpenAI Chat Completions-style tool
+  traffic. The engine can validate model-emitted tool calls and application
+  tool results in streaming and non-streaming flows, without making extra LLM or
+  provider calls. For more information, refer to
+  [Tool Calling](/configure-guardrails/guardrail-catalog/tool-calling) and
+  [Engine Feature Support](/reference/engine-feature-support).
+
+- The guardrail catalog adds Polygraf PII detection and masking integration.
+  You can configure Polygraf for input, output, and retrieval flows, including
+  fail-closed handling for provider failures or malformed entity spans. For more
+  information, refer to
+  [Polygraf Integration](/configure-guardrails/guardrail-catalog/third-party/polygraf).
+
+- The library adds lightweight Hugging Face classifier rails and a context bloat
+  detection rail. The classifier rails can run on input, output, or retrieval
+  text with local Transformers, vLLM, KServe, or FMS backends. The context bloat
+  rail detects padded, oversized, low-entropy, or repetitive user and retrieval
+  text before it can consume context budget.
+
+- The Guardrails server adds `/v1/checks` for standalone guardrail validation.
+  The endpoint accepts stored or inline configurations, runs `check_async`, and
+  returns whether the messages passed, were modified, or were blocked, along
+  with the processed content and blocking rail when available.
+
+- Observability adds opt-in OpenTelemetry content capture and richer LLM span
+  attributes. You can record request, response, rail, and model-call content
+  when tracing is enabled, and LLM spans now include request, response, and usage
+  attributes for both `LLMRails` and `IORails`. For more information, refer to
+  [Capturing Prompt and Response Content](/observability/tracing/content-capture)
+  and [Span Reference](/observability/tracing/span-reference).
+
+<a id="v0-23-0-breaking-changes"></a>
+### Breaking Changes
+
+- The NVIDIA NeMo Guardrails library now requires Pydantic `>=2.5,<3.0`.
+  Configuration schemas and validators use Pydantic 2 APIs. Update custom code
+  that imports, subclasses, or depends on Pydantic 1 behavior from the library's
+  configuration models before upgrading.
+
+<a id="v0-23-0-enhancements"></a>
+### Enhancements
+
+- The default embedding search implementation now uses exact NumPy search
+  instead of Annoy. Existing default knowledge-base caches are regenerated
+  automatically, and the change removes Annoy's native extension from the
+  default dependency path. For more information, refer to
+  [Embedding Search Providers](/configure-guardrails/other-configurations/embedding-search-providers).
+
+- OpenAI Responses API guidance and compatibility are improved for the LangChain
+  framework path. Function tool calls are surfaced in streaming and
+  non-streaming modes, and Harmony response format models can use the Responses
+  API configuration. For more information, refer to
+  [Model Configuration](/configure-guardrails/yaml-schema/model-configuration#openai-responses-api).
+
+- The public API is refined around the modern `Guardrails` facade and documented
+  top-level imports. Direct access to internal `LLMRails` attributes is
+  deprecated so applications can move toward stable public entry points.
+
+- The Python package is smaller because examples, repository files, and agent
+  instruction files are no longer bundled in the wheel or source distribution.
+  The release also introduces NIM-based example notebooks and retires superseded
+  examples.
+
+<a id="v0-23-0-doc-and-behavior-fixes"></a>
+### Documentation and Behavior Fixes
+
+- Streaming output rails now pass user content correctly, avoid duplicate usage
+  metadata chunks, and do not reuse resolved action parameters across chunks or
+  requests. Regex detection during output streaming now blocks matched content
+  correctly without raising `TypeError`. For more information, refer to
+  [Streaming](/run-guardrailed-inference/using-python-apis/streaming).
+
+- Tool-call metadata is preserved for `LLMRails` tool rails and processing logs,
+  so tool-aware integrations can inspect tool calls after guardrail execution.
+
+- Configuration and cache handling are more deterministic. Library files load in
+  a stable order, `EmbeddingsCache.from_dict` preserves `store_config`, and
+  evaluation YAML handling uses safe load and dump behavior.
+
+- Colang and generation fixes cover multiline `bot say` flow continuations,
+  `or` line continuations at the end of a file, and task-specific stop-token
+  selection in `generate_value`.
+
+---
+
 <a id="v0-22-0"></a>
 ## 0.22.0
 


### PR DESCRIPTION
## Summary

- Added the 0.23.0 release notes to `docs/about/release-notes.mdx`.
- Summarized the main user-facing changes from `v0.22.0..v0.23.0`, including IORails tool-calling rails, Polygraf, `/v1/checks`, OpenTelemetry content capture, Pydantic 2, NumPy embedding search, OpenAI Responses API updates, packaging changes, and key behavior fixes.

## Source Summary

- #2058 -> `docs/about/release-notes.mdx`: Documented IORails tool-calling rails.
- #2030 -> `docs/about/release-notes.mdx`: Documented tool-calling rails integration with RailsManager and ModelRegistry.
- #2016 -> `docs/about/release-notes.mdx`: Documented non-streaming tool calling for IORails.
- #2024 -> `docs/about/release-notes.mdx`: Documented streaming tool calling for IORails.
- #1693 -> `docs/about/release-notes.mdx`: Documented Polygraf PII detection and masking integration.
- #1853 -> `docs/about/release-notes.mdx`: Documented lightweight Hugging Face classifier rails.
- #1941 -> `docs/about/release-notes.mdx`: Documented context bloat detection rail.
- #2013 -> `docs/about/release-notes.mdx`: Documented the `/v1/checks` guardrail validation endpoint.
- #1972, #2009, #2083, #2098 -> `docs/about/release-notes.mdx`: Documented OpenTelemetry content capture and richer span attributes.
- #967 -> `docs/about/release-notes.mdx`: Documented the Pydantic 2 breaking change.
- #1957, #1958 -> `docs/about/release-notes.mdx`: Documented the default embedding search move from Annoy to exact NumPy search.
- #2102, #2112 -> `docs/about/release-notes.mdx`: Documented OpenAI Responses API and Harmony response format updates.
- #1933 -> `docs/about/release-notes.mdx`: Documented the public API refinement and internal `LLMRails` attribute deprecations.
- #2069, #2111, #1906 -> `docs/about/release-notes.mdx`: Documented packaging size reductions and refreshed NIM-based examples.
- #2081, #2079, #1935, #1943, #1932, #1937 -> `docs/about/release-notes.mdx`: Documented streaming output rail and regex detection fixes.
- #2073 -> `docs/about/release-notes.mdx`: Documented tool-call metadata preservation for `LLMRails`.
- #1975, #1951, #2082 -> `docs/about/release-notes.mdx`: Documented deterministic loading, embedding cache, and safe YAML handling fixes.
- #1650, #1947, #1699 -> `docs/about/release-notes.mdx`: Documented Colang and generation fixes.

## Validation

- `make docs-fern`
- `ReadLints` reported no errors for `docs/about/release-notes.mdx`.

## Notes

- `poetry run pre-commit run --files docs/about/release-notes.mdx` was not run because `poetry` is not installed in the local shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for 0.23.0 highlighting new tool-calling support, PII detection/masking, lightweight classifier rails, a validation endpoint, and optional OpenTelemetry content capture.

* **Breaking Changes**
  * Updated the supported Pydantic range to newer versions, with corresponding schema and validation updates.

* **Enhancements**
  * Improved search behavior, API guidance, public-facing guardrails access, and packaging for examples/notebooks.

* **Bug Fixes**
  * Fixed streaming behavior, tool-call metadata handling, config/cache consistency, and several generation-related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->