### PR TITLE
feat(service): Add /v1/health and /healthz endpoints for health checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,8 @@ RUN python -c "from fastembed.embedding import FlagEmbedding; FlagEmbedding('sen
 
 RUN nemoguardrails --help
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python -c "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/v1/health').status == 200 else 1)"
+
 ENTRYPOINT ["nemoguardrails"]
 CMD ["server", "--verbose", "--config=/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,9 @@ RUN python -c "from fastembed.embedding import FlagEmbedding; FlagEmbedding('sen
 
 RUN nemoguardrails --help
 
+ENV NEMO_GUARDRAILS_HEALTHCHECK_URL=http://localhost:8000/v1/health
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD python -c "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/v1/health').status == 200 else 1)"
+    CMD python -c "import os, urllib.request, sys; sys.exit(0 if urllib.request.urlopen(os.environ['NEMO_GUARDRAILS_HEALTHCHECK_URL']).status == 200 else 1)"
 
 ENTRYPOINT ["nemoguardrails"]
 CMD ["server", "--verbose", "--config=/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN nemoguardrails --help
 
 ENV NEMO_GUARDRAILS_HEALTHCHECK_URL=http://localhost:8000/v1/health
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD python -c "import os, urllib.request, sys; sys.exit(0 if urllib.request.urlopen(os.environ['NEMO_GUARDRAILS_HEALTHCHECK_URL']).status == 200 else 1)"
+    CMD python -c "import os, urllib.request, sys; opener = urllib.request.build_opener(urllib.request.ProxyHandler({})); sys.exit(0 if opener.open(os.environ['NEMO_GUARDRAILS_HEALTHCHECK_URL']).status == 200 else 1)"
 
 ENTRYPOINT ["nemoguardrails"]
 CMD ["server", "--verbose", "--config=/config"]

--- a/docs/deployment/using-docker.mdx
+++ b/docs/deployment/using-docker.mdx
@@ -111,6 +111,21 @@ docker run -it \
   nemoguardrails chat --config=/config --verbose
 ```
 
+## Container Health Check
+
+The image defines a Docker `HEALTHCHECK` that probes the server's liveness endpoint, so `docker ps` and orchestrators can report container health.
+By default it requests `http://localhost:8000/v1/health`, which matches the default `CMD` (the `server` command on port `8000` with no path prefix).
+
+If you run the container on a different port or behind a path prefix, override the probe URL with the `NEMO_GUARDRAILS_HEALTHCHECK_URL` environment variable so the healthcheck targets the address the server actually serves:
+
+```bash
+docker run \
+  -p 9000:9000 \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -e NEMO_GUARDRAILS_HEALTHCHECK_URL=http://localhost:9000/v1/health \
+  nemoguardrails server --config=/config --port 9000
+```
+
 ## AlignScore Fact-Checking
 
 If one of your configurations uses the AlignScore fact-checking model, run the AlignScore server in a separate container:

--- a/docs/deployment/using-docker.mdx
+++ b/docs/deployment/using-docker.mdx
@@ -106,10 +106,16 @@ To use the Chat CLI interface, run the Docker container in interactive mode:
 
 ```bash
 docker run -it \
+  --no-healthcheck \
   -e OPENAI_API_KEY=$OPENAI_API_KEY \
   -v </path/to/local/config/>:/config \
   nemoguardrails chat --config=/config --verbose
 ```
+
+The image's built-in Docker `HEALTHCHECK` probes the server's liveness endpoint, so it is only meaningful when the container runs the default `server` command.
+Other commands such as `chat`, `actions-server`, `convert`, or `eval` do not serve a health endpoint.
+This means Docker would report the container as `unhealthy`.
+Add `--no-healthcheck` to `docker run` whenever the container does not run the server, as shown in the `chat` example above.
 
 ## Container Health Check
 
@@ -125,6 +131,9 @@ docker run \
   -e NEMO_GUARDRAILS_HEALTHCHECK_URL=http://localhost:9000/v1/health \
   nemoguardrails server --config=/config --port 9000
 ```
+
+The health check applies only to the `server` application.
+For other commands, disable it with `--no-healthcheck`.
 
 ## AlignScore Fact-Checking
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -602,6 +602,12 @@ navigation:
                 title: List Challenges
                 slug: list-challenges
           - health:
+              - endpoint: GET /v1/health
+                title: Health Check
+                slug: get-health
+              - endpoint: GET /healthz
+                title: Health Check (Alias)
+                slug: get-healthz
               - endpoint: GET /
                 title: Get Server Health or Chat UI
                 slug: get-root

--- a/docs/run-rails/using-fastapi-server/run-guardrails-server.mdx
+++ b/docs/run-rails/using-fastapi-server/run-guardrails-server.mdx
@@ -226,6 +226,23 @@ For production deployments, disable it using the `--disable-chat-ui` flag.
 
 </Info>
 
+## Health Check
+
+The server exposes a liveness endpoint at `GET /v1/health` for orchestrators, load balancers, and container runtimes.
+It returns HTTP `200` with the `application/health+json` media type and a body of `{"status": "pass"}` whenever the server process is running and able to serve requests.
+
+```bash
+curl http://localhost:8000/v1/health
+```
+
+```json
+{"status": "pass"}
+```
+
+The check is intentionally shallow: it reflects only that the server process is up, and does not verify guardrails configurations, the model provider, or any datastore.
+Use this endpoint rather than `GET /` for health probes, because `GET /` redirects to the chat UI when the UI is enabled.
+When the server runs behind a path prefix (`--prefix`), the endpoint is served at `<prefix>/v1/health`.
+
 ## Related Topics
 
 - [Chat with a Guardrailed Model](/run-guardrailed-inference/using-fastapi-server/chat-with-guardrailed-model)

--- a/docs/run-rails/using-fastapi-server/run-guardrails-server.mdx
+++ b/docs/run-rails/using-fastapi-server/run-guardrails-server.mdx
@@ -228,7 +228,7 @@ For production deployments, disable it using the `--disable-chat-ui` flag.
 
 ## Health Check
 
-The server exposes a liveness endpoint at `GET /v1/health` for orchestrators, load balancers, and container runtimes.
+The server exposes a liveness endpoint at `GET /v1/health` (also available as `GET /healthz`) for orchestrators, load balancers, and container runtimes.
 It returns HTTP `200` with the `application/health+json` media type and a body of `{"status": "pass"}` whenever the server process is running and able to serve requests.
 
 ```bash
@@ -241,7 +241,7 @@ curl http://localhost:8000/v1/health
 
 The check is intentionally shallow: it reflects only that the server process is up, and does not verify guardrails configurations, the model provider, or any datastore.
 Use this endpoint rather than `GET /` for health probes, because `GET /` redirects to the chat UI when the UI is enabled.
-When the server runs behind a path prefix (`--prefix`), the endpoint is served at `<prefix>/v1/health`.
+When the server runs behind a path prefix (`--prefix`), the endpoints are served at `<prefix>/v1/health` and `<prefix>/healthz`.
 
 ## Related Topics
 

--- a/fern/openapi.yml
+++ b/fern/openapi.yml
@@ -189,6 +189,51 @@ paths:
                     - id: jailbreak-1
                       description: Attempt to bypass safety guardrails.
                       category: jailbreak
+  /v1/health:
+    get:
+      operationId: getHealth
+      tags:
+        - Health
+      summary: Liveness health check
+      description: |
+        Shallow liveness check. Returns HTTP 200 while the server process is
+        running and able to serve requests. It does not verify guardrails
+        configurations, the model provider, or any datastore.
+      responses:
+        "200":
+          description: The server process is up and able to serve requests.
+          content:
+            application/health+json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: pass
+              example:
+                status: pass
+  /healthz:
+    get:
+      operationId: getHealthz
+      tags:
+        - Health
+      summary: Liveness health check (alias)
+      description: |
+        Kubernetes-style alias for `GET /v1/health`. Returns the same shallow
+        liveness response.
+      responses:
+        "200":
+          description: The server process is up and able to serve requests.
+          content:
+            application/health+json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: pass
+              example:
+                status: pass
   /:
     get:
       operationId: getRoot

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -256,10 +256,12 @@ async def get_rails_configs():
 @app.get(
     "/v1/health",
     summary="Liveness health check.",
+    tags=["Health"],
 )
 @app.get(
     "/healthz",
     summary="Liveness health check.",
+    tags=["Health"],
 )
 async def health():
     """Return HTTP 200 while the server process is running and able to serve requests."""

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -257,6 +257,10 @@ async def get_rails_configs():
     "/v1/health",
     summary="Liveness health check.",
 )
+@app.get(
+    "/healthz",
+    summary="Liveness health check.",
+)
 async def health():
     """Return HTTP 200 while the server process is running and able to serve requests."""
     return JSONResponse(content={"status": "pass"}, media_type="application/health+json")

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -29,7 +29,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ValidationError
-from starlette.responses import RedirectResponse, StreamingResponse
+from starlette.responses import JSONResponse, RedirectResponse, StreamingResponse
 
 from nemoguardrails import LLMRails, RailsConfig, utils
 from nemoguardrails.rails.llm.config import Model
@@ -251,6 +251,15 @@ async def get_rails_configs():
     ]
 
     return [{"id": config_id} for config_id in config_ids]
+
+
+@app.get(
+    "/v1/health",
+    summary="Liveness health check.",
+)
+async def health():
+    """Return HTTP 200 while the server process is running and able to serve requests."""
+    return JSONResponse(content={"status": "pass"}, media_type="application/health+json")
 
 
 @app.get(

--- a/tests/server/test_health.py
+++ b/tests/server/test_health.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
+from fastapi.testclient import TestClient
+
+from nemoguardrails.server import api
+
+client = TestClient(api.app)
+
+ENDPOINT = "/v1/health"
+
+
+def test_health_returns_200_pass_status():
+    """GET /v1/health returns HTTP 200 with a JSON body of {"status": "pass"}."""
+    response = client.get(ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pass"}
+
+
+def test_health_uses_health_json_media_type():
+    """GET /v1/health responds with the application/health+json media type."""
+    response = client.get(ENDPOINT)
+
+    assert response.headers["content-type"].startswith("application/health+json")

--- a/tests/server/test_health.py
+++ b/tests/server/test_health.py
@@ -56,3 +56,12 @@ def test_health_ok_without_config_or_cached_rails(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"status": "pass"}
+
+
+def test_healthz_alias_matches_health_contract():
+    """GET /healthz returns the same 200 application/health+json {"status": "pass"} response as /v1/health."""
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/health+json"
+    assert response.json() == {"status": "pass"}

--- a/tests/server/test_health.py
+++ b/tests/server/test_health.py
@@ -34,7 +34,25 @@ def test_health_returns_200_pass_status():
 
 
 def test_health_uses_health_json_media_type():
-    """GET /v1/health responds with the application/health+json media type."""
+    """GET /v1/health responds with exactly the application/health+json media type."""
     response = client.get(ENDPOINT)
 
-    assert response.headers["content-type"].startswith("application/health+json")
+    assert response.headers["content-type"] == "application/health+json"
+
+
+def test_health_rejects_post_with_405():
+    """POST /v1/health returns HTTP 405 because the endpoint is GET-only."""
+    response = client.post(ENDPOINT)
+
+    assert response.status_code == 405
+
+
+def test_health_ok_without_config_or_cached_rails(monkeypatch):
+    """GET /v1/health returns 200 with no default config and no cached rails instances."""
+    monkeypatch.setattr(api.app, "default_config_id", None)
+    monkeypatch.setattr(api, "llm_rails_instances", {})
+
+    response = client.get(ENDPOINT)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pass"}


### PR DESCRIPTION
## Description

Adds `/v1/health` and `/healthz` endpoints for use by Kubernetes / Docker / clients to check the service is running. It's a shallow check, and doesn't check for downstream dependencies like the main-model or Guardrail models. It also doesn't check if a default Guardrails config was configured at server start-time, or if any are cached in the server `llm_rails_instances` variable.

## Related Issue(s)

* [NGUARD-808](https://jirasw.nvidia.com/browse/NGUARD-808)

## Test Plan

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
...................................................................................................... [  1%]
......................................................................................s...ss.ss.ss.s.s [  3%]
....s..s.........................................................s.................................... [  5%]
...................................................................................................... [  7%]
..........................................................................................ss.......... [  9%]
...................................................................................................... [ 11%]
...s.................................................................................................. [ 13%]
...................................................................................................... [ 14%]
...................................................................................................... [ 16%]
...................................................................................................... [ 18%]
...................................................................................................... [ 20%]
...s...............................................................................s.................. [ 22%]
...................................................................................................... [ 24%]
.........................................................s............................................ [ 26%]
...................................................................................................... [ 27%]
...................................................................................................... [ 29%]
...................................................................................................... [ 31%]
.....................................................................ssss.sss......................sss [ 33%]
ss.sss..........................................................................................s..... [ 35%]
...................................................................................................... [ 37%]
...................................................................................................... [ 39%]
.........................................................s....................s.....s................. [ 41%]
...................................................................................................... [ 42%]
...................................................................................................... [ 44%]
...................................................................................................... [ 46%]
..........................s.ssssss.s...............ssss..ss....ss..s...........................sssssss [ 48%]
.s..s...sss.s......................................................................................... [ 50%]
...................................................................................................... [ 52%]
..........................................sss.s...s.s..ss............................................. [ 54%]
..........................................ss.......................................................... [ 55%]
.....................................s................................................................ [ 57%]
...................................................................................................... [ 59%]
.................................sssss...........sssssss.sssssss.ss.ss................................ [ 61%]
.................................................................s.................................... [ 63%]
...................................................................................................... [ 65%]
...................................................................................................... [ 67%]
.....................................................................................................s [ 68%]
ssss.....................................................................................sssssss...... [ 70%]
............s.....................................ss.................................................. [ 72%]
...................................................................................................... [ 74%]
......................................ss.................................s.s.......................... [ 76%]
...................................................................................................... [ 78%]
...................................................................................................... [ 80%]
.....................................................................................ss............... [ 82%]
.....s..........s....................sssssssssssss.................................................... [ 83%]
....................ssssss.......................s.................................................... [ 85%]
.s.ss................................................................................................. [ 87%]
.ss.......................................s........................................................... [ 89%]
...............s...........................s.......................................................... [ 91%]
..s............................ss........................s.....s...................................... [ 93%]
......................................................................................sssssssss.ssssss [ 95%]
ssss.................................................................................................. [ 96%]
.................................................................................s.................... [ 98%]
................................................................                                       [100%]

══════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue
to run, but snapshot(x) will only return x and inline-snapshot will not be able to fix snapshots or generate
reports.


===================================== 5292 passed, 178 skipped in 30.52s =====================================
```


## Integration tests

### Local server health checks

**Server**
```
$ uv run nemoguardrails server --config examples/configs --default-config-id nemoguards
INFO:     Started server process [20447]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:62546 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:62550 - "GET /healthz HTTP/1.1" 200 OK
```

**Client**

```
$ curl -i http://localhost:8000/v1/health
HTTP/1.1 200 OK
date: Mon, 13 Jul 2026 19:41:13 GMT
server: uvicorn
content-length: 17
content-type: application/health+json

{"status":"pass"}%
$ curl -i http://localhost:8000/healthz
HTTP/1.1 200 OK
date: Mon, 13 Jul 2026 19:41:19 GMT
server: uvicorn
content-length: 17
content-type: application/health+json

{"status":"pass"}%
```

### Docker health checks

**Server**
```
# Build image
$ docker build -t nemoguardrails:health-test .

# Inspect health check
$ docker inspect --format '{{json .Config.Healthcheck}}' nemoguardrails:health-test
{"Test":["CMD-SHELL","python -c \"import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/v1/health').status == 200 else 1)\""],"Interval":30000000000,"Timeout":5000000000,"StartPeriod":60000000000,"Retries":3}

# Run the container
$ docker run -d --name ng-health -p 8000:8000 nemoguardrails:health-test
89f354c836fe1f040d05503d93a78be2f6dc2b59da6e97523585e6e7748bc690

# Check if the service is up (waited for a couple of minutes)
$ docker logs -f ng-health
Warning: Input is not a terminal (fd=0).
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:40768 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:38594 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     192.168.65.1:40653 - "GET /v1/health HTTP/1.1" 200 OK <- From the client curl command below
INFO:     192.168.65.1:18994 - "GET /healthz HTTP/1.1" 200 OK <- From the client curl command below
INFO:     127.0.0.1:49318 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:49280 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:52430 - "GET /v1/health HTTP/1.1" 200 OK
INFO:     127.0.0.1:59394 - "GET /v1/health HTTP/1.1" 200 OK
```

**Client** checking health endpoints inside Docker container

```
$ curl -i http://localhost:8000/v1/health
HTTP/1.1 200 OK
date: Mon, 13 Jul 2026 19:48:35 GMT
server: uvicorn
content-length: 17
content-type: application/health+json

{"status":"pass"}%
➜  ~ curl -i http://localhost:8000/healthz
HTTP/1.1 200 OK
date: Mon, 13 Jul 2026 19:48:39 GMT
server: uvicorn
content-length: 17
content-type: application/health+json

{"status":"pass"}%
```

**Docker inspect health**
```
$ docker inspect \
  --format='{{.State.Health.Status}}' \
  ng-health

healthy
```

## Docs build check

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 290 pages at /Users/tgasser/projects/nemo_guardrails_worktree/feat/service-health/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries
npm notice New minor version of npm available! 11.12.1 -> 11.18.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.18.0
npm notice To update run: npm install -g npm@11.18.0
node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" check
All checks passed
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added liveness health-check endpoints at `/v1/health` and `/healthz`.
  * Health checks return a standardized success response when the server process is available.
  * Containers now report their health automatically based on the server health endpoint.

* **Documentation**
  * Documented health-check endpoints, response formats, and behavior, including prefixed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->