### PR TITLE
fix(streaming): fail closed when rail actions fail

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -2015,8 +2015,26 @@ class LLMRails(BaseGuardrails):
                         action_params=action_params,
                     )
 
-                    result = await self.runtime.action_dispatcher.execute_action(action_name, params)
+                    try:
+                        result, status = await self.runtime.action_dispatcher.execute_action(action_name, params)
+                    except Exception:
+                        log.exception("Action %s failed during sequential streaming", action_name)
+                        result, status = None, "failed"
                     self._explain_info = self._ensure_explain_info()
+
+                    if status != "success":
+                        error_message = f"Action {action_name} failed with status: {status}"
+                        log.error(error_message)
+                        error_data = {
+                            "error": {
+                                "message": f"Internal error in {flow_id} rail: {error_message}",
+                                "type": "internal_error",
+                                "param": flow_id,
+                                "code": "rail_execution_failure",
+                            }
+                        }
+                        yield json.dumps(error_data)
+                        return
 
                     action_func = self.runtime.action_dispatcher.get_action(action_name)
 

--- a/tests/test_streaming_internal_errors.py
+++ b/tests/test_streaming_internal_errors.py
@@ -23,6 +23,7 @@ import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.imports import check_optional_dependency
 from tests.utils import TestChat
 
@@ -107,6 +108,67 @@ async def test_streaming_action_execution_failure():
     assert "failing safety check" in error["error"]["message"]
     assert "Action failing_rail_action failed with status: failed" in error["error"]["message"]
     assert error["error"]["param"] == "failing safety check"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action_error",
+    [
+        pytest.param(RuntimeError("Action execution failed"), id="runtime-error"),
+        pytest.param(LLMCallException(RuntimeError("LLM call failed")), id="llm-call-error"),
+    ],
+)
+async def test_sequential_streaming_action_execution_failure(action_error: Exception):
+    """Test fail-closed behavior in sequential streaming when a rail action fails."""
+
+    @action(is_system_action=True)
+    def failing_rail_action(**params):
+        raise action_error
+
+    config = RailsConfig.from_content(
+        config={
+            "models": [{"type": "main", "engine": "openai", "model": "gpt-3.5-turbo"}],
+            "rails": {
+                "output": {
+                    "parallel": False,
+                    "flows": ["failing safety check"],
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                    },
+                }
+            },
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+        define flow
+          user express greeting
+          bot express greeting
+
+        define subflow failing safety check
+          execute failing_rail_action
+        """,
+    )
+
+    llm_completions = [
+        'bot express greeting\n  "Hello there! How can I help you?"',
+    ]
+
+    chat = TestChat(config, llm_completions=llm_completions, streaming=True)
+    chat.app.register_action(failing_rail_action)
+
+    chunks = await collect_streaming_chunks(chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]))
+
+    internal_error_chunks = find_internal_error_chunks(chunks)
+    assert len(internal_error_chunks) == 1
+    error = internal_error_chunks[0]["error"]
+    assert error == {
+        "message": "Internal error in failing safety check rail: Action failing_rail_action failed with status: failed",
+        "type": "internal_error",
+        "param": "failing safety check",
+        "code": "rail_execution_failure",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fail closed when a sequential streaming output-rail action fails. dispatcher result is unpacked explicitly, and failed actions now return the same structured `rail_execution_failure` response as the parallel streaming path.

Adds an end-to-end regression test using a file-based rail configuration.

## Verification

https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/29028725375/attempts/1#summary-86155422708

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming now stops immediately and returns a clear internal error if an output-rail action fails during sequential execution.
  * Error responses in streamed output are now more specific, including the affected rail and failure status.
  * Added test coverage for sequential streaming failures to ensure consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->