### PR TITLE
chore: restore uv default dev group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: ty
         name: ty
-        entry: uv run --locked --group=dev ty check
+        entry: uv run --locked ty check
         language: system
         pass_filenames: false
         always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ skill discovery.
 - Install development dependencies:
 
   ```bash
-  uv sync --group dev
+  uv sync
   ```
 
 - Documentation tooling requires Node.js 22. The Fern CLI version is pinned in
@@ -83,11 +83,11 @@ as tox and package coverage.
 | Docs check | `make docs-fern` |
 | Ruff diagnosis | `uv run ruff check path/to/file.py` |
 | Ruff formatting diagnosis | `uv run ruff format path/to/file.py` |
-| ty diagnosis | `uv run --locked --group=dev ty check` |
+| ty diagnosis | `uv run --locked ty check` |
 
 | Change type | Minimum validation |
 | --- | --- |
-| Docs or repository metadata only | `uv run --locked --group=dev pre-commit run --files <changed files>`; build docs when rendering, links, examples, or docs configuration may be affected |
+| Docs or repository metadata only | `uv run --locked pre-commit run --files <changed files>`; build docs when rendering, links, examples, or docs configuration may be affected |
 | Runtime bug fix | Focused regression test plus pre-commit on changed files; broaden when shared behavior is touched |
 | Public API, config, or Colang behavior | Focused tests plus related docs/examples; add broader package tests when compatibility risk is meaningful |
 | Server, streaming, tracing, actions, or generation | Targeted tests for the changed path and fallback/unsupported path |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Clone the repository and install development dependencies:
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
 cd nemoguardrails
-uv sync --group dev
+uv sync
 ```
 
 Documentation tooling requires Node.js 22. The Fern CLI version is pinned in
@@ -161,7 +161,7 @@ Valid optional extras are `sdd`, `eval`, `gcp`, `tracing`, `jailbreak`,
 `multilingual`, `server`, `chat-ui`, and `all`. For example:
 
 ```bash
-uv sync --group dev --extra server --extra tracing
+uv sync --extra server --extra tracing
 ```
 
 For temporary local investigation tools, use the uv-managed environment

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,10 @@ docs-fern-fix-empty-links:
 	node scripts/fix-empty-fern-links.mjs
 
 pre-commit:
-	uv run --locked --group=dev pre-commit run --all-files
+	uv run --locked pre-commit run --all-files
 
 pre-commit-install:
-	uv run --locked --group=dev pre-commit install
+	uv run --locked pre-commit install
 
 help:
 	@printf '%s\n' \

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -33,7 +33,7 @@ Next you'll install the NeMo Guardrails uv-managed virtual environment and honch
 The honcho package is used to read the [`Procfile`](Procfile) and bring up the OpenAI service and Mock LLMs for benchmarking.
 
 ```shell
-$ uv sync --group dev --extra server
+$ uv sync --extra server
 $ uv pip install honcho
 ```
 

--- a/benchmark/embedding_backend/README.md
+++ b/benchmark/embedding_backend/README.md
@@ -38,7 +38,7 @@ regardless.
 Sync the project's development environment:
 
 ```bash
-uv sync --group dev
+uv sync
 ```
 
 > **Note (Annoy native build).** Annoy is a C++ extension. On a machine without a prebuilt

--- a/docs/getting-started/installation-guide.mdx
+++ b/docs/getting-started/installation-guide.mdx
@@ -85,7 +85,7 @@ pip install -e .
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
 cd nemoguardrails
-uv sync --no-dev --extra server
+uv sync --extra server
 ```
 
 When using uv, prefix CLI commands with `uv run`:

--- a/docs/getting-started/installation-guide.mdx
+++ b/docs/getting-started/installation-guide.mdx
@@ -85,7 +85,7 @@ pip install -e .
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Guardrails.git nemoguardrails
 cd nemoguardrails
-uv sync --extra server
+uv sync --no-dev --extra server
 ```
 
 When using uv, prefix CLI commands with `uv run`:

--- a/examples/configs/sensitive_data_detection_v2/README.md
+++ b/examples/configs/sensitive_data_detection_v2/README.md
@@ -9,7 +9,7 @@ This example demonstrates how to detect and redact sensitive data using [Presidi
   You can install it with:
 
   ```bash
-  uv sync --group dev --extra sdd
+  uv sync --no-dev --extra sdd
   ```
 
 - `en_core_web_lg` spaCy model

--- a/nemoguardrails/imports.py
+++ b/nemoguardrails/imports.py
@@ -47,7 +47,7 @@ def optional_import(
             f"Install it with pip install {package_name} or uv add {package_name}."
         )
         if extra:
-            msg += f" To install the project extra, run uv sync --extra {extra}."
+            msg += f" To install the project extra, run uv sync --no-dev --extra {extra}."
         if error == "raise":
             raise ImportError(msg) from e
         elif error == "warn":
@@ -101,7 +101,7 @@ def import_optional_dependency(
     try:
         module = importlib.import_module(name)
     except ImportError as e:
-        extra_msg = f" Install it with uv sync --extra {extra}." if extra else ""
+        extra_msg = f" Install it with uv sync --no-dev --extra {extra}." if extra else ""
         msg = f"Missing optional dependency '{install_name}'.{extra_msg}"
         if errors == "raise":
             raise ImportError(msg) from e

--- a/nemoguardrails/imports.py
+++ b/nemoguardrails/imports.py
@@ -47,7 +47,7 @@ def optional_import(
             f"Install it with pip install {package_name} or uv add {package_name}."
         )
         if extra:
-            msg += f" To install the project extra, run uv sync --no-dev --extra {extra}."
+            msg += f" To install the NeMo Guardrails extra, run pip install 'nemoguardrails[{extra}]'."
         if error == "raise":
             raise ImportError(msg) from e
         elif error == "warn":
@@ -101,7 +101,7 @@ def import_optional_dependency(
     try:
         module = importlib.import_module(name)
     except ImportError as e:
-        extra_msg = f" Install it with uv sync --no-dev --extra {extra}." if extra else ""
+        extra_msg = f" Install the NeMo Guardrails extra with pip install 'nemoguardrails[{extra}]'." if extra else ""
         msg = f"Missing optional dependency '{install_name}'.{extra_msg}"
         if errors == "raise":
             raise ImportError(msg) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ dev = [
 [tool.uv]
 package = true
 required-version = "==0.11.26"
-default-groups = []
 
 # Flat layout: the importable package is ./nemoguardrails (not under ./src).
 # uv_build ships everything under the module dir (Python plus the .co/.lark/.yml

--- a/scripts/telemetry-smoke.md
+++ b/scripts/telemetry-smoke.md
@@ -12,7 +12,7 @@ The driver lives at [`scripts/telemetry_smoke.py`](../scripts/telemetry_smoke.py
 
 ## Prerequisites
 
-- `uv sync --group dev` so `jsonschema` is available for local schema validation.
+- `uv sync` so `jsonschema` is available for local schema validation.
 - `tests/telemetry/smoke_fixtures/{cfg1,cfg2,cfg3,rich}/` and `examples/configs/nemoguards/` are present in the working tree.
 - `CI`, `GITHUB_ACTIONS`, and `PYTEST_CURRENT_TEST` must NOT be exported in the calling shell. The driver refuses to start otherwise. `unset` them first.
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -42,7 +42,7 @@ class TestOptionalImport:
         with pytest.raises(ImportError) as exc_info:
             optional_import("nonexistent_module_xyz", error="raise", extra="test")
         assert "Missing optional dependency" in str(exc_info.value)
-        assert "uv add nonexistent_module_xyz. To install the project extra, run uv sync --extra test." in str(
+        assert "uv add nonexistent_module_xyz. To install the project extra, run uv sync --no-dev --extra test." in str(
             exc_info.value
         )
 
@@ -67,7 +67,7 @@ class TestOptionalImport:
             result = optional_import("nonexistent_module_xyz", error="warn", extra="test")
             assert result is None
             assert len(w) == 1
-            assert "uv sync --extra test" in str(w[0].message)
+            assert "uv sync --no-dev --extra test" in str(w[0].message)
 
     def test_missing_module_ignore(self):
         result = optional_import("nonexistent_module_xyz", error="ignore")
@@ -105,7 +105,7 @@ class TestImportOptionalDependency:
         with pytest.raises(ImportError) as exc_info:
             import_optional_dependency("nonexistent_module_xyz", errors="raise", extra="test")
         assert "Missing optional dependency" in str(exc_info.value)
-        assert "uv sync --extra test" in str(exc_info.value)
+        assert "uv sync --no-dev --extra test" in str(exc_info.value)
 
     def test_missing_module_warn(self):
         with warnings.catch_warnings(record=True) as w:
@@ -122,7 +122,7 @@ class TestImportOptionalDependency:
             result = import_optional_dependency("nonexistent_module_xyz", errors="warn", extra="test")
             assert result is None
             assert len(w) == 1
-            assert "uv sync --extra test" in str(w[0].message)
+            assert "uv sync --no-dev --extra test" in str(w[0].message)
 
     def test_missing_module_ignore(self):
         result = import_optional_dependency("nonexistent_module_xyz", errors="ignore")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -42,9 +42,8 @@ class TestOptionalImport:
         with pytest.raises(ImportError) as exc_info:
             optional_import("nonexistent_module_xyz", error="raise", extra="test")
         assert "Missing optional dependency" in str(exc_info.value)
-        assert "uv add nonexistent_module_xyz. To install the project extra, run uv sync --no-dev --extra test." in str(
-            exc_info.value
-        )
+        assert "uv add nonexistent_module_xyz. To install the NeMo Guardrails extra" in str(exc_info.value)
+        assert "pip install 'nemoguardrails[test]'" in str(exc_info.value)
 
     def test_missing_module_raise_with_package_name(self):
         with pytest.raises(ImportError) as exc_info:
@@ -67,7 +66,7 @@ class TestOptionalImport:
             result = optional_import("nonexistent_module_xyz", error="warn", extra="test")
             assert result is None
             assert len(w) == 1
-            assert "uv sync --no-dev --extra test" in str(w[0].message)
+            assert "pip install 'nemoguardrails[test]'" in str(w[0].message)
 
     def test_missing_module_ignore(self):
         result = optional_import("nonexistent_module_xyz", error="ignore")
@@ -105,7 +104,7 @@ class TestImportOptionalDependency:
         with pytest.raises(ImportError) as exc_info:
             import_optional_dependency("nonexistent_module_xyz", errors="raise", extra="test")
         assert "Missing optional dependency" in str(exc_info.value)
-        assert "uv sync --no-dev --extra test" in str(exc_info.value)
+        assert "pip install 'nemoguardrails[test]'" in str(exc_info.value)
 
     def test_missing_module_warn(self):
         with warnings.catch_warnings(record=True) as w:
@@ -122,7 +121,7 @@ class TestImportOptionalDependency:
             result = import_optional_dependency("nonexistent_module_xyz", errors="warn", extra="test")
             assert result is None
             assert len(w) == 1
-            assert "uv sync --no-dev --extra test" in str(w[0].message)
+            assert "pip install 'nemoguardrails[test]'" in str(w[0].message)
 
     def test_missing_module_ignore(self):
         result = import_optional_dependency("nonexistent_module_xyz", errors="ignore")

--- a/tests/test_sensitive_data_detection.py
+++ b/tests/test_sensitive_data_detection.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # We detect if the environment is set up correct for SDD (presidio + downloaded spacy model)
-# uv sync --extra sdd --group dev
+# uv sync --extra sdd
 # python -m spacy download en_core_web_lg
 
 import subprocess


### PR DESCRIPTION
## Description

restore uv default dev group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, installation, benchmark, telemetry, and example instructions to use the newer `uv sync` command format.
  * Clarified optional dependency guidance so install commands now omit development dependencies where appropriate.

* **Bug Fixes**
  * Aligned missing-dependency error messages with the updated installation command shown to users.
  * Updated related checks and examples to match the new command output and workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->