### PR TITLE
Handle brackets inside string arguments in split_args

### DIFF
--- a/nemoguardrails/colang/v1_0/lang/utils.py
+++ b/nemoguardrails/colang/v1_0/lang/utils.py
@@ -50,13 +50,21 @@ def split_args(args_str: str) -> List[str]:
     closing_char = {"[": "]", "(": ")", "{": "}", "'": "'", '"': '"'}
 
     for char in args_str:
+        # While inside a string literal, only the matching closing quote is
+        # special; brackets, commas and the other quote type are literal text.
+        if stack and stack[-1] in "\"'":
+            if char == stack[-1]:
+                stack.pop()
+            current.append(char)
+            continue
+
         if char in "([{":
             stack.append(char)
             current.append(char)
-        elif char in "\"'" and (len(stack) == 0 or stack[-1] != char):
+        elif char in "\"'":
             stack.append(char)
             current.append(char)
-        elif char in ")]}\"'":
+        elif char in ")]}":
             if not stack:
                 raise ValueError(f"Invalid syntax for string: {args_str}; unexpected closing '{char}'")
             if char != closing_char[stack[-1]]:

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -55,3 +55,28 @@ def test_split_args_unbalanced_closing_bracket_raises_value_error(args_str):
     # the ValueError the function uses to report invalid syntax.
     with pytest.raises(ValueError):
         split_args(args_str)
+
+
+@pytest.mark.parametrize(
+    "args_str, expected",
+    [
+        # A closing bracket inside a quoted string is literal text, not structural.
+        ('x="]"', ['x="]"']),
+        ('x=")"', ['x=")"']),
+        ('x="}"', ['x="}"']),
+        # Real-world strings: an emoticon or a citation marker.
+        ('msg="Hello :)"', ['msg="Hello :)"']),
+        ('note="cite [1] and (2)"', ['note="cite [1] and (2)"']),
+        ('reason="closed ]"', ['reason="closed ]"']),
+        # A comma inside a string does not split the arguments.
+        ('x="a, b"', ['x="a, b"']),
+        # The other quote character inside a string is literal too.
+        ('x="it\'s ok)"', ['x="it\'s ok)"']),
+        # A bracket-in-string argument alongside a normal argument still splits.
+        ('n=1, x="]"', ["n=1", 'x="]"']),
+    ],
+)
+def test_split_args_bracket_inside_string(args_str, expected):
+    # Brackets, commas, and the other quote character inside a quoted string
+    # argument are literal text and must not be treated as structural syntax.
+    assert split_args(args_str) == expected


### PR DESCRIPTION
## Description

`split_args` (the Colang 1.0 argument parser in `nemoguardrails/colang/v1_0/lang/utils.py`) treats every bracket and quote as structural. While inside a quoted string argument, a closing bracket `)`, `]`, `}` — or the other quote character — is still handled as syntax, so it raises `ValueError` and crashes flow parsing.

This hits ordinary string values: an emoticon, a citation marker, or any clause that ends with a bracket.

```python
>>> from nemoguardrails.colang.v1_0.lang.utils import split_args
>>> split_args('msg="Hello :)"')
ValueError: Invalid syntax for string: msg="Hello :)"; expecting " and got )
```

It also crashes through the public parse path — any Colang 1.0 flow with such an inline string parameter fails to parse:

```python
>>> from nemoguardrails.colang.v1_0.lang.coyml_parser import parse_flow_elements
>>> parse_flow_elements([{"user": 'ask(reason="closed ]")'}])
ValueError: Invalid syntax for string: reason="closed ]"; expecting " and got ]
```

The function's own docstring says it "correctly handles strings and lists/dicts", and the sibling splitters in the same module (`word_split`, `char_split`, `params_tokenize`) already track string state — only `split_args` doesn't.

## Fix

Add a real in-string short-circuit: while the top of the stack is a quote, only the matching closing quote is special; brackets, commas, and the other quote type are literal text. This preserves list/dict argument parsing and still raises `ValueError` for genuinely unbalanced *unquoted* brackets (the behavior added in #2145).

## Test Plan

Added `test_split_args_bracket_inside_string` to `tests/test_parser_utils.py`, covering closing brackets `)]}`, an emoticon, a citation marker, a comma, and the other quote character inside a quoted string, plus a bracket-in-string argument alongside a normal one. The new cases fail on `develop` (`ValueError`) and pass with the fix; the existing `test_1` and the unbalanced-unquoted-bracket cases still pass.

```
$ pytest tests/test_parser_utils.py tests/colang
70 passed

$ ruff check nemoguardrails/colang/v1_0/lang/utils.py tests/test_parser_utils.py
All checks passed!
$ ruff format --check nemoguardrails/colang/v1_0/lang/utils.py tests/test_parser_utils.py
2 files already formatted
```

No linked issue — found by reading the code.
