### PR TITLE
fix(ci): run zizmor via uvx

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,6 +21,9 @@ on:
     - cron: "17 8 * * 1"
   workflow_dispatch:
 
+env:
+  ZIZMOR_VERSION: "1.26.1"
+
 permissions: {}
 
 jobs:
@@ -34,9 +37,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        with:
-          advanced-security: false
-          online-audits: true
-          token: ${{ github.token }}
-          version: "1.26.1"
+      - uses: ./.github/actions/setup-uv
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uvx "zizmor@${ZIZMOR_VERSION}" --format=github .


### PR DESCRIPTION
## Summary

Run zizmor through its documented PyPI integration with a workflow-level version variable instead of the blocked `zizmorcore/zizmor-action`.

## Reason

The repository's inherited GitHub Actions policy allows GitHub-owned and verified-creator actions. Because `zizmorcore` is not verified, the security workflow stops with `startup_failure` before creating a job or log. Running the same pinned zizmor version through `uvx` avoids the blocked action while preserving online audits.

## Revert condition

Revert to the SHA-pinned `zizmorcore/zizmor-action` when the inherited Actions policy explicitly permits it or `zizmorcore` becomes a verified GitHub organization.

## Verification

- `uv run --locked pre-commit run --files .github/workflows/zizmor.yml PR.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security workflow to run a pinned Zizmor version directly.
  * Standardized workflow setup and reporting while preserving GitHub token-based auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->