### PR TITLE
feat(library): namespace custom task prompts in self-check

### DIFF
--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -21,7 +21,7 @@ from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.library.self_check.utils import (
     SELF_CHECK_INPUT_DEFAULT_TASK,
     SELF_CHECK_INPUT_FLOW,
-    SELF_CHECK_INPUT_TASK_PARAM,
+    SELF_CHECK_INPUT_VARIANT_PARAM,
     resolve_self_check_task,
     run_self_check_task,
 )
@@ -64,7 +64,7 @@ async def self_check_input(
         triggered_rail_key="triggered_input_rail",
         start_rail_event_type="StartInputRail",
         flow_id=SELF_CHECK_INPUT_FLOW,
-        task_param=SELF_CHECK_INPUT_TASK_PARAM,
+        variant_param=SELF_CHECK_INPUT_VARIANT_PARAM,
         default_task=DEFAULT_TASK,
     )
 

--- a/nemoguardrails/library/self_check/input_check/flows.co
+++ b/nemoguardrails/library/self_check/input_check/flows.co
@@ -1,5 +1,5 @@
-flow self check input $task="self_check_input"
-  $allowed = await SelfCheckInputAction(task=$task)
+flow self check input $variant="self_check_input"
+  $allowed = await SelfCheckInputAction(task=$variant)
 
   if not $allowed
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -21,7 +21,7 @@ from nemoguardrails.actions import action
 from nemoguardrails.library.self_check.utils import (
     SELF_CHECK_OUTPUT_DEFAULT_TASK,
     SELF_CHECK_OUTPUT_FLOW,
-    SELF_CHECK_OUTPUT_TASK_PARAM,
+    SELF_CHECK_OUTPUT_VARIANT_PARAM,
     resolve_self_check_task,
     run_self_check_task,
 )
@@ -68,7 +68,7 @@ async def self_check_output(
         triggered_rail_key="triggered_output_rail",
         start_rail_event_type="StartOutputRail",
         flow_id=SELF_CHECK_OUTPUT_FLOW,
-        task_param=SELF_CHECK_OUTPUT_TASK_PARAM,
+        variant_param=SELF_CHECK_OUTPUT_VARIANT_PARAM,
         default_task=DEFAULT_TASK,
     )
 

--- a/nemoguardrails/library/self_check/output_check/flows.co
+++ b/nemoguardrails/library/self_check/output_check/flows.co
@@ -1,5 +1,5 @@
-flow self check output $task="self_check_output"
-  $allowed = await SelfCheckOutputAction(task=$task)
+flow self check output $variant="self_check_output"
+  $allowed = await SelfCheckOutputAction(task=$variant)
 
   if not $allowed
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import logging
+import warnings
+from collections.abc import Collection
 from typing import Any, Dict, List, Optional
 
 from nemoguardrails.actions.llm.utils import llm_call, warn_if_truncated
@@ -40,11 +42,26 @@ def get_self_check_task_from_rail(flow: Any, flow_id: str, task_param: str, defa
     return _get_flow_params(flow).get(task_param) or default_task
 
 
-def get_self_check_prompt_task(task: str, default_task: str) -> str:
+def get_self_check_prompt_task(
+    task: str, default_task: str, available_prompt_tasks: Optional[Collection[str]] = None
+) -> str:
     if task == default_task:
         return task
 
-    return f"{default_task} ${SELF_CHECK_TASK_PARAM}={task}"
+    prompt_task = f"{default_task} ${SELF_CHECK_TASK_PARAM}={task}"
+    if (
+        available_prompt_tasks is not None
+        and prompt_task not in available_prompt_tasks
+        and task in available_prompt_tasks
+    ):
+        warnings.warn(
+            f"The `{task}` self-check prompt task is deprecated; rename it to `{prompt_task}`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return task
+
+    return prompt_task
 
 
 def resolve_self_check_task(
@@ -129,7 +146,8 @@ async def run_self_check_task(
     max_tokens: int = 1024,
 ) -> tuple[bool, str]:
     llm = get_self_check_llm(llms, task, default_task=default_task, main_llm=main_llm)
-    prompt_task = get_self_check_prompt_task(task, default_task)
+    available_prompt_tasks = {prompt.task for prompt in llm_task_manager.config.prompts or []}
+    prompt_task = get_self_check_prompt_task(task, default_task, available_prompt_tasks)
 
     prompt = llm_task_manager.render_task_prompt(
         task=prompt_task,

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -26,8 +26,9 @@ log = logging.getLogger(__name__)
 
 SELF_CHECK_INPUT_FLOW = "self check input"
 SELF_CHECK_OUTPUT_FLOW = "self check output"
-SELF_CHECK_INPUT_TASK_PARAM = "task"
-SELF_CHECK_OUTPUT_TASK_PARAM = "task"
+SELF_CHECK_TASK_PARAM = "task"
+SELF_CHECK_INPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
+SELF_CHECK_OUTPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
 SELF_CHECK_INPUT_DEFAULT_TASK = "self_check_input"
 SELF_CHECK_OUTPUT_DEFAULT_TASK = "self_check_output"
 
@@ -37,6 +38,13 @@ def get_self_check_task_from_rail(flow: Any, flow_id: str, task_param: str, defa
         return None
 
     return _get_flow_params(flow).get(task_param) or default_task
+
+
+def get_self_check_prompt_task(task: str, default_task: str) -> str:
+    if task == default_task:
+        return task
+
+    return f"{default_task} ${SELF_CHECK_TASK_PARAM}={task}"
 
 
 def resolve_self_check_task(
@@ -121,15 +129,16 @@ async def run_self_check_task(
     max_tokens: int = 1024,
 ) -> tuple[bool, str]:
     llm = get_self_check_llm(llms, task, default_task=default_task, main_llm=main_llm)
+    prompt_task = get_self_check_prompt_task(task, default_task)
 
     prompt = llm_task_manager.render_task_prompt(
-        task=task,
+        task=prompt_task,
         context=prompt_context,
     )
-    stop = llm_task_manager.get_stop_tokens(task=task)
-    task_max_tokens = llm_task_manager.get_max_tokens(task=task) or max_tokens
+    stop = llm_task_manager.get_stop_tokens(task=prompt_task)
+    task_max_tokens = llm_task_manager.get_max_tokens(task=prompt_task) or max_tokens
 
-    llm_call_info_var.set(LLMCallInfo(task=task))
+    llm_call_info_var.set(LLMCallInfo(task=prompt_task))
 
     llm_response = await llm_call(
         llm,
@@ -140,8 +149,8 @@ async def run_self_check_task(
             "max_tokens": task_max_tokens,
         },
     )
-    warn_if_truncated(llm_response, task)
+    warn_if_truncated(llm_response, prompt_task)
     response = llm_response.content
 
-    result = parse_self_check_output(llm_task_manager, task, response)
+    result = parse_self_check_output(llm_task_manager, prompt_task, response)
     return bool(result[0]), response

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 SELF_CHECK_INPUT_FLOW = "self check input"
 SELF_CHECK_OUTPUT_FLOW = "self check output"
-SELF_CHECK_TASK_PARAM = "task"
+SELF_CHECK_TASK_PARAM = "variant"
 SELF_CHECK_INPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
 SELF_CHECK_OUTPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
 SELF_CHECK_INPUT_DEFAULT_TASK = "self_check_input"
@@ -45,6 +45,7 @@ def get_self_check_task_from_rail(flow: Any, flow_id: str, task_param: str, defa
 def get_self_check_prompt_task(
     task: str, default_task: str, available_prompt_tasks: Optional[Collection[str]] = None
 ) -> str:
+    """Resolve the prompt task name while supporting deprecated bare custom tasks."""
     if task == default_task:
         return task
 

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -28,18 +28,18 @@ log = logging.getLogger(__name__)
 
 SELF_CHECK_INPUT_FLOW = "self check input"
 SELF_CHECK_OUTPUT_FLOW = "self check output"
-SELF_CHECK_TASK_PARAM = "variant"
-SELF_CHECK_INPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
-SELF_CHECK_OUTPUT_TASK_PARAM = SELF_CHECK_TASK_PARAM
+SELF_CHECK_VARIANT_PARAM = "variant"
+SELF_CHECK_INPUT_VARIANT_PARAM = SELF_CHECK_VARIANT_PARAM
+SELF_CHECK_OUTPUT_VARIANT_PARAM = SELF_CHECK_VARIANT_PARAM
 SELF_CHECK_INPUT_DEFAULT_TASK = "self_check_input"
 SELF_CHECK_OUTPUT_DEFAULT_TASK = "self_check_output"
 
 
-def get_self_check_task_from_rail(flow: Any, flow_id: str, task_param: str, default_task: str) -> Optional[str]:
+def get_self_check_task_from_rail(flow: Any, flow_id: str, variant_param: str, default_task: str) -> Optional[str]:
     if not isinstance(flow, str) or _normalize_flow_id(flow) != flow_id:
         return None
 
-    return _get_flow_params(flow).get(task_param) or default_task
+    return _get_flow_params(flow).get(variant_param) or default_task
 
 
 def get_self_check_prompt_task(
@@ -49,7 +49,7 @@ def get_self_check_prompt_task(
     if task == default_task:
         return task
 
-    prompt_task = f"{default_task} ${SELF_CHECK_TASK_PARAM}={task}"
+    prompt_task = f"{default_task} ${SELF_CHECK_VARIANT_PARAM}={task}"
     if (
         available_prompt_tasks is not None
         and prompt_task not in available_prompt_tasks
@@ -72,7 +72,7 @@ def resolve_self_check_task(
     triggered_rail_key: str,
     start_rail_event_type: str,
     flow_id: str,
-    task_param: str,
+    variant_param: str,
     default_task: str,
 ) -> str:
     if task and not task.startswith("$"):
@@ -82,7 +82,7 @@ def resolve_self_check_task(
     context_task = get_self_check_task_from_rail(
         context.get(triggered_rail_key),
         flow_id=flow_id,
-        task_param=task_param,
+        variant_param=variant_param,
         default_task=default_task,
     )
     if context_task:
@@ -91,13 +91,13 @@ def resolve_self_check_task(
     for event in reversed(events or []):
         if event.get("type") == "start_flow" and event.get("flow_id") == flow_id:
             event_params = event.get("params") or {}
-            return event_params.get(task_param) or default_task
+            return event_params.get(variant_param) or default_task
 
         if event.get("type") == start_rail_event_type:
             event_task = get_self_check_task_from_rail(
                 event.get("flow_id"),
                 flow_id=flow_id,
-                task_param=task_param,
+                variant_param=variant_param,
                 default_task=default_task,
             )
             if event_task:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1960,8 +1960,8 @@ class RailsConfig(BaseModel):
         provided_task_prompts = [prompt.task if hasattr(prompt, "task") else prompt.get("task") for prompt in prompts]
 
         # Input moderation prompt verification
-        _validate_self_check_prompts(
-            enabled_input_rails, provided_task_prompts, "self check input", "self_check_input", "task"
+        _validate_self_check_rail_prompts(
+            enabled_input_rails, provided_task_prompts, "self check input", "self_check_input"
         )
         if "llama guard check input" in enabled_input_rails and "llama_guard_check_input" not in provided_task_prompts:
             raise InvalidRailsConfigurationError(
@@ -1975,8 +1975,8 @@ class RailsConfig(BaseModel):
         _validate_rail_prompts(enabled_input_rails, provided_task_prompts, "topic safety check input")
 
         # Output moderation prompt verification
-        _validate_self_check_prompts(
-            enabled_output_rails, provided_task_prompts, "self check output", "self_check_output", "task"
+        _validate_self_check_rail_prompts(
+            enabled_output_rails, provided_task_prompts, "self check output", "self_check_output"
         )
         if (
             "llama guard check output" in enabled_output_rails
@@ -2363,22 +2363,23 @@ def _get_flow_model(flow_text) -> Optional[str]:
     return flow_text.split(MODEL_PREFIX)[-1].strip()
 
 
-def _validate_self_check_prompts(
-    rails: list[str],
-    prompts: list[Any],
-    flow_name: str,
-    default_task: str,
-    task_param: str,
+def _validate_self_check_rail_prompts(
+    rails: list[str], prompts: list[Any], validation_rail: str, default_task: str
 ) -> None:
+    """Ensure every enabled self-check rail has a prompt for its resolved task.
+
+    A self-check rail may select a custom task via `$task=...`; the task falls
+    back to `default_task` when omitted. Custom prompts are scoped under the
+    default task name.
+    """
     for rail in rails:
-        normalized = _normalize_flow_id(rail)
-        if normalized != flow_name:
+        if _normalize_flow_id(rail) != validation_rail:
             continue
-        custom_task = _get_flow_params(rail).get(task_param)
-        expected = custom_task if custom_task else default_task
-        if expected not in prompts:
+        task = _get_flow_params(rail).get("task") or default_task
+        prompt_task = task if task == default_task else f"{default_task} $task={task}"
+        if prompt_task not in prompts:
             raise InvalidRailsConfigurationError(
-                f"Missing a `{expected}` prompt template, which is required for the `{rail}` rail."
+                f"Missing a `{prompt_task}` prompt template, which is required for the `{rail}` rail."
             )
 
 

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -2369,14 +2369,14 @@ def _validate_self_check_rail_prompts(
 ) -> None:
     """Ensure every enabled self-check rail has a prompt for its resolved task.
 
-    A self-check rail may select a custom task via `$task=...`; the task falls
+    A self-check rail may select a custom task via `$variant=...`; the task falls
     back to `default_task` when omitted. Custom prompts are scoped under the
     default task name.
     """
     for rail in rails:
         if _normalize_flow_id(rail) != validation_rail:
             continue
-        task = _get_flow_params(rail).get("task") or default_task
+        task = _get_flow_params(rail).get("variant") or default_task
         prompt_task = get_self_check_prompt_task(task, default_task, prompts)
         if prompt_task not in prompts:
             raise InvalidRailsConfigurationError(

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -43,6 +43,7 @@ from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidRailsConfigurationError,
 )
+from nemoguardrails.library.self_check.utils import get_self_check_prompt_task
 
 log = logging.getLogger(__name__)
 
@@ -2376,7 +2377,7 @@ def _validate_self_check_rail_prompts(
         if _normalize_flow_id(rail) != validation_rail:
             continue
         task = _get_flow_params(rail).get("task") or default_task
-        prompt_task = task if task == default_task else f"{default_task} $task={task}"
+        prompt_task = get_self_check_prompt_task(task, default_task, prompts)
         if prompt_task not in prompts:
             raise InvalidRailsConfigurationError(
                 f"Missing a `{prompt_task}` prompt template, which is required for the `{rail}` rail."

--- a/tests/integrations/langchain/test_streaming.py
+++ b/tests/integrations/langchain/test_streaming.py
@@ -384,24 +384,25 @@ async def test_sequential_streaming_output_rails_allowed(
 
 @pytest.mark.asyncio
 async def test_streaming_input_rails_preserve_multiple_custom_tasks():
+    """Verify streaming runs each configured custom input self-check task."""
     config = RailsConfig.from_content(
         config={
             "models": [],
             "rails": {
                 "input": {
                     "flows": [
-                        "self check input $task=check_harmful",
-                        "self check input $task=check_off_topic",
+                        "self check input $variant=check_harmful",
+                        "self check input $variant=check_off_topic",
                     ],
                 }
             },
             "prompts": [
                 {
-                    "task": "self_check_input $task=check_harmful",
+                    "task": "self_check_input $variant=check_harmful",
                     "content": "User input: {{ user_input }}\nAnswer No.",
                 },
                 {
-                    "task": "self_check_input $task=check_off_topic",
+                    "task": "self_check_input $variant=check_off_topic",
                     "content": "User input: {{ user_input }}\nAnswer No.",
                 },
                 {
@@ -451,7 +452,7 @@ async def test_streaming_output_rails_preserve_custom_task():
             "models": [],
             "rails": {
                 "output": {
-                    "flows": ["self check output $task=check_data_leakage"],
+                    "flows": ["self check output $variant=check_data_leakage"],
                     "streaming": {
                         "enabled": True,
                         "chunk_size": 4,
@@ -462,7 +463,7 @@ async def test_streaming_output_rails_preserve_custom_task():
             },
             "prompts": [
                 {
-                    "task": "self_check_output $task=check_data_leakage",
+                    "task": "self_check_output $variant=check_data_leakage",
                     "content": """
                     Bot response: {{ bot_response }}
                     Answer No.
@@ -514,6 +515,7 @@ async def test_streaming_output_rails_preserve_custom_task():
 @pytest.mark.parametrize("parallel", [False, True], ids=["sequential", "parallel"])
 @pytest.mark.asyncio
 async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
+    """Verify streaming blocks without emitting content rejected by a custom task."""
     config = RailsConfig.from_content(
         config={
             "models": [],
@@ -521,8 +523,8 @@ async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
                 "output": {
                     "parallel": parallel,
                     "flows": [
-                        "self check output $task=check_inappropriate",
-                        "self check output $task=check_data_leakage",
+                        "self check output $variant=check_inappropriate",
+                        "self check output $variant=check_data_leakage",
                     ],
                     "streaming": {
                         "enabled": True,
@@ -534,11 +536,11 @@ async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
             },
             "prompts": [
                 {
-                    "task": "self_check_output $task=check_inappropriate",
+                    "task": "self_check_output $variant=check_inappropriate",
                     "content": "Bot response: {{ bot_response }}\nAnswer No.",
                 },
                 {
-                    "task": "self_check_output $task=check_data_leakage",
+                    "task": "self_check_output $variant=check_data_leakage",
                     "content": "Bot response: {{ bot_response }}\nAnswer Yes.",
                 },
                 {
@@ -577,7 +579,7 @@ async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
 
     assert all("blocked_data_leakage" not in chunk for chunk in chunks)
     errors = [json.loads(chunk) for chunk in chunks if chunk.startswith('{"error":')]
-    assert errors[-1]["error"]["param"] == "self check output $task=check_data_leakage"
+    assert errors[-1]["error"]["param"] == "self check output $variant=check_data_leakage"
     assert inappropriate_llm.inference_count > 0
     assert data_leakage_llm.inference_count > 0
     assert default_llm.inference_count == 0

--- a/tests/integrations/langchain/test_streaming.py
+++ b/tests/integrations/langchain/test_streaming.py
@@ -383,6 +383,68 @@ async def test_sequential_streaming_output_rails_allowed(
 
 
 @pytest.mark.asyncio
+async def test_streaming_input_rails_preserve_multiple_custom_tasks():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "input": {
+                    "flows": [
+                        "self check input $task=check_harmful",
+                        "self check input $task=check_off_topic",
+                    ],
+                }
+            },
+            "prompts": [
+                {
+                    "task": "self_check_input $task=check_harmful",
+                    "content": "User input: {{ user_input }}\nAnswer No.",
+                },
+                {
+                    "task": "self_check_input $task=check_off_topic",
+                    "content": "User input: {{ user_input }}\nAnswer No.",
+                },
+                {
+                    "task": "self_check_input",
+                    "content": "User input: {{ user_input }}\nAnswer Yes.",
+                },
+            ],
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+
+        define flow
+          user express greeting
+          bot tell joke
+        """,
+    )
+    harmful_llm = FakeLLMModel(responses=["No"])
+    off_topic_llm = FakeLLMModel(responses=["No"])
+    default_llm = FakeLLMModel(responses=["Yes"])
+    chat = TestChat(
+        config,
+        llm_completions=[
+            '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
+            '  "This response should stream safely."',
+        ],
+        streaming=True,
+    )
+    chat.app.runtime.registered_action_params["llms"]["check_harmful"] = harmful_llm
+    chat.app.runtime.registered_action_params["llms"]["check_off_topic"] = off_topic_llm
+    chat.app.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
+
+    chunks = []
+    async for chunk in chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]):
+        chunks.append(chunk)
+
+    assert "".join(chunks) == "This response should stream safely."
+    assert harmful_llm.inference_count == 1
+    assert off_topic_llm.inference_count == 1
+    assert default_llm.inference_count == 0
+
+
+@pytest.mark.asyncio
 async def test_streaming_output_rails_preserve_custom_task():
     config = RailsConfig.from_content(
         config={
@@ -400,7 +462,7 @@ async def test_streaming_output_rails_preserve_custom_task():
             },
             "prompts": [
                 {
-                    "task": "check_data_leakage",
+                    "task": "self_check_output $task=check_data_leakage",
                     "content": """
                     Bot response: {{ bot_response }}
                     Answer No.
@@ -446,6 +508,77 @@ async def test_streaming_output_rails_preserve_custom_task():
 
     assert "".join(chunks) == "This response should stream safely."
     assert custom_llm.inference_count > 0
+    assert default_llm.inference_count == 0
+
+
+@pytest.mark.parametrize("parallel", [False, True], ids=["sequential", "parallel"])
+@pytest.mark.asyncio
+async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    "parallel": parallel,
+                    "flows": [
+                        "self check output $task=check_inappropriate",
+                        "self check output $task=check_data_leakage",
+                    ],
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 32,
+                        "context_size": 0,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "prompts": [
+                {
+                    "task": "self_check_output $task=check_inappropriate",
+                    "content": "Bot response: {{ bot_response }}\nAnswer No.",
+                },
+                {
+                    "task": "self_check_output $task=check_data_leakage",
+                    "content": "Bot response: {{ bot_response }}\nAnswer Yes.",
+                },
+                {
+                    "task": "self_check_output",
+                    "content": "Bot response: {{ bot_response }}\nAnswer No.",
+                },
+            ],
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+
+        define flow
+          user express greeting
+          bot tell joke
+        """,
+    )
+    inappropriate_llm = FakeLLMModel(responses=["No"] * 4)
+    data_leakage_llm = FakeLLMModel(responses=["Yes"] * 4)
+    default_llm = FakeLLMModel(responses=["No"] * 4)
+    chat = TestChat(
+        config,
+        llm_completions=[
+            '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
+            '  "This response contains blocked_data_leakage."',
+        ],
+        streaming=True,
+    )
+    chat.app.runtime.registered_action_params["llms"]["check_inappropriate"] = inappropriate_llm
+    chat.app.runtime.registered_action_params["llms"]["check_data_leakage"] = data_leakage_llm
+    chat.app.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
+
+    chunks = []
+    async for chunk in chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]):
+        chunks.append(chunk)
+
+    errors = [json.loads(chunk) for chunk in chunks if chunk.startswith('{"error":')]
+    assert errors[-1]["error"]["param"] == "self check output $task=check_data_leakage"
+    assert inappropriate_llm.inference_count > 0
+    assert data_leakage_llm.inference_count > 0
     assert default_llm.inference_count == 0
 
 

--- a/tests/integrations/langchain/test_streaming.py
+++ b/tests/integrations/langchain/test_streaming.py
@@ -575,6 +575,7 @@ async def test_streaming_output_rails_preserve_multiple_custom_tasks(parallel):
     async for chunk in chat.app.stream_async(messages=[{"role": "user", "content": "Hi!"}]):
         chunks.append(chunk)
 
+    assert all("blocked_data_leakage" not in chunk for chunk in chunks)
     errors = [json.loads(chunk) for chunk in chunks if chunk.startswith('{"error":')]
     assert errors[-1]["error"]["param"] == "self check output $task=check_data_leakage"
     assert inappropriate_llm.inference_count > 0

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_generate_async_parallel_runs_all_tasks.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_generate_async_parallel_runs_all_tasks.yaml
@@ -1,0 +1,302 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_harmful.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 35
+          completion_tokens: 1
+          total_tokens: 36
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_off_topic.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: allowed_parallel_response
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 34
+          completion_tokens: 1
+          total_tokens: 35
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: allowed_parallel_response
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 31
+          completion_tokens: 4
+          total_tokens: 35
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_generate_async_sequential_blocks_output.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_generate_async_sequential_blocks_output.yaml
@@ -1,0 +1,302 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_harmful.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 35
+          completion_tokens: 1
+          total_tokens: 36
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_off_topic.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: unsafe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_provider_error_raises.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_provider_error_raises.yaml
@@ -1,0 +1,57 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: nonexistent-self-check-model
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input is unsafe.
+          Otherwise return "safe".
+          User input: hello
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Origin
+      access-control-expose-headers:
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        error:
+          message: The model `nonexistent-self-check-model` does not exist or you do not have access to it.
+          type: invalid_request_error
+          param: null
+          code: model_not_found

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_second_task_blocks.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_second_task_blocks.yaml
@@ -1,0 +1,148 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_harmful.
+          Otherwise return "safe".
+          User input: blocked_off_topic
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 1
+          total_tokens: 34
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_off_topic.
+          Otherwise return "safe".
+          User input: blocked_off_topic
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: unsafe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 31
+          completion_tokens: 4
+          total_tokens: 35
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_tasks_allow.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_input_tasks_allow.yaml
@@ -1,0 +1,152 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_harmful.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 35
+          completion_tokens: 1
+          total_tokens: 36
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_off_topic.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_rails_streaming[parallel-allows].yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_rails_streaming[parallel-allows].yaml
@@ -1,0 +1,302 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: allowed_output_streaming_response
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: allowed_output_streaming_response
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: allowed_output_streaming_response
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: allowed_output_streaming_response
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_rails_streaming[sequential-blocks].yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_rails_streaming[sequential-blocks].yaml
@@ -1,0 +1,152 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: unsafe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_second_task_blocks.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_second_task_blocks.yaml
@@ -1,0 +1,148 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      Host:
+      - api.openai.com
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-httpx/0.28.1
+      Content-Type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: unsafe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_second_task_blocks_fake_main_stream.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_output_second_task_blocks_fake_main_stream.yaml
@@ -1,0 +1,152 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_inappropriate.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the bot response contains blocked_data_leakage.
+          Otherwise return "safe".
+          Bot response: blocked_data_leakage
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: unsafe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 36
+          completion_tokens: 1
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'

--- a/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_stream_async_runs_input_tasks.yaml
+++ b/tests/recorded/rails/library/cassettes/test_self_check/test_multiple_self_check_stream_async_runs_input_tasks.yaml
@@ -1,0 +1,152 @@
+version: 1
+interactions:
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-4.1-mini
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_harmful.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      temperature: 0.001
+      max_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-4.1-mini-2025-04-14
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          logprobs: null
+          finish_reason: stop
+        usage:
+          prompt_tokens: 35
+          completion_tokens: 1
+          total_tokens: 36
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: '[RECORDED_SYSTEM_FINGERPRINT]'
+- request:
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+    headers:
+      host:
+      - api.openai.com
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.28.1
+      content-type:
+      - application/json
+    parsed_body:
+      model: gpt-5.4-nano
+      messages:
+      - role: user
+        content: |-
+          Return "unsafe" only if the user input contains blocked_off_topic.
+          Otherwise return "safe".
+          User input: allowed_multi_self_check_input
+      max_completion_tokens: 32
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+    body:
+      parsed_body:
+        id: '[RECORDED_RESPONSE_ID]'
+        object: chat.completion
+        created: 0
+        model: gpt-5.4-nano-2026-03-17
+        choices:
+        - index: 0
+          message:
+            role: assistant
+            content: safe
+            refusal: null
+            annotations: []
+          finish_reason: stop
+        usage:
+          prompt_tokens: 33
+          completion_tokens: 4
+          total_tokens: 37
+          prompt_tokens_details:
+            cached_tokens: 0
+            audio_tokens: 0
+          completion_tokens_details:
+            reasoning_tokens: 0
+            audio_tokens: 0
+            accepted_prediction_tokens: 0
+            rejected_prediction_tokens: 0
+        service_tier: default
+        system_fingerprint: null

--- a/tests/recorded/rails/library/configs.py
+++ b/tests/recorded/rails/library/configs.py
@@ -29,6 +29,7 @@ CONTENT_SAFETY_INVALID_MODEL_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "
 NIM_TOPIC_CONTROL_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nim_topic_control")
 NIM_JAILBREAK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nim_jailbreak")
 OPENAI_SELF_CHECK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_self_check")
+OPENAI_MULTI_SELF_CHECK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_multi_self_check")
 OPENAI_INPUT_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_input_stack")
 OPENAI_OUTPUT_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_output_stack")
 FULL_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "full_stack")

--- a/tests/recorded/rails/library/configs.py
+++ b/tests/recorded/rails/library/configs.py
@@ -30,6 +30,9 @@ NIM_TOPIC_CONTROL_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nim_topic_c
 NIM_JAILBREAK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "nim_jailbreak")
 OPENAI_SELF_CHECK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_self_check")
 OPENAI_MULTI_SELF_CHECK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_multi_self_check")
+OPENAI_MULTI_SELF_CHECK_INVALID_MODEL_CONFIG = RailsConfigSource.from_path(
+    CONFIGS_DIR, "openai_multi_self_check_invalid_model"
+)
 OPENAI_INPUT_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_input_stack")
 OPENAI_OUTPUT_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "openai_output_stack")
 FULL_STACK_CONFIG = RailsConfigSource.from_path(CONFIGS_DIR, "full_stack")

--- a/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
@@ -33,7 +33,7 @@ rails:
       - self check output $task=check_data_leakage
 
 prompts:
-  - task: check_harmful
+  - task: self_check_input $task=check_harmful
     content: |
       Return "unsafe" only if the user input contains blocked_harmful.
       Otherwise return "safe".
@@ -41,7 +41,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: check_off_topic
+  - task: self_check_input $task=check_off_topic
     content: |
       Return "unsafe" only if the user input contains blocked_off_topic.
       Otherwise return "safe".
@@ -49,7 +49,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: check_inappropriate
+  - task: self_check_output $task=check_inappropriate
     content: |
       Return "unsafe" only if the bot response contains blocked_inappropriate.
       Otherwise return "safe".
@@ -57,7 +57,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: check_data_leakage
+  - task: self_check_output $task=check_data_leakage
     content: |
       Return "unsafe" only if the bot response contains blocked_data_leakage.
       Otherwise return "safe".

--- a/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
@@ -14,6 +14,11 @@ models:
     model: gpt-5.4-nano
     parameters:
       max_retries: 0
+  - type: check_inappropriate
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
   - type: check_data_leakage
     engine: openai
     model: gpt-4.1-mini

--- a/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
@@ -30,15 +30,15 @@ passthrough: true
 rails:
   input:
     flows:
-      - self check input $task=check_harmful
-      - self check input $task=check_off_topic
+      - self check input $variant=check_harmful
+      - self check input $variant=check_off_topic
   output:
     flows:
-      - self check output $task=check_inappropriate
-      - self check output $task=check_data_leakage
+      - self check output $variant=check_inappropriate
+      - self check output $variant=check_data_leakage
 
 prompts:
-  - task: self_check_input $task=check_harmful
+  - task: self_check_input $variant=check_harmful
     content: |
       Return "unsafe" only if the user input contains blocked_harmful.
       Otherwise return "safe".
@@ -46,7 +46,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: self_check_input $task=check_off_topic
+  - task: self_check_input $variant=check_off_topic
     content: |
       Return "unsafe" only if the user input contains blocked_off_topic.
       Otherwise return "safe".
@@ -54,7 +54,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: self_check_output $task=check_inappropriate
+  - task: self_check_output $variant=check_inappropriate
     content: |
       Return "unsafe" only if the bot response contains blocked_inappropriate.
       Otherwise return "safe".
@@ -62,7 +62,7 @@ prompts:
     output_parser: is_content_safe
     max_tokens: 32
 
-  - task: self_check_output $task=check_data_leakage
+  - task: self_check_output $variant=check_data_leakage
     content: |
       Return "unsafe" only if the bot response contains blocked_data_leakage.
       Otherwise return "safe".

--- a/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check/config.yml
@@ -1,0 +1,66 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+  - type: self_check_input
+    engine: openai
+    model: gpt-4.1-mini
+    parameters:
+      max_retries: 0
+  - type: check_off_topic
+    engine: openai
+    model: gpt-5.4-nano
+    parameters:
+      max_retries: 0
+  - type: check_data_leakage
+    engine: openai
+    model: gpt-4.1-mini
+    parameters:
+      max_retries: 0
+
+passthrough: true
+
+rails:
+  input:
+    flows:
+      - self check input $task=check_harmful
+      - self check input $task=check_off_topic
+  output:
+    flows:
+      - self check output $task=check_inappropriate
+      - self check output $task=check_data_leakage
+
+prompts:
+  - task: check_harmful
+    content: |
+      Return "unsafe" only if the user input contains blocked_harmful.
+      Otherwise return "safe".
+      User input: {{ user_input }}
+    output_parser: is_content_safe
+    max_tokens: 32
+
+  - task: check_off_topic
+    content: |
+      Return "unsafe" only if the user input contains blocked_off_topic.
+      Otherwise return "safe".
+      User input: {{ user_input }}
+    output_parser: is_content_safe
+    max_tokens: 32
+
+  - task: check_inappropriate
+    content: |
+      Return "unsafe" only if the bot response contains blocked_inappropriate.
+      Otherwise return "safe".
+      Bot response: {{ bot_response }}
+    output_parser: is_content_safe
+    max_tokens: 32
+
+  - task: check_data_leakage
+    content: |
+      Return "unsafe" only if the bot response contains blocked_data_leakage.
+      Otherwise return "safe".
+      Bot response: {{ bot_response }}
+    output_parser: is_content_safe
+    max_tokens: 32

--- a/tests/recorded/rails/library/configs/openai_multi_self_check_invalid_model/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check_invalid_model/config.yml
@@ -1,0 +1,22 @@
+models:
+  - type: invalid_custom_check
+    engine: openai
+    model: nonexistent-self-check-model
+    parameters:
+      max_retries: 0
+
+passthrough: true
+
+rails:
+  input:
+    flows:
+      - self check input $task=invalid_custom_check
+
+prompts:
+  - task: self_check_input $task=invalid_custom_check
+    content: |
+      Return "unsafe" only if the user input is unsafe.
+      Otherwise return "safe".
+      User input: {{ user_input }}
+    output_parser: is_content_safe
+    max_tokens: 32

--- a/tests/recorded/rails/library/configs/openai_multi_self_check_invalid_model/config.yml
+++ b/tests/recorded/rails/library/configs/openai_multi_self_check_invalid_model/config.yml
@@ -10,10 +10,10 @@ passthrough: true
 rails:
   input:
     flows:
-      - self check input $task=invalid_custom_check
+      - self check input $variant=invalid_custom_check
 
 prompts:
-  - task: self_check_input $task=invalid_custom_check
+  - task: self_check_input $variant=invalid_custom_check
     content: |
       Return "unsafe" only if the user input is unsafe.
       Otherwise return "safe".

--- a/tests/recorded/rails/library/test_self_check.py
+++ b/tests/recorded/rails/library/test_self_check.py
@@ -40,10 +40,12 @@ pytestmark = [pytest.mark.recorded, pytest.mark.vcr, pytest.mark.asyncio]
 
 
 def _llm_routes(rails, start):
+    """Return recorded task, provider, and model routes from the given call index."""
     return [(call.task, call.llm_provider_name, call.llm_model_name) for call in rails.explain().llm_calls[start:]]
 
 
 def _self_check_routes(rails, start):
+    """Return self-check routes from the given call index."""
     return [route for route in _llm_routes(rails, start) if route[0] and route[0].startswith("self_check_")]
 
 
@@ -74,6 +76,7 @@ async def test_self_check_output_blocks_assistant_message(openai_api_key):
 
 
 async def test_multiple_self_check_input_second_task_blocks(openai_api_key):
+    """Verify the second sequential input task blocks and records its route."""
     rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
     start = len(rails.explain().llm_calls)
 
@@ -82,21 +85,22 @@ async def test_multiple_self_check_input_second_task_blocks(openai_api_key):
         rail_types=[RailType.INPUT],
     )
 
-    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check input $task=check_off_topic")
+    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check input $variant=check_off_topic")
     assert _llm_routes(rails, start) == [
-        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
-        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_input $variant=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_off_topic", "openai", "gpt-5.4-nano"),
     ]
     assert normalize_rails_result(result) == snapshot(
         {
             "status": "blocked",
-            "rail": "self check input $task=check_off_topic",
+            "rail": "self check input $variant=check_off_topic",
             "content": "I'm sorry, I can't respond to that.",
         }
     )
 
 
 async def test_multiple_self_check_input_tasks_allow(openai_api_key):
+    """Verify all sequential input tasks run when they allow the message."""
     rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
     start = len(rails.explain().llm_calls)
 
@@ -107,8 +111,8 @@ async def test_multiple_self_check_input_tasks_allow(openai_api_key):
 
     assert_rails_result(result, status=RailStatus.PASSED)
     assert _llm_routes(rails, start) == [
-        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
-        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_input $variant=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_off_topic", "openai", "gpt-5.4-nano"),
     ]
     assert normalize_rails_result(result) == snapshot(
         {"status": "passed", "rail": None, "content": "allowed_multi_self_check_input"}
@@ -116,6 +120,7 @@ async def test_multiple_self_check_input_tasks_allow(openai_api_key):
 
 
 async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
+    """Verify the second sequential output task blocks and records its route."""
     rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
     start = len(rails.explain().llm_calls)
 
@@ -127,21 +132,22 @@ async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
         rail_types=[RailType.OUTPUT],
     )
 
-    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check output $task=check_data_leakage")
+    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check output $variant=check_data_leakage")
     assert _llm_routes(rails, start) == [
-        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
-        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_output $variant=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $variant=check_data_leakage", "openai", "gpt-4.1-mini"),
     ]
     assert normalize_rails_result(result) == snapshot(
         {
             "status": "blocked",
-            "rail": "self check output $task=check_data_leakage",
+            "rail": "self check output $variant=check_data_leakage",
             "content": "I'm sorry, I can't respond to that.",
         }
     )
 
 
 async def test_multiple_self_check_generate_async_sequential_blocks_output(openai_api_key):
+    """Verify sequential self-check tasks block generated output."""
     rails = build_rails(
         OPENAI_MULTI_SELF_CHECK_CONFIG,
         llm=FakeLLMModel(responses=["blocked_data_leakage"]),
@@ -156,14 +162,15 @@ async def test_multiple_self_check_generate_async_sequential_blocks_output(opena
     assert isinstance(result, GenerationResponse)
     assert result.response == snapshot([{"role": "assistant", "content": "I'm sorry, I can't respond to that."}])
     assert _self_check_routes(rails, start) == [
-        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
-        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
-        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
-        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_output $variant=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $variant=check_data_leakage", "openai", "gpt-4.1-mini"),
     ]
 
 
 async def test_multiple_self_check_generate_async_parallel_runs_all_tasks(openai_api_key):
+    """Verify parallel generation runs every configured self-check task."""
     config = load_config(OPENAI_MULTI_SELF_CHECK_CONFIG)
     config.rails.input.parallel = True
     config.rails.output.parallel = True
@@ -178,14 +185,15 @@ async def test_multiple_self_check_generate_async_parallel_runs_all_tasks(openai
     assert isinstance(result, GenerationResponse)
     assert result.response == snapshot([{"role": "assistant", "content": "allowed_parallel_response"}])
     assert sorted(_self_check_routes(rails, start)) == [
-        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
-        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
-        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
-        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_input $variant=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_output $variant=check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_output $variant=check_inappropriate", "openai", "gpt-5.4-nano"),
     ]
 
 
 async def test_multiple_self_check_stream_async_runs_input_tasks(openai_api_key):
+    """Verify streaming generation runs every configured input self-check task."""
     config = enable_streaming(load_config(OPENAI_MULTI_SELF_CHECK_CONFIG))
     config.rails.output.flows = []
     rails = LLMRails(config, llm=FakeLLMModel(responses=["allowed_streaming_response"]), verbose=False)
@@ -198,8 +206,8 @@ async def test_multiple_self_check_stream_async_runs_input_tasks(openai_api_key)
         chunks.append(chunk)
 
     assert _self_check_routes(rails, start) == [
-        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
-        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_input $variant=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $variant=check_off_topic", "openai", "gpt-5.4-nano"),
     ]
     assert normalize_stream_chunks(chunks) == snapshot(
         {"content": "allowed_streaming_response", "chunks": ["allowed_streaming_response"], "errors": []}
@@ -207,6 +215,7 @@ async def test_multiple_self_check_stream_async_runs_input_tasks(openai_api_key)
 
 
 async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(openai_api_key):
+    """Verify the second output task blocks content from a supplied stream."""
     rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG, streaming=True)
     chunks = []
     async for chunk in rails.stream_async(
@@ -222,14 +231,14 @@ async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(op
             "content": "blocked_data_leakage",
             "chunks": [
                 "blocked_data_leakage",
-                '{"error": {"message": "Blocked by self check output $task=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $task=check_data_leakage", "code": "content_blocked"}}',
+                '{"error": {"message": "Blocked by self check output $variant=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $variant=check_data_leakage", "code": "content_blocked"}}',
             ],
             "errors": [
                 {
                     "error": {
-                        "message": "Blocked by self check output $task=check_data_leakage rails.",
+                        "message": "Blocked by self check output $variant=check_data_leakage rails.",
                         "type": "guardrails_violation",
-                        "param": "self check output $task=check_data_leakage",
+                        "param": "self check output $variant=check_data_leakage",
                         "code": "content_blocked",
                     }
                 }
@@ -240,6 +249,7 @@ async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(op
 
 @pytest.mark.parametrize("parallel", [False, True], ids=["sequential-blocks", "parallel-allows"])
 async def test_multiple_self_check_output_rails_streaming(openai_api_key, parallel):
+    """Verify sequential and parallel output tasks use their configured routes."""
     config = enable_streaming(load_config(OPENAI_MULTI_SELF_CHECK_CONFIG))
     config.rails.input.flows = []
     config.rails.output.parallel = parallel
@@ -262,8 +272,8 @@ async def test_multiple_self_check_output_rails_streaming(openai_api_key, parall
     if not parallel:
         assert_blocked_stream_error(chunks)
     expected_routes = [
-        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
-        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_output $variant=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $variant=check_data_leakage", "openai", "gpt-4.1-mini"),
     ]
     routes = _self_check_routes(rails, start)
     if parallel:
@@ -281,14 +291,14 @@ async def test_multiple_self_check_output_rails_streaming(openai_api_key, parall
             {
                 "content": "",
                 "chunks": [
-                    '{"error": {"message": "Blocked by self check output $task=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $task=check_data_leakage", "code": "content_blocked"}}'
+                    '{"error": {"message": "Blocked by self check output $variant=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $variant=check_data_leakage", "code": "content_blocked"}}'
                 ],
                 "errors": [
                     {
                         "error": {
-                            "message": "Blocked by self check output $task=check_data_leakage rails.",
+                            "message": "Blocked by self check output $variant=check_data_leakage rails.",
                             "type": "guardrails_violation",
-                            "param": "self check output $task=check_data_leakage",
+                            "param": "self check output $variant=check_data_leakage",
                             "code": "content_blocked",
                         }
                     }
@@ -298,6 +308,7 @@ async def test_multiple_self_check_output_rails_streaming(openai_api_key, parall
 
 
 async def test_multiple_self_check_input_provider_error_raises(openai_api_key):
+    """Verify provider errors from a custom input task are propagated."""
     with pytest.raises(LLMCallException) as exc_info:
         await check_rails(
             OPENAI_MULTI_SELF_CHECK_INVALID_MODEL_CONFIG,

--- a/tests/recorded/rails/library/test_self_check.py
+++ b/tests/recorded/rails/library/test_self_check.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import pytest
 
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.rails.llm.options import RailStatus, RailType
 from tests.recorded.assertions import (
     assert_blocked_stream_error,
@@ -24,7 +25,11 @@ from tests.recorded.assertions import (
 )
 from tests.recorded.normalization import normalize_rails_result, normalize_stream_chunks
 from tests.recorded.rails.helpers import build_rails
-from tests.recorded.rails.library.configs import OPENAI_MULTI_SELF_CHECK_CONFIG, OPENAI_SELF_CHECK_CONFIG
+from tests.recorded.rails.library.configs import (
+    OPENAI_MULTI_SELF_CHECK_CONFIG,
+    OPENAI_MULTI_SELF_CHECK_INVALID_MODEL_CONFIG,
+    OPENAI_SELF_CHECK_CONFIG,
+)
 from tests.recorded.rails.library.helpers import check_rails, stream_with_fake_main
 from tests.recorded.snapshots import snapshot
 
@@ -84,6 +89,25 @@ async def test_multiple_self_check_input_second_task_blocks(openai_api_key):
     )
 
 
+async def test_multiple_self_check_input_tasks_allow(openai_api_key):
+    rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
+    start = len(rails.explain().llm_calls)
+
+    result = await rails.check_async(
+        [{"role": "user", "content": "allowed_multi_self_check_input"}],
+        rail_types=[RailType.INPUT],
+    )
+
+    assert_rails_result(result, status=RailStatus.PASSED)
+    assert _llm_routes(rails, start) == [
+        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+    ]
+    assert normalize_rails_result(result) == snapshot(
+        {"status": "passed", "rail": None, "content": "allowed_multi_self_check_input"}
+    )
+
+
 async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
     rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
     start = len(rails.explain().llm_calls)
@@ -108,6 +132,46 @@ async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
             "content": "I'm sorry, I can't respond to that.",
         }
     )
+
+
+async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(openai_api_key):
+    chunks = await stream_with_fake_main(
+        OPENAI_MULTI_SELF_CHECK_CONFIG,
+        "blocked_data_leakage",
+        [{"role": "user", "content": "hello"}],
+    )
+
+    assert_blocked_stream_error(chunks)
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {
+            "content": "blocked_data_leakage",
+            "chunks": [
+                "blocked_data_leakage",
+                '{"error": {"message": "Blocked by self check output $task=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $task=check_data_leakage", "code": "content_blocked"}}',
+            ],
+            "errors": [
+                {
+                    "error": {
+                        "message": "Blocked by self check output $task=check_data_leakage rails.",
+                        "type": "guardrails_violation",
+                        "param": "self check output $task=check_data_leakage",
+                        "code": "content_blocked",
+                    }
+                }
+            ],
+        }
+    )
+
+
+async def test_multiple_self_check_input_provider_error_raises(openai_api_key):
+    with pytest.raises(LLMCallException) as exc_info:
+        await check_rails(
+            OPENAI_MULTI_SELF_CHECK_INVALID_MODEL_CONFIG,
+            [{"role": "user", "content": "hello"}],
+            rail_types=(RailType.INPUT,),
+        )
+
+    assert getattr(exc_info.value.inner_exception, "status_code", None) == 404
 
 
 async def test_self_check_facts_blocks_unsupported_response(openai_api_key):

--- a/tests/recorded/rails/library/test_self_check.py
+++ b/tests/recorded/rails/library/test_self_check.py
@@ -72,8 +72,8 @@ async def test_multiple_self_check_input_second_task_blocks(openai_api_key):
 
     assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check input $task=check_off_topic")
     assert _llm_routes(rails, start) == [
-        ("check_harmful", "openai", "gpt-4.1-mini"),
-        ("check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
     ]
     assert normalize_rails_result(result) == snapshot(
         {
@@ -98,8 +98,8 @@ async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
 
     assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check output $task=check_data_leakage")
     assert _llm_routes(rails, start) == [
-        ("check_inappropriate", "openai", "gpt-5.4-nano"),
-        ("check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
     ]
     assert normalize_rails_result(result) == snapshot(
         {

--- a/tests/recorded/rails/library/test_self_check.py
+++ b/tests/recorded/rails/library/test_self_check.py
@@ -23,11 +23,16 @@ from tests.recorded.assertions import (
     assert_rails_result,
 )
 from tests.recorded.normalization import normalize_rails_result, normalize_stream_chunks
-from tests.recorded.rails.library.configs import OPENAI_SELF_CHECK_CONFIG
+from tests.recorded.rails.helpers import build_rails
+from tests.recorded.rails.library.configs import OPENAI_MULTI_SELF_CHECK_CONFIG, OPENAI_SELF_CHECK_CONFIG
 from tests.recorded.rails.library.helpers import check_rails, stream_with_fake_main
 from tests.recorded.snapshots import snapshot
 
 pytestmark = [pytest.mark.recorded, pytest.mark.vcr, pytest.mark.asyncio]
+
+
+def _llm_routes(rails, start):
+    return [(call.task, call.llm_provider_name, call.llm_model_name) for call in rails.explain().llm_calls[start:]]
 
 
 async def test_self_check_input_blocks_user_message(openai_api_key):
@@ -53,6 +58,55 @@ async def test_self_check_output_blocks_assistant_message(openai_api_key):
     assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check output")
     assert normalize_rails_result(result) == snapshot(
         {"status": "blocked", "rail": "self check output", "content": "I'm sorry, I can't respond to that."}
+    )
+
+
+async def test_multiple_self_check_input_second_task_blocks(openai_api_key):
+    rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
+    start = len(rails.explain().llm_calls)
+
+    result = await rails.check_async(
+        [{"role": "user", "content": "blocked_off_topic"}],
+        rail_types=[RailType.INPUT],
+    )
+
+    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check input $task=check_off_topic")
+    assert _llm_routes(rails, start) == [
+        ("check_harmful", "openai", "gpt-4.1-mini"),
+        ("check_off_topic", "openai", "gpt-5.4-nano"),
+    ]
+    assert normalize_rails_result(result) == snapshot(
+        {
+            "status": "blocked",
+            "rail": "self check input $task=check_off_topic",
+            "content": "I'm sorry, I can't respond to that.",
+        }
+    )
+
+
+async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
+    rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG)
+    start = len(rails.explain().llm_calls)
+
+    result = await rails.check_async(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "blocked_data_leakage"},
+        ],
+        rail_types=[RailType.OUTPUT],
+    )
+
+    assert_rails_result(result, status=RailStatus.BLOCKED, rail="self check output $task=check_data_leakage")
+    assert _llm_routes(rails, start) == [
+        ("check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("check_data_leakage", "openai", "gpt-4.1-mini"),
+    ]
+    assert normalize_rails_result(result) == snapshot(
+        {
+            "status": "blocked",
+            "rail": "self check output $task=check_data_leakage",
+            "content": "I'm sorry, I can't respond to that.",
+        }
     )
 
 

--- a/tests/recorded/rails/library/test_self_check.py
+++ b/tests/recorded/rails/library/test_self_check.py
@@ -17,27 +17,34 @@ from __future__ import annotations
 
 import pytest
 
+from nemoguardrails import LLMRails
 from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.rails.llm.options import RailStatus, RailType
+from nemoguardrails.rails.llm.options import GenerationResponse, RailStatus, RailType
 from tests.recorded.assertions import (
     assert_blocked_stream_error,
     assert_rails_result,
 )
 from tests.recorded.normalization import normalize_rails_result, normalize_stream_chunks
-from tests.recorded.rails.helpers import build_rails
+from tests.recorded.rails.helpers import async_chunks, build_rails
 from tests.recorded.rails.library.configs import (
     OPENAI_MULTI_SELF_CHECK_CONFIG,
     OPENAI_MULTI_SELF_CHECK_INVALID_MODEL_CONFIG,
     OPENAI_SELF_CHECK_CONFIG,
 )
-from tests.recorded.rails.library.helpers import check_rails, stream_with_fake_main
+from tests.recorded.rails.library.helpers import check_rails
+from tests.recorded.rails_config import enable_streaming, load_config
 from tests.recorded.snapshots import snapshot
+from tests.utils import FakeLLMModel
 
 pytestmark = [pytest.mark.recorded, pytest.mark.vcr, pytest.mark.asyncio]
 
 
 def _llm_routes(rails, start):
     return [(call.task, call.llm_provider_name, call.llm_model_name) for call in rails.explain().llm_calls[start:]]
+
+
+def _self_check_routes(rails, start):
+    return [route for route in _llm_routes(rails, start) if route[0] and route[0].startswith("self_check_")]
 
 
 async def test_self_check_input_blocks_user_message(openai_api_key):
@@ -134,12 +141,80 @@ async def test_multiple_self_check_output_second_task_blocks(openai_api_key):
     )
 
 
-async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(openai_api_key):
-    chunks = await stream_with_fake_main(
+async def test_multiple_self_check_generate_async_sequential_blocks_output(openai_api_key):
+    rails = build_rails(
         OPENAI_MULTI_SELF_CHECK_CONFIG,
-        "blocked_data_leakage",
-        [{"role": "user", "content": "hello"}],
+        llm=FakeLLMModel(responses=["blocked_data_leakage"]),
     )
+    start = len(rails.explain().llm_calls)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "allowed_multi_self_check_input"}],
+        options={"log": {"activated_rails": True, "llm_calls": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == snapshot([{"role": "assistant", "content": "I'm sorry, I can't respond to that."}])
+    assert _self_check_routes(rails, start) == [
+        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+    ]
+
+
+async def test_multiple_self_check_generate_async_parallel_runs_all_tasks(openai_api_key):
+    config = load_config(OPENAI_MULTI_SELF_CHECK_CONFIG)
+    config.rails.input.parallel = True
+    config.rails.output.parallel = True
+    rails = LLMRails(config, llm=FakeLLMModel(responses=["allowed_parallel_response"]), verbose=False)
+    start = len(rails.explain().llm_calls)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "allowed_multi_self_check_input"}],
+        options={"log": {"activated_rails": True, "llm_calls": True}},
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert result.response == snapshot([{"role": "assistant", "content": "allowed_parallel_response"}])
+    assert sorted(_self_check_routes(rails, start)) == [
+        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
+    ]
+
+
+async def test_multiple_self_check_stream_async_runs_input_tasks(openai_api_key):
+    config = enable_streaming(load_config(OPENAI_MULTI_SELF_CHECK_CONFIG))
+    config.rails.output.flows = []
+    rails = LLMRails(config, llm=FakeLLMModel(responses=["allowed_streaming_response"]), verbose=False)
+    start = len(rails.explain().llm_calls)
+
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "allowed_multi_self_check_input"}],
+    ):
+        chunks.append(chunk)
+
+    assert _self_check_routes(rails, start) == [
+        ("self_check_input $task=check_harmful", "openai", "gpt-4.1-mini"),
+        ("self_check_input $task=check_off_topic", "openai", "gpt-5.4-nano"),
+    ]
+    assert normalize_stream_chunks(chunks) == snapshot(
+        {"content": "allowed_streaming_response", "chunks": ["allowed_streaming_response"], "errors": []}
+    )
+
+
+async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(openai_api_key):
+    rails = build_rails(OPENAI_MULTI_SELF_CHECK_CONFIG, streaming=True)
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "hello"}],
+        generator=async_chunks(["blocked_data_leakage"]),
+        options={"rails": ["output"]},
+    ):
+        chunks.append(chunk)
 
     assert_blocked_stream_error(chunks)
     assert normalize_stream_chunks(chunks) == snapshot(
@@ -161,6 +236,65 @@ async def test_multiple_self_check_output_second_task_blocks_fake_main_stream(op
             ],
         }
     )
+
+
+@pytest.mark.parametrize("parallel", [False, True], ids=["sequential-blocks", "parallel-allows"])
+async def test_multiple_self_check_output_rails_streaming(openai_api_key, parallel):
+    config = enable_streaming(load_config(OPENAI_MULTI_SELF_CHECK_CONFIG))
+    config.rails.input.flows = []
+    config.rails.output.parallel = parallel
+    config.rails.output.streaming.enabled = True
+    config.rails.output.streaming.chunk_size = 1
+    config.rails.output.streaming.context_size = 0
+    config.rails.output.streaming.stream_first = False
+    rails = LLMRails(config, verbose=False)
+    start = len(rails.explain().llm_calls)
+
+    output = "allowed_output_streaming_response" if parallel else "blocked_data_leakage"
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "hello"}],
+        generator=async_chunks([output]),
+        options={"rails": ["output"]},
+    ):
+        chunks.append(chunk)
+
+    if not parallel:
+        assert_blocked_stream_error(chunks)
+    expected_routes = [
+        ("self_check_output $task=check_inappropriate", "openai", "gpt-5.4-nano"),
+        ("self_check_output $task=check_data_leakage", "openai", "gpt-4.1-mini"),
+    ]
+    routes = _self_check_routes(rails, start)
+    if parallel:
+        assert sorted(routes) == sorted(expected_routes * 2)
+        assert normalize_stream_chunks(chunks) == snapshot(
+            {
+                "content": "allowed_output_streaming_response",
+                "chunks": ["allowed_output_streaming_response"],
+                "errors": [],
+            }
+        )
+    else:
+        assert routes == expected_routes
+        assert normalize_stream_chunks(chunks) == snapshot(
+            {
+                "content": "",
+                "chunks": [
+                    '{"error": {"message": "Blocked by self check output $task=check_data_leakage rails.", "type": "guardrails_violation", "param": "self check output $task=check_data_leakage", "code": "content_blocked"}}'
+                ],
+                "errors": [
+                    {
+                        "error": {
+                            "message": "Blocked by self check output $task=check_data_leakage rails.",
+                            "type": "guardrails_violation",
+                            "param": "self check output $task=check_data_leakage",
+                            "code": "content_blocked",
+                        }
+                    }
+                ],
+            }
+        )
 
 
 async def test_multiple_self_check_input_provider_error_raises(openai_api_key):
@@ -192,11 +326,14 @@ async def test_self_check_facts_blocks_unsupported_response(openai_api_key):
 
 
 async def test_self_check_output_blocks_fake_main_stream(openai_api_key):
-    chunks = await stream_with_fake_main(
-        OPENAI_SELF_CHECK_CONFIG,
-        "blocked_self_check_output",
-        [{"role": "user", "content": "hello"}],
-    )
+    rails = build_rails(OPENAI_SELF_CHECK_CONFIG, streaming=True)
+    chunks = []
+    async for chunk in rails.stream_async(
+        messages=[{"role": "user", "content": "hello"}],
+        generator=async_chunks(["blocked_self_check_output"]),
+        options={"rails": ["output"]},
+    ):
+        chunks.append(chunk)
 
     assert_blocked_stream_error(chunks)
     assert normalize_stream_chunks(chunks) == snapshot(

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -819,6 +819,39 @@ async def test_run_self_check_task_uses_concrete_task_without_runtime_context():
     assert default_llm.inference_count == 0
 
 
+@pytest.mark.asyncio
+async def test_run_self_check_task_supports_deprecated_bare_prompt_task():
+    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$task=check_harmful`"):
+        config = RailsConfig.from_content(
+            yaml_content="""
+            models: []
+            rails:
+                input:
+                    flows:
+                        - self check input $task=check_harmful
+            prompts:
+                - task: check_harmful
+                  content: Is this message harmful? {{ user_input }}
+            """,
+        )
+
+    task_llm = FakeLLMModel(responses=["No"])
+    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$task=check_harmful`"):
+        is_safe, response = await run_self_check_task(
+            task="check_harmful",
+            prompt_context={"user_input": "hello"},
+            llms={"check_harmful": task_llm},
+            default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
+            main_llm=None,
+            llm_task_manager=LLMTaskManager(config),
+            lowest_temperature=config.lowest_temperature,
+        )
+
+    assert is_safe
+    assert response == "No"
+    assert task_llm.inference_count == 1
+
+
 def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
     assert (
         get_self_check_task_from_rail(

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -23,6 +23,7 @@ from nemoguardrails.library.self_check.utils import (
     SELF_CHECK_INPUT_FLOW,
     SELF_CHECK_INPUT_TASK_PARAM,
     get_self_check_llm,
+    get_self_check_prompt_task,
     get_self_check_task_from_rail,
     resolve_self_check_task,
     run_self_check_task,
@@ -52,12 +53,12 @@ multi_input_config = RailsConfig.from_content(
                 - self check input $task=check_harmful
                 - self check input $task=check_off_topic
     prompts:
-        - task: check_harmful
+        - task: self_check_input $task=check_harmful
           content: |
             Is this message harmful?
             User message: "{{ user_input }}"
             Answer (Yes or No):
-        - task: check_off_topic
+        - task: self_check_input $task=check_off_topic
           content: |
             Is this message off-topic?
             User message: "{{ user_input }}"
@@ -136,12 +137,12 @@ multi_output_config = RailsConfig.from_content(
                 - self check output $task=check_inappropriate
                 - self check output $task=check_data_leakage
     prompts:
-        - task: check_inappropriate
+        - task: self_check_output $task=check_inappropriate
           content: |
             Is this response inappropriate?
             Bot response: "{{ bot_response }}"
             Answer (Yes or No):
-        - task: check_data_leakage
+        - task: self_check_output $task=check_data_leakage
           content: |
             Does this response leak sensitive data?
             Bot response: "{{ bot_response }}"
@@ -275,7 +276,7 @@ def test_mixed_input_rails_run_custom_and_default_tasks():
                     - self check input $task=check_harmful
                     - self check input
         prompts:
-            - task: check_harmful
+            - task: self_check_input $task=check_harmful
               content: |
                 Is this message harmful?
                 User message: "{{ user_input }}"
@@ -348,7 +349,7 @@ def test_mixed_output_rails_run_custom_and_default_tasks():
                     - self check output $task=check_inappropriate
                     - self check output
         prompts:
-            - task: check_inappropriate
+            - task: self_check_output $task=check_inappropriate
               content: |
                 Is this response inappropriate?
                 Bot response: "{{ bot_response }}"
@@ -405,12 +406,12 @@ per_task_input_config = RailsConfig.from_content(
                 - self check input $task=check_harmful
                 - self check input $task=check_off_topic
     prompts:
-        - task: check_harmful
+        - task: self_check_input $task=check_harmful
           content: |
             Is this message harmful?
             User message: "{{ user_input }}"
             Answer (Yes or No):
-        - task: check_off_topic
+        - task: self_check_input $task=check_off_topic
           content: |
             Is this message off-topic?
             User message: "{{ user_input }}"
@@ -484,12 +485,12 @@ per_task_output_config = RailsConfig.from_content(
                 - self check output $task=check_inappropriate
                 - self check output $task=check_data_leakage
     prompts:
-        - task: check_inappropriate
+        - task: self_check_output $task=check_inappropriate
           content: |
             Is this response inappropriate?
             Bot response: "{{ bot_response }}"
             Answer (Yes or No):
-        - task: check_data_leakage
+        - task: self_check_output $task=check_data_leakage
           content: |
             Does this response leak sensitive data?
             Bot response: "{{ bot_response }}"
@@ -550,7 +551,7 @@ def test_per_task_llm_output_first_blocks_skips_second():
     assert data_leakage_llm.inference_count == 0
 
 
-def test_parallel_input_rail_uses_custom_task():
+def test_parallel_input_rails_use_custom_tasks():
     config = RailsConfig.from_content(
         """
         define user express greeting
@@ -571,22 +572,24 @@ def test_parallel_input_rail_uses_custom_task():
                 parallel: true
                 flows:
                     - self check input $task=check_harmful
+                    - self check input $task=check_off_topic
         prompts:
-            - task: check_harmful
+            - task: self_check_input $task=check_harmful
               content: |
                 Is this message harmful?
                 User message: "{{ user_input }}"
                 Answer (Yes or No):
-            - task: self_check_input
+            - task: self_check_input $task=check_off_topic
               content: |
-                Is this message safe?
+                Is this message off-topic?
                 User message: "{{ user_input }}"
                 Answer (Yes or No):
 
         enable_rails_exceptions: True
         """,
     )
-    custom_llm = FakeLLMModel(responses=["No"])
+    harmful_llm = FakeLLMModel(responses=["No"])
+    off_topic_llm = FakeLLMModel(responses=["Yes"])
     default_llm = FakeLLMModel(responses=["Yes"])
 
     chat = TestChat(
@@ -597,17 +600,20 @@ def test_parallel_input_rail_uses_custom_task():
         ],
     )
     rails = chat.app
-    rails.runtime.registered_action_params["llms"]["check_harmful"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["check_harmful"] = harmful_llm
+    rails.runtime.registered_action_params["llms"]["check_off_topic"] = off_topic_llm
     rails.runtime.registered_action_params["llms"]["self_check_input"] = default_llm
 
     new_message = rails.generate(messages=[{"role": "user", "content": "hello"}])
 
-    assert new_message["role"] == "assistant"
-    assert custom_llm.inference_count == 1
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "InputRailException"
+    assert harmful_llm.inference_count == 1
+    assert off_topic_llm.inference_count == 1
     assert default_llm.inference_count == 0
 
 
-def test_parallel_output_rail_uses_custom_task():
+def test_parallel_output_rails_use_custom_tasks():
     config = RailsConfig.from_content(
         """
         define user ask question
@@ -624,22 +630,24 @@ def test_parallel_output_rail_uses_custom_task():
                 parallel: true
                 flows:
                     - self check output $task=check_inappropriate
+                    - self check output $task=check_data_leakage
         prompts:
-            - task: check_inappropriate
+            - task: self_check_output $task=check_inappropriate
               content: |
                 Is this response inappropriate?
                 Bot response: "{{ bot_response }}"
                 Answer (Yes or No):
-            - task: self_check_output
+            - task: self_check_output $task=check_data_leakage
               content: |
-                Is this response safe?
+                Does this response leak data?
                 Bot response: "{{ bot_response }}"
                 Answer (Yes or No):
 
         enable_rails_exceptions: True
         """,
     )
-    custom_llm = FakeLLMModel(responses=["No"])
+    inappropriate_llm = FakeLLMModel(responses=["No"])
+    data_leakage_llm = FakeLLMModel(responses=["Yes"])
     default_llm = FakeLLMModel(responses=["Yes"])
 
     chat = TestChat(
@@ -650,14 +658,16 @@ def test_parallel_output_rail_uses_custom_task():
         ],
     )
     rails = chat.app
-    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = custom_llm
+    rails.runtime.registered_action_params["llms"]["check_inappropriate"] = inappropriate_llm
+    rails.runtime.registered_action_params["llms"]["check_data_leakage"] = data_leakage_llm
     rails.runtime.registered_action_params["llms"]["self_check_output"] = default_llm
 
     new_message = rails.generate(messages=[{"role": "user", "content": "tell me something"}])
 
-    assert new_message["role"] == "assistant"
-    assert new_message["content"] == "Here is the answer."
-    assert custom_llm.inference_count == 1
+    assert new_message["role"] == "exception"
+    assert new_message["content"]["type"] == "OutputRailException"
+    assert inappropriate_llm.inference_count == 1
+    assert data_leakage_llm.inference_count == 1
     assert default_llm.inference_count == 0
 
 
@@ -886,6 +896,24 @@ def test_resolve_self_check_task_defaults_unresolved_placeholders():
     assert _resolve_input_task(context={"triggered_input_rail": "self check input"}) == SELF_CHECK_INPUT_DEFAULT_TASK
     assert _resolve_input_task(task="$task") == SELF_CHECK_INPUT_DEFAULT_TASK
     assert _resolve_input_task() == SELF_CHECK_INPUT_DEFAULT_TASK
+
+
+def test_custom_task_rail_without_prompt_fails_at_config_load():
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_harmful` prompt template"):
+        RailsConfig.from_content(
+            yaml_content="""
+            models: []
+            rails:
+                input:
+                    flows:
+                        - self check input $task=check_harmful
+            """,
+        )
+
+
+def test_get_self_check_prompt_task_namespaces_custom_tasks():
+    assert get_self_check_prompt_task("self_check_input", "self_check_input") == "self_check_input"
+    assert get_self_check_prompt_task("check_harmful", "self_check_input") == "self_check_input $task=check_harmful"
 
 
 def test_input_no_model_raises_error():

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -50,15 +50,15 @@ multi_input_config = RailsConfig.from_content(
     rails:
         input:
             flows:
-                - self check input $task=check_harmful
-                - self check input $task=check_off_topic
+                - self check input $variant=check_harmful
+                - self check input $variant=check_off_topic
     prompts:
-        - task: self_check_input $task=check_harmful
+        - task: self_check_input $variant=check_harmful
           content: |
             Is this message harmful?
             User message: "{{ user_input }}"
             Answer (Yes or No):
-        - task: self_check_input $task=check_off_topic
+        - task: self_check_input $variant=check_off_topic
           content: |
             Is this message off-topic?
             User message: "{{ user_input }}"
@@ -134,15 +134,15 @@ multi_output_config = RailsConfig.from_content(
     rails:
         output:
             flows:
-                - self check output $task=check_inappropriate
-                - self check output $task=check_data_leakage
+                - self check output $variant=check_inappropriate
+                - self check output $variant=check_data_leakage
     prompts:
-        - task: self_check_output $task=check_inappropriate
+        - task: self_check_output $variant=check_inappropriate
           content: |
             Is this response inappropriate?
             Bot response: "{{ bot_response }}"
             Answer (Yes or No):
-        - task: self_check_output $task=check_data_leakage
+        - task: self_check_output $variant=check_data_leakage
           content: |
             Does this response leak sensitive data?
             Bot response: "{{ bot_response }}"
@@ -239,7 +239,7 @@ default_task_config = RailsConfig.from_content(
 
 
 def test_default_task_input_still_works():
-    """Self check input without $task should use default self_check_input task."""
+    """Self check input without $variant should use default self_check_input task."""
     chat = TestChat(
         default_task_config,
         llm_completions=[
@@ -273,10 +273,10 @@ def test_mixed_input_rails_run_custom_and_default_tasks():
         rails:
             input:
                 flows:
-                    - self check input $task=check_harmful
+                    - self check input $variant=check_harmful
                     - self check input
         prompts:
-            - task: self_check_input $task=check_harmful
+            - task: self_check_input $variant=check_harmful
               content: |
                 Is this message harmful?
                 User message: "{{ user_input }}"
@@ -313,7 +313,7 @@ def test_mixed_input_rails_run_custom_and_default_tasks():
 
 
 def test_default_task_output_still_works():
-    """Self check output without $task should use default self_check_output task."""
+    """Self check output without $variant should use default self_check_output task."""
     chat = TestChat(
         default_task_config,
         llm_completions=[
@@ -346,10 +346,10 @@ def test_mixed_output_rails_run_custom_and_default_tasks():
         rails:
             output:
                 flows:
-                    - self check output $task=check_inappropriate
+                    - self check output $variant=check_inappropriate
                     - self check output
         prompts:
-            - task: self_check_output $task=check_inappropriate
+            - task: self_check_output $variant=check_inappropriate
               content: |
                 Is this response inappropriate?
                 Bot response: "{{ bot_response }}"
@@ -403,15 +403,15 @@ per_task_input_config = RailsConfig.from_content(
     rails:
         input:
             flows:
-                - self check input $task=check_harmful
-                - self check input $task=check_off_topic
+                - self check input $variant=check_harmful
+                - self check input $variant=check_off_topic
     prompts:
-        - task: self_check_input $task=check_harmful
+        - task: self_check_input $variant=check_harmful
           content: |
             Is this message harmful?
             User message: "{{ user_input }}"
             Answer (Yes or No):
-        - task: self_check_input $task=check_off_topic
+        - task: self_check_input $variant=check_off_topic
           content: |
             Is this message off-topic?
             User message: "{{ user_input }}"
@@ -482,15 +482,15 @@ per_task_output_config = RailsConfig.from_content(
     rails:
         output:
             flows:
-                - self check output $task=check_inappropriate
-                - self check output $task=check_data_leakage
+                - self check output $variant=check_inappropriate
+                - self check output $variant=check_data_leakage
     prompts:
-        - task: self_check_output $task=check_inappropriate
+        - task: self_check_output $variant=check_inappropriate
           content: |
             Is this response inappropriate?
             Bot response: "{{ bot_response }}"
             Answer (Yes or No):
-        - task: self_check_output $task=check_data_leakage
+        - task: self_check_output $variant=check_data_leakage
           content: |
             Does this response leak sensitive data?
             Bot response: "{{ bot_response }}"
@@ -552,6 +552,7 @@ def test_per_task_llm_output_first_blocks_skips_second():
 
 
 def test_parallel_input_rails_use_custom_tasks():
+    """Verify parallel input rails route each custom task to its own model."""
     config = RailsConfig.from_content(
         """
         define user express greeting
@@ -571,15 +572,15 @@ def test_parallel_input_rails_use_custom_tasks():
             input:
                 parallel: true
                 flows:
-                    - self check input $task=check_harmful
-                    - self check input $task=check_off_topic
+                    - self check input $variant=check_harmful
+                    - self check input $variant=check_off_topic
         prompts:
-            - task: self_check_input $task=check_harmful
+            - task: self_check_input $variant=check_harmful
               content: |
                 Is this message harmful?
                 User message: "{{ user_input }}"
                 Answer (Yes or No):
-            - task: self_check_input $task=check_off_topic
+            - task: self_check_input $variant=check_off_topic
               content: |
                 Is this message off-topic?
                 User message: "{{ user_input }}"
@@ -614,6 +615,7 @@ def test_parallel_input_rails_use_custom_tasks():
 
 
 def test_parallel_output_rails_use_custom_tasks():
+    """Verify parallel output rails route each custom task to its own model."""
     config = RailsConfig.from_content(
         """
         define user ask question
@@ -629,15 +631,15 @@ def test_parallel_output_rails_use_custom_tasks():
             output:
                 parallel: true
                 flows:
-                    - self check output $task=check_inappropriate
-                    - self check output $task=check_data_leakage
+                    - self check output $variant=check_inappropriate
+                    - self check output $variant=check_data_leakage
         prompts:
-            - task: self_check_output $task=check_inappropriate
+            - task: self_check_output $variant=check_inappropriate
               content: |
                 Is this response inappropriate?
                 Bot response: "{{ bot_response }}"
                 Answer (Yes or No):
-            - task: self_check_output $task=check_data_leakage
+            - task: self_check_output $variant=check_data_leakage
               content: |
                 Does this response leak data?
                 Bot response: "{{ bot_response }}"
@@ -821,14 +823,15 @@ async def test_run_self_check_task_uses_concrete_task_without_runtime_context():
 
 @pytest.mark.asyncio
 async def test_run_self_check_task_supports_deprecated_bare_prompt_task():
-    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$task=check_harmful`"):
+    """Verify bare custom prompt tasks remain supported with a warning."""
+    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$variant=check_harmful`"):
         config = RailsConfig.from_content(
             yaml_content="""
             models: []
             rails:
                 input:
                     flows:
-                        - self check input $task=check_harmful
+                        - self check input $variant=check_harmful
             prompts:
                 - task: check_harmful
                   content: Is this message harmful? {{ user_input }}
@@ -836,7 +839,7 @@ async def test_run_self_check_task_supports_deprecated_bare_prompt_task():
         )
 
     task_llm = FakeLLMModel(responses=["No"])
-    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$task=check_harmful`"):
+    with pytest.warns(DeprecationWarning, match="rename it to `self_check_input \\$variant=check_harmful`"):
         is_safe, response = await run_self_check_task(
             task="check_harmful",
             prompt_context={"user_input": "hello"},
@@ -855,7 +858,7 @@ async def test_run_self_check_task_supports_deprecated_bare_prompt_task():
 def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
     assert (
         get_self_check_task_from_rail(
-            "self check input $task=check_harmful",
+            "self check input $variant=check_harmful",
             flow_id=SELF_CHECK_INPUT_FLOW,
             task_param=SELF_CHECK_INPUT_TASK_PARAM,
             default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
@@ -875,7 +878,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
 
     assert (
         get_self_check_task_from_rail(
-            "self check output $task=check_inappropriate",
+            "self check output $variant=check_inappropriate",
             flow_id=SELF_CHECK_INPUT_FLOW,
             task_param=SELF_CHECK_INPUT_TASK_PARAM,
             default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
@@ -887,7 +890,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
 def test_resolve_self_check_task_prefers_explicit_task():
     task = _resolve_input_task(
         task="check_harmful",
-        context={"triggered_input_rail": "self check input $task=check_off_topic"},
+        context={"triggered_input_rail": "self check input $variant=check_off_topic"},
     )
 
     assert task == "check_harmful"
@@ -895,8 +898,8 @@ def test_resolve_self_check_task_prefers_explicit_task():
 
 def test_resolve_self_check_task_uses_triggered_rail_context():
     task = _resolve_input_task(
-        task="$task",
-        context={"triggered_input_rail": "self check input $task=check_harmful"},
+        task="$variant",
+        context={"triggered_input_rail": "self check input $variant=check_harmful"},
     )
 
     assert task == "check_harmful"
@@ -904,11 +907,11 @@ def test_resolve_self_check_task_uses_triggered_rail_context():
 
 def test_resolve_self_check_task_uses_latest_start_rail_event():
     task = _resolve_input_task(
-        task="$task",
+        task="$variant",
         events=[
-            {"type": "StartInputRail", "flow_id": "self check input $task=check_off_topic"},
-            {"type": "SomeOtherEvent", "flow_id": "self check input $task=ignored"},
-            {"type": "StartInputRail", "flow_id": "self check input $task=check_harmful"},
+            {"type": "StartInputRail", "flow_id": "self check input $variant=check_off_topic"},
+            {"type": "SomeOtherEvent", "flow_id": "self check input $variant=ignored"},
+            {"type": "StartInputRail", "flow_id": "self check input $variant=check_harmful"},
         ],
     )
 
@@ -918,7 +921,7 @@ def test_resolve_self_check_task_uses_latest_start_rail_event():
 def test_resolve_self_check_task_uses_start_flow_params():
     task = _resolve_input_task(
         events=[
-            {"type": "start_flow", "flow_id": SELF_CHECK_INPUT_FLOW, "params": {"task": "check_harmful"}},
+            {"type": "start_flow", "flow_id": SELF_CHECK_INPUT_FLOW, "params": {"variant": "check_harmful"}},
         ],
     )
 
@@ -927,19 +930,20 @@ def test_resolve_self_check_task_uses_start_flow_params():
 
 def test_resolve_self_check_task_defaults_unresolved_placeholders():
     assert _resolve_input_task(context={"triggered_input_rail": "self check input"}) == SELF_CHECK_INPUT_DEFAULT_TASK
-    assert _resolve_input_task(task="$task") == SELF_CHECK_INPUT_DEFAULT_TASK
+    assert _resolve_input_task(task="$variant") == SELF_CHECK_INPUT_DEFAULT_TASK
     assert _resolve_input_task() == SELF_CHECK_INPUT_DEFAULT_TASK
 
 
 def test_bare_triggered_rail_uses_default_over_event_history():
+    """Verify a bare triggered rail selects the default task."""
     task = _resolve_input_task(
-        task="$task",
+        task="$variant",
         context={"triggered_input_rail": "self check input"},
         events=[
             {
                 "type": "start_flow",
                 "flow_id": SELF_CHECK_INPUT_FLOW,
-                "params": {"task": "check_harmful"},
+                "params": {"variant": "check_harmful"},
             }
         ],
     )
@@ -948,21 +952,23 @@ def test_bare_triggered_rail_uses_default_over_event_history():
 
 
 def test_custom_task_rail_without_prompt_fails_at_config_load():
-    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_harmful` prompt template"):
+    """Verify a custom self-check rail requires a corresponding prompt."""
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$variant=check_harmful` prompt template"):
         RailsConfig.from_content(
             yaml_content="""
             models: []
             rails:
                 input:
                     flows:
-                        - self check input $task=check_harmful
+                        - self check input $variant=check_harmful
             """,
         )
 
 
 def test_get_self_check_prompt_task_namespaces_custom_tasks():
+    """Verify custom prompt tasks are namespaced under their default task."""
     assert get_self_check_prompt_task("self_check_input", "self_check_input") == "self_check_input"
-    assert get_self_check_prompt_task("check_harmful", "self_check_input") == "self_check_input $task=check_harmful"
+    assert get_self_check_prompt_task("check_harmful", "self_check_input") == "self_check_input $variant=check_harmful"
 
 
 def test_input_no_model_raises_error():

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -21,7 +21,7 @@ from nemoguardrails import RailsConfig
 from nemoguardrails.library.self_check.utils import (
     SELF_CHECK_INPUT_DEFAULT_TASK,
     SELF_CHECK_INPUT_FLOW,
-    SELF_CHECK_INPUT_TASK_PARAM,
+    SELF_CHECK_INPUT_VARIANT_PARAM,
     get_self_check_llm,
     get_self_check_prompt_task,
     get_self_check_task_from_rail,
@@ -792,7 +792,7 @@ def _resolve_input_task(task=None, context=None, events=None):
         triggered_rail_key="triggered_input_rail",
         start_rail_event_type="StartInputRail",
         flow_id=SELF_CHECK_INPUT_FLOW,
-        task_param=SELF_CHECK_INPUT_TASK_PARAM,
+        variant_param=SELF_CHECK_INPUT_VARIANT_PARAM,
         default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
     )
 
@@ -860,7 +860,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
         get_self_check_task_from_rail(
             "self check input $variant=check_harmful",
             flow_id=SELF_CHECK_INPUT_FLOW,
-            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            variant_param=SELF_CHECK_INPUT_VARIANT_PARAM,
             default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
         )
         == "check_harmful"
@@ -870,7 +870,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
         get_self_check_task_from_rail(
             "self check input",
             flow_id=SELF_CHECK_INPUT_FLOW,
-            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            variant_param=SELF_CHECK_INPUT_VARIANT_PARAM,
             default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
         )
         == SELF_CHECK_INPUT_DEFAULT_TASK
@@ -880,7 +880,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
         get_self_check_task_from_rail(
             "self check output $variant=check_inappropriate",
             flow_id=SELF_CHECK_INPUT_FLOW,
-            task_param=SELF_CHECK_INPUT_TASK_PARAM,
+            variant_param=SELF_CHECK_INPUT_VARIANT_PARAM,
             default_task=SELF_CHECK_INPUT_DEFAULT_TASK,
         )
         is None

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -898,6 +898,22 @@ def test_resolve_self_check_task_defaults_unresolved_placeholders():
     assert _resolve_input_task() == SELF_CHECK_INPUT_DEFAULT_TASK
 
 
+def test_bare_triggered_rail_uses_default_over_event_history():
+    task = _resolve_input_task(
+        task="$task",
+        context={"triggered_input_rail": "self check input"},
+        events=[
+            {
+                "type": "start_flow",
+                "flow_id": SELF_CHECK_INPUT_FLOW,
+                "params": {"task": "check_harmful"},
+            }
+        ],
+    )
+
+    assert task == SELF_CHECK_INPUT_DEFAULT_TASK
+
+
 def test_custom_task_rail_without_prompt_fails_at_config_load():
     with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_harmful` prompt template"):
         RailsConfig.from_content(

--- a/tests/test_rails_config.py
+++ b/tests/test_rails_config.py
@@ -99,15 +99,15 @@ def test_check_prompt_exist_for_self_check_rails():
 
 
 def test_check_prompt_exist_for_custom_self_check_task():
-    """Test that custom $task= values on self-check rails are validated."""
+    """Test that custom $variant= values on self-check rails are validated."""
 
     # Custom input task with matching prompt passes
     values = {
         "rails": {
-            "input": {"flows": ["self check input $task=check_harmful"]},
+            "input": {"flows": ["self check input $variant=check_harmful"]},
             "output": {"flows": []},
         },
-        "prompts": [{"task": "self_check_input $task=check_harmful", "content": "..."}],
+        "prompts": [{"task": "self_check_input $variant=check_harmful", "content": "..."}],
     }
     result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
     assert result == values
@@ -115,12 +115,12 @@ def test_check_prompt_exist_for_custom_self_check_task():
     # Custom input task without matching prompt fails
     values = {
         "rails": {
-            "input": {"flows": ["self check input $task=check_harmful"]},
+            "input": {"flows": ["self check input $variant=check_harmful"]},
             "output": {"flows": []},
         },
         "prompts": [],
     }
-    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_harmful` prompt template"):
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$variant=check_harmful` prompt template"):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Multiple custom tasks, one missing, fails
@@ -128,35 +128,37 @@ def test_check_prompt_exist_for_custom_self_check_task():
         "rails": {
             "input": {
                 "flows": [
-                    "self check input $task=check_harmful",
-                    "self check input $task=check_off_topic",
+                    "self check input $variant=check_harmful",
+                    "self check input $variant=check_off_topic",
                 ]
             },
             "output": {"flows": []},
         },
-        "prompts": [{"task": "self_check_input $task=check_harmful", "content": "..."}],
+        "prompts": [{"task": "self_check_input $variant=check_harmful", "content": "..."}],
     }
-    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_off_topic` prompt template"):
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$variant=check_off_topic` prompt template"):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Custom output task without matching prompt fails
     values = {
         "rails": {
             "input": {"flows": []},
-            "output": {"flows": ["self check output $task=check_inappropriate"]},
+            "output": {"flows": ["self check output $variant=check_inappropriate"]},
         },
         "prompts": [],
     }
-    with pytest.raises(ValueError, match=r"Missing a `self_check_output \$task=check_inappropriate` prompt template"):
+    with pytest.raises(
+        ValueError, match=r"Missing a `self_check_output \$variant=check_inappropriate` prompt template"
+    ):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Custom output task with matching prompt passes
     values = {
         "rails": {
             "input": {"flows": []},
-            "output": {"flows": ["self check output $task=check_inappropriate"]},
+            "output": {"flows": ["self check output $variant=check_inappropriate"]},
         },
-        "prompts": [{"task": "self_check_output $task=check_inappropriate", "content": "..."}],
+        "prompts": [{"task": "self_check_output $variant=check_inappropriate", "content": "..."}],
     }
     result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
     assert result == values

--- a/tests/test_rails_config.py
+++ b/tests/test_rails_config.py
@@ -107,7 +107,7 @@ def test_check_prompt_exist_for_custom_self_check_task():
             "input": {"flows": ["self check input $task=check_harmful"]},
             "output": {"flows": []},
         },
-        "prompts": [{"task": "check_harmful", "content": "..."}],
+        "prompts": [{"task": "self_check_input $task=check_harmful", "content": "..."}],
     }
     result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
     assert result == values
@@ -120,7 +120,7 @@ def test_check_prompt_exist_for_custom_self_check_task():
         },
         "prompts": [],
     }
-    with pytest.raises(ValueError, match="Missing a `check_harmful` prompt template"):
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_harmful` prompt template"):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Multiple custom tasks, one missing, fails
@@ -134,9 +134,9 @@ def test_check_prompt_exist_for_custom_self_check_task():
             },
             "output": {"flows": []},
         },
-        "prompts": [{"task": "check_harmful", "content": "..."}],
+        "prompts": [{"task": "self_check_input $task=check_harmful", "content": "..."}],
     }
-    with pytest.raises(ValueError, match="Missing a `check_off_topic` prompt template"):
+    with pytest.raises(ValueError, match=r"Missing a `self_check_input \$task=check_off_topic` prompt template"):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Custom output task without matching prompt fails
@@ -147,7 +147,7 @@ def test_check_prompt_exist_for_custom_self_check_task():
         },
         "prompts": [],
     }
-    with pytest.raises(ValueError, match="Missing a `check_inappropriate` prompt template"):
+    with pytest.raises(ValueError, match=r"Missing a `self_check_output \$task=check_inappropriate` prompt template"):
         RailsConfig.check_prompt_exist_for_self_check_rails(values)
 
     # Custom output task with matching prompt passes
@@ -156,7 +156,7 @@ def test_check_prompt_exist_for_custom_self_check_task():
             "input": {"flows": []},
             "output": {"flows": ["self check output $task=check_inappropriate"]},
         },
-        "prompts": [{"task": "check_inappropriate", "content": "..."}],
+        "prompts": [{"task": "self_check_output $task=check_inappropriate", "content": "..."}],
     }
     result = RailsConfig.check_prompt_exist_for_self_check_rails(values)
     assert result == values

--- a/tests/v2_x/test_multiple_self_check_rails.py
+++ b/tests/v2_x/test_multiple_self_check_rails.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.testing.fake_model import FakeLLMModel
+
+
+@pytest.mark.asyncio
+async def test_multiple_self_check_input_tasks():
+    config = RailsConfig.from_content(
+        colang_content="""
+        import core
+        import guardrails
+        import nemoguardrails.library.self_check.input_check
+
+        flow input rails $input_text
+            self check input $task="check_harmful"
+            self check input $task="check_off_topic"
+
+        flow main
+            await user said $text
+            bot say "ordinary response"
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        models: []
+        enable_rails_exceptions: true
+        prompts:
+          - task: check_harmful
+            content: User input {{ user_input }}
+            output_parser: is_content_safe
+          - task: check_off_topic
+            content: User input {{ user_input }}
+            output_parser: is_content_safe
+        """,
+    )
+    llm = FakeLLMModel(responses=["safe", "unsafe"])
+    rails = LLMRails(config, llm=llm)
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "blocked_off_topic"}])
+
+    assert [call.task for call in rails.explain().llm_calls] == ["check_harmful", "check_off_topic"]
+    assert [event["type"] for event in result["events"]] == ["InputRailException"]
+    assert llm.inference_count == 2
+
+
+@pytest.mark.asyncio
+async def test_multiple_self_check_output_tasks():
+    config = RailsConfig.from_content(
+        colang_content="""
+        import core
+        import guardrails
+        import nemoguardrails.library.self_check.output_check
+
+        flow output rails $output_text
+            self check output $task="check_inappropriate"
+            self check output $task="check_data_leakage"
+
+        flow main
+            await user said $text
+            bot say "response containing blocked_data_leakage"
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        models: []
+        enable_rails_exceptions: true
+        prompts:
+          - task: check_inappropriate
+            content: Bot response {{ bot_response }}
+            output_parser: is_content_safe
+          - task: check_data_leakage
+            content: Bot response {{ bot_response }}
+            output_parser: is_content_safe
+        """,
+    )
+    llm = FakeLLMModel(responses=["safe", "unsafe"])
+    rails = LLMRails(config, llm=llm)
+
+    result = await rails.generate_async(messages=[{"role": "user", "content": "hello"}])
+
+    assert [call.task for call in rails.explain().llm_calls] == ["check_inappropriate", "check_data_leakage"]
+    assert [event["type"] for event in result["events"]] == ["OutputRailException"]
+    assert llm.inference_count == 2

--- a/tests/v2_x/test_multiple_self_check_rails.py
+++ b/tests/v2_x/test_multiple_self_check_rails.py
@@ -21,6 +21,7 @@ from nemoguardrails.testing.fake_model import FakeLLMModel
 
 @pytest.mark.asyncio
 async def test_multiple_self_check_input_tasks():
+    """Verify Colang 2 runs multiple custom input self-check tasks."""
     config = RailsConfig.from_content(
         colang_content="""
         import core
@@ -28,8 +29,8 @@ async def test_multiple_self_check_input_tasks():
         import nemoguardrails.library.self_check.input_check
 
         flow input rails $input_text
-            self check input $task="check_harmful"
-            self check input $task="check_off_topic"
+            self check input $variant="check_harmful"
+            self check input $variant="check_off_topic"
 
         flow main
             await user said $text
@@ -40,10 +41,10 @@ async def test_multiple_self_check_input_tasks():
         models: []
         enable_rails_exceptions: true
         prompts:
-          - task: self_check_input $task=check_harmful
+          - task: self_check_input $variant=check_harmful
             content: User input {{ user_input }}
             output_parser: is_content_safe
-          - task: self_check_input $task=check_off_topic
+          - task: self_check_input $variant=check_off_topic
             content: User input {{ user_input }}
             output_parser: is_content_safe
         """,
@@ -54,8 +55,8 @@ async def test_multiple_self_check_input_tasks():
     result = await rails.generate_async(messages=[{"role": "user", "content": "blocked_off_topic"}])
 
     assert [call.task for call in rails.explain().llm_calls] == [
-        "self_check_input $task=check_harmful",
-        "self_check_input $task=check_off_topic",
+        "self_check_input $variant=check_harmful",
+        "self_check_input $variant=check_off_topic",
     ]
     assert [event["type"] for event in result["events"]] == ["InputRailException"]
     assert llm.inference_count == 2
@@ -63,6 +64,7 @@ async def test_multiple_self_check_input_tasks():
 
 @pytest.mark.asyncio
 async def test_multiple_self_check_output_tasks():
+    """Verify Colang 2 runs multiple custom output self-check tasks."""
     config = RailsConfig.from_content(
         colang_content="""
         import core
@@ -70,8 +72,8 @@ async def test_multiple_self_check_output_tasks():
         import nemoguardrails.library.self_check.output_check
 
         flow output rails $output_text
-            self check output $task="check_inappropriate"
-            self check output $task="check_data_leakage"
+            self check output $variant="check_inappropriate"
+            self check output $variant="check_data_leakage"
 
         flow main
             await user said $text
@@ -82,10 +84,10 @@ async def test_multiple_self_check_output_tasks():
         models: []
         enable_rails_exceptions: true
         prompts:
-          - task: self_check_output $task=check_inappropriate
+          - task: self_check_output $variant=check_inappropriate
             content: Bot response {{ bot_response }}
             output_parser: is_content_safe
-          - task: self_check_output $task=check_data_leakage
+          - task: self_check_output $variant=check_data_leakage
             content: Bot response {{ bot_response }}
             output_parser: is_content_safe
         """,
@@ -96,8 +98,8 @@ async def test_multiple_self_check_output_tasks():
     result = await rails.generate_async(messages=[{"role": "user", "content": "hello"}])
 
     assert [call.task for call in rails.explain().llm_calls] == [
-        "self_check_output $task=check_inappropriate",
-        "self_check_output $task=check_data_leakage",
+        "self_check_output $variant=check_inappropriate",
+        "self_check_output $variant=check_data_leakage",
     ]
     assert [event["type"] for event in result["events"]] == ["OutputRailException"]
     assert llm.inference_count == 2

--- a/tests/v2_x/test_multiple_self_check_rails.py
+++ b/tests/v2_x/test_multiple_self_check_rails.py
@@ -40,10 +40,10 @@ async def test_multiple_self_check_input_tasks():
         models: []
         enable_rails_exceptions: true
         prompts:
-          - task: check_harmful
+          - task: self_check_input $task=check_harmful
             content: User input {{ user_input }}
             output_parser: is_content_safe
-          - task: check_off_topic
+          - task: self_check_input $task=check_off_topic
             content: User input {{ user_input }}
             output_parser: is_content_safe
         """,
@@ -53,7 +53,10 @@ async def test_multiple_self_check_input_tasks():
 
     result = await rails.generate_async(messages=[{"role": "user", "content": "blocked_off_topic"}])
 
-    assert [call.task for call in rails.explain().llm_calls] == ["check_harmful", "check_off_topic"]
+    assert [call.task for call in rails.explain().llm_calls] == [
+        "self_check_input $task=check_harmful",
+        "self_check_input $task=check_off_topic",
+    ]
     assert [event["type"] for event in result["events"]] == ["InputRailException"]
     assert llm.inference_count == 2
 
@@ -79,10 +82,10 @@ async def test_multiple_self_check_output_tasks():
         models: []
         enable_rails_exceptions: true
         prompts:
-          - task: check_inappropriate
+          - task: self_check_output $task=check_inappropriate
             content: Bot response {{ bot_response }}
             output_parser: is_content_safe
-          - task: check_data_leakage
+          - task: self_check_output $task=check_data_leakage
             content: Bot response {{ bot_response }}
             output_parser: is_content_safe
         """,
@@ -92,6 +95,9 @@ async def test_multiple_self_check_output_tasks():
 
     result = await rails.generate_async(messages=[{"role": "user", "content": "hello"}])
 
-    assert [call.task for call in rails.explain().llm_calls] == ["check_inappropriate", "check_data_leakage"]
+    assert [call.task for call in rails.explain().llm_calls] == [
+        "self_check_output $task=check_inappropriate",
+        "self_check_output $task=check_data_leakage",
+    ]
     assert [event["type"] for event in result["events"]] == ["OutputRailException"]
     assert llm.inference_count == 2


### PR DESCRIPTION
## Description

Follow-up to #1874. Namespace custom self-check prompt task identifiers under
`self_check_input` and `self_check_output` while preserving task-specific model
routing.

Adds Colang 1 and 2 coverage plus recorded public-API coverage for sequential,
parallel, and streaming execution. Review requested from @RobGeada.


## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change.

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-check rails now support multiple custom tasks with distinct prompt templates and model routing.
  * Input and output safety checks correctly preserve task-specific behavior during generation and streaming.
  * Custom task prompt validation now provides clearer missing-template errors.

* **Bug Fixes**
  * Improved task resolution when runtime context is unavailable or contains conflicting history.
  * Corrected sequential and parallel self-check execution and output-blocking behavior.

* **Tests**
  * Expanded coverage for multi-task checks, streaming, parallel execution, provider errors, and prompt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->