### PR TITLE
ci: enforce coverage quality gates

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,15 +2,19 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 0.25%
+        informational: false
     patch:
       default:
+        target: 90%
+        threshold: 0%
         informational: true
 
 comment:
   layout: " diff, flags, files"
   behavior: default
-  require_changes: false # if true: only post the comment if coverage changes
+  require_changes: "coverage_drop OR uncovered_patch"
   require_base: false # [true :: must have a base report to post]
   require_head: true # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,7 +77,7 @@ jobs:
           # Enable the langchain-community provider drift canary only when
           # testing upgraded dependencies (the scheduled latest-deps job).
           LANGCHAIN_PROVIDER_DRIFT_CHECK: ${{ inputs.upgrade-deps && '1' || '' }}
-        run: make test-coverage
+        run: make test-coverage ARGS="--cov-fail-under=85 --cov-report=term"
 
       - name: Run pytest without coverage
         if: inputs.with-coverage == false


### PR DESCRIPTION
## Description

This change turns the existing package coverage signal into a staged quality
gate now that the full test suite consistently reports approximately 86%
coverage.

It makes the following changes:

- Enforces an 85% package-wide floor in the canonical coverage job with
  pytest-cov's `--cov-fail-under` option.
- Restores a terminal coverage report alongside the existing XML report so the
  measured total and failure reason are visible directly in CI logs.
- Makes the Codecov project status non-informational, compares it with the base
  commit using `target: auto`, and permits a 0.25 percentage-point tolerance.
- Sets a 90% patch coverage target while keeping the patch status informational
  during the initial observation period.
- Limits Codecov PR comments to project coverage drops or uncovered patch lines
  to reduce comments that do not require contributor attention.

The absolute 85% CI floor protects against a large package-wide regression even
when no usable Codecov base report is available. The relative Codecov project
status prevents gradual erosion from the current baseline. The patch target
encourages changed code to exceed the historical package average without making
that new policy a merge gate before its behavior has been observed across
representative pull requests.

The coverage run remains limited to the existing Ubuntu/Python 3.11 matrix entry
in `.github/workflows/pr-tests.yml`; this avoids repeating an equivalent coverage
measurement across the full Python compatibility matrix.

### References

- Codecov project and patch status semantics:
  [Status Checks](https://docs.codecov.com/docs/commit-status)
- Codecov blocking, relative, and patch coverage examples:
  [Common Configurations](https://docs.codecov.com/docs/common-recipe-list)
- Codecov PR comment filters, including `coverage_drop` and `uncovered_patch`:
  [Pull Request Comments](https://docs.codecov.com/docs/pull-request-comments)
- Codecov repository YAML locations and validation:
  [Codecov YAML](https://docs.codecov.com/docs/codecov-yaml)
- pytest-cov definitions for `--cov-fail-under` and multiple report formats:
  [Configuration](https://pytest-cov.readthedocs.io/en/stable/config.html)
- pytest-cov explanation that explicit non-terminal reports suppress the default
  terminal report:
  [Reporting](https://pytest-cov.readthedocs.io/en/stable/reporting.html)


## Verification

- `uv run --locked pre-commit run --files .github/codecov.yml .github/workflows/_test.yml`
  - Passed YAML, whitespace, zizmor, and ty checks.
- `curl --fail-with-body --silent --show-error --data-binary @.github/codecov.yml https://api.codecov.io/validate`
  - Codecov returned `Valid!` and normalized the configured project and patch
    statuses as expected.
- `make test-coverage ARGS="--cov-fail-under=85 --cov-report=term"`
  - 5,254 tests passed and 178 were skipped.
  - Total package coverage was 86.05%.
  - The 85% coverage requirement passed.
  - The run used macOS, Python 3.12.7, and no live provider credentials.
- `git diff --check`
  - Passed.

Residual CI-specific behavior will be exercised by the PR's canonical Ubuntu,
Python 3.11 coverage job. The 90% patch target is intentionally informational;
promoting `codecov/patch` to a required check should be a separate maintainer
decision after observing representative PRs. Repository branch protection was
not modified by this change.


## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable. No user documentation change is required for this CI-only policy.
- [x] I've added tests if applicable. No new test behavior is introduced; the full package coverage suite passed.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed. Complete after automated review runs.
- [ ] @<maintainer-or-team> responsible for reviewing the proposed CI and Codecov policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased automated test coverage requirements to 85%.
  * Added terminal coverage reporting to test runs.

* **Chores**
  * Updated coverage reporting rules to flag coverage drops and uncovered changes.
  * Applied stricter project coverage thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->