### PR TITLE
test(llmrails): characterize public behavior (1/9)

### DIFF
--- a/tests/rails/llm/test_llmrails_public_contract.py
+++ b/tests/rails/llm/test_llmrails_public_contract.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from tests.utils import FakeLLMModel
+
+
+def _config() -> RailsConfig:
+    return RailsConfig.from_content(config={"models": []})
+
+
+def test_constructor_keeps_public_state_visible():
+    config = _config()
+    llm = FakeLLMModel(responses=[])
+
+    rails = LLMRails(config=config, llm=llm)
+
+    assert rails.config is config
+    assert rails.llm is llm
+    assert rails.runtime is not None
+    assert rails.llm_generation_actions is not None
+    assert rails.events_history_cache == {}
+    assert rails.explain_info is None
+
+
+def test_update_llm_keeps_runtime_generation_actions_and_public_attr_in_sync():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    new_llm = FakeLLMModel(responses=["updated"])
+
+    rails.update_llm(new_llm)
+
+    assert rails.llm is new_llm
+    assert rails.llm_generation_actions.llm is new_llm
+    assert rails.runtime.registered_action_params["llm"] is new_llm
+
+
+@pytest.mark.asyncio
+async def test_sync_wrappers_raise_when_called_from_async_loop():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+
+    with pytest.raises(RuntimeError, match="sync `generate` inside async code"):
+        rails.generate(prompt="hi")
+
+    with pytest.raises(RuntimeError, match="sync `generate_events` inside async code"):
+        rails.generate_events([])
+
+    with pytest.raises(RuntimeError, match="sync `generate_events` inside async code"):
+        rails.process_events([])
+
+    with pytest.raises(RuntimeError, match="sync `check` inside async code"):
+        rails.check([{"role": "user", "content": "hi"}])
+
+
+def test_getstate_serializes_config_only():
+    rails = LLMRails(config=_config(), llm=FakeLLMModel(responses=[]))
+    rails.events_history_cache["cached"] = [{"type": "CachedEvent"}]
+    rails.register_action_param("custom_param", object())
+
+    state = rails.__getstate__()
+
+    assert state == {"config": rails.config}


### PR DESCRIPTION
## Description

Adds characterization tests for the existing public `LLMRails` compatibility surface before implementation is moved.

### Why

The stack needs a stable, reviewable contract for constructor visibility, `update_llm`, sync wrappers, and serialization behavior.

### What Changed

- Adds public behavior coverage for `LLMRails`.
- Makes no production-code changes.

### Review Guidance

The recorded compatibility baseline is maintained in #2122. Use the [LLMRails decomposition review matrix](https://github.com/NVIDIA-NeMo/Guardrails/pull/2123#issuecomment-4865418226) to map each behavior to its exact test node. Merge #2122 first, then rebase this stack onto the updated `develop` branch.

Review whether these tests faithfully capture current behavior without over-specifying the later implementation.

This nine-part stack turns `LLMRails` into a public compatibility shell while moving owned behavior into focused modules. Review each PR only against its parent. Parts 2-6 intentionally stage behavior-preserving extraction; part 7 consolidates shared type contracts and logger naming; part 8 establishes the final package ownership; part 9 contains the explicit semantic follow-ups.

For parts 2-6, please distinguish stack-local correctness or compatibility problems from naming and placement concerns already resolved in parts 7-8. If an intermediate name or location is correct and mergeable at that point, prefer reviewing its final form in the resolving PR instead of requesting duplicate churn. Public API changes, behavior changes, import cycles, or an independently broken intermediate branch remain in scope wherever they appear. Much of the apparent added LOC is moved code plus focused tests; the corresponding implementation is removed or delegated from `llmrails.py` in the same PR.

### Stack Position

Part 1 of 9.

- Previous: none, based on `develop`
- Next: [#2124](https://github.com/NVIDIA-NeMo/Guardrails/pull/2124)

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | [#2123](https://github.com/NVIDIA-NeMo/Guardrails/pull/2123) | `restack/llmrails-01-public-contract-tests` | `develop` |
| 2 | [#2124](https://github.com/NVIDIA-NeMo/Guardrails/pull/2124) | `restack/llmrails-02-startup` | `restack/llmrails-01-public-contract-tests` |
| 3 | [#2125](https://github.com/NVIDIA-NeMo/Guardrails/pull/2125) | `restack/llmrails-03-runtime-conversation` | `restack/llmrails-02-startup` |
| 4 | [#2126](https://github.com/NVIDIA-NeMo/Guardrails/pull/2126) | `restack/llmrails-04-generation` | `restack/llmrails-03-runtime-conversation` |
| 5 | [#2127](https://github.com/NVIDIA-NeMo/Guardrails/pull/2127) | `restack/llmrails-05-streaming` | `restack/llmrails-04-generation` |
| 6 | [#2128](https://github.com/NVIDIA-NeMo/Guardrails/pull/2128) | `restack/llmrails-06-checks-final` | `restack/llmrails-05-streaming` |
| 7 | [#2129](https://github.com/NVIDIA-NeMo/Guardrails/pull/2129) | `restack/llmrails-07-consistency` | `restack/llmrails-06-checks-final` |
| 8 | [#2130](https://github.com/NVIDIA-NeMo/Guardrails/pull/2130) | `restack/llmrails-08-boundary-ownership` | `restack/llmrails-07-consistency` |
| 9 | [#2131](https://github.com/NVIDIA-NeMo/Guardrails/pull/2131) | `restack/llmrails-09-followups` | `restack/llmrails-08-boundary-ownership` |

## Verification

```text
make test
poetry run pre-commit run --all-files

Rebase checkpoints: stack 2: 5202 passed, 178 skipped; stack 4: 5263 passed, 178 skipped; stack 5: 5284 passed, 178 skipped; final stack: 5320 passed, 178 skipped. Final pre-commit: all hooks passed. Base: develop at 3fc828b7f.
```

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
