### PR TITLE
chore(deps): add uv dependency cooldown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,10 @@ When updating the canonical uv version, update
 `.github/actions/setup-uv/action.yml`, `.gitlab-ci.yml`, and the uv image version
 and digest in `Dockerfile` together.
 
+Dependency resolution uses a seven-day cooldown, so newly uploaded distributions
+are eligible only after seven days. To make an emergency package update without
+waiting, use `uv lock --upgrade-package <package> --exclude-newer-package <package>=false`.
+
 Clone the repository and install development dependencies:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ dev = [
 
 [tool.uv]
 package = true
+exclude-newer = "7 days"
 
 # Flat layout: the importable package is ./nemoguardrails (not under ./src).
 # uv_build ships everything under the module dir (Python plus the .co/.lark/.yml

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"


### PR DESCRIPTION
## Description

Adds a seven-day dependency cooldown to uv resolution. Newly uploaded package
distributions are excluded until the cooldown expires, and the lockfile records
the relative cutoff. Contributor guidance documents the per-package emergency
override.

## Verification

- `uv lock --check`
- `uv run --locked pre-commit run --files pyproject.toml uv.lock CONTRIBUTING.md PR.md`

No tests were added because this changes dependency-resolution configuration and
documentation only.

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup guidance to explain the seven-day dependency-resolution cooldown.
  * Added instructions for performing emergency package updates when needed.

* **Chores**
  * Configured dependency handling to avoid resolving newly published package versions for seven days, improving build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->