### PR TITLE
fix(colang): raise ValueError for unbalanced closing bracket in split_args

### DIFF
--- a/nemoguardrails/colang/v1_0/lang/utils.py
+++ b/nemoguardrails/colang/v1_0/lang/utils.py
@@ -58,9 +58,7 @@ def split_args(args_str: str) -> List[str]:
             current.append(char)
         elif char in ")]}\"'":
             if not stack:
-                raise ValueError(
-                    f"Invalid syntax for string: {args_str}; unexpected closing '{char}'"
-                )
+                raise ValueError(f"Invalid syntax for string: {args_str}; unexpected closing '{char}'")
             if char != closing_char[stack[-1]]:
                 raise ValueError(
                     f"Invalid syntax for string: {args_str}; expecting {closing_char[stack[-1]]} and got {char}"

--- a/nemoguardrails/colang/v1_0/lang/utils.py
+++ b/nemoguardrails/colang/v1_0/lang/utils.py
@@ -57,6 +57,10 @@ def split_args(args_str: str) -> List[str]:
             stack.append(char)
             current.append(char)
         elif char in ")]}\"'":
+            if not stack:
+                raise ValueError(
+                    f"Invalid syntax for string: {args_str}; unexpected closing '{char}'"
+                )
             if char != closing_char[stack[-1]]:
                 raise ValueError(
                     f"Invalid syntax for string: {args_str}; expecting {closing_char[stack[-1]]} and got {char}"

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from nemoguardrails.colang.v1_0.lang.utils import get_numbered_lines, split_args
 
 
@@ -44,3 +46,12 @@ def test_get_numbered_lines_or_continuation_merges():
     # A valid " or" continuation still merges onto the next line.
     lines = get_numbered_lines("define flow test\n  a or\n  b")
     assert [line["text"] for line in lines] == ["define flow test", "a or b"]
+
+
+@pytest.mark.parametrize("args_str", [")", "a)b", "foo]", "x=1, y)", "}"])
+def test_split_args_unbalanced_closing_bracket_raises_value_error(args_str):
+    # A stray closing bracket with no matching opener previously indexed an empty
+    # `stack` (`closing_char[stack[-1]]`), raising an uncaught IndexError instead of
+    # the ValueError the function uses to report invalid syntax.
+    with pytest.raises(ValueError):
+        split_args(args_str)


### PR DESCRIPTION
Fixes #2144

### Description
`split_args` reads `closing_char[stack[-1]]` for every closing character, but when a `)`, `]`, or `}` appears with an empty bracket stack, `stack[-1]` raises an uncaught `IndexError`. (Quote characters are unaffected — they are treated as openers on an empty stack.) This adds an explicit empty-stack guard that raises the same `ValueError` the function already uses to report malformed input, so callers get a consistent, catchable error instead of an `IndexError`.

### Steps to reproduce (before this fix)
```python
from nemoguardrails.colang.v1_0.lang.utils import split_args
split_args("x=1, y)")   # IndexError: list index out of range
```
Also affected: `")"`, `"a)b"`, `"foo]"`, `"}"`.

### Test plan
- Added a parametrized regression test in `tests/test_parser_utils.py` covering `")"`, `"a)b"`, `"foo]"`, `"x=1, y)"`, `"}"`; each now asserts `ValueError`.
- Verified the new test fails before the fix (`IndexError`) and passes after; existing `split_args` tests and the mismatched-bracket `ValueError` path are unchanged.

### AI disclosure
This change was drafted with the assistance of an AI coding assistant; I reproduced the bug and verified the fix and tests before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument parsing to handle unexpected closing brackets more gracefully.
  * Replaced an internal crash case with a clear error message when bracket or quote characters are unbalanced.
  * Added coverage for several malformed input examples to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->