### PR TITLE
feat(iorails)!: Support non-streaming GenerationResponse

### DIFF
--- a/examples/configs/nemoguards/config.yml
+++ b/examples/configs/nemoguards/config.yml
@@ -1,7 +1,7 @@
 models:
   - type: main
     engine: nim
-    model: meta/llama-3.3-70b-instruct
+    model: nvidia/nemotron-3-ultra-550b-a55b
 
   - type: content_safety
     engine: nim

--- a/examples/configs/nemoguards/config.yml
+++ b/examples/configs/nemoguards/config.yml
@@ -1,7 +1,7 @@
 models:
   - type: main
     engine: nim
-    model: nvidia/nemotron-3-ultra-550b-a55b
+    model: meta/llama-3.3-70b-instruct
 
   - type: content_safety
     engine: nim

--- a/nemoguardrails/base_guardrails.py
+++ b/nemoguardrails/base_guardrails.py
@@ -27,9 +27,10 @@ that actually provide them.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional, Union
 
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.options import GenerationOptions
 
 
 class BaseGuardrails(ABC):
@@ -44,12 +45,14 @@ class BaseGuardrails(ABC):
     config: RailsConfig
 
     @abstractmethod
-    def generate(self, *args: Any, **kwargs: Any) -> Any:
+    def generate(self, *args: Any, options: Optional[Union[dict, GenerationOptions]] = None, **kwargs: Any) -> Any:
         """Generate an LLM response synchronously with guardrails applied."""
         ...
 
     @abstractmethod
-    async def generate_async(self, *args: Any, **kwargs: Any) -> Any:
+    async def generate_async(
+        self, *args: Any, options: Optional[Union[dict, GenerationOptions]] = None, **kwargs: Any
+    ) -> Any:
         """Generate an LLM response asynchronously with guardrails applied."""
         ...
 

--- a/nemoguardrails/guardrails/actions/content_safety_action.py
+++ b/nemoguardrails/guardrails/actions/content_safety_action.py
@@ -121,10 +121,13 @@ def _content_safety_to_rail_result(parsed: object) -> RailResult:
     """
     if isinstance(parsed, (list, tuple)):
         if parsed and parsed[0] is True:
-            return RailResult(is_safe=True)
+            return RailResult(is_safe=True, return_value={"allowed": True, "policy_violations": []})
         if parsed and parsed[0] is False:
-            if len(parsed) > 1:
-                categories = ", ".join(str(c) for c in parsed[1:])
-                return RailResult(is_safe=False, reason=f"Safety categories: {categories}")
-            return RailResult(is_safe=False, reason="Unknown")
+            violations = [str(c) for c in parsed[1:]]
+            verdict = {"allowed": False, "policy_violations": violations}
+            if violations:
+                return RailResult(
+                    is_safe=False, reason=f"Safety categories: {', '.join(violations)}", return_value=verdict
+                )
+            return RailResult(is_safe=False, reason="Unknown", return_value=verdict)
     raise RuntimeError(f"Unexpected content safety parse result: {parsed}")

--- a/nemoguardrails/guardrails/actions/jailbreak_detection_action.py
+++ b/nemoguardrails/guardrails/actions/jailbreak_detection_action.py
@@ -41,6 +41,7 @@ class JailbreakDetectionAction(RailAction):
             raise RuntimeError(f"Jailbreak response missing 'jailbreak' field: {response}")
 
         score = response.get("score", "unknown")
-        if response["jailbreak"]:
-            return RailResult(is_safe=False, reason=f"Score: {score}")
-        return RailResult(is_safe=True, reason=f"Score: {score}")
+        is_jailbreak = response["jailbreak"]
+        if is_jailbreak:
+            return RailResult(is_safe=False, reason=f"Score: {score}", return_value=is_jailbreak)
+        return RailResult(is_safe=True, reason=f"Score: {score}", return_value=is_jailbreak)

--- a/nemoguardrails/guardrails/actions/topic_safety_action.py
+++ b/nemoguardrails/guardrails/actions/topic_safety_action.py
@@ -63,5 +63,5 @@ class TopicSafetyInputAction(RailAction):
 
     def _parse_response(self, response: Any) -> RailResult:
         if response.lower().strip() == "off-topic":
-            return RailResult(is_safe=False, reason="Topic safety: off-topic")
-        return RailResult(is_safe=True)
+            return RailResult(is_safe=False, reason="Topic safety: off-topic", return_value={"on_topic": False})
+        return RailResult(is_safe=True, return_value={"on_topic": True})

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -172,6 +172,10 @@ class EngineRegistry:
             raise TypeError(f"Engine '{name}' is {type(engine).__name__}, expected {expected_type.__name__}")
         return engine
 
+    def provider_name(self, model_type: str) -> str:
+        """Return the provider/engine name (e.g. 'nim', 'openai') for a model engine."""
+        return self._get_engine(model_type, ModelEngine).model_config.engine or "unknown"
+
     async def model_call(self, model_type: str, messages: list[dict], **kwargs: Any) -> LLMResponse:
         """Route a chat completion request to the named model engine.
 

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -38,7 +38,7 @@ from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.llmrails import LLMRails
-from nemoguardrails.rails.llm.options import GenerationResponse, RailsResult, RailType
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse, RailsResult, RailType
 from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
@@ -205,35 +205,61 @@ class Guardrails(BaseGuardrails):
             await self.startup()
 
     def generate(
-        self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> Union[str, dict, GenerationResponse, Tuple[dict, dict]]:
         """Generate an LLM response synchronously with guardrails applied.
         Supported in both IORails and LLMRails
         """
 
         generate_messages = self._convert_to_messages(prompt, messages)
-        return self.rails_engine.generate(messages=generate_messages, **kwargs)
-
-    @overload
-    async def generate_async(self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs) -> str: ...
+        return self.rails_engine.generate(messages=generate_messages, options=options, **kwargs)
 
     @overload
     async def generate_async(
-        self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
+    ) -> str: ...
+
+    @overload
+    async def generate_async(
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> dict: ...
 
     @overload
     async def generate_async(
-        self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> GenerationResponse: ...
 
     @overload
     async def generate_async(
-        self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> tuple[dict, dict]: ...
 
     async def generate_async(
-        self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
+        self,
+        prompt: str | None = None,
+        messages: LLMMessages | None = None,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> str | dict | GenerationResponse | tuple[dict, dict]:
         """Generate an LLM response asynchronously with guardrails applied.
         Supported by both LLMRails and IORails
@@ -241,7 +267,7 @@ class Guardrails(BaseGuardrails):
         await self._ensure_started()
 
         generate_messages = self._convert_to_messages(prompt, messages)
-        return await self.rails_engine.generate_async(messages=generate_messages, **kwargs)
+        return await self.rails_engine.generate_async(messages=generate_messages, options=options, **kwargs)
 
     def stream_async(
         self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -23,7 +23,7 @@ LLM responses with programmable guardrails.
 
 import logging
 import warnings
-from typing import Any, AsyncIterator, Callable, List, Optional, Tuple, Type, Union, cast, overload
+from typing import Any, AsyncIterator, Callable, List, Optional, Tuple, Type, Union, cast
 
 from typing_extensions import Self
 
@@ -181,24 +181,6 @@ class Guardrails(BaseGuardrails):
         llmrails = cast(LLMRails, self.rails_engine)
         llmrails.passthrough_fn = fn
 
-    @staticmethod
-    def _convert_to_messages(prompt: str | None = None, messages: LLMMessages | None = None) -> LLMMessages:
-        """Return messages in standard format, converting a prompt string if needed.
-
-        If messages is provided, returns it as-is.
-        If prompt is provided, wraps it as [{"role": "user", "content": prompt}].
-        """
-
-        # Priority: messages first, then prompt
-        if messages:
-            return messages
-
-        if prompt:
-            # Convert string prompt to standard format
-            return [{"role": "user", "content": prompt}]
-
-        raise ValueError("Neither prompt nor messages provided for generation")
-
     async def _ensure_started(self) -> None:
         """Lazy initialization: call startup() on first use if not already started."""
         if not self._started:
@@ -214,45 +196,7 @@ class Guardrails(BaseGuardrails):
         """Generate an LLM response synchronously with guardrails applied.
         Supported in both IORails and LLMRails
         """
-
-        generate_messages = self._convert_to_messages(prompt, messages)
-        return self.rails_engine.generate(messages=generate_messages, options=options, **kwargs)
-
-    @overload
-    async def generate_async(
-        self,
-        prompt: str | None = None,
-        messages: LLMMessages | None = None,
-        options: Optional[Union[dict, GenerationOptions]] = None,
-        **kwargs,
-    ) -> str: ...
-
-    @overload
-    async def generate_async(
-        self,
-        prompt: str | None = None,
-        messages: LLMMessages | None = None,
-        options: Optional[Union[dict, GenerationOptions]] = None,
-        **kwargs,
-    ) -> dict: ...
-
-    @overload
-    async def generate_async(
-        self,
-        prompt: str | None = None,
-        messages: LLMMessages | None = None,
-        options: Optional[Union[dict, GenerationOptions]] = None,
-        **kwargs,
-    ) -> GenerationResponse: ...
-
-    @overload
-    async def generate_async(
-        self,
-        prompt: str | None = None,
-        messages: LLMMessages | None = None,
-        options: Optional[Union[dict, GenerationOptions]] = None,
-        **kwargs,
-    ) -> tuple[dict, dict]: ...
+        return self.rails_engine.generate(prompt=prompt, messages=messages, options=options, **kwargs)
 
     async def generate_async(
         self,
@@ -266,15 +210,15 @@ class Guardrails(BaseGuardrails):
         """
         await self._ensure_started()
 
-        generate_messages = self._convert_to_messages(prompt, messages)
-        return await self.rails_engine.generate_async(messages=generate_messages, options=options, **kwargs)
+        return await self.rails_engine.generate_async(prompt=prompt, messages=messages, options=options, **kwargs)
 
     def stream_async(
         self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
     ) -> AsyncIterator[str | dict]:
         """Generate an LLM response asynchronously with streaming support."""
 
-        stream_messages = self._convert_to_messages(prompt, messages)
+        # TODO: Move prompt/message normalization into IORails when streaming GenerationOptions added
+        stream_messages = IORails._convert_to_messages(prompt, messages)
 
         async def _with_startup(iterator: AsyncIterator[str | dict]) -> AsyncIterator[str | dict]:
             await self._ensure_started()

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional, TypeAlias
 
-from nemoguardrails.types import UsageInfo
+from nemoguardrails.types import LLMResponse, UsageInfo
 
 # LLMMessage can contain role/content, plus optional tool_calls / tool_call_id / name; content may be None
 LLMMessage: TypeAlias = dict[str, Any]
@@ -84,6 +84,20 @@ class RailResult:
     triggered_rail: str | None = None
     records: tuple[RailCallRecord, ...] = field(default=(), compare=False)
     return_value: Any = field(default=None, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class TimedLLMResponse:
+    """An LLM response paired with wall-clock start/finish timestamps and a monotonic duration.
+
+    Returned by IORails' main-model call helper so the sequential and speculative paths both
+    carry real timing into the generation ``RailCallRecord``.
+    """
+
+    response: LLMResponse
+    started_at: float
+    finished_at: float
+    duration: float
 
 
 # Default max character length for truncate(). Used to keep DEBUG log lines short.

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -135,7 +135,16 @@ def serialize_prompt(messages: list[dict]) -> str:
     """Render a chat message list to a role-labeled string for GenerationLog's ``prompt``.
 
     Content parity with LLMRails' logged prompt, not byte-for-byte format parity: each
-    message becomes ``"<role>: <content>"`` and messages are blank-line separated. A
-    message with no content (e.g. a reasoning-only or tool-call turn) renders as empty.
+    message becomes ``"<role>: <content>"``. Non-content fields present on the message
+    (``name``, ``tool_call_id``, ``tool_calls``, ``reasoning``) are appended as a compact
+    ``[key=value, ...]`` suffix so tool-call and reasoning-only turns are preserved rather
+    than dropped. Messages are blank-line separated.
     """
-    return "\n\n".join(f"{m.get('role', '')}: {m.get('content') or ''}" for m in messages)
+    lines = []
+    for m in messages:
+        line = f"{m.get('role', '')}: {m.get('content') or ''}"
+        extras = [f"{key}={m[key]}" for key in ("name", "tool_call_id", "tool_calls", "reasoning") if m.get(key)]
+        if extras:
+            line += f" [{', '.join(extras)}]"
+        lines.append(line)
+    return "\n\n".join(lines)

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -56,6 +56,8 @@ class RailCallRecord:
     usage: Optional[UsageInfo] = None
     llm_model_name: Optional[str] = None
     llm_provider_name: Optional[str] = None
+    prompt: Optional[str] = None
+    completion: Optional[str] = None
     started_at: Optional[float] = None
     finished_at: Optional[float] = None
     duration: Optional[float] = None
@@ -127,3 +129,13 @@ def truncate(text: object, max_len: int | None = None) -> str:
     if len(s) <= limit:
         return s
     return s[:limit] + "..."
+
+
+def serialize_prompt(messages: list[dict]) -> str:
+    """Render a chat message list to a role-labeled string for GenerationLog's ``prompt``.
+
+    Content parity with LLMRails' logged prompt, not byte-for-byte format parity: each
+    message becomes ``"<role>: <content>"`` and messages are blank-line separated. A
+    message with no content (e.g. a reasoning-only or tool-call turn) renders as empty.
+    """
+    return "\n\n".join(f"{m.get('role', '')}: {m.get('content') or ''}" for m in messages)

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -48,9 +48,11 @@ class RailCallRecord:
     flow: str
     rail_type: str
     is_safe: bool
+    made_call: bool = False
     action_name: Optional[str] = None
     return_value: Any = None
     task: Optional[str] = None
+    request_id: Optional[str] = None
     usage: Optional[UsageInfo] = None
     llm_model_name: Optional[str] = None
     llm_provider_name: Optional[str] = None

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -16,9 +16,11 @@
 
 import secrets
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, TypeAlias
+from typing import Any, Optional, TypeAlias
+
+from nemoguardrails.types import UsageInfo
 
 # LLMMessage can contain role/content, plus optional tool_calls / tool_call_id / name; content may be None
 LLMMessage: TypeAlias = dict[str, Any]
@@ -33,12 +35,51 @@ class RailDirection(Enum):
 
 
 @dataclass(frozen=True, slots=True)
+class RailCallRecord:
+    """One rail's execution record, carried on RailResult for GenerationLog synthesis.
+
+    Captures what a single rail did — its verdict and the (at most one) model call it
+    made — as engine-neutral data. IORails maps a ``RailCallRecord`` to an
+    ``ActivatedRail`` (with a single synthetic ``ExecutedAction`` and ``LLMCallInfo``);
+    the raw ``usage``/timing is kept here so this module stays free of the pydantic
+    ``GenerationLog`` types. Tool rails that make no model call leave ``usage`` None.
+    """
+
+    flow: str
+    rail_type: str
+    is_safe: bool
+    action_name: Optional[str] = None
+    return_value: Any = None
+    task: Optional[str] = None
+    usage: Optional[UsageInfo] = None
+    llm_model_name: Optional[str] = None
+    llm_provider_name: Optional[str] = None
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    duration: Optional[float] = None
+
+
+@dataclass(frozen=True, slots=True)
 class RailResult:
-    """Result of a rail safety check."""
+    """Result of a rail safety check.
+
+    ``records`` carries the per-rail execution records for every rail that ran in this
+    check (not just the blocking one), so IORails can synthesize a ``GenerationLog``.
+    It is empty unless log collection is active. ``return_value`` is the rail's
+    structured verdict (e.g. ``{"allowed": ..., "policy_violations": [...]}``) when the
+    action supplies one, used as the log's ``ExecutedAction.return_value``.
+
+    ``records`` and ``return_value`` are log-capture metadata, not part of the safety
+    verdict, so they are excluded from equality and hashing (``compare=False``) — two
+    results with the same ``is_safe``/``reason``/``triggered_rail`` compare equal
+    regardless of captured log data.
+    """
 
     is_safe: bool
     reason: str | None = None
     triggered_rail: str | None = None
+    records: tuple[RailCallRecord, ...] = field(default=(), compare=False)
+    return_value: Any = field(default=None, compare=False)
 
 
 # Default max character length for truncate(). Used to keep DEBUG log lines short.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -63,10 +63,16 @@ from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
-from nemoguardrails.rails.llm.options import GenerationOptions, RailsResult, RailStatus, RailType
+from nemoguardrails.rails.llm.options import (
+    GenerationOptions,
+    GenerationResponse,
+    RailsResult,
+    RailStatus,
+    RailType,
+)
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.tracing.constants import GuardrailsAttributes
-from nemoguardrails.types import LLMModel, LLMResponse, ToolCall
+from nemoguardrails.types import LLMModel, LLMResponse, ToolCall, UsageInfo
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -168,6 +174,105 @@ def _build_assistant_message(content: str, tool_calls: Optional[list[ToolCall]])
         "content": content or None,
         "tool_calls": _serialize_tool_calls(tool_calls),
     }
+
+
+def _usage_to_dict(usage: UsageInfo) -> dict:
+    """Serialize ``UsageInfo`` token counts to a dict, dropping ``None`` values.
+
+    ``input_tokens``/``output_tokens``/``total_tokens`` default to 0 and are always
+    kept; ``reasoning_tokens``/``cached_tokens`` default to ``None`` and are omitted
+    unless the provider reported them.
+    """
+    fields = {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.total_tokens,
+        "reasoning_tokens": usage.reasoning_tokens,
+        "cached_tokens": usage.cached_tokens,
+    }
+    return {key: value for key, value in fields.items() if value is not None}
+
+
+def _build_llm_metadata(response: LLMResponse) -> Optional[dict]:
+    """Assemble ``llm_metadata`` from the main call's ``provider_metadata`` plus usage.
+
+    Mirrors LLMRails' ``llm_metadata`` (the provider metadata blob) and adds a
+    structured ``usage`` sub-key with token counts that LLMRails does not expose
+    outside its ``log``. Returns ``None`` when neither is present.
+    """
+    metadata = dict(response.provider_metadata or {})
+    if response.usage:
+        usage = _usage_to_dict(response.usage)
+        if usage:
+            metadata["usage"] = usage
+    return metadata or None
+
+
+def _build_generation_response(
+    response_text: str, reasoning_content: Optional[str], response: LLMResponse
+) -> GenerationResponse:
+    """Build the structured ``GenerationResponse`` returned when ``options`` are supplied.
+
+    Reasoning goes to the ``reasoning_content`` field with clean message content (no
+    inline ``<think>`` prefix — that is the bare-return shape). Tool calls use the
+    canonical ``ToolCall.to_dict()`` shape (dict arguments), matching LLMRails'
+    ``GenerationResponse.tool_calls`` rather than the OpenAI-wire JSON-string shape
+    used for the bare message. ``llm_output`` stays ``None`` to match LLMRails, whose
+    ``raw_response`` source is never populated.
+    """
+    result = GenerationResponse(response=[{"role": "assistant", "content": response_text}])
+    if reasoning_content:
+        result.reasoning_content = reasoning_content
+    if response.tool_calls:
+        result.tool_calls = [tool_call.to_dict() for tool_call in response.tool_calls]
+    llm_metadata = _build_llm_metadata(response)
+    if llm_metadata:
+        result.llm_metadata = llm_metadata
+    return result
+
+
+def _finalize_refusal(structured: bool) -> Union[LLMMessage, GenerationResponse]:
+    """Shape the refusal message for the active return contract (structured vs bare)."""
+    message: LLMMessage = {"role": "assistant", "content": REFUSAL_MESSAGE}
+    if structured:
+        return GenerationResponse(response=[message])
+    return message
+
+
+def _response_content_for_capture(result: Union[LLMMessage, GenerationResponse]) -> Optional[str]:
+    """Extract the assistant content for content capture from either return shape."""
+    if isinstance(result, GenerationResponse):
+        response = result.response
+        if isinstance(response, list) and response:
+            last = response[-1]
+            content = last.get("content") if isinstance(last, dict) else None
+            return content if isinstance(content, str) else None
+        return response if isinstance(response, str) else None
+    return result.get("content")
+
+
+def _raise_on_unsupported_options(options: Optional[GenerationOptions], state: object) -> None:
+    """Raise for ``GenerationOptions``/``state`` features IORails cannot honor.
+
+    ``state`` and ``output_vars``/``output_data`` require Colang runtime state that
+    IORails does not have and raise ``ValueError``; ``log`` is deferred to a follow-up
+    PR and raises ``NotImplementedError``. These raise rather than silently returning
+    empty data, mirroring how LLMRails rejects options it cannot fulfill.
+    """
+    if state is not None:
+        raise ValueError("state is not supported by IORails; it is a stateless input/output rails engine")
+    if options is None:
+        return
+    if options.output_vars:
+        raise ValueError("output_vars/output_data is not supported by IORails; it has no Colang context to return")
+    log_options = options.log
+    if log_options and (
+        log_options.activated_rails
+        or log_options.llm_calls
+        or log_options.internal_events
+        or log_options.colang_history
+    ):
+        raise NotImplementedError("GenerationResponse `log` is not supported by IORails")
 
 
 def _coerce_generation_options(options: Optional[Union[dict, GenerationOptions]]) -> Optional[GenerationOptions]:
@@ -464,7 +569,7 @@ class IORails(BaseGuardrails):
         """Context manager (used for testing rather than long-lived instance)"""
         await self.stop()
 
-    def generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
+    def generate(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
         """Synchronous version of generate_async.
 
         Telemetry is disabled for the ephemeral IORails object used for
@@ -488,7 +593,7 @@ class IORails(BaseGuardrails):
 
         return asyncio.run(_run_sync_iorails())
 
-    async def generate_async(self, messages: LLMMessages, **kwargs) -> LLMMessage:
+    async def generate_async(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
         """Public entry: submit the request to the internal work queue.
 
         The queue enforces non-streaming concurrency limits
@@ -514,7 +619,7 @@ class IORails(BaseGuardrails):
                     record_nonstream_rejected()
                 raise
 
-    async def _run_generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
+    async def _run_generate(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
         """Runs inside a queue worker task.  Wraps the pipeline in
         ``traced_request`` so each request gets its own span + request ID,
         then delegates to ``_do_generate`` for the actual input rails →
@@ -533,7 +638,7 @@ class IORails(BaseGuardrails):
             # Capture content once here at the traced_request boundary so any
             # future early-return added to _do_generate is covered automatically.
             if self._content_capture_enabled:
-                set_request_content(request_span, messages, result.get("content"))
+                set_request_content(request_span, messages, _response_content_for_capture(result))
             elapsed_ms = (time.monotonic() - t0) * 1000
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             return result
@@ -560,12 +665,16 @@ class IORails(BaseGuardrails):
 
     async def _do_generate(
         self, messages: LLMMessages, req_id: str, request_span: Optional["Span"] = None, **kwargs
-    ) -> LLMMessage:
+    ) -> Union[LLMMessage, GenerationResponse]:
         """Core pipeline: tool-result rails -> input rails -> LLM call -> tool-call + output rails."""
         log.info("[%s] generate_async called", req_id)
         log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
 
         options = _coerce_generation_options(kwargs.get("options"))
+        _raise_on_unsupported_options(options, kwargs.get("state"))
+        # When options are supplied we return a structured GenerationResponse
+        # (mirroring LLMRails' `if gen_options:` branch); otherwise a bare LLMMessage.
+        has_generation_response = options is not None
         # Pass llm_params (including tool definitions) unchanged to the LLM call.
         llm_kwargs = options.llm_params if (options and options.llm_params) else {}
         input_enabled = options.rails.input if options else True
@@ -581,7 +690,7 @@ class IORails(BaseGuardrails):
             log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return {"role": "assistant", "content": REFUSAL_MESSAGE}
+            return _finalize_refusal(has_generation_response)
 
         if self._speculative_generation:
             response = await self._do_generate_speculative(
@@ -591,7 +700,7 @@ class IORails(BaseGuardrails):
             response = await self._do_generate_sequential(messages, req_id, llm_kwargs, input_enabled=input_enabled)
 
         if response is None:
-            return {"role": "assistant", "content": REFUSAL_MESSAGE}
+            return _finalize_refusal(has_generation_response)
 
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
@@ -612,7 +721,7 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Tool call blocked: %s", req_id, tool_call.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return {"role": "assistant", "content": REFUSAL_MESSAGE}
+                return _finalize_refusal(has_generation_response)
 
         # Output rails check the final answer, not reasoning traces.
         # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
@@ -627,10 +736,14 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return {"role": "assistant", "content": REFUSAL_MESSAGE}
+                return _finalize_refusal(has_generation_response)
 
-        # TODO: Support returning GenerationResponse `reasoning_content` to match LLMRails
-        # For now, embed the reasoning on the content with think-tags
+        if has_generation_response:
+            return _build_generation_response(response_text, reasoning_content, response)
+
+        # Bare return path: reasoning is delivered inline as a <think> prefix
+        # (LLMRails legacy shape). The structured path above instead puts it in the
+        # reasoning_content field and keeps the message content clean.
         if reasoning_content:
             response_text = f"<think>{reasoning_content}</think>\n" + response_text
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     LLMMessages,
     RailCallRecord,
     RailDirection,
+    TimedLLMResponse,
     get_request_id,
     serialize_prompt,
     truncate,
@@ -193,10 +194,7 @@ def _build_llm_metadata(response: LLMResponse) -> Optional[dict]:
 
 
 def _make_generation_record(
-    response: LLMResponse,
-    started_at: Optional[float],
-    finished_at: Optional[float],
-    duration: Optional[float],
+    timed: TimedLLMResponse,
     provider_name: Optional[str],
     prompt: Optional[str],
 ) -> RailCallRecord:
@@ -204,9 +202,10 @@ def _make_generation_record(
 
     Unifies the main call with the rail calls so the log builder can treat every LLM call
     the same way. ``prompt`` is the serialized main-model messages; ``completion`` is the
-    response content. ``started_at``/``finished_at`` are wall-clock timestamps;
-    ``duration`` is a monotonic delta.
+    response content. Timing comes from ``timed``: ``started_at``/``finished_at`` are
+    wall-clock timestamps and ``duration`` is a monotonic delta.
     """
+    response = timed.response
     return RailCallRecord(
         flow="generation",
         rail_type="generation",
@@ -220,9 +219,9 @@ def _make_generation_record(
         llm_provider_name=provider_name,
         prompt=prompt,
         completion=response.content,
-        started_at=started_at,
-        finished_at=finished_at,
-        duration=duration,
+        started_at=timed.started_at,
+        finished_at=timed.finished_at,
+        duration=timed.duration,
     )
 
 
@@ -942,6 +941,22 @@ class IORails(BaseGuardrails):
 
         return _build_assistant_message(response_text, response.tool_calls)
 
+    async def _timed_main_call(self, messages: LLMMessages, llm_kwargs: dict) -> TimedLLMResponse:
+        """Call the main model, returning the response with wall-clock start/finish and a monotonic duration.
+
+        Shared by the sequential and speculative paths so the main call's ``RailCallRecord``
+        always carries real timing (the speculative path previously left it None).
+        """
+        started_at = time.time()
+        t0 = time.monotonic()
+        response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        return TimedLLMResponse(
+            response=response,
+            started_at=started_at,
+            finished_at=time.time(),
+            duration=time.monotonic() - t0,
+        )
+
     async def _do_generate_sequential(
         self,
         messages: LLMMessages,
@@ -963,16 +978,12 @@ class IORails(BaseGuardrails):
             return None
 
         log.info("[%s] Calling main LLM", req_id)
-        started_at = time.time()
-        t0 = time.monotonic()
-        response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
-        duration = time.monotonic() - t0
-        finished_at = time.time()
+        timed_llm_response = await self._timed_main_call(messages, llm_kwargs)
         if records_out is not None:
             provider = self.engine_registry.provider_name("main")
             prompt = serialize_prompt(messages)
-            records_out.append(_make_generation_record(response, started_at, finished_at, duration, provider, prompt))
-        return response
+            records_out.append(_make_generation_record(timed_llm_response, provider, prompt))
+        return timed_llm_response.response
 
     async def _do_generate_speculative(
         self,
@@ -988,7 +999,7 @@ class IORails(BaseGuardrails):
         log.info("[%s] Speculative generation: launching input rails + LLM concurrently", req_id)
 
         rails_task = asyncio.create_task(self.rails_manager.is_input_safe(messages, enabled=input_enabled))
-        gen_task = asyncio.create_task(self.engine_registry.model_call("main", messages, **llm_kwargs))
+        gen_task = asyncio.create_task(self._timed_main_call(messages, llm_kwargs))
 
         try:
             response = await self._parallel_input_rail_and_response_generation(
@@ -1065,11 +1076,11 @@ class IORails(BaseGuardrails):
                 return None
 
             # Rails passed — wait for generation to finish
-            response = await gen_task
+            timed = await gen_task
             set_speculative_span_attrs(request_span, first_completed, "none")
         else:
             # Generation finished first — wait for rails verdict
-            response = gen_task.result()
+            timed = gen_task.result()
 
             input_result = await rails_task
             if records_out is not None:
@@ -1086,13 +1097,11 @@ class IORails(BaseGuardrails):
 
             set_speculative_span_attrs(request_span, first_completed, "none")
 
-        log.debug("[%s] Main LLM response: %s", req_id, truncate(response.content))
-        # Speculative races the main call, so per-call timing isn't tracked here; the
-        # generation record carries usage/model without timestamps or a duration.
+        log.debug("[%s] Main LLM response: %s", req_id, truncate(timed.response.content))
         if records_out is not None:
             provider = self.engine_registry.provider_name("main")
-            records_out.append(_make_generation_record(response, None, None, None, provider, main_prompt))
-        return response
+            records_out.append(_make_generation_record(timed, provider, main_prompt))
+        return timed.response
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:
         """Synchronous version of ``check_async``.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1046,6 +1046,12 @@ class IORails(BaseGuardrails):
         main_prompt: str = "",
     ) -> Optional[LLMResponse]:
         """Race input rails against LLM generation, return LLMResponse or None (rejected)."""
+
+        def _record_generation(timed: TimedLLMResponse) -> None:
+            if records_out is not None:
+                provider = self.engine_registry.provider_name("main")
+                records_out.append(_make_generation_record(timed, provider, main_prompt))
+
         done, _ = await asyncio.wait({rails_task, gen_task}, return_when=asyncio.FIRST_COMPLETED)
 
         first_completed = (
@@ -1066,7 +1072,10 @@ class IORails(BaseGuardrails):
                 # tasks finish simultaneously, gen_task may hold a stored exception that
                 # would leak through suppress(CancelledError). gather drains it safely.
                 gen_result = (await asyncio.gather(gen_task, return_exceptions=True))[0]
-                if isinstance(gen_result, BaseException) and not isinstance(gen_result, asyncio.CancelledError):
+                if isinstance(gen_result, TimedLLMResponse):
+                    # Generation completed before cancellation took effect — record the call that was made.
+                    _record_generation(gen_result)
+                elif isinstance(gen_result, BaseException) and not isinstance(gen_result, asyncio.CancelledError):
                     log.warning("[%s] LLM generation error suppressed: %s", req_id, gen_result)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.INPUT)
@@ -1088,6 +1097,7 @@ class IORails(BaseGuardrails):
 
             if not input_result.is_safe:
                 log.info("[%s] Input blocked (speculative, gen-first): %s", req_id, input_result.reason)
+                _record_generation(timed)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.INPUT)
                 set_speculative_span_attrs(
@@ -1098,9 +1108,7 @@ class IORails(BaseGuardrails):
             set_speculative_span_attrs(request_span, first_completed, "none")
 
         log.debug("[%s] Main LLM response: %s", req_id, truncate(timed.response.content))
-        if records_out is not None:
-            provider = self.engine_registry.provider_name("main")
-            records_out.append(_make_generation_record(timed, provider, main_prompt))
+        _record_generation(timed)
         return timed.response
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -696,9 +696,33 @@ class IORails(BaseGuardrails):
         """Context manager (used for testing rather than long-lived instance)"""
         await self.stop()
 
+    @staticmethod
+    def _convert_to_messages(
+        prompt: Optional[Union[str, LLMMessages]] = None,
+        messages: Optional[Union[LLMMessages, str]] = None,
+    ) -> LLMMessages:
+        """Normalize a prompt string or a message list into the standard messages format.
+
+        Argument order mirrors the ``Guardrails`` facade and LLMRails (prompt first).
+        ``messages`` takes priority when both are supplied; a prompt string becomes a
+        single user turn. A wrong-typed value — a list passed as ``prompt`` or a string
+        passed as ``messages`` (the common positional mix-ups) — raises ``TypeError``;
+        neither provided raises ``ValueError``.
+        """
+        if messages is not None and not isinstance(messages, list):
+            raise TypeError("messages must be a list of {'role', 'content'} dicts; pass a string via prompt=")
+        if prompt is not None and not isinstance(prompt, str):
+            raise TypeError("prompt must be a string; pass a message list via messages=")
+        if messages:
+            return messages
+        if prompt:
+            return [{"role": "user", "content": prompt}]
+        raise ValueError("Neither prompt nor messages provided for generation")
+
     def generate(
         self,
-        messages: LLMMessages,
+        prompt: Optional[str] = None,
+        messages: Optional[LLMMessages] = None,
         options: Optional[Union[dict, GenerationOptions]] = None,
         **kwargs,
     ) -> Union[LLMMessage, GenerationResponse]:
@@ -709,6 +733,7 @@ class IORails(BaseGuardrails):
         `generate_async()` and `stream_async()` methods for non-streaming
         and streaming requests respectively.
         """
+        messages = self._convert_to_messages(prompt, messages)
 
         # Disable tracing and metrics for synchronous generation calls
         sync_config = self.config.model_copy(deep=True)
@@ -721,13 +746,14 @@ class IORails(BaseGuardrails):
             """Spin up a short-lived IORails engine for one synchronous generate call."""
             # Avoid counting this sync-API bridge as a separate user-created IORails instance.
             async with IORails(sync_config, _report_usage=False) as iorails_engine:
-                return await iorails_engine.generate_async(messages, options=options, **kwargs)
+                return await iorails_engine.generate_async(messages=messages, options=options, **kwargs)
 
         return asyncio.run(_run_sync_iorails())
 
     async def generate_async(
         self,
-        messages: LLMMessages,
+        prompt: Optional[str] = None,
+        messages: Optional[LLMMessages] = None,
         options: Optional[Union[dict, GenerationOptions]] = None,
         **kwargs,
     ) -> Union[LLMMessage, GenerationResponse]:
@@ -746,6 +772,7 @@ class IORails(BaseGuardrails):
         ``requests.errors{error.type=QueueFull}`` and
         ``nonstream.rejections`` — honest dual-signal reporting.
         """
+        messages = self._convert_to_messages(prompt, messages)
         await self.start()
         metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
         with metrics_ctx:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -569,7 +569,12 @@ class IORails(BaseGuardrails):
         """Context manager (used for testing rather than long-lived instance)"""
         await self.stop()
 
-    def generate(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
+    def generate(
+        self,
+        messages: LLMMessages,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
+    ) -> Union[LLMMessage, GenerationResponse]:
         """Synchronous version of generate_async.
 
         Telemetry is disabled for the ephemeral IORails object used for
@@ -589,11 +594,16 @@ class IORails(BaseGuardrails):
             """Spin up a short-lived IORails engine for one synchronous generate call."""
             # Avoid counting this sync-API bridge as a separate user-created IORails instance.
             async with IORails(sync_config, _report_usage=False) as iorails_engine:
-                return await iorails_engine.generate_async(messages, **kwargs)
+                return await iorails_engine.generate_async(messages, options=options, **kwargs)
 
         return asyncio.run(_run_sync_iorails())
 
-    async def generate_async(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
+    async def generate_async(
+        self,
+        messages: LLMMessages,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
+    ) -> Union[LLMMessage, GenerationResponse]:
         """Public entry: submit the request to the internal work queue.
 
         The queue enforces non-streaming concurrency limits
@@ -613,13 +623,18 @@ class IORails(BaseGuardrails):
         metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
         with metrics_ctx:
             try:
-                return await self._generate_async_queue.submit(self._run_generate, messages, **kwargs)
+                return await self._generate_async_queue.submit(self._run_generate, messages, options=options, **kwargs)
             except asyncio.QueueFull:
                 if self._metrics_enabled:
                     record_nonstream_rejected()
                 raise
 
-    async def _run_generate(self, messages: LLMMessages, **kwargs) -> Union[LLMMessage, GenerationResponse]:
+    async def _run_generate(
+        self,
+        messages: LLMMessages,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
+    ) -> Union[LLMMessage, GenerationResponse]:
         """Runs inside a queue worker task.  Wraps the pipeline in
         ``traced_request`` so each request gets its own span + request ID,
         then delegates to ``_do_generate`` for the actual input rails →
@@ -630,7 +645,7 @@ class IORails(BaseGuardrails):
         with traced_request(tracer) as (request_span, req_id):
             t0 = time.monotonic()
             try:
-                result = await self._do_generate(messages, req_id, request_span, **kwargs)
+                result = await self._do_generate(messages, req_id, request_span, options=options, **kwargs)
             except Exception:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
@@ -664,17 +679,23 @@ class IORails(BaseGuardrails):
         )
 
     async def _do_generate(
-        self, messages: LLMMessages, req_id: str, request_span: Optional["Span"] = None, **kwargs
+        self,
+        messages: LLMMessages,
+        req_id: str,
+        request_span: Optional["Span"] = None,
+        *,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        **kwargs,
     ) -> Union[LLMMessage, GenerationResponse]:
         """Core pipeline: tool-result rails -> input rails -> LLM call -> tool-call + output rails."""
         log.info("[%s] generate_async called", req_id)
         log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
 
-        options = _coerce_generation_options(kwargs.get("options"))
+        options = _coerce_generation_options(options)
         _raise_on_unsupported_options(options, kwargs.get("state"))
         # When options are supplied we return a structured GenerationResponse
         # (mirroring LLMRails' `if gen_options:` branch); otherwise a bare LLMMessage.
-        has_generation_response = options is not None
+        has_generation_options = options is not None
         # Pass llm_params (including tool definitions) unchanged to the LLM call.
         llm_kwargs = options.llm_params if (options and options.llm_params) else {}
         input_enabled = options.rails.input if options else True
@@ -690,7 +711,7 @@ class IORails(BaseGuardrails):
             log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return _finalize_refusal(has_generation_response)
+            return _finalize_refusal(has_generation_options)
 
         if self._speculative_generation:
             response = await self._do_generate_speculative(
@@ -700,7 +721,7 @@ class IORails(BaseGuardrails):
             response = await self._do_generate_sequential(messages, req_id, llm_kwargs, input_enabled=input_enabled)
 
         if response is None:
-            return _finalize_refusal(has_generation_response)
+            return _finalize_refusal(has_generation_options)
 
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
@@ -721,7 +742,7 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Tool call blocked: %s", req_id, tool_call.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _finalize_refusal(has_generation_response)
+                return _finalize_refusal(has_generation_options)
 
         # Output rails check the final answer, not reasoning traces.
         # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
@@ -736,9 +757,9 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _finalize_refusal(has_generation_response)
+                return _finalize_refusal(has_generation_options)
 
-        if has_generation_response:
+        if has_generation_options:
             return _build_generation_response(response_text, reasoning_content, response)
 
         # Bare return path: reasoning is delivered inline as a <think> prefix

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -37,6 +37,7 @@ from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
+    RailCallRecord,
     RailDirection,
     get_request_id,
     truncate,
@@ -60,19 +61,24 @@ from nemoguardrails.guardrails.telemetry import (
     traced_request,
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
 from nemoguardrails.rails.llm.options import (
+    ActivatedRail,
+    ExecutedAction,
+    GenerationLog,
     GenerationOptions,
     GenerationResponse,
+    GenerationStats,
     RailsResult,
     RailStatus,
     RailType,
 )
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.tracing.constants import GuardrailsAttributes
-from nemoguardrails.types import LLMModel, LLMResponse, ToolCall, UsageInfo
+from nemoguardrails.types import LLMModel, LLMResponse, ToolCall
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -176,40 +182,137 @@ def _build_assistant_message(content: str, tool_calls: Optional[list[ToolCall]])
     }
 
 
-def _usage_to_dict(usage: UsageInfo) -> dict:
-    """Serialize ``UsageInfo`` token counts to a dict, dropping ``None`` values.
-
-    ``input_tokens``/``output_tokens``/``total_tokens`` default to 0 and are always
-    kept; ``reasoning_tokens``/``cached_tokens`` default to ``None`` and are omitted
-    unless the provider reported them.
-    """
-    fields = {
-        "input_tokens": usage.input_tokens,
-        "output_tokens": usage.output_tokens,
-        "total_tokens": usage.total_tokens,
-        "reasoning_tokens": usage.reasoning_tokens,
-        "cached_tokens": usage.cached_tokens,
-    }
-    return {key: value for key, value in fields.items() if value is not None}
-
-
 def _build_llm_metadata(response: LLMResponse) -> Optional[dict]:
-    """Assemble ``llm_metadata`` from the main call's ``provider_metadata`` plus usage.
+    """Return the main call's ``provider_metadata`` verbatim (LLMRails mirror).
 
-    Mirrors LLMRails' ``llm_metadata`` (the provider metadata blob) and adds a
-    structured ``usage`` sub-key with token counts that LLMRails does not expose
-    outside its ``log``. Returns ``None`` when neither is present.
+    A pure passthrough — token usage lives in ``log`` (``log.llm_calls`` / ``log.stats``),
+    not here, matching LLMRails. Returns ``None`` when the main call carried no metadata.
     """
-    metadata = dict(response.provider_metadata or {})
-    if response.usage:
-        usage = _usage_to_dict(response.usage)
-        if usage:
-            metadata["usage"] = usage
-    return metadata or None
+    return dict(response.provider_metadata or {}) or None
+
+
+def _make_generation_record(
+    response: LLMResponse, started_at: Optional[float], finished_at: Optional[float]
+) -> RailCallRecord:
+    """Represent the main generation call as a ``RailCallRecord`` (rail_type "generation").
+
+    Unifies the main call with the rail calls so the log builder can treat every LLM call
+    the same way.
+    """
+    duration = (finished_at - started_at) if (started_at is not None and finished_at is not None) else None
+    return RailCallRecord(
+        flow="generation",
+        rail_type="generation",
+        is_safe=True,
+        action_name="generate_bot_message",
+        task="general",
+        usage=response.usage,
+        llm_model_name=response.model,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration=duration,
+    )
+
+
+def _record_has_llm_call(record: RailCallRecord) -> bool:
+    """True when a record reflects a model call (has usage or a model name)."""
+    return record.usage is not None or record.llm_model_name is not None
+
+
+def _call_info(record: RailCallRecord) -> LLMCallInfo:
+    """Map a ``RailCallRecord`` to a ``LLMCallInfo`` for the log."""
+    usage = record.usage
+    return LLMCallInfo(
+        task=record.task,
+        duration=record.duration,
+        total_tokens=usage.total_tokens if usage else None,
+        prompt_tokens=usage.input_tokens if usage else None,
+        completion_tokens=usage.output_tokens if usage else None,
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        llm_model_name=record.llm_model_name or "unknown",
+        llm_provider_name=record.llm_provider_name or "unknown",
+    )
+
+
+def _activated_rail(record: RailCallRecord) -> ActivatedRail:
+    """Map a ``RailCallRecord`` to an ``ActivatedRail`` with one synthetic ``ExecutedAction``.
+
+    IORails runs one model-backed check per rail (not a Colang action chain), so each rail
+    gets a single ``ExecutedAction`` carrying the rail's structured verdict as
+    ``return_value`` and its (at most one) LLM call.
+    """
+    action = ExecutedAction(
+        action_name=record.action_name or record.flow,
+        action_params={},
+        return_value=record.return_value,
+        llm_calls=[_call_info(record)] if _record_has_llm_call(record) else [],
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        duration=record.duration,
+    )
+    return ActivatedRail(
+        type=record.rail_type,
+        name=record.flow,
+        executed_actions=[action],
+        stop=not record.is_safe,
+        started_at=record.started_at,
+        finished_at=record.finished_at,
+        duration=record.duration,
+    )
+
+
+def _build_generation_stats(
+    records: list[RailCallRecord], call_records: list[RailCallRecord], total_duration: Optional[float]
+) -> GenerationStats:
+    """Aggregate per-phase durations and token totals across every recorded call."""
+
+    def _phase_duration(*rail_types: str) -> Optional[float]:
+        total = sum((r.duration or 0.0) for r in records if r.rail_type in rail_types)
+        return total or None
+
+    return GenerationStats(
+        input_rails_duration=_phase_duration("input", "tool_input"),
+        output_rails_duration=_phase_duration("output", "tool_output"),
+        generation_rails_duration=_phase_duration("generation"),
+        total_duration=total_duration,
+        llm_calls_duration=sum((r.duration or 0.0) for r in call_records) or None,
+        llm_calls_count=len(call_records),
+        llm_calls_total_prompt_tokens=sum(r.usage.input_tokens for r in call_records if r.usage),
+        llm_calls_total_completion_tokens=sum(r.usage.output_tokens for r in call_records if r.usage),
+        llm_calls_total_tokens=sum(r.usage.total_tokens for r in call_records if r.usage),
+    )
+
+
+def _build_generation_log(
+    records: list[RailCallRecord], options: Optional[GenerationOptions], total_duration: Optional[float]
+) -> Optional[GenerationLog]:
+    """Synthesize a ``GenerationLog`` from collected rail + generation records.
+
+    Returns ``None`` unless ``options.log`` requests ``activated_rails`` or ``llm_calls``.
+    ``stats`` is always included when either is requested (matching LLMRails); the
+    per-rail ``activated_rails`` and flat ``llm_calls`` are gated on their own flags.
+    ``internal_events`` / ``colang_history`` are rejected earlier (Colang-only).
+    """
+    log_options = options.log if options else None
+    if not log_options or not (log_options.activated_rails or log_options.llm_calls):
+        return None
+
+    call_records = [record for record in records if _record_has_llm_call(record)]
+    generation_log = GenerationLog()
+    generation_log.stats = _build_generation_stats(records, call_records, total_duration)
+    if log_options.activated_rails:
+        generation_log.activated_rails = [_activated_rail(record) for record in records]
+    if log_options.llm_calls:
+        generation_log.llm_calls = [_call_info(record) for record in call_records]
+    return generation_log
 
 
 def _build_generation_response(
-    response_text: str, reasoning_content: Optional[str], response: LLMResponse
+    response_text: str,
+    reasoning_content: Optional[str],
+    response: LLMResponse,
+    log: Optional[GenerationLog] = None,
 ) -> GenerationResponse:
     """Build the structured ``GenerationResponse`` returned when ``options`` are supplied.
 
@@ -218,7 +321,8 @@ def _build_generation_response(
     canonical ``ToolCall.to_dict()`` shape (dict arguments), matching LLMRails'
     ``GenerationResponse.tool_calls`` rather than the OpenAI-wire JSON-string shape
     used for the bare message. ``llm_output`` stays ``None`` to match LLMRails, whose
-    ``raw_response`` source is never populated.
+    ``raw_response`` source is never populated. ``log`` is set when the caller requested
+    log details via ``options.log``.
     """
     result = GenerationResponse(response=[{"role": "assistant", "content": response_text}])
     if reasoning_content:
@@ -228,15 +332,24 @@ def _build_generation_response(
     llm_metadata = _build_llm_metadata(response)
     if llm_metadata:
         result.llm_metadata = llm_metadata
+    if log is not None:
+        result.log = log
     return result
 
 
-def _finalize_refusal(structured: bool) -> Union[LLMMessage, GenerationResponse]:
-    """Shape the refusal message for the active return contract (structured vs bare)."""
+def _finalize_refusal(structured: bool, log: Optional[GenerationLog] = None) -> Union[LLMMessage, GenerationResponse]:
+    """Shape the refusal message for the active return contract (structured vs bare).
+
+    On the structured path the collected ``log`` (rails that ran up to the block) is
+    attached when the caller requested it.
+    """
     message: LLMMessage = {"role": "assistant", "content": REFUSAL_MESSAGE}
-    if structured:
-        return GenerationResponse(response=[message])
-    return message
+    if not structured:
+        return message
+    result = GenerationResponse(response=[message])
+    if log is not None:
+        result.log = log
+    return result
 
 
 def _response_content_for_capture(result: Union[LLMMessage, GenerationResponse]) -> Optional[str]:
@@ -255,9 +368,10 @@ def _raise_on_unsupported_options(options: Optional[GenerationOptions], state: o
     """Raise for ``GenerationOptions``/``state`` features IORails cannot honor.
 
     ``state`` and ``output_vars``/``output_data`` require Colang runtime state that
-    IORails does not have and raise ``ValueError``; ``log`` is deferred to a follow-up
-    PR and raises ``NotImplementedError``. These raise rather than silently returning
-    empty data, mirroring how LLMRails rejects options it cannot fulfill.
+    IORails does not have and raise ``ValueError``. ``log.internal_events`` /
+    ``log.colang_history`` are Colang-runtime-only and raise ``NotImplementedError``;
+    ``log.activated_rails`` / ``log.llm_calls`` are supported. These raise rather than
+    silently returning empty data, mirroring how LLMRails rejects options it cannot fulfill.
     """
     if state is not None:
         raise ValueError("state is not supported by IORails; it is a stateless input/output rails engine")
@@ -266,13 +380,11 @@ def _raise_on_unsupported_options(options: Optional[GenerationOptions], state: o
     if options.output_vars:
         raise ValueError("output_vars/output_data is not supported by IORails; it has no Colang context to return")
     log_options = options.log
-    if log_options and (
-        log_options.activated_rails
-        or log_options.llm_calls
-        or log_options.internal_events
-        or log_options.colang_history
-    ):
-        raise NotImplementedError("GenerationResponse `log` is not supported by IORails")
+    if log_options and (log_options.internal_events or log_options.colang_history):
+        raise NotImplementedError(
+            "GenerationLog `internal_events` and `colang_history` are not supported by IORails "
+            "(no Colang runtime); use `activated_rails` and/or `llm_calls`"
+        )
 
 
 def _coerce_generation_options(options: Optional[Union[dict, GenerationOptions]]) -> Optional[GenerationOptions]:
@@ -703,25 +815,40 @@ class IORails(BaseGuardrails):
         tool_input_enabled = options.rails.tool_input if options else True
         tool_output_enabled = options.rails.tool_output if options else True
 
+        # Per-rail + generation records accumulated for the GenerationLog (built only when
+        # options.log requests it). Each rail check and the main call append their record.
+        t_start = time.monotonic()
+        records: list[RailCallRecord] = []
+
+        def _blocked_return() -> Union[LLMMessage, GenerationResponse]:
+            """Refusal shaped for the return contract, carrying the log of rails run so far."""
+            log_obj = (
+                _build_generation_log(records, options, time.monotonic() - t_start) if has_generation_options else None
+            )
+            return _finalize_refusal(has_generation_options, log_obj)
+
         # Agent/client executes tool-calls and sends results to Main LLM with prior conversation history.
         # Symmetric with INPUT rails
         log.info("[%s] Running tool result rails", req_id)
         tool_result = await self.rails_manager.are_tool_results_safe(messages, enabled=tool_input_enabled)
+        records.extend(tool_result.records)
         if not tool_result.is_safe:
             log.info("[%s] Tool result blocked: %s", req_id, tool_result.reason)
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return _finalize_refusal(has_generation_options)
+            return _blocked_return()
 
         if self._speculative_generation:
             response = await self._do_generate_speculative(
-                messages, req_id, llm_kwargs, request_span, input_enabled=input_enabled
+                messages, req_id, llm_kwargs, request_span, input_enabled=input_enabled, records_out=records
             )
         else:
-            response = await self._do_generate_sequential(messages, req_id, llm_kwargs, input_enabled=input_enabled)
+            response = await self._do_generate_sequential(
+                messages, req_id, llm_kwargs, input_enabled=input_enabled, records_out=records
+            )
 
         if response is None:
-            return _finalize_refusal(has_generation_options)
+            return _blocked_return()
 
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
@@ -738,11 +865,12 @@ class IORails(BaseGuardrails):
             tool_call = await self.rails_manager.are_tool_calls_safe(
                 response.tool_calls, llm_kwargs, enabled=tool_output_enabled
             )
+            records.extend(tool_call.records)
             if not tool_call.is_safe:
                 log.info("[%s] Tool call blocked: %s", req_id, tool_call.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _finalize_refusal(has_generation_options)
+                return _blocked_return()
 
         # Output rails check the final answer, not reasoning traces.
         # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
@@ -753,14 +881,16 @@ class IORails(BaseGuardrails):
         if not is_tool_call_only:
             log.info("[%s] Running output rails", req_id)
             output_result = await self.rails_manager.is_output_safe(messages, response_text, enabled=output_enabled)
+            records.extend(output_result.records)
             if not output_result.is_safe:
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _finalize_refusal(has_generation_options)
+                return _blocked_return()
 
         if has_generation_options:
-            return _build_generation_response(response_text, reasoning_content, response)
+            log_obj = _build_generation_log(records, options, time.monotonic() - t_start)
+            return _build_generation_response(response_text, reasoning_content, response, log_obj)
 
         # Bare return path: reasoning is delivered inline as a <think> prefix
         # (LLMRails legacy shape). The structured path above instead puts it in the
@@ -771,11 +901,19 @@ class IORails(BaseGuardrails):
         return _build_assistant_message(response_text, response.tool_calls)
 
     async def _do_generate_sequential(
-        self, messages: LLMMessages, req_id: str, llm_kwargs: dict, *, input_enabled: Union[bool, list[str]] = True
+        self,
+        messages: LLMMessages,
+        req_id: str,
+        llm_kwargs: dict,
+        *,
+        input_enabled: Union[bool, list[str]] = True,
+        records_out: Optional[list[RailCallRecord]] = None,
     ) -> Optional[LLMResponse]:
         """Sequential path: input rails block before LLM generation starts."""
         log.info("[%s] Running input rails", req_id)
         input_result = await self.rails_manager.is_input_safe(messages, enabled=input_enabled)
+        if records_out is not None:
+            records_out.extend(input_result.records)
         if not input_result.is_safe:
             log.info("[%s] Input blocked: %s", req_id, input_result.reason)
             if self._metrics_enabled:
@@ -783,7 +921,12 @@ class IORails(BaseGuardrails):
             return None
 
         log.info("[%s] Calling main LLM", req_id)
-        return await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        started_at = time.monotonic()
+        response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        finished_at = time.monotonic()
+        if records_out is not None:
+            records_out.append(_make_generation_record(response, started_at, finished_at))
+        return response
 
     async def _do_generate_speculative(
         self,
@@ -793,6 +936,7 @@ class IORails(BaseGuardrails):
         request_span: Optional["Span"] = None,
         *,
         input_enabled: Union[bool, list[str]] = True,
+        records_out: Optional[list[RailCallRecord]] = None,
     ) -> Optional[LLMResponse]:
         """Speculative path: input rails and LLM generation race concurrently."""
         log.info("[%s] Speculative generation: launching input rails + LLM concurrently", req_id)
@@ -802,7 +946,7 @@ class IORails(BaseGuardrails):
 
         try:
             response = await self._parallel_input_rail_and_response_generation(
-                rails_task, gen_task, req_id, request_span
+                rails_task, gen_task, req_id, request_span, records_out=records_out
             )
         except BaseException as outer_exc:
             for t in (rails_task, gen_task):
@@ -835,6 +979,8 @@ class IORails(BaseGuardrails):
         gen_task: asyncio.Task,
         req_id: str,
         request_span: Optional["Span"] = None,
+        *,
+        records_out: Optional[list[RailCallRecord]] = None,
     ) -> Optional[LLMResponse]:
         """Race input rails against LLM generation, return LLMResponse or None (rejected)."""
         done, _ = await asyncio.wait({rails_task, gen_task}, return_when=asyncio.FIRST_COMPLETED)
@@ -847,6 +993,8 @@ class IORails(BaseGuardrails):
 
         if rails_task in done:
             input_result = rails_task.result()
+            if records_out is not None:
+                records_out.extend(input_result.records)
 
             if not input_result.is_safe:
                 log.info("[%s] Input blocked (speculative): %s", req_id, input_result.reason)
@@ -872,6 +1020,8 @@ class IORails(BaseGuardrails):
             response = gen_task.result()
 
             input_result = await rails_task
+            if records_out is not None:
+                records_out.extend(input_result.records)
 
             if not input_result.is_safe:
                 log.info("[%s] Input blocked (speculative, gen-first): %s", req_id, input_result.reason)
@@ -885,6 +1035,10 @@ class IORails(BaseGuardrails):
             set_speculative_span_attrs(request_span, first_completed, "none")
 
         log.debug("[%s] Main LLM response: %s", req_id, truncate(response.content))
+        # Speculative races the main call, so per-call timing isn't tracked here; the
+        # generation record carries usage/model without a duration.
+        if records_out is not None:
+            records_out.append(_make_generation_record(response, None, None))
         return response
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -192,22 +192,29 @@ def _build_llm_metadata(response: LLMResponse) -> Optional[dict]:
 
 
 def _make_generation_record(
-    response: LLMResponse, started_at: Optional[float], finished_at: Optional[float]
+    response: LLMResponse,
+    started_at: Optional[float],
+    finished_at: Optional[float],
+    duration: Optional[float],
+    provider_name: Optional[str],
 ) -> RailCallRecord:
     """Represent the main generation call as a ``RailCallRecord`` (rail_type "generation").
 
     Unifies the main call with the rail calls so the log builder can treat every LLM call
-    the same way.
+    the same way. ``started_at``/``finished_at`` are wall-clock timestamps; ``duration``
+    is a monotonic delta.
     """
-    duration = (finished_at - started_at) if (started_at is not None and finished_at is not None) else None
     return RailCallRecord(
         flow="generation",
         rail_type="generation",
         is_safe=True,
+        made_call=True,
         action_name="generate_bot_message",
         task="general",
+        request_id=response.request_id,
         usage=response.usage,
         llm_model_name=response.model,
+        llm_provider_name=provider_name,
         started_at=started_at,
         finished_at=finished_at,
         duration=duration,
@@ -215,8 +222,8 @@ def _make_generation_record(
 
 
 def _record_has_llm_call(record: RailCallRecord) -> bool:
-    """True when a record reflects a model call (has usage or a model name)."""
-    return record.usage is not None or record.llm_model_name is not None
+    """True when a record reflects a model/API call (made a call, or carries usage/model)."""
+    return record.made_call or record.usage is not None or record.llm_model_name is not None
 
 
 def _call_info(record: RailCallRecord) -> LLMCallInfo:
@@ -230,6 +237,7 @@ def _call_info(record: RailCallRecord) -> LLMCallInfo:
         completion_tokens=usage.output_tokens if usage else None,
         started_at=record.started_at,
         finished_at=record.finished_at,
+        id=record.request_id,
         llm_model_name=record.llm_model_name or "unknown",
         llm_provider_name=record.llm_provider_name or "unknown",
     )
@@ -921,11 +929,14 @@ class IORails(BaseGuardrails):
             return None
 
         log.info("[%s] Calling main LLM", req_id)
-        started_at = time.monotonic()
+        started_at = time.time()
+        t0 = time.monotonic()
         response = await self.engine_registry.model_call("main", messages, **llm_kwargs)
-        finished_at = time.monotonic()
+        duration = time.monotonic() - t0
+        finished_at = time.time()
         if records_out is not None:
-            records_out.append(_make_generation_record(response, started_at, finished_at))
+            provider = self.engine_registry.provider_name("main")
+            records_out.append(_make_generation_record(response, started_at, finished_at, duration, provider))
         return response
 
     async def _do_generate_speculative(
@@ -1036,9 +1047,10 @@ class IORails(BaseGuardrails):
 
         log.debug("[%s] Main LLM response: %s", req_id, truncate(response.content))
         # Speculative races the main call, so per-call timing isn't tracked here; the
-        # generation record carries usage/model without a duration.
+        # generation record carries usage/model without timestamps or a duration.
         if records_out is not None:
-            records_out.append(_make_generation_record(response, None, None))
+            provider = self.engine_registry.provider_name("main")
+            records_out.append(_make_generation_record(response, None, None, None, provider))
         return response
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -40,6 +40,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     RailCallRecord,
     RailDirection,
     get_request_id,
+    serialize_prompt,
     truncate,
 )
 from nemoguardrails.guardrails.rails_manager import RailsManager
@@ -197,12 +198,14 @@ def _make_generation_record(
     finished_at: Optional[float],
     duration: Optional[float],
     provider_name: Optional[str],
+    prompt: Optional[str],
 ) -> RailCallRecord:
     """Represent the main generation call as a ``RailCallRecord`` (rail_type "generation").
 
     Unifies the main call with the rail calls so the log builder can treat every LLM call
-    the same way. ``started_at``/``finished_at`` are wall-clock timestamps; ``duration``
-    is a monotonic delta.
+    the same way. ``prompt`` is the serialized main-model messages; ``completion`` is the
+    response content. ``started_at``/``finished_at`` are wall-clock timestamps;
+    ``duration`` is a monotonic delta.
     """
     return RailCallRecord(
         flow="generation",
@@ -215,6 +218,8 @@ def _make_generation_record(
         usage=response.usage,
         llm_model_name=response.model,
         llm_provider_name=provider_name,
+        prompt=prompt,
+        completion=response.content,
         started_at=started_at,
         finished_at=finished_at,
         duration=duration,
@@ -238,6 +243,8 @@ def _call_info(record: RailCallRecord) -> LLMCallInfo:
         started_at=record.started_at,
         finished_at=record.finished_at,
         id=record.request_id,
+        prompt=record.prompt,
+        completion=record.completion,
         llm_model_name=record.llm_model_name or "unknown",
         llm_provider_name=record.llm_provider_name or "unknown",
     )
@@ -936,7 +943,8 @@ class IORails(BaseGuardrails):
         finished_at = time.time()
         if records_out is not None:
             provider = self.engine_registry.provider_name("main")
-            records_out.append(_make_generation_record(response, started_at, finished_at, duration, provider))
+            prompt = serialize_prompt(messages)
+            records_out.append(_make_generation_record(response, started_at, finished_at, duration, provider, prompt))
         return response
 
     async def _do_generate_speculative(
@@ -957,7 +965,12 @@ class IORails(BaseGuardrails):
 
         try:
             response = await self._parallel_input_rail_and_response_generation(
-                rails_task, gen_task, req_id, request_span, records_out=records_out
+                rails_task,
+                gen_task,
+                req_id,
+                request_span,
+                records_out=records_out,
+                main_prompt=serialize_prompt(messages),
             )
         except BaseException as outer_exc:
             for t in (rails_task, gen_task):
@@ -992,6 +1005,7 @@ class IORails(BaseGuardrails):
         request_span: Optional["Span"] = None,
         *,
         records_out: Optional[list[RailCallRecord]] = None,
+        main_prompt: str = "",
     ) -> Optional[LLMResponse]:
         """Race input rails against LLM generation, return LLMResponse or None (rejected)."""
         done, _ = await asyncio.wait({rails_task, gen_task}, return_when=asyncio.FIRST_COMPLETED)
@@ -1050,7 +1064,7 @@ class IORails(BaseGuardrails):
         # generation record carries usage/model without timestamps or a duration.
         if records_out is not None:
             provider = self.engine_registry.provider_name("main")
-            records_out.append(_make_generation_record(response, None, None, None, provider))
+            records_out.append(_make_generation_record(response, None, None, None, provider, main_prompt))
         return response
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -23,7 +23,10 @@ helpers for the common call patterns (LLM, API, local).
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
@@ -36,12 +39,39 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.telemetry import action_span, record_span_error
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
-from nemoguardrails.types import LLMResponse
+from nemoguardrails.types import LLMResponse, UsageInfo
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RailLLMCall:
+    """Usage/model/timing captured for the LLM call a rail made, for GenerationLog.
+
+    Set by :meth:`RailAction._get_llm_response` and read by RailsManager right after the
+    rail runs (same async task), so the caller can build the per-rail ``RailCallRecord``.
+    """
+
+    usage: Optional[UsageInfo]
+    llm_model_name: Optional[str]
+    started_at: float
+    finished_at: float
+    duration: float
+
+
+# Request-scoped: the last LLM call a rail made. ``RailAction.run`` clears it at the
+# start of each rail so a rail that makes no model call leaves it None.
+_rail_llm_call_var: ContextVar[Optional[RailLLMCall]] = ContextVar("rail_llm_call", default=None)
+
+
+def take_rail_llm_call() -> Optional[RailLLMCall]:
+    """Return and clear the LLM call captured for the rail that just ran."""
+    call = _rail_llm_call_var.get()
+    _rail_llm_call_var.set(None)
+    return call
 
 
 class RailAction(ABC):
@@ -81,6 +111,9 @@ class RailAction(ABC):
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Execute the full rail pipeline and return a safety result."""
+        # Clear any capture from a prior rail on this task; a rail that makes no model
+        # call then leaves it None and produces a record with no LLM call.
+        _rail_llm_call_var.set(None)
         with action_span(self._tracer, self.action_name) as span:
             req_id = get_request_id()
             base_flow = _get_flow_name(flow)
@@ -153,10 +186,26 @@ class RailAction(ABC):
         messages: list[dict],
         **kwargs: Any,
     ) -> LLMResponse:
-        """Call an LLM via EngineRegistry and return the structured response."""
+        """Call an LLM via EngineRegistry and return the structured response.
+
+        Captures usage/model/timing into a request-scoped contextvar so RailsManager can
+        record this call in the GenerationLog after the rail runs.
+        """
         if not model_type:
             raise RuntimeError("model_type is required for LLM calls")
-        return await self.engine_registry.model_call(model_type, messages, **kwargs)
+        started_at = time.monotonic()
+        response = await self.engine_registry.model_call(model_type, messages, **kwargs)
+        finished_at = time.monotonic()
+        _rail_llm_call_var.set(
+            RailLLMCall(
+                usage=response.usage,
+                llm_model_name=response.model,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration=finished_at - started_at,
+            )
+        )
+        return response
 
     async def _get_api_response(
         self,

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -49,14 +49,19 @@ log = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class RailLLMCall:
-    """Usage/model/timing captured for the LLM call a rail made, for GenerationLog.
+    """Usage/model/timing captured for the call a rail made, for GenerationLog.
 
-    Set by :meth:`RailAction._get_llm_response` and read by RailsManager right after the
-    rail runs (same async task), so the caller can build the per-rail ``RailCallRecord``.
+    Set by :meth:`RailAction._get_llm_response` (LLM rails) or
+    :meth:`RailAction._get_api_response` (API rails, e.g. jailbreak — usage/model None),
+    and read by RailsManager right after the rail runs (same async task), so the caller
+    can build the per-rail ``RailCallRecord``. ``started_at``/``finished_at`` are
+    wall-clock (``time.time()``) timestamps; ``duration`` is a monotonic delta.
     """
 
     usage: Optional[UsageInfo]
     llm_model_name: Optional[str]
+    request_id: Optional[str]
+    provider_name: Optional[str]
     started_at: float
     finished_at: float
     duration: float
@@ -67,7 +72,7 @@ class RailLLMCall:
 _rail_llm_call_var: ContextVar[Optional[RailLLMCall]] = ContextVar("rail_llm_call", default=None)
 
 
-def take_rail_llm_call() -> Optional[RailLLMCall]:
+def get_and_clear_rail_llm_call_contextvar() -> Optional[RailLLMCall]:
     """Return and clear the LLM call captured for the rail that just ran."""
     call = _rail_llm_call_var.get()
     _rail_llm_call_var.set(None)
@@ -193,16 +198,20 @@ class RailAction(ABC):
         """
         if not model_type:
             raise RuntimeError("model_type is required for LLM calls")
-        started_at = time.monotonic()
+        started_at = time.time()
+        t0 = time.monotonic()
         response = await self.engine_registry.model_call(model_type, messages, **kwargs)
-        finished_at = time.monotonic()
+        duration = time.monotonic() - t0
+        finished_at = time.time()
         _rail_llm_call_var.set(
             RailLLMCall(
                 usage=response.usage,
                 llm_model_name=response.model,
+                request_id=response.request_id,
+                provider_name=self.engine_registry.provider_name(model_type),
                 started_at=started_at,
                 finished_at=finished_at,
-                duration=finished_at - started_at,
+                duration=duration,
             )
         )
         return response
@@ -213,8 +222,29 @@ class RailAction(ABC):
         body: dict[str, Any],
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Call an API endpoint via EngineRegistry and return the response dict."""
-        return await self.engine_registry.api_call(api_name, body, **kwargs)
+        """Call an API endpoint via EngineRegistry and return the response dict.
+
+        Records the call (with no token usage or model name) so API-backed rails such as
+        jailbreak detection still appear in the GenerationLog's ``llm_calls`` and counts,
+        matching LLMRails.
+        """
+        started_at = time.time()
+        t0 = time.monotonic()
+        response = await self.engine_registry.api_call(api_name, body, **kwargs)
+        duration = time.monotonic() - t0
+        finished_at = time.time()
+        _rail_llm_call_var.set(
+            RailLLMCall(
+                usage=None,
+                llm_model_name=None,
+                request_id=None,
+                provider_name=None,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration=duration,
+            )
+        )
+        return response
 
     async def _get_local_response(self, **kwargs: Any) -> Any:
         """Run a local/in-process check. Override in subclasses that need it."""

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -34,6 +34,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     LLMMessages,
     RailResult,
     get_request_id,
+    serialize_prompt,
     truncate,
 )
 from nemoguardrails.guardrails.telemetry import action_span, record_span_error
@@ -62,6 +63,8 @@ class RailLLMCall:
     llm_model_name: Optional[str]
     request_id: Optional[str]
     provider_name: Optional[str]
+    prompt: Optional[str]
+    completion: Optional[str]
     started_at: float
     finished_at: float
     duration: float
@@ -209,6 +212,8 @@ class RailAction(ABC):
                 llm_model_name=response.model,
                 request_id=response.request_id,
                 provider_name=self.engine_registry.provider_name(model_type),
+                prompt=serialize_prompt(messages),
+                completion=response.content,
                 started_at=started_at,
                 finished_at=finished_at,
                 duration=duration,
@@ -239,6 +244,8 @@ class RailAction(ABC):
                 llm_model_name=None,
                 request_id=None,
                 provider_name=None,
+                prompt=None,
+                completion=None,
                 started_at=started_at,
                 finished_at=finished_at,
                 duration=duration,

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -197,29 +197,39 @@ class RailAction(ABC):
         """Call an LLM via EngineRegistry and return the structured response.
 
         Captures usage/model/timing into a request-scoped contextvar so RailsManager can
-        record this call in the GenerationLog after the rail runs.
+        record this call in the GenerationLog after the rail runs. The capture happens in a
+        ``finally`` so a call that raises is still recorded as an attempt (usage/model/
+        completion left None), matching LLMRails counting a failed call.
         """
         if not model_type:
             raise RuntimeError("model_type is required for LLM calls")
         started_at = time.time()
         t0 = time.monotonic()
-        response = await self.engine_registry.model_call(model_type, messages, **kwargs)
-        duration = time.monotonic() - t0
-        finished_at = time.time()
-        _rail_llm_call_var.set(
-            RailLLMCall(
-                usage=response.usage,
-                llm_model_name=response.model,
-                request_id=response.request_id,
-                provider_name=self.engine_registry.provider_name(model_type),
-                prompt=serialize_prompt(messages),
-                completion=response.content,
-                started_at=started_at,
-                finished_at=finished_at,
-                duration=duration,
+        usage: Optional[UsageInfo] = None
+        model_name: Optional[str] = None
+        request_id: Optional[str] = None
+        completion: Optional[str] = None
+        try:
+            response = await self.engine_registry.model_call(model_type, messages, **kwargs)
+            usage = response.usage
+            model_name = response.model
+            request_id = response.request_id
+            completion = response.content
+            return response
+        finally:
+            _rail_llm_call_var.set(
+                RailLLMCall(
+                    usage=usage,
+                    llm_model_name=model_name,
+                    request_id=request_id,
+                    provider_name=self.engine_registry.provider_name(model_type),
+                    prompt=serialize_prompt(messages),
+                    completion=completion,
+                    started_at=started_at,
+                    finished_at=time.time(),
+                    duration=time.monotonic() - t0,
+                )
             )
-        )
-        return response
 
     async def _get_api_response(
         self,
@@ -231,27 +241,27 @@ class RailAction(ABC):
 
         Records the call (with no token usage or model name) so API-backed rails such as
         jailbreak detection still appear in the GenerationLog's ``llm_calls`` and counts,
-        matching LLMRails.
+        matching LLMRails. Recorded in a ``finally`` so a call that raises is still counted
+        as an attempt.
         """
         started_at = time.time()
         t0 = time.monotonic()
-        response = await self.engine_registry.api_call(api_name, body, **kwargs)
-        duration = time.monotonic() - t0
-        finished_at = time.time()
-        _rail_llm_call_var.set(
-            RailLLMCall(
-                usage=None,
-                llm_model_name=None,
-                request_id=None,
-                provider_name=None,
-                prompt=None,
-                completion=None,
-                started_at=started_at,
-                finished_at=finished_at,
-                duration=duration,
+        try:
+            return await self.engine_registry.api_call(api_name, body, **kwargs)
+        finally:
+            _rail_llm_call_var.set(
+                RailLLMCall(
+                    usage=None,
+                    llm_model_name=None,
+                    request_id=None,
+                    provider_name=None,
+                    prompt=None,
+                    completion=None,
+                    started_at=started_at,
+                    finished_at=time.time(),
+                    duration=time.monotonic() - t0,
+                )
             )
-        )
-        return response
 
     async def _get_local_response(self, **kwargs: Any) -> Any:
         """Run a local/in-process check. Override in subclasses that need it."""

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -105,6 +105,8 @@ def _rail_call_record(flow: str, rail_type: str, result: RailResult, call: Optio
         usage=call.usage if call else None,
         llm_model_name=call.llm_model_name if call else None,
         llm_provider_name=call.provider_name if call else None,
+        prompt=call.prompt if call else None,
+        completion=call.completion if call else None,
         started_at=call.started_at if call else None,
         finished_at=call.finished_at if call else None,
         duration=call.duration if call else None,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -47,7 +47,7 @@ from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_r
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
 from nemoguardrails.llm.taskmanager import LLMTaskManager
-from nemoguardrails.rails.llm.config import _get_flow_name
+from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
 from nemoguardrails.types import ToolCall
 
 if TYPE_CHECKING:
@@ -87,14 +87,20 @@ def _rail_call_record(flow: str, rail_type: str, result: RailResult, call: Optio
     action's structured verdict when present, else a minimal ``{"allowed": is_safe}``.
     """
     verdict = result.return_value if result.return_value is not None else {"allowed": result.is_safe}
+    # GenerationLog parity with LLMRails: action_name/task use the prompt-template key
+    # (underscores) rather than the space-separated Colang flow name; ``flow`` keeps spaces.
+    base_name = _get_flow_name(flow) or flow
+    model = _get_flow_model(flow)
+    action_name = base_name.replace(" ", "_")
+    task = f"{action_name} $model={model}" if model else action_name
     return RailCallRecord(
         flow=flow,
         rail_type=rail_type,
         is_safe=result.is_safe,
         made_call=call is not None,
-        action_name=_get_flow_name(flow),
+        action_name=action_name,
         return_value=verdict,
-        task=flow,
+        task=task,
         request_id=call.request_id if call else None,
         usage=call.usage if call else None,
         llm_model_name=call.llm_model_name if call else None,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -429,7 +429,9 @@ class RailsManager:
         rails: Mapping[str, Coroutine[Any, Any, RailResult]],
         direction: RailDirection,
     ) -> RailResult:
-        """Run rail coroutines concurrently, cancelling remaining on first unsafe result."""
+        """Run rail coroutines concurrently; on the first unsafe result, finish draining its
+        completion batch (so rails that finished alongside it still contribute their records)
+        before cancelling the rest."""
         req_id = get_request_id()
         task_to_flow: dict[asyncio.Task, str] = {asyncio.create_task(coro): flow for flow, coro in rails.items()}
         tasks = list(task_to_flow.keys())
@@ -440,24 +442,22 @@ class RailsManager:
         try:
             while pending_tasks:
                 done, pending_tasks = await asyncio.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
+                first_unsafe: Optional[RailResult] = None
                 for task in sorted(done, key=lambda t: task_order[t]):
                     result = task.result()
                     collected.extend(result.records)
                     flow = task_to_flow[task]
                     log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
-                    if not result.is_safe:
-                        log.info(
-                            "[%s] %s flow %s blocked (cancelling %d remaining)",
-                            req_id,
-                            direction.value,
-                            flow,
-                            len(pending_tasks),
-                        )
+                    if not result.is_safe and first_unsafe is None:
+                        first_unsafe = result
+                        log.info("[%s] %s flow %s blocked", req_id, direction.value, flow)
+                if first_unsafe is not None:
+                    if pending_tasks:
+                        log.info("[%s] %s cancelling %d remaining", req_id, direction.value, len(pending_tasks))
                         for t in pending_tasks:
                             t.cancel()
-                        if pending_tasks:
-                            await asyncio.wait(pending_tasks)
-                        return replace(result, records=tuple(collected))
+                        await asyncio.wait(pending_tasks)
+                    return replace(first_unsafe, records=tuple(collected))
             return RailResult(is_safe=True, records=tuple(collected))
         except BaseException:
             for t in tasks:

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -42,7 +42,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     RailResult,
     get_request_id,
 )
-from nemoguardrails.guardrails.rail_action import RailAction, RailLLMCall, take_rail_llm_call
+from nemoguardrails.guardrails.rail_action import RailAction, RailLLMCall, get_and_clear_rail_llm_call_contextvar
 from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
@@ -91,11 +91,14 @@ def _rail_call_record(flow: str, rail_type: str, result: RailResult, call: Optio
         flow=flow,
         rail_type=rail_type,
         is_safe=result.is_safe,
+        made_call=call is not None,
         action_name=_get_flow_name(flow),
         return_value=verdict,
         task=flow,
+        request_id=call.request_id if call else None,
         usage=call.usage if call else None,
         llm_model_name=call.llm_model_name if call else None,
+        llm_provider_name=call.provider_name if call else None,
         started_at=call.started_at if call else None,
         finished_at=call.finished_at if call else None,
         duration=call.duration if call else None,
@@ -327,7 +330,7 @@ class RailsManager:
         with rail_span(self._tracer, flow, direction) as span:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)
-            call = take_rail_llm_call()
+            call = get_and_clear_rail_llm_call_contextvar()
             if not result.is_safe and result.triggered_rail is None:
                 result = replace(result, triggered_rail=_get_flow_name(flow) or flow)
             result = replace(result, records=(_rail_call_record(flow, direction.value.lower(), result, call),))
@@ -350,7 +353,8 @@ class RailsManager:
         with rail_span(self._tracer, flow, RailDirection.OUTPUT) as span:
             result = await self._tool_call_actions[flow].run(toolset, tool_calls)
             # Tool rails are model-free, so no LLM call is captured (usage stays None).
-            result = replace(result, records=(_rail_call_record(flow, "tool_output", result, take_rail_llm_call()),))
+            call = get_and_clear_rail_llm_call_contextvar()
+            result = replace(result, records=(_rail_call_record(flow, "tool_output", result, call),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
                 set_rail_content(
@@ -374,7 +378,8 @@ class RailsManager:
                 if not result.is_safe:
                     break
             # Tool rails are model-free, so no LLM call is captured (usage stays None).
-            result = replace(result, records=(_rail_call_record(flow, "tool_input", result, take_rail_llm_call()),))
+            call = get_and_clear_rail_llm_call_contextvar()
+            result = replace(result, records=(_rail_call_record(flow, "tool_input", result, call),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
                 all_results = [r for exchange in exchanges for r in exchange.results]

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -37,11 +37,12 @@ from nemoguardrails.guardrails.actions.tool_result_action import ToolResultRailA
 from nemoguardrails.guardrails.actions.topic_safety_action import TopicSafetyInputAction
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import (
+    RailCallRecord,
     RailDirection,
     RailResult,
     get_request_id,
 )
-from nemoguardrails.guardrails.rail_action import RailAction
+from nemoguardrails.guardrails.rail_action import RailAction, RailLLMCall, take_rail_llm_call
 from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
@@ -77,6 +78,28 @@ _TOOL_ACTION_CLASSES: dict[str, type[ToolRailAction]] = {
 }
 
 _ToolActionT = TypeVar("_ToolActionT", bound=ToolRailAction)
+
+
+def _rail_call_record(flow: str, rail_type: str, result: RailResult, call: Optional[RailLLMCall]) -> RailCallRecord:
+    """Build the per-rail GenerationLog record from a rail's result + its captured LLM call.
+
+    ``call`` is None for model-free rails (e.g. tool validators); ``return_value`` uses the
+    action's structured verdict when present, else a minimal ``{"allowed": is_safe}``.
+    """
+    verdict = result.return_value if result.return_value is not None else {"allowed": result.is_safe}
+    return RailCallRecord(
+        flow=flow,
+        rail_type=rail_type,
+        is_safe=result.is_safe,
+        action_name=_get_flow_name(flow),
+        return_value=verdict,
+        task=flow,
+        usage=call.usage if call else None,
+        llm_model_name=call.llm_model_name if call else None,
+        started_at=call.started_at if call else None,
+        finished_at=call.finished_at if call else None,
+        duration=call.duration if call else None,
+    )
 
 
 class RailsManager:
@@ -304,8 +327,10 @@ class RailsManager:
         with rail_span(self._tracer, flow, direction) as span:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)
+            call = take_rail_llm_call()
             if not result.is_safe and result.triggered_rail is None:
                 result = replace(result, triggered_rail=_get_flow_name(flow) or flow)
+            result = replace(result, records=(_rail_call_record(flow, direction.value.lower(), result, call),))
             mark_rail_stop(span, result.is_safe)
             # Capture rail input + block reason after the action runs.
             # RailAction.run() catches its own exceptions and returns
@@ -324,6 +349,8 @@ class RailsManager:
         """Dispatch a single tool-call rail to its action, wrapped in an OUTPUT rail span."""
         with rail_span(self._tracer, flow, RailDirection.OUTPUT) as span:
             result = await self._tool_call_actions[flow].run(toolset, tool_calls)
+            # Tool rails are model-free, so no LLM call is captured (usage stays None).
+            result = replace(result, records=(_rail_call_record(flow, "tool_output", result, take_rail_llm_call()),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
                 set_rail_content(
@@ -346,6 +373,8 @@ class RailsManager:
                 result = await action.run(exchange.results, exchange.calls)
                 if not result.is_safe:
                     break
+            # Tool rails are model-free, so no LLM call is captured (usage stays None).
+            result = replace(result, records=(_rail_call_record(flow, "tool_input", result, take_rail_llm_call()),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
                 all_results = [r for exchange in exchanges for r in exchange.results]
@@ -368,14 +397,16 @@ class RailsManager:
         """Run rail coroutines sequentially, short-circuiting on first unsafe result."""
         req_id = get_request_id()
         remaining = iter(rails.items())
+        collected: list[RailCallRecord] = []
         try:
             for flow, coro in remaining:
                 result = await coro
+                collected.extend(result.records)
                 log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
                 if not result.is_safe:
                     log.info("[%s] %s flow %s blocked", req_id, direction.value, flow)
-                    return result
-            return RailResult(is_safe=True)
+                    return replace(result, records=tuple(collected))
+            return RailResult(is_safe=True, records=tuple(collected))
         finally:
             for _, coro in remaining:
                 coro.close()
@@ -391,12 +422,14 @@ class RailsManager:
         tasks = list(task_to_flow.keys())
         task_order = {task: i for i, task in enumerate(tasks)}
         pending_tasks: set[asyncio.Task] = set(tasks)
+        collected: list[RailCallRecord] = []
 
         try:
             while pending_tasks:
                 done, pending_tasks = await asyncio.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
                 for task in sorted(done, key=lambda t: task_order[t]):
                     result = task.result()
+                    collected.extend(result.records)
                     flow = task_to_flow[task]
                     log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
                     if not result.is_safe:
@@ -411,8 +444,8 @@ class RailsManager:
                             t.cancel()
                         if pending_tasks:
                             await asyncio.wait(pending_tasks)
-                        return result
-            return RailResult(is_safe=True)
+                        return replace(result, records=tuple(collected))
+            return RailResult(is_safe=True, records=tuple(collected))
         except BaseException:
             for t in tasks:
                 if not t.done():

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -123,8 +123,8 @@ class TestGuardrailsRouting:
             guardrails.update_llm(mock_new_llm)
 
             # Verify all calls went to LLMRails
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages)
+            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(messages=messages)
             guardrails.rails_engine.explain.assert_called_once()
             guardrails.rails_engine.update_llm.assert_called_once_with(mock_new_llm)
@@ -178,8 +178,8 @@ class TestGuardrailsRouting:
             with pytest.raises(NotImplementedError, match="IORails doesn't support update_llm()"):
                 guardrails.update_llm(mock_new_llm)
 
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages)
+            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(
                 messages=messages,
                 options=None,
@@ -257,8 +257,8 @@ class TestGuardrailsRouting:
             guardrails.update_llm(mock_new_llm)
 
             # Verify all calls went to LLMRails
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages)
+            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(messages=messages)
             guardrails.rails_engine.explain.assert_called_once()
             guardrails.rails_engine.update_llm.assert_called_once_with(mock_new_llm)
@@ -649,7 +649,7 @@ class TestGenerateAsync:
 
             # Verify generate_async was called with correct messages
             expected_messages = [{"role": "user", "content": "Hello async!"}]
-            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=expected_messages)
+            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=expected_messages, options=None)
             assert result == "Async response"
 
     @pytest.mark.asyncio
@@ -668,7 +668,7 @@ class TestGenerateAsync:
             ]
             result = await guardrails.generate_async(messages=messages)
 
-            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=messages)
+            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=messages, options=None)
             assert result == "Async conversation response"
 
     @pytest.mark.asyncio
@@ -685,7 +685,7 @@ class TestGenerateAsync:
             # Verify kwargs were passed through
             expected_messages = [{"role": "user", "content": "Test"}]
             mock_llmrails_instance.generate_async.assert_awaited_once_with(
-                messages=expected_messages, temperature=0.5, top_p=0.9
+                messages=expected_messages, options=None, temperature=0.5, top_p=0.9
             )
             assert result == "Response"
 
@@ -901,6 +901,7 @@ class TestIntegration:
         expected_messages = [{"role": "user", "content": "Test"}]
         mock_llmrails_instance.generate.assert_called_once_with(
             messages=expected_messages,
+            options=None,
             temperature=0.7,
             max_tokens=100,
             top_p=0.9,

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -1977,3 +1977,24 @@ class TestGuardrailsCheckEndToEnd:
             assert result.status == RailStatus.BLOCKED
             assert result.rail == "jailbreak detection model"
             assert result.content == REFUSAL_MESSAGE
+
+
+class TestOptionsForwarding:
+    """The facade forwards a caller-supplied ``options`` object to the engine verbatim."""
+
+    @pytest.mark.asyncio
+    @patch.object(LLMRails, "__init__", return_value=None)
+    async def test_options_forwarded_unchanged(self, _mock_init, _content_safety_rails_config):
+        """A non-None options object reaches both generate and generate_async as the same instance."""
+        options = GenerationOptions()
+        messages = [{"role": "user", "content": "hi"}]
+
+        async with Guardrails(config=_content_safety_rails_config, use_iorails=False) as guardrails:
+            guardrails.rails_engine.generate = MagicMock(return_value="sync")
+            guardrails.rails_engine.generate_async = AsyncMock(return_value="async")
+
+            guardrails.generate(messages=messages, options=options)
+            await guardrails.generate_async(messages=messages, options=options)
+
+            assert guardrails.rails_engine.generate.call_args.kwargs["options"] is options
+            assert guardrails.rails_engine.generate_async.call_args.kwargs["options"] is options

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -123,8 +123,8 @@ class TestGuardrailsRouting:
             guardrails.update_llm(mock_new_llm)
 
             # Verify all calls went to LLMRails
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate.assert_called_once_with(prompt=None, messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(prompt=None, messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(messages=messages)
             guardrails.rails_engine.explain.assert_called_once()
             guardrails.rails_engine.update_llm.assert_called_once_with(mock_new_llm)
@@ -178,8 +178,8 @@ class TestGuardrailsRouting:
             with pytest.raises(NotImplementedError, match="IORails doesn't support update_llm()"):
                 guardrails.update_llm(mock_new_llm)
 
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate.assert_called_once_with(prompt=None, messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(prompt=None, messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(
                 messages=messages,
                 options=None,
@@ -257,8 +257,8 @@ class TestGuardrailsRouting:
             guardrails.update_llm(mock_new_llm)
 
             # Verify all calls went to LLMRails
-            guardrails.rails_engine.generate.assert_called_once_with(messages=messages, options=None)
-            guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages, options=None)
+            guardrails.rails_engine.generate.assert_called_once_with(prompt=None, messages=messages, options=None)
+            guardrails.rails_engine.generate_async.assert_called_once_with(prompt=None, messages=messages, options=None)
             guardrails.rails_engine.stream_async.assert_called_once_with(messages=messages)
             guardrails.rails_engine.explain.assert_called_once()
             guardrails.rails_engine.update_llm.assert_called_once_with(mock_new_llm)
@@ -553,93 +553,13 @@ class TestRequireIORails:
         mock_llmrails_class.assert_called_once_with(_content_safety_rails_config, None, False)
 
 
-class TestConvertToMessages:
-    """Tests for the _convert_to_messages static method."""
-
-    def test_prompt_string(self):
-        """Test conversion of string prompt to LLMMessages."""
-        result = Guardrails._convert_to_messages(prompt="Hello, how are you?")
-
-        expected = [{"role": "user", "content": "Hello, how are you?"}]
-        assert result == expected
-
-    def test_empty_string_prompt(self):
-        """Test conversion of empty string prompt raises ValueError."""
-        # Empty string is falsy, so it should raise an error
-        with pytest.raises(ValueError, match="Neither prompt nor messages provided"):
-            Guardrails._convert_to_messages(prompt="")
-
-    def test_messages_single_message(self):
-        """Test conversion with single message."""
-        messages = [{"role": "user", "content": "What is the weather?"}]
-        result = Guardrails._convert_to_messages(messages=messages)
-        assert result == messages
-
-    def test_messages_multiple_messages(self):
-        """Test conversion with multiple messages."""
-        messages = [
-            {"role": "user", "content": "What is AI?"},
-            {"role": "assistant", "content": "AI is artificial intelligence."},
-            {"role": "user", "content": "Tell me more."},
-        ]
-        result = Guardrails._convert_to_messages(messages=messages)
-
-        assert result == messages
-
-    def test_messages_with_system_message(self):
-        """Test conversion with system message."""
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hello!"},
-        ]
-        result = Guardrails._convert_to_messages(messages=messages)
-
-        assert result == messages
-
-    def test_empty_messages_list(self):
-        """Test conversion with empty messages list raises ValueError."""
-        # Empty list is falsy, so it should raise an error
-        messages = []
-        with pytest.raises(ValueError, match="Neither prompt nor messages provided"):
-            Guardrails._convert_to_messages(messages=messages)
-
-    def test_messages_take_priority_over_prompt(self):
-        """Test that messages parameter takes priority when both are provided."""
-        messages = [{"role": "user", "content": "From messages"}]
-        result = Guardrails._convert_to_messages(prompt="From prompt", messages=messages)
-        assert result == messages
-
-    def test_neither_prompt_nor_messages_raises_error(self):
-        """Test that providing neither prompt nor messages raises ValueError."""
-        with pytest.raises(ValueError, match="Neither prompt nor messages provided"):
-            Guardrails._convert_to_messages()
-
-    def test_multiline_string_prompt(self):
-        """Test conversion of multiline string prompt."""
-        multiline_prompt = """Line 1
-Line 2
-Line 3"""
-        result = Guardrails._convert_to_messages(prompt=multiline_prompt)
-
-        expected = [{"role": "user", "content": multiline_prompt}]
-        assert result == expected
-
-    def test_string_prompt_with_special_characters(self):
-        """Test conversion of string prompt with special characters."""
-        special_prompt = "Hello! @#$%^&*() How's the weather? \"quoted\" 'text'"
-        result = Guardrails._convert_to_messages(prompt=special_prompt)
-
-        expected = [{"role": "user", "content": special_prompt}]
-        assert result == expected
-
-
 class TestGenerateAsync:
     """Tests for the asynchronous generate_async method."""
 
     @pytest.mark.asyncio
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     async def test_generate_async_with_string_prompt(self, mock_llmrails_class, _nemoguards_rails_config):
-        """Test generate_async method with a string prompt using context manager."""
+        """generate_async passes a string prompt through to the engine unchanged (facade is a passthrough)."""
         mock_llmrails_instance = MagicMock()
         mock_llmrails_class.return_value = mock_llmrails_instance
         mock_llmrails_instance.generate_async = AsyncMock(return_value="Async response")
@@ -647,9 +567,9 @@ class TestGenerateAsync:
         async with Guardrails(config=_nemoguards_rails_config, use_iorails=False) as guardrails:
             result = await guardrails.generate_async(prompt="Hello async!")
 
-            # Verify generate_async was called with correct messages
-            expected_messages = [{"role": "user", "content": "Hello async!"}]
-            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=expected_messages, options=None)
+            mock_llmrails_instance.generate_async.assert_awaited_once_with(
+                prompt="Hello async!", messages=None, options=None
+            )
             assert result == "Async response"
 
     @pytest.mark.asyncio
@@ -668,7 +588,7 @@ class TestGenerateAsync:
             ]
             result = await guardrails.generate_async(messages=messages)
 
-            mock_llmrails_instance.generate_async.assert_awaited_once_with(messages=messages, options=None)
+            mock_llmrails_instance.generate_async.assert_awaited_once_with(prompt=None, messages=messages, options=None)
             assert result == "Async conversation response"
 
     @pytest.mark.asyncio
@@ -682,10 +602,8 @@ class TestGenerateAsync:
         async with Guardrails(config=_nemoguards_rails_config, use_iorails=False) as guardrails:
             result = await guardrails.generate_async(prompt="Test", temperature=0.5, top_p=0.9)
 
-            # Verify kwargs were passed through
-            expected_messages = [{"role": "user", "content": "Test"}]
             mock_llmrails_instance.generate_async.assert_awaited_once_with(
-                messages=expected_messages, options=None, temperature=0.5, top_p=0.9
+                prompt="Test", messages=None, options=None, temperature=0.5, top_p=0.9
             )
             assert result == "Response"
 
@@ -897,10 +815,10 @@ class TestIntegration:
             top_p=0.9,
         )
 
-        # Verify all kwargs were passed through
-        expected_messages = [{"role": "user", "content": "Test"}]
+        # The facade is a passthrough; prompt/messages are forwarded to the engine verbatim.
         mock_llmrails_instance.generate.assert_called_once_with(
-            messages=expected_messages,
+            prompt="Test",
+            messages=None,
             options=None,
             temperature=0.7,
             max_tokens=100,

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -26,7 +26,7 @@ from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
-from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
@@ -90,7 +90,7 @@ class TestGenerateAsync:
 
     @pytest.mark.asyncio
     async def test_safe_input_and_output_with_generation_options(self, iorails):
-        """Returns LLM response when both input and output rails pass."""
+        """Passing options returns a GenerationResponse wrapping the LLM response."""
         messages = [{"role": "user", "content": "hi"}]
         llm_response = "Hello from LLM"
 
@@ -103,7 +103,8 @@ class TestGenerateAsync:
 
         result = await iorails.generate_async(messages, options=options)
 
-        assert result == {"role": "assistant", "content": llm_response}
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": llm_response}]
         iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, **llm_params)
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response, enabled=True)

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -81,7 +81,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": llm_response}
         iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
@@ -101,7 +101,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(messages, options=options)
+        result = await iorails.generate_async(messages=messages, options=options)
 
         assert isinstance(result, GenerationResponse)
         assert result.response == [{"role": "assistant", "content": llm_response}]
@@ -130,7 +130,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = mock_generate
         iorails.rails_manager.is_output_safe = mock_output_safe
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert call_order == ["input", "generate", "output"]
 
     @pytest.mark.asyncio
@@ -141,7 +141,7 @@ class TestGenerateAsync:
         iorails.rails_manager.is_output_safe = AsyncMock()
 
         messages = [{"role": "user", "content": "bad input"}]
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
@@ -158,7 +158,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_input_safe.assert_called_once_with(messages, enabled=True)
@@ -176,7 +176,7 @@ class TestGenerateAsync:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
-            result = await iorails.generate_async(messages)
+            result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         record_blocked.assert_called_once_with(RailDirection.OUTPUT)
@@ -191,7 +191,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        await iorails.generate_async(messages, options={"llm_params": llm_params})
+        await iorails.generate_async(messages=messages, options={"llm_params": llm_params})
 
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, **llm_params)
 
@@ -202,7 +202,7 @@ class TestGenerateAsync:
         iorails.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM internal error"))
 
         with pytest.raises(RuntimeError, match="LLM internal error"):
-            await iorails.generate_async([{"role": "user", "content": "hi"}])
+            await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
 
 class TestToolCalling:
@@ -219,7 +219,7 @@ class TestToolCalling:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        await iorails.generate_async(messages, options=options)
+        await iorails.generate_async(messages=messages, options=options)
 
         iorails.engine_registry.model_call.assert_called_once_with(
             "main", messages, tools=[tool], tool_choice="auto", parallel_tool_calls=True
@@ -241,7 +241,7 @@ class TestToolCalling:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", tool_calls=tool_calls))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result["role"] == "assistant"
         assert result["content"] is None
@@ -259,7 +259,7 @@ class TestToolCalling:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", tool_calls=tool_calls))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         iorails.rails_manager.is_output_safe.assert_not_called()
         assert result["tool_calls"][0]["function"]["name"] == "f"
@@ -276,7 +276,7 @@ class TestToolCalling:
         )
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "some text", enabled=True)
         assert result["content"] == "some text"
@@ -668,7 +668,7 @@ class TestAutoStart:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         assert not iorails._running
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         iorails.engine_registry.start.assert_called_once()
         assert iorails._running
@@ -681,8 +681,8 @@ class TestAutoStart:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         iorails.engine_registry.start.assert_called_once()
 
@@ -746,7 +746,7 @@ class TestGenerate:
 
         # Patch IORails so the temp instance inside generate() uses our mocked iorails
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
-            result = iorails.generate(messages)
+            result = iorails.generate(messages=messages)
 
         assert result == expected
 
@@ -761,7 +761,7 @@ class TestGenerate:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
-            iorails.generate(messages, options=options)
+            iorails.generate(messages=messages, options=options)
 
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, temperature=0.5)
 
@@ -775,7 +775,7 @@ class TestGenerate:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails) as mock_iorails:
-            iorails.generate(messages)
+            iorails.generate(messages=messages)
 
         mock_iorails.assert_called_once()
         assert mock_iorails.call_args.kwargs == {"_report_usage": False}
@@ -784,7 +784,7 @@ class TestGenerate:
         """generate() raises RuntimeError when called inside a running event loop."""
 
         async def call_generate():
-            iorails_sync.generate([{"role": "user", "content": "hi"}])
+            iorails_sync.generate(messages=[{"role": "user", "content": "hi"}])
 
         with pytest.raises(RuntimeError):
             asyncio.run(call_generate())
@@ -850,7 +850,7 @@ class TestIORailsConfigToCallURL:
         main_engine._running = True
 
         try:
-            await iorails.generate_async([{"role": "user", "content": "Hi"}])
+            await iorails.generate_async(messages=[{"role": "user", "content": "Hi"}])
         finally:
             await iorails.stop()
 

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -111,7 +111,7 @@ class TestLogGating:
         """With options but no log flags, `res.log` stays None."""
         _stub_pipeline(iorails, input_records=[_input_record()])
 
-        result = await iorails.generate_async(_USER, options={})
+        result = await iorails.generate_async(messages=_USER, options={})
 
         assert isinstance(result, GenerationResponse)
         assert result.log is None
@@ -125,7 +125,7 @@ class TestLlmCallsAndStats:
         """`log.llm_calls` lists main + each rail call; `log.stats` sums their tokens."""
         _stub_pipeline(iorails, input_records=[_input_record()], output_records=[_output_record()])
 
-        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"llm_calls": True}})
 
         assert result.log is not None
         stats = result.log.stats
@@ -147,7 +147,7 @@ class TestActivatedRails:
         verdict = {"allowed": False, "policy_violations": ["Violence", "Criminal Planning/Confessions"]}
         _stub_pipeline(iorails, input_records=[_input_record(is_safe=False, return_value=verdict)], input_safe=False)
 
-        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"activated_rails": True}})
 
         assert result.log is not None
         rail = next(r for r in result.log.activated_rails if r.name == _CS_INPUT_FLOW)
@@ -160,7 +160,7 @@ class TestActivatedRails:
         """A blocking input rail is marked stop=True, and the blocked request still logs it."""
         _stub_pipeline(iorails, input_records=[_input_record(is_safe=False)], input_safe=False)
 
-        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"activated_rails": True}})
 
         assert isinstance(result, GenerationResponse)
         assert result.log is not None
@@ -177,7 +177,7 @@ class TestUnsupportedLogOptions:
         _stub_pipeline(iorails, input_records=[_input_record()])
 
         with pytest.raises(NotImplementedError):
-            await iorails.generate_async(_USER, options={"log": {"internal_events": True}})
+            await iorails.generate_async(messages=_USER, options={"log": {"internal_events": True}})
 
     @pytest.mark.asyncio
     async def test_colang_history_raises(self, iorails):
@@ -185,7 +185,7 @@ class TestUnsupportedLogOptions:
         _stub_pipeline(iorails, input_records=[_input_record()])
 
         with pytest.raises(NotImplementedError):
-            await iorails.generate_async(_USER, options={"log": {"colang_history": True}})
+            await iorails.generate_async(messages=_USER, options={"log": {"colang_history": True}})
 
 
 class TestUsageRemovedFromLlmMetadata:
@@ -204,7 +204,7 @@ class TestUsageRemovedFromLlmMetadata:
             )
         )
 
-        result = await iorails.generate_async(_USER, options={})
+        result = await iorails.generate_async(messages=_USER, options={})
 
         assert result.llm_metadata == {"response_headers": {"nvcf-status": "fulfilled"}}
 
@@ -217,7 +217,7 @@ class TestUsageRemovedFromLlmMetadata:
             return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15))
         )
 
-        result = await iorails.generate_async(_USER, options={})
+        result = await iorails.generate_async(messages=_USER, options={})
 
         assert result.llm_metadata is None
 

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -30,7 +30,7 @@ import pytest
 import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailCallRecord, RailResult
-from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.guardrails.iorails import IORails, _activated_rail
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.types import LLMResponse, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
@@ -220,3 +220,56 @@ class TestUsageRemovedFromLlmMetadata:
         result = await iorails.generate_async(_USER, options={})
 
         assert result.llm_metadata is None
+
+
+class TestActivatedRailHelper:
+    """`_activated_rail` maps a RailCallRecord to an ActivatedRail + synthetic ExecutedAction."""
+
+    def test_record_with_llm_call(self):
+        """A model-backed rail yields one ExecutedAction with its verdict and a single LLMCallInfo."""
+        record = RailCallRecord(
+            flow=_CS_INPUT_FLOW,
+            rail_type="input",
+            is_safe=False,
+            action_name="content_safety_check_input",
+            return_value={"allowed": False, "policy_violations": ["Violence"]},
+            task="content_safety_check_input $model=content_safety",
+            usage=UsageInfo(input_tokens=762, output_tokens=22, total_tokens=784),
+            llm_model_name="nvidia/llama-3.1-nemoguard-8b-content-safety",
+            llm_provider_name="nim",
+            started_at=1.0,
+            finished_at=1.5,
+            duration=0.5,
+        )
+
+        rail = _activated_rail(record)
+
+        assert rail.type == "input"
+        assert rail.name == _CS_INPUT_FLOW
+        assert rail.stop is True
+        assert rail.duration == 0.5
+        action = rail.executed_actions[0]
+        assert action.action_name == "content_safety_check_input"
+        assert action.return_value == {"allowed": False, "policy_violations": ["Violence"]}
+        assert len(action.llm_calls) == 1
+        assert action.llm_calls[0].total_tokens == 784
+        assert action.llm_calls[0].llm_model_name == "nvidia/llama-3.1-nemoguard-8b-content-safety"
+
+    def test_record_without_llm_call(self):
+        """A model-free rail (usage=None) yields an empty llm_calls list; action_name falls back to flow."""
+        record = RailCallRecord(
+            flow="tool call validation",
+            rail_type="tool_output",
+            is_safe=True,
+            action_name=None,
+            return_value={"allowed": True},
+        )
+
+        rail = _activated_rail(record)
+
+        assert rail.type == "tool_output"
+        assert rail.stop is False
+        action = rail.executed_actions[0]
+        assert action.action_name == "tool call validation"
+        assert action.llm_calls == []
+        assert action.return_value == {"allowed": True}

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -273,3 +273,21 @@ class TestActivatedRailHelper:
         assert action.action_name == "tool call validation"
         assert action.llm_calls == []
         assert action.return_value == {"allowed": True}
+
+    def test_api_rail_made_call_without_usage_counts(self):
+        """An API rail (made_call=True, usage=None, e.g. jailbreak) still yields one llm_call."""
+        record = RailCallRecord(
+            flow="jailbreak detection model",
+            rail_type="input",
+            is_safe=True,
+            made_call=True,
+            action_name="jailbreak detection model",
+            return_value=False,
+            task="jailbreak detection model",
+        )
+
+        rail = _activated_rail(record)
+
+        assert len(rail.executed_actions[0].llm_calls) == 1
+        assert rail.executed_actions[0].llm_calls[0].total_tokens is None
+        assert rail.executed_actions[0].return_value is False

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -291,3 +291,40 @@ class TestActivatedRailHelper:
         assert len(rail.executed_actions[0].llm_calls) == 1
         assert rail.executed_actions[0].llm_calls[0].total_tokens is None
         assert rail.executed_actions[0].return_value is False
+
+    def test_record_maps_prompt_and_completion(self):
+        """A record's captured prompt/completion surface on the mapped LLMCallInfo."""
+        record = RailCallRecord(
+            flow=_CS_INPUT_FLOW,
+            rail_type="input",
+            is_safe=True,
+            made_call=True,
+            action_name="content_safety_check_input",
+            return_value={"allowed": True},
+            task="content_safety_check_input $model=content_safety",
+            usage=UsageInfo(input_tokens=10, output_tokens=2, total_tokens=12),
+            prompt="user: hi",
+            completion='{"User Safety": "safe"}',
+        )
+
+        call = _activated_rail(record).executed_actions[0].llm_calls[0]
+
+        assert call.prompt == "user: hi"
+        assert call.completion == '{"User Safety": "safe"}'
+
+    def test_api_rail_record_has_no_prompt_or_completion(self):
+        """An API rail (jailbreak) captures no content, so prompt/completion map to None."""
+        record = RailCallRecord(
+            flow="jailbreak detection model",
+            rail_type="input",
+            is_safe=True,
+            made_call=True,
+            action_name="jailbreak_detection_model",
+            return_value=False,
+            task="jailbreak_detection_model",
+        )
+
+        call = _activated_rail(record).executed_actions[0].llm_calls[0]
+
+        assert call.prompt is None
+        assert call.completion is None

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GenerationLog + token usage for IORails (PR B), matching LLMRails' log contract.
+
+When ``options.log`` requests ``activated_rails`` and/or ``llm_calls``, IORails
+synthesizes a ``GenerationLog`` from the per-rail ``RailCallRecord``s carried on each
+``RailResult`` plus the main generation call: ``activated_rails`` (one synthetic
+``ExecutedAction`` per rail carrying the real verdict as ``return_value``), a flat
+``llm_calls`` list (main + every rail), and aggregate ``stats``. ``internal_events``
+and ``colang_history`` are Colang-runtime-only and raise ``NotImplementedError``.
+Token usage lives only in ``log`` — it is no longer surfaced under ``llm_metadata``.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from nemoguardrails.guardrails.guardrails_types import RailCallRecord, RailResult
+from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.types import LLMResponse, UsageInfo
+from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+_USER = [{"role": "user", "content": "hi"}]
+
+_CS_INPUT_FLOW = "content safety check input $model=content_safety"
+_CS_OUTPUT_FLOW = "content safety check output $model=content_safety"
+
+
+@pytest_asyncio.fixture
+async def iorails():
+    """Started IORails instance with worker-queue teardown after each test."""
+    async with started_iorails(NEMOGUARDS_CONFIG) as iorails:
+        yield iorails
+
+
+def _input_record(*, is_safe: bool = True, return_value=None) -> RailCallRecord:
+    """A content-safety input-rail record with a NeMoGuard-style verdict + usage."""
+    return RailCallRecord(
+        flow=_CS_INPUT_FLOW,
+        rail_type="input",
+        is_safe=is_safe,
+        action_name="content_safety_check_input",
+        return_value=return_value if return_value is not None else {"allowed": is_safe, "policy_violations": []},
+        task="content_safety_check_input $model=content_safety",
+        usage=UsageInfo(input_tokens=762, output_tokens=8, total_tokens=770),
+        llm_model_name="nvidia/llama-3.1-nemoguard-8b-content-safety",
+        llm_provider_name="nim",
+        started_at=1.0,
+        finished_at=1.5,
+        duration=0.5,
+    )
+
+
+def _output_record() -> RailCallRecord:
+    """A content-safety output-rail record with usage."""
+    return RailCallRecord(
+        flow=_CS_OUTPUT_FLOW,
+        rail_type="output",
+        is_safe=True,
+        action_name="content_safety_check_output",
+        return_value={"allowed": True, "policy_violations": []},
+        task="content_safety_check_output $model=content_safety",
+        usage=UsageInfo(input_tokens=855, output_tokens=15, total_tokens=870),
+        llm_model_name="nvidia/llama-3.1-nemoguard-8b-content-safety",
+        llm_provider_name="nim",
+        started_at=3.0,
+        finished_at=3.4,
+        duration=0.4,
+    )
+
+
+def _stub_pipeline(iorails: IORails, *, input_records=(), output_records=(), input_safe=True) -> None:
+    """Stub input/output rails to return given records, and a main call with usage."""
+    iorails.rails_manager.is_input_safe = AsyncMock(
+        return_value=RailResult(
+            is_safe=input_safe,
+            reason=None if input_safe else "unsafe",
+            triggered_rail=None if input_safe else _CS_INPUT_FLOW,
+            records=tuple(input_records),
+        )
+    )
+    iorails.rails_manager.is_output_safe = AsyncMock(
+        return_value=RailResult(is_safe=True, records=tuple(output_records))
+    )
+    iorails.engine_registry.model_call = AsyncMock(
+        return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=99, output_tokens=50, total_tokens=149))
+    )
+
+
+class TestLogGating:
+    """`log` is only built when explicitly requested."""
+
+    @pytest.mark.asyncio
+    async def test_log_none_when_not_requested(self, iorails):
+        """With options but no log flags, `res.log` stays None."""
+        _stub_pipeline(iorails, input_records=[_input_record()])
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is None
+
+
+class TestLlmCallsAndStats:
+    """Flat `llm_calls` list and aggregate `stats` cover the main call plus every rail."""
+
+    @pytest.mark.asyncio
+    async def test_llm_calls_and_stats_aggregate_main_and_rails(self, iorails):
+        """`log.llm_calls` lists main + each rail call; `log.stats` sums their tokens."""
+        _stub_pipeline(iorails, input_records=[_input_record()], output_records=[_output_record()])
+
+        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+
+        assert result.log is not None
+        stats = result.log.stats
+        assert stats.llm_calls_count == 3
+        assert stats.llm_calls_total_prompt_tokens == 762 + 855 + 99
+        assert stats.llm_calls_total_completion_tokens == 8 + 15 + 50
+        assert stats.llm_calls_total_tokens == 770 + 870 + 149
+
+        totals = sorted(call.total_tokens for call in result.log.llm_calls)
+        assert totals == [149, 770, 870]
+
+
+class TestActivatedRails:
+    """`activated_rails` carries one synthetic action per rail with the real verdict."""
+
+    @pytest.mark.asyncio
+    async def test_activated_rail_carries_verdict_as_return_value(self, iorails):
+        """The rail's structured verdict is preserved as executed_actions[0].return_value."""
+        verdict = {"allowed": False, "policy_violations": ["Violence", "Criminal Planning/Confessions"]}
+        _stub_pipeline(iorails, input_records=[_input_record(is_safe=False, return_value=verdict)], input_safe=False)
+
+        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+
+        assert result.log is not None
+        rail = next(r for r in result.log.activated_rails if r.name == _CS_INPUT_FLOW)
+        assert rail.type == "input"
+        assert rail.executed_actions[0].action_name == "content_safety_check_input"
+        assert rail.executed_actions[0].return_value == verdict
+
+    @pytest.mark.asyncio
+    async def test_stop_set_on_blocking_rail(self, iorails):
+        """A blocking input rail is marked stop=True, and the blocked request still logs it."""
+        _stub_pipeline(iorails, input_records=[_input_record(is_safe=False)], input_safe=False)
+
+        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        rail = next(r for r in result.log.activated_rails if r.name == _CS_INPUT_FLOW)
+        assert rail.stop is True
+
+
+class TestUnsupportedLogOptions:
+    """Colang-runtime-only log fields raise NotImplementedError."""
+
+    @pytest.mark.asyncio
+    async def test_internal_events_raises(self, iorails):
+        """Requesting internal_events raises — IORails runs no Colang event stream."""
+        _stub_pipeline(iorails, input_records=[_input_record()])
+
+        with pytest.raises(NotImplementedError):
+            await iorails.generate_async(_USER, options={"log": {"internal_events": True}})
+
+    @pytest.mark.asyncio
+    async def test_colang_history_raises(self, iorails):
+        """Requesting colang_history raises — IORails produces no Colang transcript."""
+        _stub_pipeline(iorails, input_records=[_input_record()])
+
+        with pytest.raises(NotImplementedError):
+            await iorails.generate_async(_USER, options={"log": {"colang_history": True}})
+
+
+class TestUsageRemovedFromLlmMetadata:
+    """Token usage moved to `log`; `llm_metadata` is a pure provider_metadata passthrough."""
+
+    @pytest.mark.asyncio
+    async def test_llm_metadata_has_no_usage_key(self, iorails):
+        """provider_metadata is surfaced verbatim; no `usage` sub-key is added."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(
+                content="Hi",
+                provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}},
+                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15),
+            )
+        )
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert result.llm_metadata == {"response_headers": {"nvcf-status": "fulfilled"}}
+
+    @pytest.mark.asyncio
+    async def test_llm_metadata_none_when_only_usage(self, iorails):
+        """With usage but no provider_metadata, llm_metadata is None (usage no longer graft-in)."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15))
+        )
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert result.llm_metadata is None

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -102,6 +102,22 @@ class TestRailRecordCapture:
         assert record.request_id == "req-cs-input"
         assert record.return_value == {"allowed": True, "policy_violations": []}
 
+    @pytest.mark.asyncio
+    async def test_failed_model_call_still_records_the_attempt(self, iorails):
+        """A rail whose model call raises still yields a record marked made_call=True (usage/model None)."""
+        iorails.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        result = await iorails.rails_manager.is_input_safe(_USER)
+
+        assert result.is_safe is False
+        assert len(result.records) == 1
+        record = result.records[0]
+        assert record.made_call is True
+        assert record.usage is None
+        assert record.llm_model_name is None
+        assert record.llm_provider_name == "nim"
+        assert record.duration is not None
+
 
 class TestGenerationLogEndToEnd:
     """Full generate_async path builds a GenerationLog from real rail + main-call records."""

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real rail-call capture → GenerationLog for IORails (PR B, Phase 2b).
+
+Exercises the ACTUAL RailAction + RailsManager pipeline (not stubbed at the
+rails-manager level): a rail's model call is captured (usage/model/timing) and its
+verdict preserved onto the RailResult, then surfaced as per-rail RailCallRecords that
+IORails turns into GenerationLog entries. Only the engine's ``model_call`` is mocked,
+so the real content-safety actions parse the responses and produce real records.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE
+from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.types import LLMResponse, UsageInfo
+from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG
+
+_USER = [{"role": "user", "content": "hi"}]
+_CS_INPUT = "content safety check input $model=content_safety"
+_CS_MODEL = "nvidia/llama-3.1-nemoguard-8b-content-safety"
+_MAIN_MODEL = "meta/llama-3.3-70b-instruct"
+
+# {"User Safety": "safe", "Response Safety": "safe"} parses safe for both the input
+# parser (reads User Safety) and the output parser (reads Response Safety).
+_SAFE_BOTH = json.dumps({"User Safety": "safe", "Response Safety": "safe"})
+_UNSAFE_INPUT = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
+
+
+@pytest_asyncio.fixture
+async def iorails():
+    """Started IORails on a content-safety-only config (input + output rails)."""
+    async with started_iorails(CONTENT_SAFETY_CONFIG) as engine:
+        yield engine
+
+
+class TestRailRecordCapture:
+    """A real rail run captures its LLM call + verdict onto RailResult.records."""
+
+    @pytest.mark.asyncio
+    async def test_is_input_safe_captures_usage_and_verdict(self, iorails):
+        """is_input_safe returns a record carrying the rail's tokens, model, and verdict."""
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(
+                content=_SAFE_BOTH,
+                usage=UsageInfo(input_tokens=762, output_tokens=8, total_tokens=770),
+                model=_CS_MODEL,
+            )
+        )
+
+        result = await iorails.rails_manager.is_input_safe(_USER)
+
+        assert result.is_safe is True
+        assert len(result.records) == 1
+        record = result.records[0]
+        assert record.flow == _CS_INPUT
+        assert record.rail_type == "input"
+        assert record.usage.total_tokens == 770
+        assert record.llm_model_name == _CS_MODEL
+        assert record.return_value == {"allowed": True, "policy_violations": []}
+
+
+class TestGenerationLogEndToEnd:
+    """Full generate_async path builds a GenerationLog from real rail + main-call records."""
+
+    @pytest.mark.asyncio
+    async def test_stats_and_activated_rails(self, iorails):
+        """log covers input CS + main + output CS calls, with the content-safety verdict."""
+
+        async def _model_call(model_type, messages, **kwargs):
+            if model_type == "content_safety":
+                return LLMResponse(
+                    content=_SAFE_BOTH,
+                    usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
+                    model=_CS_MODEL,
+                )
+            return LLMResponse(
+                content="Hi",
+                usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
+                model=_MAIN_MODEL,
+            )
+
+        iorails.engine_registry.model_call = AsyncMock(side_effect=_model_call)
+
+        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True, "activated_rails": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        stats = result.log.stats
+        assert stats.llm_calls_count == 3
+        assert stats.llm_calls_total_prompt_tokens == 100 + 20 + 100
+        assert stats.llm_calls_total_completion_tokens == 10 + 5 + 10
+        assert stats.llm_calls_total_tokens == 110 + 25 + 110
+
+        cs_rail = next(rail for rail in result.log.activated_rails if rail.name == _CS_INPUT)
+        assert cs_rail.type == "input"
+        assert cs_rail.executed_actions[0].return_value == {"allowed": True, "policy_violations": []}
+        assert any(rail.type == "generation" for rail in result.log.activated_rails)
+
+    @pytest.mark.asyncio
+    async def test_blocked_input_logs_verdict_and_stop(self, iorails):
+        """A blocked input rail logs its unsafe verdict + stop, and the request refuses."""
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(
+                content=_UNSAFE_INPUT,
+                usage=UsageInfo(input_tokens=762, output_tokens=22, total_tokens=784),
+                model=_CS_MODEL,
+            )
+        )
+
+        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
+        assert result.log is not None
+        cs_rail = next(rail for rail in result.log.activated_rails if rail.name == _CS_INPUT)
+        assert cs_rail.stop is True
+        verdict = cs_rail.executed_actions[0].return_value
+        assert verdict["allowed"] is False
+        assert len(verdict["policy_violations"]) >= 1

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -45,6 +45,27 @@ _SAFE_BOTH = json.dumps({"User Safety": "safe", "Response Safety": "safe"})
 _UNSAFE_INPUT = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
 
 
+def _cs_and_main_model_call(*, cs_request_id=None, main_request_id=None):
+    """Build a ``model_call`` side_effect: content-safety returns _SAFE_BOTH, the main model returns "Hi"."""
+
+    async def _model_call(model_type, messages, **kwargs):
+        if model_type == "content_safety":
+            return LLMResponse(
+                content=_SAFE_BOTH,
+                usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
+                model=_CS_MODEL,
+                request_id=cs_request_id,
+            )
+        return LLMResponse(
+            content="Hi",
+            usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
+            model=_MAIN_MODEL,
+            request_id=main_request_id,
+        )
+
+    return _model_call
+
+
 @pytest_asyncio.fixture
 async def iorails():
     """Started IORails on a content-safety-only config (input + output rails)."""
@@ -88,23 +109,9 @@ class TestGenerationLogEndToEnd:
     @pytest.mark.asyncio
     async def test_stats_and_activated_rails(self, iorails):
         """log covers input CS + main + output CS calls, with the content-safety verdict."""
-
-        async def _model_call(model_type, messages, **kwargs):
-            if model_type == "content_safety":
-                return LLMResponse(
-                    content=_SAFE_BOTH,
-                    usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
-                    model=_CS_MODEL,
-                    request_id="req-cs",
-                )
-            return LLMResponse(
-                content="Hi",
-                usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
-                model=_MAIN_MODEL,
-                request_id="req-main",
-            )
-
-        iorails.engine_registry.model_call = AsyncMock(side_effect=_model_call)
+        iorails.engine_registry.model_call = AsyncMock(
+            side_effect=_cs_and_main_model_call(cs_request_id="req-cs", main_request_id="req-main")
+        )
 
         result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True, "activated_rails": True}})
 
@@ -128,21 +135,7 @@ class TestGenerationLogEndToEnd:
     @pytest.mark.asyncio
     async def test_llm_calls_capture_prompt_and_completion(self, iorails):
         """Each LLM-backed call in the log carries its serialized prompt and raw completion."""
-
-        async def _model_call(model_type, messages, **kwargs):
-            if model_type == "content_safety":
-                return LLMResponse(
-                    content=_SAFE_BOTH,
-                    usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
-                    model=_CS_MODEL,
-                )
-            return LLMResponse(
-                content="Hi",
-                usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
-                model=_MAIN_MODEL,
-            )
-
-        iorails.engine_registry.model_call = AsyncMock(side_effect=_model_call)
+        iorails.engine_registry.model_call = AsyncMock(side_effect=_cs_and_main_model_call())
 
         result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
 

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -126,6 +126,59 @@ class TestGenerationLogEndToEnd:
         assert any(rail.type == "generation" for rail in result.log.activated_rails)
 
     @pytest.mark.asyncio
+    async def test_llm_calls_capture_prompt_and_completion(self, iorails):
+        """Each LLM-backed call in the log carries its serialized prompt and raw completion."""
+
+        async def _model_call(model_type, messages, **kwargs):
+            if model_type == "content_safety":
+                return LLMResponse(
+                    content=_SAFE_BOTH,
+                    usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
+                    model=_CS_MODEL,
+                )
+            return LLMResponse(
+                content="Hi",
+                usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
+                model=_MAIN_MODEL,
+            )
+
+        iorails.engine_registry.model_call = AsyncMock(side_effect=_model_call)
+
+        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        llm_calls = result.log.llm_calls or []
+        cs_call = next(c for c in llm_calls if c.task and "content_safety_check_input" in c.task)
+        main_call = next(c for c in llm_calls if c.task == "general")
+
+        assert cs_call.completion == _SAFE_BOTH
+        assert cs_call.prompt is not None
+        assert "hi" in cs_call.prompt
+        assert main_call.completion == "Hi"
+        assert main_call.prompt is not None
+        assert "hi" in main_call.prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_serializes_role_and_content(self, iorails):
+        """The serialized prompt is role-labeled so a reader can tell system from user turns."""
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(
+                content=_SAFE_BOTH,
+                usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
+                model=_CS_MODEL,
+            )
+        )
+
+        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+
+        assert result.log is not None
+        llm_calls = result.log.llm_calls or []
+        cs_call = next(c for c in llm_calls if c.task and "content_safety_check_input" in c.task)
+        assert cs_call.prompt is not None
+        assert "user:" in cs_call.prompt or "system:" in cs_call.prompt
+
+    @pytest.mark.asyncio
     async def test_blocked_input_logs_verdict_and_stop(self, iorails):
         """A blocked input rail logs its unsafe verdict + stop, and the request refuses."""
         iorails.engine_registry.model_call = AsyncMock(

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -113,7 +113,9 @@ class TestGenerationLogEndToEnd:
             side_effect=_cs_and_main_model_call(cs_request_id="req-cs", main_request_id="req-main")
         )
 
-        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True, "activated_rails": True}})
+        result = await iorails.generate_async(
+            messages=_USER, options={"log": {"llm_calls": True, "activated_rails": True}}
+        )
 
         assert isinstance(result, GenerationResponse)
         assert result.log is not None
@@ -137,7 +139,7 @@ class TestGenerationLogEndToEnd:
         """Each LLM-backed call in the log carries its serialized prompt and raw completion."""
         iorails.engine_registry.model_call = AsyncMock(side_effect=_cs_and_main_model_call())
 
-        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"llm_calls": True}})
 
         assert isinstance(result, GenerationResponse)
         assert result.log is not None
@@ -163,7 +165,7 @@ class TestGenerationLogEndToEnd:
             )
         )
 
-        result = await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"llm_calls": True}})
 
         assert result.log is not None
         llm_calls = result.log.llm_calls or []
@@ -182,7 +184,7 @@ class TestGenerationLogEndToEnd:
             )
         )
 
-        result = await iorails.generate_async(_USER, options={"log": {"activated_rails": True}})
+        result = await iorails.generate_async(messages=_USER, options={"log": {"activated_rails": True}})
 
         assert isinstance(result, GenerationResponse)
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -63,6 +63,7 @@ class TestRailRecordCapture:
                 content=_SAFE_BOTH,
                 usage=UsageInfo(input_tokens=762, output_tokens=8, total_tokens=770),
                 model=_CS_MODEL,
+                request_id="req-cs-input",
             )
         )
 
@@ -73,8 +74,11 @@ class TestRailRecordCapture:
         record = result.records[0]
         assert record.flow == _CS_INPUT
         assert record.rail_type == "input"
+        assert record.made_call is True
         assert record.usage.total_tokens == 770
         assert record.llm_model_name == _CS_MODEL
+        assert record.llm_provider_name == "nim"
+        assert record.request_id == "req-cs-input"
         assert record.return_value == {"allowed": True, "policy_violations": []}
 
 
@@ -91,11 +95,13 @@ class TestGenerationLogEndToEnd:
                     content=_SAFE_BOTH,
                     usage=UsageInfo(input_tokens=100, output_tokens=10, total_tokens=110),
                     model=_CS_MODEL,
+                    request_id="req-cs",
                 )
             return LLMResponse(
                 content="Hi",
                 usage=UsageInfo(input_tokens=20, output_tokens=5, total_tokens=25),
                 model=_MAIN_MODEL,
+                request_id="req-main",
             )
 
         iorails.engine_registry.model_call = AsyncMock(side_effect=_model_call)
@@ -113,6 +119,10 @@ class TestGenerationLogEndToEnd:
         cs_rail = next(rail for rail in result.log.activated_rails if rail.name == _CS_INPUT)
         assert cs_rail.type == "input"
         assert cs_rail.executed_actions[0].return_value == {"allowed": True, "policy_violations": []}
+        # id + provider are threaded through the capture (parity fixes).
+        cs_call = cs_rail.executed_actions[0].llm_calls[0]
+        assert cs_call.id == "req-cs"
+        assert cs_call.llm_provider_name == "nim"
         assert any(rail.type == "generation" for rail in result.log.activated_rails)
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -78,7 +78,7 @@ async def _generate_structured(iorails: IORails, response: LLMResponse, *, optio
     """Stub safe rails + a fixed model response, then run the structured (``options``) path."""
     _stub_safe_rails(iorails)
     _stub_model(iorails, response)
-    return await iorails.generate_async(_USER, options={} if options is None else options, **kwargs)
+    return await iorails.generate_async(messages=_USER, options={} if options is None else options, **kwargs)
 
 
 class TestStructuredResponseTrigger:
@@ -102,7 +102,7 @@ class TestStructuredResponseTrigger:
         _stub_safe_rails(iorails)
         _stub_model(iorails, LLMResponse(content="Hello"))
 
-        result = await iorails.generate_async(_USER)
+        result = await iorails.generate_async(messages=_USER)
 
         assert not isinstance(result, GenerationResponse)
         assert result == {"role": "assistant", "content": "Hello"}
@@ -246,7 +246,7 @@ class TestUnsupportedOptionGuards:
         _stub_model(iorails, LLMResponse(content="Hello"))
 
         with pytest.raises(ValueError):
-            await iorails.generate_async(_USER, **gen_kwargs)
+            await iorails.generate_async(messages=_USER, **gen_kwargs)
 
     @pytest.mark.asyncio
     async def test_colang_only_log_flag_raises(self, iorails):
@@ -260,7 +260,7 @@ class TestUnsupportedOptionGuards:
         _stub_model(iorails, LLMResponse(content="Hello"))
 
         with pytest.raises(NotImplementedError):
-            await iorails.generate_async(_USER, options={"log": {"internal_events": True}})
+            await iorails.generate_async(messages=_USER, options={"log": {"internal_events": True}})
 
 
 class TestBlockedStructuredResponse:
@@ -280,7 +280,7 @@ class TestBlockedStructuredResponse:
         )
         _stub_model(iorails, LLMResponse(content="bad answer"))
 
-        result = await iorails.generate_async(_USER, options={})
+        result = await iorails.generate_async(messages=_USER, options={})
 
         assert isinstance(result, GenerationResponse)
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
@@ -298,7 +298,7 @@ class TestBarePathUnchanged:
         _stub_safe_rails(iorails)
         _stub_model(iorails, LLMResponse(content="Hello", reasoning="thinking step"))
 
-        result = await iorails.generate_async(_USER)
+        result = await iorails.generate_async(messages=_USER)
 
         assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
 
@@ -313,9 +313,89 @@ class TestSyncGenerateStructured:
         iorails_sync.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails_sync):
-            result = iorails_sync.generate(_USER, options={})
+            result = iorails_sync.generate(messages=_USER, options={})
 
         assert isinstance(result, GenerationResponse)
+
+
+class TestPromptAndMessages:
+    """IORails accepts a keyword-only ``prompt`` (converted to messages) or a ``messages`` list."""
+
+    @pytest.mark.asyncio
+    async def test_prompt_string_generates(self, iorails):
+        """A keyword prompt string is converted to a user message and generates normally."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hi"))
+
+        result = await iorails.generate_async(prompt="Hello", options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": "Hi"}]
+
+    @pytest.mark.asyncio
+    async def test_neither_prompt_nor_messages_raises(self, iorails):
+        """generate_async with neither prompt nor messages raises ValueError."""
+        with pytest.raises(ValueError):
+            await iorails.generate_async()
+
+    def test_sync_generate_neither_raises(self, iorails_sync):
+        """The sync generate with neither prompt nor messages raises ValueError."""
+        with pytest.raises(ValueError):
+            iorails_sync.generate()
+
+    @pytest.mark.asyncio
+    async def test_list_passed_positionally_as_prompt_raises_typeerror(self, iorails):
+        """A message list in the positional prompt slot raises TypeError, not a silent misparse."""
+        with pytest.raises(TypeError):
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+
+class TestConvertToMessages:
+    """``IORails._convert_to_messages`` normalizes prompt/messages (moved from the facade)."""
+
+    def test_messages_passthrough(self):
+        """A multi-turn message list (system + user + assistant) is returned unchanged."""
+        msgs = [
+            {"role": "system", "content": "be nice"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert IORails._convert_to_messages(messages=msgs) is msgs
+
+    def test_prompt_wrapped_as_user_turn(self):
+        """A prompt string (content preserved verbatim) becomes a single user message."""
+        prompt = 'Line 1\nLine 2 with "quotes" & symbols'
+        assert IORails._convert_to_messages(prompt=prompt) == [{"role": "user", "content": prompt}]
+
+    def test_messages_win_when_both_supplied(self):
+        """When both are given, messages takes priority and prompt is ignored."""
+        msgs = [{"role": "user", "content": "hi"}]
+        assert IORails._convert_to_messages(prompt="ignored", messages=msgs) is msgs
+
+    def test_string_messages_raises_typeerror(self):
+        """A string in the messages slot raises TypeError pointing at prompt=."""
+        with pytest.raises(TypeError):
+            IORails._convert_to_messages(messages="hi")
+
+    def test_list_prompt_raises_typeerror(self):
+        """A message list in the prompt slot raises TypeError pointing at messages=."""
+        with pytest.raises(TypeError):
+            IORails._convert_to_messages(prompt=[{"role": "user", "content": "hi"}])
+
+    def test_empty_string_prompt_raises_valueerror(self):
+        """An empty prompt string is falsy, so it counts as 'neither provided'."""
+        with pytest.raises(ValueError):
+            IORails._convert_to_messages(prompt="")
+
+    def test_empty_messages_list_raises_valueerror(self):
+        """An empty messages list is falsy, so it counts as 'neither provided'."""
+        with pytest.raises(ValueError):
+            IORails._convert_to_messages(messages=[])
+
+    def test_neither_raises_valueerror(self):
+        """Neither prompt nor messages raises ValueError."""
+        with pytest.raises(ValueError):
+            IORails._convert_to_messages()
 
 
 class TestResponseContentForCapture:

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -299,13 +299,18 @@ class TestUnsupportedOptionGuards:
             await iorails.generate_async(_USER, options={"output_vars": ["relevant_chunks"]})
 
     @pytest.mark.asyncio
-    async def test_log_request_flag_raises(self, iorails):
-        """Requesting any ``log`` detail raises NotImplementedError while ``log`` is deferred."""
+    async def test_colang_only_log_flag_raises(self, iorails):
+        """Colang-runtime-only log details raise NotImplementedError.
+
+        ``activated_rails``/``llm_calls`` are supported and produce a GenerationLog;
+        only ``internal_events`` and ``colang_history`` (which need the Colang runtime)
+        are rejected.
+        """
         _stub_safe_rails(iorails)
         _stub_model(iorails, LLMResponse(content="Hello"))
 
         with pytest.raises(NotImplementedError):
-            await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+            await iorails.generate_async(_USER, options={"log": {"internal_events": True}})
 
     @pytest.mark.asyncio
     async def test_state_argument_raises(self, iorails):

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -19,10 +19,11 @@ When ``options`` is supplied, ``generate_async``/``generate`` return a
 ``GenerationResponse`` instead of a bare ``LLMMessage`` dict, mirroring LLMRails'
 ``if gen_options:`` branch. When ``options`` is absent the bare dict is returned
 unchanged. The structured path populates ``response``, ``reasoning_content``,
-``tool_calls`` (as ``ToolCall.to_dict()`` with dict arguments), and
-``llm_metadata`` (main-call ``provider_metadata`` plus a ``usage`` sub-key);
-``llm_output`` is always ``None`` (parity with LLMRails' unwired ``raw_response``);
-``log`` is deferred; and ``output_vars``/``state``/``log`` request options raise.
+``tool_calls`` (as ``ToolCall.to_dict()`` with dict arguments), ``log`` (from
+per-rail records), and ``llm_metadata`` (main-call ``provider_metadata`` only —
+token usage lives in ``log``); ``llm_output`` is always ``None`` (parity with
+LLMRails' unwired ``raw_response``). ``output_vars``/``state`` raise ``ValueError``
+and ``log.internal_events``/``log.colang_history`` raise ``NotImplementedError``.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -66,27 +67,32 @@ def _stub_model(iorails: IORails, response: LLMResponse) -> None:
 
 _USER = [{"role": "user", "content": "hi"}]
 
+_WEATHER_TOOL_CALL = ToolCall(
+    id="call_1",
+    type="function",
+    function=ToolCallFunction(name="get_weather", arguments={"city": "SF"}),
+)
+
+
+async def _generate_structured(iorails: IORails, response: LLMResponse, *, options=None, **kwargs):
+    """Stub safe rails + a fixed model response, then run the structured (``options``) path."""
+    _stub_safe_rails(iorails)
+    _stub_model(iorails, response)
+    return await iorails.generate_async(_USER, options={} if options is None else options, **kwargs)
+
 
 class TestStructuredResponseTrigger:
     """``options`` presence decides GenerationResponse vs. bare dict."""
 
     @pytest.mark.asyncio
-    async def test_options_dict_returns_generation_response(self, iorails):
-        """A dict ``options`` argument switches the return type to GenerationResponse."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        result = await iorails.generate_async(_USER, options={"llm_params": {"temperature": 0.5}})
-
-        assert isinstance(result, GenerationResponse)
-
-    @pytest.mark.asyncio
-    async def test_generation_options_returns_generation_response(self, iorails):
-        """A GenerationOptions instance also switches the return type."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        result = await iorails.generate_async(_USER, options=GenerationOptions())
+    @pytest.mark.parametrize(
+        "options",
+        [{"llm_params": {"temperature": 0.5}}, GenerationOptions()],
+        ids=["dict", "GenerationOptions"],
+    )
+    async def test_options_returns_generation_response(self, iorails, options):
+        """Any ``options`` value (dict or GenerationOptions) switches the return type to GenerationResponse."""
+        result = await _generate_structured(iorails, LLMResponse(content="Hello"), options=options)
 
         assert isinstance(result, GenerationResponse)
 
@@ -108,11 +114,9 @@ class TestResponseField:
     @pytest.mark.asyncio
     async def test_plain_content_wrapped_in_list(self, iorails):
         """``response`` is ``[{"role":"assistant","content": text}]``."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello there"))
+        result = await _generate_structured(iorails, LLMResponse(content="Hello there"))
 
-        result = await iorails.generate_async(_USER, options={})
-
+        assert isinstance(result, GenerationResponse)
         assert result.response == [{"role": "assistant", "content": "Hello there"}]
 
 
@@ -120,25 +124,17 @@ class TestReasoningContent:
     """Reasoning goes to ``reasoning_content`` with clean content (no inline <think>)."""
 
     @pytest.mark.asyncio
-    async def test_native_reasoning_in_field_content_clean(self, iorails):
-        """Provider ``reasoning`` populates ``reasoning_content``; ``response`` content has no <think> prefix."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello", reasoning="thinking step"))
-
-        result = await iorails.generate_async(_USER, options={})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.reasoning_content == "thinking step"
-        assert result.response == [{"role": "assistant", "content": "Hello"}]
-        iorails.rails_manager.is_output_safe.assert_called_once_with(_USER, "Hello", enabled=True)
-
-    @pytest.mark.asyncio
-    async def test_inline_think_tags_extracted_to_field(self, iorails):
-        """Inline <think> tags are stripped into ``reasoning_content`` and never reach output rails."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="<think>thinking step</think>Hello"))
-
-        result = await iorails.generate_async(_USER, options={})
+    @pytest.mark.parametrize(
+        "response",
+        [
+            LLMResponse(content="Hello", reasoning="thinking step"),
+            LLMResponse(content="<think>thinking step</think>Hello"),
+        ],
+        ids=["native-reasoning-field", "inline-think-tags"],
+    )
+    async def test_reasoning_extracted_content_clean(self, iorails, response):
+        """Reasoning (native field or inline <think>) goes to ``reasoning_content``; response content stays clean and output rails see only the clean text."""
+        result = await _generate_structured(iorails, response)
 
         assert isinstance(result, GenerationResponse)
         assert result.reasoning_content == "thinking step"
@@ -148,10 +144,7 @@ class TestReasoningContent:
     @pytest.mark.asyncio
     async def test_no_reasoning_field_is_none(self, iorails):
         """Absent reasoning leaves ``reasoning_content`` as None."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="plain answer"))
-
-        result = await iorails.generate_async(_USER, options={})
+        result = await _generate_structured(iorails, LLMResponse(content="plain answer"))
 
         assert isinstance(result, GenerationResponse)
         assert result.reasoning_content is None
@@ -164,15 +157,7 @@ class TestToolCalls:
     @pytest.mark.asyncio
     async def test_tool_calls_serialized_with_dict_arguments(self, iorails):
         """``tool_calls`` is a list of ``to_dict()`` entries whose ``arguments`` stay a dict, not a JSON string."""
-        _stub_safe_rails(iorails)
-        tool_call = ToolCall(
-            id="call_1",
-            type="function",
-            function=ToolCallFunction(name="get_weather", arguments={"city": "SF"}),
-        )
-        _stub_model(iorails, LLMResponse(content="", tool_calls=[tool_call]))
-
-        result = await iorails.generate_async(_USER, options={})
+        result = await _generate_structured(iorails, LLMResponse(content="", tool_calls=[_WEATHER_TOOL_CALL]))
 
         assert isinstance(result, GenerationResponse)
         assert result.tool_calls == [
@@ -186,15 +171,7 @@ class TestToolCalls:
     @pytest.mark.asyncio
     async def test_response_message_has_no_tool_calls_key(self, iorails):
         """In the structured path tool calls live only in the top-level field, not on the message."""
-        _stub_safe_rails(iorails)
-        tool_call = ToolCall(
-            id="call_1",
-            type="function",
-            function=ToolCallFunction(name="get_weather", arguments={"city": "SF"}),
-        )
-        _stub_model(iorails, LLMResponse(content="", tool_calls=[tool_call]))
-
-        result = await iorails.generate_async(_USER, options={})
+        result = await _generate_structured(iorails, LLMResponse(content="", tool_calls=[_WEATHER_TOOL_CALL]))
 
         assert isinstance(result, GenerationResponse)
         assert result.response == [{"role": "assistant", "content": ""}]
@@ -203,10 +180,7 @@ class TestToolCalls:
     @pytest.mark.asyncio
     async def test_no_tool_calls_field_is_none(self, iorails):
         """A text-only response leaves ``tool_calls`` as None."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        result = await iorails.generate_async(_USER, options={})
+        result = await _generate_structured(iorails, LLMResponse(content="Hello"))
 
         assert isinstance(result, GenerationResponse)
         assert result.tool_calls is None
@@ -216,47 +190,28 @@ class TestLLMMetadata:
     """``llm_metadata`` is the main-call ``provider_metadata`` verbatim; usage lives in ``log``."""
 
     @pytest.mark.asyncio
-    async def test_provider_metadata_passthrough(self, iorails):
-        """provider_metadata is surfaced verbatim; token usage is NOT added under ``usage``."""
-        _stub_safe_rails(iorails)
-        _stub_model(
-            iorails,
-            LLMResponse(
-                content="Hello",
-                provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}},
-                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15),
+    @pytest.mark.parametrize(
+        "response, expected",
+        [
+            (
+                LLMResponse(
+                    content="Hello",
+                    provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}},
+                    usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15),
+                ),
+                {"response_headers": {"nvcf-status": "fulfilled"}},
             ),
-        )
-
-        result = await iorails.generate_async(_USER, options={})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata == {"response_headers": {"nvcf-status": "fulfilled"}}
-
-    @pytest.mark.asyncio
-    async def test_usage_alone_does_not_populate_metadata(self, iorails):
-        """With usage but no provider_metadata, ``llm_metadata`` is None — usage moved to log."""
-        _stub_safe_rails(iorails)
-        _stub_model(
-            iorails,
-            LLMResponse(content="Hello", usage=UsageInfo(input_tokens=3, output_tokens=4, total_tokens=7)),
-        )
-
-        result = await iorails.generate_async(_USER, options={})
+            (LLMResponse(content="Hello", usage=UsageInfo(input_tokens=3, output_tokens=4, total_tokens=7)), None),
+            (LLMResponse(content="Hello"), None),
+        ],
+        ids=["provider-metadata-passthrough", "usage-only-none", "nothing-none"],
+    )
+    async def test_llm_metadata_is_provider_metadata_only(self, iorails, response, expected):
+        """llm_metadata is the main-call provider_metadata verbatim (else None); token usage is never grafted under ``usage``."""
+        result = await _generate_structured(iorails, response)
 
         assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata is None
-
-    @pytest.mark.asyncio
-    async def test_no_metadata_or_usage_is_none(self, iorails):
-        """No provider_metadata and no usage leaves ``llm_metadata`` as None."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        result = await iorails.generate_async(_USER, options={})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata is None
+        assert result.llm_metadata == expected
 
 
 class TestLLMOutput:
@@ -265,38 +220,33 @@ class TestLLMOutput:
     @pytest.mark.asyncio
     async def test_llm_output_none_even_when_requested(self, iorails):
         """``options={"llm_output": True}`` is accepted but the field stays None."""
-        _stub_safe_rails(iorails)
-        _stub_model(
-            iorails,
-            LLMResponse(content="Hello", provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}}),
-        )
-
-        result = await iorails.generate_async(_USER, options={"llm_output": True})
+        response = LLMResponse(content="Hello", provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}})
+        result = await _generate_structured(iorails, response, options={"llm_output": True})
 
         assert isinstance(result, GenerationResponse)
         assert result.llm_output is None
 
 
 class TestUnsupportedOptionGuards:
-    """Colang-coupled options IORails cannot honor raise ValueError."""
+    """Colang-coupled options IORails cannot honor raise."""
 
     @pytest.mark.asyncio
-    async def test_output_vars_true_raises(self, iorails):
-        """``output_vars=True`` requests Colang context IORails has no access to."""
+    @pytest.mark.parametrize(
+        "gen_kwargs",
+        [
+            {"options": {"output_vars": True}},
+            {"options": {"output_vars": ["relevant_chunks"]}},
+            {"options": {}, "state": {"conversation": []}},
+        ],
+        ids=["output_vars-true", "output_vars-list", "state-arg"],
+    )
+    async def test_colang_state_option_raises_value_error(self, iorails, gen_kwargs):
+        """``output_vars`` (any form) and ``state`` need Colang runtime context IORails lacks — ValueError."""
         _stub_safe_rails(iorails)
         _stub_model(iorails, LLMResponse(content="Hello"))
 
         with pytest.raises(ValueError):
-            await iorails.generate_async(_USER, options={"output_vars": True})
-
-    @pytest.mark.asyncio
-    async def test_output_vars_list_raises(self, iorails):
-        """A list of ``output_vars`` also raises."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        with pytest.raises(ValueError):
-            await iorails.generate_async(_USER, options={"output_vars": ["relevant_chunks"]})
+            await iorails.generate_async(_USER, **gen_kwargs)
 
     @pytest.mark.asyncio
     async def test_colang_only_log_flag_raises(self, iorails):
@@ -312,25 +262,23 @@ class TestUnsupportedOptionGuards:
         with pytest.raises(NotImplementedError):
             await iorails.generate_async(_USER, options={"log": {"internal_events": True}})
 
-    @pytest.mark.asyncio
-    async def test_state_argument_raises(self, iorails):
-        """A ``state`` argument is unsupported for the stateless IORails engine."""
-        _stub_safe_rails(iorails)
-        _stub_model(iorails, LLMResponse(content="Hello"))
-
-        with pytest.raises(ValueError):
-            await iorails.generate_async(_USER, options={}, state={"conversation": []})
-
 
 class TestBlockedStructuredResponse:
     """A blocked request returns the refusal in ``response`` with the other fields empty."""
 
     @pytest.mark.asyncio
-    async def test_input_block_returns_refusal_response(self, iorails):
-        """Input-rail block yields a GenerationResponse whose response is the refusal message."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        _stub_model(iorails, LLMResponse(content="unused"))
+    @pytest.mark.parametrize(
+        "input_safe, output_safe", [(False, True), (True, False)], ids=["input-block", "output-block"]
+    )
+    async def test_block_returns_refusal_response(self, iorails, input_safe, output_safe):
+        """A block at either the input or output rail yields a GenerationResponse whose response is the refusal and whose other fields are empty."""
+        iorails.rails_manager.is_input_safe = AsyncMock(
+            return_value=RailResult(is_safe=input_safe, reason=None if input_safe else "unsafe")
+        )
+        iorails.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(is_safe=output_safe, reason=None if output_safe else "unsafe")
+        )
+        _stub_model(iorails, LLMResponse(content="bad answer"))
 
         result = await iorails.generate_async(_USER, options={})
 
@@ -339,18 +287,6 @@ class TestBlockedStructuredResponse:
         assert result.tool_calls is None
         assert result.reasoning_content is None
         assert result.llm_metadata is None
-
-    @pytest.mark.asyncio
-    async def test_output_block_returns_refusal_response(self, iorails):
-        """Output-rail block yields a GenerationResponse whose response is the refusal message."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
-        _stub_model(iorails, LLMResponse(content="bad answer"))
-
-        result = await iorails.generate_async(_USER, options={})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
 
 class TestBarePathUnchanged:
@@ -385,25 +321,17 @@ class TestSyncGenerateStructured:
 class TestResponseContentForCapture:
     """`_response_content_for_capture` extracts assistant text from either return shape."""
 
-    def test_generation_response_list(self):
-        """A structured (list) response yields the last assistant message's content."""
-        result = GenerationResponse(response=[{"role": "assistant", "content": "hi there"}])
-        assert _response_content_for_capture(result) == "hi there"
-
-    def test_generation_response_str(self):
-        """A structured (str) response is returned as-is."""
-        result = GenerationResponse(response="hi there")
-        assert _response_content_for_capture(result) == "hi there"
-
-    def test_generation_response_empty_list(self):
-        """An empty response list has no content to capture."""
-        assert _response_content_for_capture(GenerationResponse(response=[])) is None
-
-    def test_generation_response_non_str_content(self):
-        """A non-string message content is not captured."""
-        result = GenerationResponse(response=[{"role": "assistant", "content": None}])
-        assert _response_content_for_capture(result) is None
-
-    def test_bare_message_dict(self):
-        """The bare-dict return path reads content off the message directly."""
-        assert _response_content_for_capture({"role": "assistant", "content": "hi there"}) == "hi there"
+    @pytest.mark.parametrize(
+        "result, expected",
+        [
+            (GenerationResponse(response=[{"role": "assistant", "content": "hi there"}]), "hi there"),
+            (GenerationResponse(response="hi there"), "hi there"),
+            (GenerationResponse(response=[]), None),
+            (GenerationResponse(response=[{"role": "assistant", "content": None}]), None),
+            ({"role": "assistant", "content": "hi there"}, "hi there"),
+        ],
+        ids=["structured-list", "structured-str", "empty-list", "non-str-content", "bare-dict"],
+    )
+    def test_capture_content(self, result, expected):
+        """Assistant content is pulled from structured list/str responses and from the bare-dict path; non-str/absent content yields None."""
+        assert _response_content_for_capture(result) == expected

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -31,7 +31,7 @@ import pytest
 import pytest_asyncio
 
 from nemoguardrails.guardrails.guardrails_types import RailResult
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails, _response_content_for_capture
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from nemoguardrails.types import LLMResponse, ToolCall, ToolCallFunction, UsageInfo
@@ -380,3 +380,30 @@ class TestSyncGenerateStructured:
             result = iorails_sync.generate(_USER, options={})
 
         assert isinstance(result, GenerationResponse)
+
+
+class TestResponseContentForCapture:
+    """`_response_content_for_capture` extracts assistant text from either return shape."""
+
+    def test_generation_response_list(self):
+        """A structured (list) response yields the last assistant message's content."""
+        result = GenerationResponse(response=[{"role": "assistant", "content": "hi there"}])
+        assert _response_content_for_capture(result) == "hi there"
+
+    def test_generation_response_str(self):
+        """A structured (str) response is returned as-is."""
+        result = GenerationResponse(response="hi there")
+        assert _response_content_for_capture(result) == "hi there"
+
+    def test_generation_response_empty_list(self):
+        """An empty response list has no content to capture."""
+        assert _response_content_for_capture(GenerationResponse(response=[])) is None
+
+    def test_generation_response_non_str_content(self):
+        """A non-string message content is not captured."""
+        result = GenerationResponse(response=[{"role": "assistant", "content": None}])
+        assert _response_content_for_capture(result) is None
+
+    def test_bare_message_dict(self):
+        """The bare-dict return path reads content off the message directly."""
+        assert _response_content_for_capture({"role": "assistant", "content": "hi there"}) == "hi there"

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -213,11 +213,11 @@ class TestToolCalls:
 
 
 class TestLLMMetadata:
-    """``llm_metadata`` carries main-call ``provider_metadata`` plus a ``usage`` sub-key."""
+    """``llm_metadata`` is the main-call ``provider_metadata`` verbatim; usage lives in ``log``."""
 
     @pytest.mark.asyncio
-    async def test_provider_metadata_and_usage_merged(self, iorails):
-        """provider_metadata is surfaced and structured usage is added under ``usage``."""
+    async def test_provider_metadata_passthrough(self, iorails):
+        """provider_metadata is surfaced verbatim; token usage is NOT added under ``usage``."""
         _stub_safe_rails(iorails)
         _stub_model(
             iorails,
@@ -231,14 +231,11 @@ class TestLLMMetadata:
         result = await iorails.generate_async(_USER, options={})
 
         assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata == {
-            "response_headers": {"nvcf-status": "fulfilled"},
-            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
-        }
+        assert result.llm_metadata == {"response_headers": {"nvcf-status": "fulfilled"}}
 
     @pytest.mark.asyncio
-    async def test_usage_only_when_no_provider_metadata(self, iorails):
-        """With usage but no provider_metadata, ``llm_metadata`` holds just the ``usage`` sub-key."""
+    async def test_usage_alone_does_not_populate_metadata(self, iorails):
+        """With usage but no provider_metadata, ``llm_metadata`` is None — usage moved to log."""
         _stub_safe_rails(iorails)
         _stub_model(
             iorails,
@@ -248,32 +245,7 @@ class TestLLMMetadata:
         result = await iorails.generate_async(_USER, options={})
 
         assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata == {"usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}}
-
-    @pytest.mark.asyncio
-    async def test_usage_includes_reasoning_and_cached_tokens_when_present(self, iorails):
-        """Non-None ``reasoning_tokens``/``cached_tokens`` appear in the ``usage`` sub-key."""
-        _stub_safe_rails(iorails)
-        _stub_model(
-            iorails,
-            LLMResponse(
-                content="Hello",
-                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15, reasoning_tokens=3, cached_tokens=2),
-            ),
-        )
-
-        result = await iorails.generate_async(_USER, options={})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.llm_metadata == {
-            "usage": {
-                "input_tokens": 10,
-                "output_tokens": 5,
-                "total_tokens": 15,
-                "reasoning_tokens": 3,
-                "cached_tokens": 2,
-            }
-        }
+        assert result.llm_metadata is None
 
     @pytest.mark.asyncio
     async def test_no_metadata_or_usage_is_none(self, iorails):

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured GenerationResponse return from IORails, matching LLMRails.
+
+When ``options`` is supplied, ``generate_async``/``generate`` return a
+``GenerationResponse`` instead of a bare ``LLMMessage`` dict, mirroring LLMRails'
+``if gen_options:`` branch. When ``options`` is absent the bare dict is returned
+unchanged. The structured path populates ``response``, ``reasoning_content``,
+``tool_calls`` (as ``ToolCall.to_dict()`` with dict arguments), and
+``llm_metadata`` (main-call ``provider_metadata`` plus a ``usage`` sub-key);
+``llm_output`` is always ``None`` (parity with LLMRails' unwired ``raw_response``);
+``log`` is deferred; and ``output_vars``/``state``/``log`` request options raise.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
+from nemoguardrails.types import LLMResponse, ToolCall, ToolCallFunction, UsageInfo
+from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+
+@pytest_asyncio.fixture
+async def iorails():
+    """Started IORails instance with worker-queue teardown after each test."""
+    async with started_iorails(NEMOGUARDS_CONFIG) as iorails:
+        yield iorails
+
+
+@pytest.fixture
+def iorails_sync():
+    """Unstarted IORails instance for driving the synchronous ``generate`` path."""
+    return IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+
+def _stub_safe_rails(iorails: IORails) -> None:
+    """Default-safe input, output, and tool-call rails so tests focus on the LLM response."""
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.are_tool_calls_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+def _stub_model(iorails: IORails, response: LLMResponse) -> None:
+    """Make the main-model call return a fixed structured LLMResponse."""
+    iorails.engine_registry.model_call = AsyncMock(return_value=response)
+
+
+_USER = [{"role": "user", "content": "hi"}]
+
+
+class TestStructuredResponseTrigger:
+    """``options`` presence decides GenerationResponse vs. bare dict."""
+
+    @pytest.mark.asyncio
+    async def test_options_dict_returns_generation_response(self, iorails):
+        """A dict ``options`` argument switches the return type to GenerationResponse."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        result = await iorails.generate_async(_USER, options={"llm_params": {"temperature": 0.5}})
+
+        assert isinstance(result, GenerationResponse)
+
+    @pytest.mark.asyncio
+    async def test_generation_options_returns_generation_response(self, iorails):
+        """A GenerationOptions instance also switches the return type."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        result = await iorails.generate_async(_USER, options=GenerationOptions())
+
+        assert isinstance(result, GenerationResponse)
+
+    @pytest.mark.asyncio
+    async def test_no_generation_options_returns_messages(self, iorails):
+        """Without ``options`` the return stays the bare assistant-message dict."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        result = await iorails.generate_async(_USER)
+
+        assert not isinstance(result, GenerationResponse)
+        assert result == {"role": "assistant", "content": "Hello"}
+
+
+class TestResponseField:
+    """The ``response`` field wraps the assistant message in a one-element list."""
+
+    @pytest.mark.asyncio
+    async def test_plain_content_wrapped_in_list(self, iorails):
+        """``response`` is ``[{"role":"assistant","content": text}]``."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello there"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert result.response == [{"role": "assistant", "content": "Hello there"}]
+
+
+class TestReasoningContent:
+    """Reasoning goes to ``reasoning_content`` with clean content (no inline <think>)."""
+
+    @pytest.mark.asyncio
+    async def test_native_reasoning_in_field_content_clean(self, iorails):
+        """Provider ``reasoning`` populates ``reasoning_content``; ``response`` content has no <think> prefix."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello", reasoning="thinking step"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.reasoning_content == "thinking step"
+        assert result.response == [{"role": "assistant", "content": "Hello"}]
+        iorails.rails_manager.is_output_safe.assert_called_once_with(_USER, "Hello", enabled=True)
+
+    @pytest.mark.asyncio
+    async def test_inline_think_tags_extracted_to_field(self, iorails):
+        """Inline <think> tags are stripped into ``reasoning_content`` and never reach output rails."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="<think>thinking step</think>Hello"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.reasoning_content == "thinking step"
+        assert result.response == [{"role": "assistant", "content": "Hello"}]
+        iorails.rails_manager.is_output_safe.assert_called_once_with(_USER, "Hello", enabled=True)
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_field_is_none(self, iorails):
+        """Absent reasoning leaves ``reasoning_content`` as None."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="plain answer"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.reasoning_content is None
+        assert result.response == [{"role": "assistant", "content": "plain answer"}]
+
+
+class TestToolCalls:
+    """``tool_calls`` use the LLMRails ``ToolCall.to_dict()`` shape (dict arguments)."""
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_serialized_with_dict_arguments(self, iorails):
+        """``tool_calls`` is a list of ``to_dict()`` entries whose ``arguments`` stay a dict, not a JSON string."""
+        _stub_safe_rails(iorails)
+        tool_call = ToolCall(
+            id="call_1",
+            type="function",
+            function=ToolCallFunction(name="get_weather", arguments={"city": "SF"}),
+        )
+        _stub_model(iorails, LLMResponse(content="", tool_calls=[tool_call]))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.tool_calls == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": {"city": "SF"}},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_response_message_has_no_tool_calls_key(self, iorails):
+        """In the structured path tool calls live only in the top-level field, not on the message."""
+        _stub_safe_rails(iorails)
+        tool_call = ToolCall(
+            id="call_1",
+            type="function",
+            function=ToolCallFunction(name="get_weather", arguments={"city": "SF"}),
+        )
+        _stub_model(iorails, LLMResponse(content="", tool_calls=[tool_call]))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": ""}]
+        assert "tool_calls" not in result.response[0]
+
+    @pytest.mark.asyncio
+    async def test_no_tool_calls_field_is_none(self, iorails):
+        """A text-only response leaves ``tool_calls`` as None."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.tool_calls is None
+
+
+class TestLLMMetadata:
+    """``llm_metadata`` carries main-call ``provider_metadata`` plus a ``usage`` sub-key."""
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_and_usage_merged(self, iorails):
+        """provider_metadata is surfaced and structured usage is added under ``usage``."""
+        _stub_safe_rails(iorails)
+        _stub_model(
+            iorails,
+            LLMResponse(
+                content="Hello",
+                provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}},
+                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15),
+            ),
+        )
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.llm_metadata == {
+            "response_headers": {"nvcf-status": "fulfilled"},
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+
+    @pytest.mark.asyncio
+    async def test_usage_only_when_no_provider_metadata(self, iorails):
+        """With usage but no provider_metadata, ``llm_metadata`` holds just the ``usage`` sub-key."""
+        _stub_safe_rails(iorails)
+        _stub_model(
+            iorails,
+            LLMResponse(content="Hello", usage=UsageInfo(input_tokens=3, output_tokens=4, total_tokens=7)),
+        )
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.llm_metadata == {"usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}}
+
+    @pytest.mark.asyncio
+    async def test_usage_includes_reasoning_and_cached_tokens_when_present(self, iorails):
+        """Non-None ``reasoning_tokens``/``cached_tokens`` appear in the ``usage`` sub-key."""
+        _stub_safe_rails(iorails)
+        _stub_model(
+            iorails,
+            LLMResponse(
+                content="Hello",
+                usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15, reasoning_tokens=3, cached_tokens=2),
+            ),
+        )
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.llm_metadata == {
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "reasoning_tokens": 3,
+                "cached_tokens": 2,
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_metadata_or_usage_is_none(self, iorails):
+        """No provider_metadata and no usage leaves ``llm_metadata`` as None."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.llm_metadata is None
+
+
+class TestLLMOutput:
+    """``llm_output`` is always None, matching LLMRails' unwired ``raw_response``."""
+
+    @pytest.mark.asyncio
+    async def test_llm_output_none_even_when_requested(self, iorails):
+        """``options={"llm_output": True}`` is accepted but the field stays None."""
+        _stub_safe_rails(iorails)
+        _stub_model(
+            iorails,
+            LLMResponse(content="Hello", provider_metadata={"response_headers": {"nvcf-status": "fulfilled"}}),
+        )
+
+        result = await iorails.generate_async(_USER, options={"llm_output": True})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.llm_output is None
+
+
+class TestUnsupportedOptionGuards:
+    """Colang-coupled options IORails cannot honor raise ValueError."""
+
+    @pytest.mark.asyncio
+    async def test_output_vars_true_raises(self, iorails):
+        """``output_vars=True`` requests Colang context IORails has no access to."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        with pytest.raises(ValueError):
+            await iorails.generate_async(_USER, options={"output_vars": True})
+
+    @pytest.mark.asyncio
+    async def test_output_vars_list_raises(self, iorails):
+        """A list of ``output_vars`` also raises."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        with pytest.raises(ValueError):
+            await iorails.generate_async(_USER, options={"output_vars": ["relevant_chunks"]})
+
+    @pytest.mark.asyncio
+    async def test_log_request_flag_raises(self, iorails):
+        """Requesting any ``log`` detail raises NotImplementedError while ``log`` is deferred."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        with pytest.raises(NotImplementedError):
+            await iorails.generate_async(_USER, options={"log": {"llm_calls": True}})
+
+    @pytest.mark.asyncio
+    async def test_state_argument_raises(self, iorails):
+        """A ``state`` argument is unsupported for the stateless IORails engine."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello"))
+
+        with pytest.raises(ValueError):
+            await iorails.generate_async(_USER, options={}, state={"conversation": []})
+
+
+class TestBlockedStructuredResponse:
+    """A blocked request returns the refusal in ``response`` with the other fields empty."""
+
+    @pytest.mark.asyncio
+    async def test_input_block_returns_refusal_response(self, iorails):
+        """Input-rail block yields a GenerationResponse whose response is the refusal message."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        _stub_model(iorails, LLMResponse(content="unused"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
+        assert result.tool_calls is None
+        assert result.reasoning_content is None
+        assert result.llm_metadata is None
+
+    @pytest.mark.asyncio
+    async def test_output_block_returns_refusal_response(self, iorails):
+        """Output-rail block yields a GenerationResponse whose response is the refusal message."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        _stub_model(iorails, LLMResponse(content="bad answer"))
+
+        result = await iorails.generate_async(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
+
+
+class TestBarePathUnchanged:
+    """The optionless bare-dict path keeps its existing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_bare_path_inlines_reasoning_prefix(self, iorails):
+        """Without ``options`` reasoning is still delivered inline as a <think> prefix."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello", reasoning="thinking step"))
+
+        result = await iorails.generate_async(_USER)
+
+        assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
+
+
+class TestSyncGenerateStructured:
+    """The synchronous ``generate`` mirrors the async structured return."""
+
+    def test_sync_generate_with_options_returns_generation_response(self, iorails_sync):
+        """``generate(options=...)`` returns a GenerationResponse from the ephemeral engine."""
+        iorails_sync.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_sync.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_sync.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
+
+        with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails_sync):
+            result = iorails_sync.generate(_USER, options={})
+
+        assert isinstance(result, GenerationResponse)

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -138,7 +138,7 @@ class TestReasoningContent:
             return_value=LLMResponse(content="Hello", reasoning="thinking step")
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
         # Output rails see the original content unchanged when reasoning came from
@@ -154,7 +154,7 @@ class TestReasoningContent:
             return_value=LLMResponse(content="<think>thinking step</think>Hello")
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "<think>thinking step</think>\nHello"}
         # Output rails MUST receive content with <think> tags stripped — this is
@@ -178,7 +178,7 @@ class TestReasoningContent:
             )
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {
             "role": "assistant",
@@ -195,7 +195,7 @@ class TestReasoningContent:
         _stub_safe_rails(iorails)
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="<think>incomplete reasoning"))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "<think>incomplete reasoning"}
         iorails.rails_manager.is_output_safe.assert_called_once_with(
@@ -209,7 +209,7 @@ class TestReasoningContent:
         _stub_safe_rails(iorails)
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="orphan</think> reply"))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "orphan</think> reply"}
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "orphan</think> reply", enabled=True)
@@ -224,7 +224,7 @@ class TestReasoningContent:
             return_value=LLMResponse(content="bad answer", reasoning="reasoning step")
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
 
@@ -238,7 +238,7 @@ class TestReasoningContent:
             return_value=LLMResponse(content="<think>thinking</think>bad answer")
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         # Output rails see only the stripped content — they're judging the model
@@ -254,7 +254,7 @@ class TestReasoningContent:
             return_value=LLMResponse(content="<think>fallback reasoning</think>Hi", reasoning="")
         )
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "<think>fallback reasoning</think>\nHi"}
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "Hi", enabled=True)
@@ -266,7 +266,7 @@ class TestReasoningContent:
         _stub_safe_rails(iorails)
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="plain answer"))
 
-        result = await iorails.generate_async(messages)
+        result = await iorails.generate_async(messages=messages)
 
         assert result == {"role": "assistant", "content": "plain answer"}
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "plain answer", enabled=True)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -140,7 +140,7 @@ class TestGenerateAsyncWithTracing:
     async def test_creates_span(self, iorails_tracing, exporter):
         _stub_safe_pipeline(iorails_tracing)
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert result == {"role": "assistant", "content": "Hello"}
         spans = exporter.get_finished_spans()
@@ -152,7 +152,7 @@ class TestGenerateAsyncWithTracing:
     async def test_span_has_required_attributes(self, iorails_tracing, exporter):
         _stub_safe_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         attrs = dict(spans[0].attributes)
@@ -173,7 +173,7 @@ class TestGenerateAsyncWithTracing:
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing.rails_manager.is_input_safe = capture_req_id
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         span_req_id = spans[0].attributes["request.id"]
@@ -185,7 +185,7 @@ class TestGenerateAsyncWithTracing:
         iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM failed"))
 
         with pytest.raises(RuntimeError, match="LLM failed"):
-            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
@@ -198,7 +198,7 @@ class TestGenerateAsyncWithTracing:
         """A span is still created and completed even when input rails block."""
         iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         spans = exporter.get_finished_spans()
@@ -211,7 +211,7 @@ class TestGenerateAsyncWithoutTracing:
     async def test_no_spans_exported(self, iorails_no_tracing, exporter):
         _stub_safe_pipeline(iorails_no_tracing)
 
-        result = await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert result == {"role": "assistant", "content": "Hello"}
         assert len(exporter.get_finished_spans()) == 0
@@ -229,7 +229,7 @@ class TestGenerateAsyncWithoutTracing:
         _stub_safe_pipeline(iorails_no_tracing)
         iorails_no_tracing.rails_manager.is_input_safe = capture_req_id
 
-        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert captured_req_id is not None
         assert len(captured_req_id) == REQUEST_ID_HEX_CHARS
@@ -264,7 +264,7 @@ class TestEndToEndTracing:
         iorails_tracing.rails_manager.is_output_safe = capturing_output_check
 
         messages = [{"role": "user", "content": "hello"}]
-        result = await iorails_tracing.generate_async(messages)
+        result = await iorails_tracing.generate_async(messages=messages)
 
         # Response correctness
         assert result == {"role": "assistant", "content": "Generated response"}
@@ -317,8 +317,8 @@ class TestEndToEndTracing:
 
         messages = [{"role": "user", "content": "hi"}]
         await asyncio.gather(
-            iorails_tracing.generate_async(messages),
-            iorails_tracing.generate_async(messages),
+            iorails_tracing.generate_async(messages=messages),
+            iorails_tracing.generate_async(messages=messages),
         )
 
         spans = exporter.get_finished_spans()
@@ -347,7 +347,7 @@ class TestEndToEndTracing:
         iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("connection refused"))
 
         with pytest.raises(RuntimeError, match="connection refused"):
-            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
@@ -412,7 +412,7 @@ class TestSpanHierarchy:
         """Full safe request produces: request → rail → action → LLM/API spans."""
         _stub_deep_pipeline(iorails_tracing)
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == "Hello"
 
         spans = exporter.get_finished_spans()
@@ -445,7 +445,7 @@ class TestSpanHierarchy:
         """Rail spans have correct rail.type and rail.name attributes."""
         _stub_deep_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         rail_spans = [s for s in spans if s.name == "guardrails.rail"]
@@ -466,7 +466,7 @@ class TestSpanHierarchy:
         """When a rail blocks, its span has rail.stop=True."""
         _stub_deep_pipeline(iorails_tracing, input_safe=False)
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         spans = exporter.get_finished_spans()
@@ -480,7 +480,7 @@ class TestSpanHierarchy:
         """Unsafe request: main LLM and output rails never run, request span still completes cleanly."""
         _stub_deep_pipeline(iorails_tracing, input_safe=False)
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         spans = exporter.get_finished_spans()
@@ -521,7 +521,7 @@ class TestSpanHierarchy:
             elif isinstance(engine, ModelEngine):
                 engine.chat_completion = AsyncMock(return_value=LLMResponse(content=SAFE_INPUT_JSON))
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         spans = exporter.get_finished_spans()
@@ -556,7 +556,7 @@ class TestSpanHierarchy:
         """
         _stub_deep_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
 
@@ -624,7 +624,7 @@ class TestSpanHierarchy:
         """Action spans have correct action.name attributes."""
         _stub_deep_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         action_spans = [s for s in spans if s.name == "guardrails.action"]
@@ -639,7 +639,7 @@ class TestSpanHierarchy:
         """LLM spans have GenAI semantic convention attributes."""
         _stub_deep_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         llm_spans = [s for s in spans if "gen_ai.request.model" in (s.attributes or {})]
@@ -661,7 +661,7 @@ class TestSpanHierarchy:
         """
         _stub_deep_pipeline(iorails_no_tracing)
 
-        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert len(exporter.get_finished_spans()) == 0
 
@@ -686,7 +686,7 @@ class TestSpanHierarchy:
 
             async with iorails:
                 _stub_deep_pipeline(iorails)
-                await iorails.generate_async([{"role": "user", "content": "hi"}])
+                await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         # Zero spans of any kind
         assert exporter.get_finished_spans() == ()
@@ -1009,7 +1009,7 @@ class TestOtelNotInstalled:
             async with iorails:
                 _stub_safe_pipeline(iorails)
 
-                result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+                result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
                 assert result == {"role": "assistant", "content": "Hello"}
                 assert iorails._tracing_enabled is False
@@ -1071,7 +1071,7 @@ class TestGenerateAsyncRequestMetrics:
         no errors, requests.active back to 0."""
         _stub_safe_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.requests"][0].value == 1
@@ -1087,7 +1087,7 @@ class TestGenerateAsyncRequestMetrics:
         iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM failed"))
 
         with pytest.raises(RuntimeError, match="LLM failed"):
-            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.requests"][0].value == 1
@@ -1100,7 +1100,7 @@ class TestGenerateAsyncRequestMetrics:
     async def test_no_metrics_emitted_when_metrics_disabled(self, iorails_no_tracing, metric_reader):
         _stub_safe_pipeline(iorails_no_tracing)
 
-        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points == {}
@@ -1110,7 +1110,7 @@ class TestGenerateAsyncRequestMetrics:
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         points = collect_metric_points(metric_reader)
@@ -1127,7 +1127,7 @@ class TestGenerateAsyncRequestMetrics:
             return_value=RailResult(is_safe=False, reason="unsafe response")
         )
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         points = collect_metric_points(metric_reader)
@@ -1143,7 +1143,7 @@ class TestGenerateAsyncRequestMetrics:
             return_value=RailResult(is_safe=False, reason="unsafe")
         )
 
-        result = await iorails_no_tracing.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         points = collect_metric_points(metric_reader)
@@ -1168,7 +1168,7 @@ class TestGenerateAsyncRequestMetrics:
         iorails_tracing._generate_async_queue.submit = AsyncMock(side_effect=asyncio.QueueFull("admission queue full"))
 
         with pytest.raises(asyncio.QueueFull, match="admission queue full"):
-            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.nonstream.rejections"][0].value == 1
@@ -1186,7 +1186,7 @@ class TestGenerateAsyncRequestMetrics:
         iorails_tracing._generate_async_queue.submit = AsyncMock(side_effect=asyncio.QueueFull("admission queue full"))
 
         with pytest.raises(asyncio.QueueFull):
-            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.nonstream.rejections"][0].value == 1
@@ -1221,7 +1221,7 @@ class TestGenerateAsyncRequestMetrics:
                 iorails._do_generate = _gated_generate(gate)
 
                 tasks = [
-                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    asyncio.create_task(iorails.generate_async(messages=[{"role": "user", "content": f"m{i}"}]))
                     for i in range(2)
                 ]
                 # Wait until exactly one is executing and one is queued.
@@ -1249,7 +1249,7 @@ class TestGenerateAsyncRequestMetrics:
         )
 
         with pytest.raises(asyncio.QueueFull):
-            await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+            await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert "guardrails.nonstream.rejections" not in points
@@ -1577,7 +1577,7 @@ class TestIndependentTracingAndMetrics:
                 iorails = IORails(RailsConfig.from_content(config=_make_metrics_only_config()))
             async with iorails:
                 _stub_safe_pipeline(iorails)
-                await iorails.generate_async([{"role": "user", "content": "hi"}])
+                await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert points["guardrails.requests"][0].value == 1
@@ -1594,7 +1594,7 @@ class TestIndependentTracingAndMetrics:
                 iorails = IORails(RailsConfig.from_content(config=_make_tracing_only_config()))
             async with iorails:
                 _stub_safe_pipeline(iorails)
-                await iorails.generate_async([{"role": "user", "content": "hi"}])
+                await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
         assert any(s.name == "guardrails.request" for s in spans)
@@ -1635,7 +1635,7 @@ class TestNonstreamStateGauges:
         async with iorails:
             iorails._do_generate = _gated_generate(gate)
 
-            task = asyncio.create_task(iorails.generate_async([{"role": "user", "content": "hi"}]))
+            task = asyncio.create_task(iorails.generate_async(messages=[{"role": "user", "content": "hi"}]))
             # Wait for the worker to pick up the item and enter
             # the gated generate (busy_count=1, pending=0).
             await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=0)
@@ -1670,7 +1670,7 @@ class TestNonstreamStateGauges:
                 iorails._do_generate = _gated_generate(gate)
 
                 tasks = [
-                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    asyncio.create_task(iorails.generate_async(messages=[{"role": "user", "content": f"m{i}"}]))
                     for i in range(3)
                 ]
                 # Wait for one worker to pick up an item and the other two
@@ -1782,7 +1782,7 @@ class TestRequestsActiveAggregate:
             async with iorails:
                 iorails._do_generate = _gated_generate(gate)
                 tasks = [
-                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"m{i}"}]))
+                    asyncio.create_task(iorails.generate_async(messages=[{"role": "user", "content": f"m{i}"}]))
                     for i in range(2)
                 ]
                 await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=1)
@@ -1850,7 +1850,7 @@ class TestRequestsActiveAggregate:
 
                 # Launch one executing + one queued non-streaming request.
                 nonstream_tasks = [
-                    asyncio.create_task(iorails.generate_async([{"role": "user", "content": f"n{i}"}]))
+                    asyncio.create_task(iorails.generate_async(messages=[{"role": "user", "content": f"n{i}"}]))
                     for i in range(2)
                 ]
                 await wait_for_queue_state(iorails._generate_async_queue, busy=1, pending=1)
@@ -1941,7 +1941,7 @@ class TestGenerateAsyncLLMMetrics:
         """
         _stub_deep_pipeline_with_usage(iorails_tracing)
 
-        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result == {"role": "assistant", "content": "Hello"}
 
         points = collect_metric_points(metric_reader)
@@ -1985,7 +1985,7 @@ class TestGenerateAsyncLLMMetrics:
         """
         _stub_deep_pipeline_with_usage(iorails_no_tracing)
 
-        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         points = collect_metric_points(metric_reader)
         assert "gen_ai.client.token.usage" not in points
@@ -2081,7 +2081,7 @@ class TestContentCaptureDisabled:
         """Capture off → request, LLM, and rail spans carry no captured content."""
         _stub_deep_pipeline(iorails_tracing)
 
-        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
 
@@ -2108,7 +2108,7 @@ class TestContentCaptureLegacyFormat:
         """Request span carries guardrails.request.input/output attrs, not gen_ai.* events."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="Hi back")
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "hello"}])
 
         span = _request_span(exporter.get_finished_spans())
         assert json.loads(span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == [{"role": "user", "content": "hello"}]
@@ -2126,7 +2126,7 @@ class TestContentCaptureLegacyFormat:
         """
         _stub_deep_pipeline(iorails_content_capture)
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "hello"}])
 
         span = _main_llm_span(exporter.get_finished_spans())
         event_names = [e.name for e in span.events]
@@ -2138,7 +2138,7 @@ class TestContentCaptureLegacyFormat:
         """A blocked input records REFUSAL_MESSAGE as guardrails.request.output."""
         _stub_deep_pipeline(iorails_content_capture, input_safe=False)
 
-        result = await iorails_content_capture.generate_async([{"role": "user", "content": "bad"}])
+        result = await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "bad"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         span = _request_span(exporter.get_finished_spans())
@@ -2159,7 +2159,7 @@ class TestContentCaptureLegacyFormat:
             return_value=RailResult(is_safe=False, reason="unsafe response")
         )
 
-        result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         span = _request_span(exporter.get_finished_spans())
@@ -2187,7 +2187,7 @@ class TestContentCaptureLegacyFormat:
             return_value=RailResult(is_safe=False, reason="unsafe response")
         )
 
-        result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE
 
         spans = exporter.get_finished_spans()
@@ -2215,7 +2215,7 @@ class TestContentCaptureJsonFormat:
         """Opt-in set → request span carries guardrails.request.* attrs (plain strings)."""
         _stub_deep_pipeline(iorails_content_capture, main_llm_response="The answer")
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "hello"}])
 
         span = _request_span(exporter.get_finished_spans())
         assert json.loads(span.attributes[GuardrailsAttributes.REQUEST_INPUT]) == [{"role": "user", "content": "hello"}]
@@ -2233,7 +2233,7 @@ class TestContentCaptureJsonFormat:
             {"role": "system", "content": "be helpful"},
             {"role": "user", "content": "hi"},
         ]
-        await iorails_content_capture.generate_async(messages)
+        await iorails_content_capture.generate_async(messages=messages)
 
         llm_span = _main_llm_span(exporter.get_finished_spans())
         sysinst = json.loads(llm_span.attributes[GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -2251,7 +2251,7 @@ class TestContentCaptureJsonFormat:
         """Opt-in set → the main LLM span carries JSON input/output message attrs."""
         _stub_deep_pipeline(iorails_content_capture)
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hello"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "hello"}])
 
         span = _main_llm_span(exporter.get_finished_spans())
         assert GenAIAttributes.GEN_AI_INPUT_MESSAGES in span.attributes
@@ -2273,7 +2273,7 @@ class TestContentCaptureEnvVarFallback:
                 iorails = IORails(config)
             async with iorails:
                 _stub_deep_pipeline(iorails)
-                await iorails.generate_async([{"role": "user", "content": "hi"}])
+                await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         span = _request_span(exporter.get_finished_spans())
         # Request span carries guardrails.request.* attrs
@@ -2297,7 +2297,7 @@ class TestContentCaptureEnvVarFallback:
                 iorails = IORails(config)
             async with iorails:
                 _stub_deep_pipeline(iorails)
-                await iorails.generate_async([{"role": "user", "content": "hi"}])
+                await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         span = _request_span(exporter.get_finished_spans())
         # No content attrs despite config=True — env=false wins
@@ -2314,7 +2314,7 @@ class TestRailContentCapture:
         """Every rail span records its rail.input; passing rails carry no rail.reason."""
         _stub_deep_pipeline(iorails_content_capture)
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "hi"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
         assert len(rail_spans) >= 1
@@ -2330,7 +2330,7 @@ class TestRailContentCapture:
         """When an input rail blocks, its span gets a reason; later rails never run."""
         _stub_deep_pipeline(iorails_content_capture, input_safe=False)
 
-        await iorails_content_capture.generate_async([{"role": "user", "content": "bad"}])
+        await iorails_content_capture.generate_async(messages=[{"role": "user", "content": "bad"}])
 
         rail_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.rail"]
         blocked = [s for s in rail_spans if GuardrailsAttributes.RAIL_REASON in s.attributes]

--- a/tests/guardrails/test_jailbreak_detection_iorails_actions.py
+++ b/tests/guardrails/test_jailbreak_detection_iorails_actions.py
@@ -52,14 +52,14 @@ class TestJailbreakPrompt:
 
 class TestJailbreakParseResponse:
     def test_safe(self, action):
-        assert action._parse_response({"jailbreak": False, "score": 0.1}) == RailResult(
-            is_safe=True, reason="Score: 0.1"
-        )
+        result = action._parse_response({"jailbreak": False, "score": 0.1})
+        assert result == RailResult(is_safe=True, reason="Score: 0.1")
+        assert result.return_value is False
 
     def test_jailbreak_detected(self, action):
-        assert action._parse_response({"jailbreak": True, "score": 0.95}) == RailResult(
-            is_safe=False, reason="Score: 0.95"
-        )
+        result = action._parse_response({"jailbreak": True, "score": 0.95})
+        assert result == RailResult(is_safe=False, reason="Score: 0.95")
+        assert result.return_value is True
 
     def test_missing_jailbreak_field_raises(self, action):
         with pytest.raises(RuntimeError, match="missing 'jailbreak' field"):

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -32,7 +32,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
-from nemoguardrails.guardrails.rails_manager import RailsManager
+from nemoguardrails.guardrails.rails_manager import RailsManager, _rail_call_record
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import GuardrailsAttributes
@@ -971,3 +971,38 @@ class TestTriggeredRail:
         result = await content_safety_rails_manager.is_input_safe(MESSAGES)
         assert result.is_safe
         assert result.triggered_rail is None
+
+
+class TestRailCallRecordNaming:
+    """`_rail_call_record` names task/action_name in LLMRails' underscore form.
+
+    The GenerationLog's ``executed_actions[].action_name`` and ``llm_calls[].task``
+    must match LLMRails, which uses the prompt-template key (underscores) rather than
+    the space-separated Colang flow name. ``flow`` itself keeps the space form.
+    """
+
+    def test_modelled_rail_uses_underscore_task_and_action_name(self):
+        """A ``$model=`` flow yields an underscore action_name plus an underscore ``$model`` task."""
+        record = _rail_call_record(
+            flow="content safety check input $model=content_safety",
+            rail_type="input",
+            result=RailResult(is_safe=True),
+            call=None,
+        )
+
+        assert record.flow == "content safety check input $model=content_safety"
+        assert record.action_name == "content_safety_check_input"
+        assert record.task == "content_safety_check_input $model=content_safety"
+
+    def test_modelless_rail_uses_underscore_action_name_and_task(self):
+        """A model-free flow (jailbreak) yields an underscore task with no ``$model`` suffix."""
+        record = _rail_call_record(
+            flow="jailbreak detection model",
+            rail_type="input",
+            result=RailResult(is_safe=True),
+            call=None,
+        )
+
+        assert record.flow == "jailbreak detection model"
+        assert record.action_name == "jailbreak_detection_model"
+        assert record.task == "jailbreak_detection_model"

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -981,31 +981,25 @@ class TestRailCallRecordNaming:
     the space-separated Colang flow name. ``flow`` itself keeps the space form.
     """
 
-    def test_modelled_rail_uses_underscore_task_and_action_name(self):
-        """A ``$model=`` flow yields an underscore action_name plus an underscore ``$model`` task."""
-        record = _rail_call_record(
-            flow="content safety check input $model=content_safety",
-            rail_type="input",
-            result=RailResult(is_safe=True),
-            call=None,
-        )
+    @pytest.mark.parametrize(
+        "flow, action_name, task",
+        [
+            (
+                "content safety check input $model=content_safety",
+                "content_safety_check_input",
+                "content_safety_check_input $model=content_safety",
+            ),
+            ("jailbreak detection model", "jailbreak_detection_model", "jailbreak_detection_model"),
+        ],
+        ids=["modelled", "modelless"],
+    )
+    def test_underscore_task_and_action_name(self, flow, action_name, task):
+        """action_name/task use the underscore prompt-template key; ``flow`` keeps its space form."""
+        record = _rail_call_record(flow=flow, rail_type="input", result=RailResult(is_safe=True), call=None)
 
-        assert record.flow == "content safety check input $model=content_safety"
-        assert record.action_name == "content_safety_check_input"
-        assert record.task == "content_safety_check_input $model=content_safety"
-
-    def test_modelless_rail_uses_underscore_action_name_and_task(self):
-        """A model-free flow (jailbreak) yields an underscore task with no ``$model`` suffix."""
-        record = _rail_call_record(
-            flow="jailbreak detection model",
-            rail_type="input",
-            result=RailResult(is_safe=True),
-            call=None,
-        )
-
-        assert record.flow == "jailbreak detection model"
-        assert record.action_name == "jailbreak_detection_model"
-        assert record.task == "jailbreak_detection_model"
+        assert record.flow == flow
+        assert record.action_name == action_name
+        assert record.task == task
 
 
 class TestSerializePrompt:

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -31,7 +31,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
-from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
+from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult, serialize_prompt
 from nemoguardrails.guardrails.rails_manager import RailsManager, _rail_call_record
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -1006,3 +1006,22 @@ class TestRailCallRecordNaming:
         assert record.flow == "jailbreak detection model"
         assert record.action_name == "jailbreak_detection_model"
         assert record.task == "jailbreak_detection_model"
+
+
+class TestSerializePrompt:
+    """`serialize_prompt` renders a message list to a role-labeled string for the log."""
+
+    def test_role_labeled_join(self):
+        """Each message renders as '<role>: <content>', blank-line separated."""
+        out = serialize_prompt(
+            [
+                {"role": "system", "content": "be nice"},
+                {"role": "user", "content": "hi"},
+            ]
+        )
+        assert out == "system: be nice\n\nuser: hi"
+
+    def test_missing_content_renders_empty(self):
+        """A message with no content (reasoning/tool turn) renders as empty, not an error."""
+        out = serialize_prompt([{"role": "assistant", "content": None}])
+        assert out == "assistant: "

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -1022,9 +1022,35 @@ class TestSerializePrompt:
         assert out == "system: be nice\n\nuser: hi"
 
     def test_missing_content_renders_empty(self):
-        """A message with no content (reasoning/tool turn) renders as empty, not an error."""
+        """A message with no content and no other fields renders as just the role label."""
         out = serialize_prompt([{"role": "assistant", "content": None}])
         assert out == "assistant: "
+
+    def test_tool_calls_preserved(self):
+        """An assistant tool-call turn keeps its tool_calls rather than rendering blank."""
+        out = serialize_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "call_1", "function": {"name": "get_weather"}}],
+                }
+            ]
+        )
+        assert "call_1" in out
+        assert "get_weather" in out
+
+    def test_tool_result_fields_preserved(self):
+        """A tool-result turn keeps its tool_call_id and name alongside the content."""
+        out = serialize_prompt([{"role": "tool", "content": "sunny", "tool_call_id": "call_1", "name": "get_weather"}])
+        assert "sunny" in out
+        assert "call_1" in out
+        assert "get_weather" in out
+
+    def test_reasoning_preserved(self):
+        """A reasoning-only turn keeps its reasoning text instead of dropping it."""
+        out = serialize_prompt([{"role": "assistant", "content": None, "reasoning": "thinking hard"}])
+        assert "thinking hard" in out
 
 
 class TestParallelBatchDrainsRecords:

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -31,7 +31,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
-from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult, serialize_prompt
+from nemoguardrails.guardrails.guardrails_types import RailCallRecord, RailDirection, RailResult, serialize_prompt
 from nemoguardrails.guardrails.rails_manager import RailsManager, _rail_call_record
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -1025,3 +1025,28 @@ class TestSerializePrompt:
         """A message with no content (reasoning/tool turn) renders as empty, not an error."""
         out = serialize_prompt([{"role": "assistant", "content": None}])
         assert out == "assistant: "
+
+
+class TestParallelBatchDrainsRecords:
+    """`_run_rails_parallel` keeps records from every task that completed in a batch."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_first_does_not_drop_later_safe_records(self):
+        """When an unsafe rail sorts before a safe one that finished in the same wait batch, the safe rail's records survive."""
+        manager = _make_rails_manager(RailsConfig.from_content(config=CONTENT_SAFETY_CONFIG))
+
+        unsafe_record = RailCallRecord(flow="jailbreak detection model", rail_type="input", is_safe=False)
+        safe_record = RailCallRecord(flow="content safety check input", rail_type="input", is_safe=True)
+
+        async def _unsafe():
+            return RailResult(is_safe=False, reason="blocked", records=(unsafe_record,))
+
+        async def _safe():
+            return RailResult(is_safe=True, records=(safe_record,))
+
+        # Insertion order sets task_order, so the unsafe rail sorts first in the done batch.
+        rails = {"unsafe": _unsafe(), "safe": _safe()}
+        result = await manager._run_rails_parallel(rails, RailDirection.INPUT)
+
+        assert result.is_safe is False
+        assert {r.flow for r in result.records} == {"jailbreak detection model", "content safety check input"}

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -123,7 +123,7 @@ class TestSingleRequest:
         iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert len(captured_ids) == 3
         for _, rid in captured_ids:
@@ -138,7 +138,7 @@ class TestSingleRequest:
         iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         ids = [rid for _, rid in captured_ids]
         assert ids[0] == ids[1] == ids[2]
@@ -150,7 +150,7 @@ class TestSingleRequest:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert get_request_id() == "no-req-id"
 
@@ -159,7 +159,7 @@ class TestSingleRequest:
         """ContextVar is reset even when the request is blocked at input."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
-        await iorails.generate_async([{"role": "user", "content": "bad"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "bad"}])
 
         assert get_request_id() == "no-req-id"
 
@@ -170,7 +170,7 @@ class TestSingleRequest:
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="bad response"))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
-        await iorails.generate_async([{"role": "user", "content": "hi"}])
+        await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert get_request_id() == "no-req-id"
 
@@ -180,7 +180,7 @@ class TestSingleRequest:
         iorails.rails_manager.is_input_safe = AsyncMock(side_effect=RuntimeError("boom"))
 
         with pytest.raises(RuntimeError, match="boom"):
-            await iorails.generate_async([{"role": "user", "content": "hi"}])
+            await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert get_request_id() == "no-req-id"
 
@@ -202,7 +202,7 @@ class TestMultipleSequentialRequests:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         for _ in range(5):
-            await iorails.generate_async([{"role": "user", "content": "hi"}])
+            await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         assert len(ids_per_request) == 5
         assert len(set(ids_per_request)) == 5, f"Expected 5 unique IDs, got: {ids_per_request}"
@@ -229,7 +229,7 @@ class TestMultipleSequentialRequests:
         iorails.rails_manager.is_output_safe = capture_output
 
         for _ in range(3):
-            await iorails.generate_async([{"role": "user", "content": "hi"}])
+            await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
         # 3 calls per request × 3 requests = 9 captures
         assert len(request_snapshots) == 9
@@ -277,9 +277,9 @@ class TestMultipleConcurrentRequests:
 
         messages = [{"role": "user", "content": "hi"}]
         results = await asyncio.gather(
-            iorails.generate_async(messages),
-            iorails.generate_async(messages),
-            iorails.generate_async(messages),
+            iorails.generate_async(messages=messages),
+            iorails.generate_async(messages=messages),
+            iorails.generate_async(messages=messages),
         )
 
         # All 3 requests completed successfully
@@ -324,7 +324,7 @@ class TestMultipleConcurrentRequests:
                 engine.engine_registry.model_call = capture_llm
                 engine.rails_manager.is_output_safe = capture_output
 
-                await engine.generate_async([{"role": "user", "content": "hi"}])
+                await engine.generate_async(messages=[{"role": "user", "content": "hi"}])
                 task_ids[task_num] = captured
 
         await asyncio.gather(
@@ -351,8 +351,8 @@ class TestMultipleConcurrentRequests:
 
         messages = [{"role": "user", "content": "hi"}]
         await asyncio.gather(
-            iorails.generate_async(messages),
-            iorails.generate_async(messages),
+            iorails.generate_async(messages=messages),
+            iorails.generate_async(messages=messages),
         )
 
         assert get_request_id() == "no-req-id"
@@ -402,7 +402,7 @@ class TestEndToEndPropagation:
             for model_engine in engine.engine_registry._engines.values():
                 model_engine._running = True
 
-            await engine.generate_async([{"role": "user", "content": "hello"}])
+            await engine.generate_async(messages=[{"role": "user", "content": "hello"}])
 
         # We expect 5 captures:
         #   1. rails_manager_input

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -30,7 +30,8 @@ from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
-from nemoguardrails.types import LLMResponse
+from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.types import LLMResponse, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG, NEMOGUARDS_SPECULATIVE_CONFIG
 
@@ -471,3 +472,25 @@ class TestSpeculativeGenerationTelemetry:
         assert "speculative_generation.mode_active" not in attrs
         assert "speculative_generation.first_completed" not in attrs
         assert "speculative_generation.first_rejector" not in attrs
+
+
+class TestSpeculativeGenerationTiming:
+    """The speculative path times the main call so its record and stats aren't left empty."""
+
+    @pytest.mark.asyncio
+    async def test_main_call_record_carries_timing(self, iorails):
+        """On the speculative path, the generation call in the log has real timestamps and a duration."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
+        )
+
+        result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        gen_call = next(c for c in (result.log.llm_calls or []) if c.task == "general")
+        assert gen_call.started_at is not None
+        assert gen_call.finished_at is not None
+        assert gen_call.duration is not None

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -515,3 +515,22 @@ class TestSpeculativeGenerationTiming:
         gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
         assert len(gen_calls) == 1
         assert gen_calls[0].duration is not None
+
+    @pytest.mark.asyncio
+    async def test_blocked_rails_first_records_simultaneously_completed_call(self, iorails):
+        """Rails block first but generation completed in the same tick — the completed call is still logged."""
+
+        async def immediate_reject(messages, *, enabled=True):
+            return RailResult(is_safe=False, reason="unsafe")
+
+        iorails.rails_manager.is_input_safe = immediate_reject
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
+        )
+
+        result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
+        assert len(gen_calls) == 1

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -494,3 +494,24 @@ class TestSpeculativeGenerationTiming:
         assert gen_call.started_at is not None
         assert gen_call.finished_at is not None
         assert gen_call.duration is not None
+
+    @pytest.mark.asyncio
+    async def test_blocked_after_generation_records_the_completed_call(self, iorails):
+        """When generation completes before the input rails block it, the completed main call is still logged."""
+
+        async def slow_reject(messages, *, enabled=True):
+            await asyncio.sleep(0.05)
+            return RailResult(is_safe=False, reason="unsafe")
+
+        iorails.rails_manager.is_input_safe = slow_reject
+        iorails.engine_registry.model_call = AsyncMock(
+            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
+        )
+
+        result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.log is not None
+        gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
+        assert len(gen_calls) == 1
+        assert gen_calls[0].duration is not None

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -38,6 +38,24 @@ from tests.guardrails.test_data import NEMOGUARDS_CONFIG, NEMOGUARDS_SPECULATIVE
 MESSAGES = [{"role": "user", "content": "hi"}]
 
 
+def _hi_model() -> AsyncMock:
+    """Main-model mock returning a fixed 'Hi' response with usage."""
+    return AsyncMock(
+        return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
+    )
+
+
+async def _slow_reject(messages, *, enabled=True):
+    """Input rails that reject after a short delay (so generation finishes first)."""
+    await asyncio.sleep(0.05)
+    return RailResult(is_safe=False, reason="unsafe")
+
+
+async def _immediate_reject(messages, *, enabled=True):
+    """Input rails that reject immediately (so rails and generation finish in the same tick)."""
+    return RailResult(is_safe=False, reason="unsafe")
+
+
 @pytest_asyncio.fixture
 async def iorails():
     async with started_iorails(NEMOGUARDS_SPECULATIVE_CONFIG) as instance:
@@ -482,9 +500,7 @@ class TestSpeculativeGenerationTiming:
         """On the speculative path, the generation call in the log has real timestamps and a duration."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.engine_registry.model_call = AsyncMock(
-            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
-        )
+        iorails.engine_registry.model_call = _hi_model()
 
         result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
 
@@ -496,17 +512,14 @@ class TestSpeculativeGenerationTiming:
         assert gen_call.duration is not None
 
     @pytest.mark.asyncio
-    async def test_blocked_after_generation_records_the_completed_call(self, iorails):
-        """When generation completes before the input rails block it, the completed main call is still logged."""
-
-        async def slow_reject(messages, *, enabled=True):
-            await asyncio.sleep(0.05)
-            return RailResult(is_safe=False, reason="unsafe")
-
-        iorails.rails_manager.is_input_safe = slow_reject
-        iorails.engine_registry.model_call = AsyncMock(
-            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
-        )
+    @pytest.mark.parametrize(
+        "reject_rails", [_slow_reject, _immediate_reject], ids=["gen-first", "rails-first-simultaneous"]
+    )
+    async def test_blocked_speculative_records_completed_call(self, iorails, reject_rails):
+        """A speculative main call that completed before the input rails blocked is still logged —
+        whether generation finished first or both finished in the same tick."""
+        iorails.rails_manager.is_input_safe = reject_rails
+        iorails.engine_registry.model_call = _hi_model()
 
         result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
 
@@ -515,22 +528,3 @@ class TestSpeculativeGenerationTiming:
         gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
         assert len(gen_calls) == 1
         assert gen_calls[0].duration is not None
-
-    @pytest.mark.asyncio
-    async def test_blocked_rails_first_records_simultaneously_completed_call(self, iorails):
-        """Rails block first but generation completed in the same tick — the completed call is still logged."""
-
-        async def immediate_reject(messages, *, enabled=True):
-            return RailResult(is_safe=False, reason="unsafe")
-
-        iorails.rails_manager.is_input_safe = immediate_reject
-        iorails.engine_registry.model_call = AsyncMock(
-            return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8))
-        )
-
-        result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})
-
-        assert isinstance(result, GenerationResponse)
-        assert result.log is not None
-        gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
-        assert len(gen_calls) == 1

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -89,7 +89,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = slow_llm
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(MESSAGES)
+        result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": "Hello from LLM"}
 
@@ -113,7 +113,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = slow_llm
         iorails.rails_manager.is_output_safe = AsyncMock()
 
-        result = await iorails.generate_async(MESSAGES)
+        result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_output_safe.assert_not_called()
@@ -138,7 +138,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = fast_llm
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails.generate_async(MESSAGES)
+        result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": "Fast LLM response"}
 
@@ -157,7 +157,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = fast_llm
         iorails.rails_manager.is_output_safe = AsyncMock()
 
-        result = await iorails.generate_async(MESSAGES)
+        result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_output_safe.assert_not_called()
@@ -174,7 +174,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM crashed"))
 
         with pytest.raises(RuntimeError, match="LLM crashed"):
-            await iorails.generate_async(MESSAGES)
+            await iorails.generate_async(messages=MESSAGES)
 
     @pytest.mark.asyncio
     async def test_rails_error_cancels_generation(self, iorails):
@@ -188,7 +188,7 @@ class TestSpeculativeGeneration:
         iorails.engine_registry.model_call = slow_llm
 
         with pytest.raises(RuntimeError, match="Rails crashed"):
-            await iorails.generate_async(MESSAGES)
+            await iorails.generate_async(messages=MESSAGES)
 
     @pytest.mark.asyncio
     async def test_rails_reject_with_simultaneous_llm_exception(self, iorails, caplog_iorails):
@@ -209,7 +209,7 @@ class TestSpeculativeGeneration:
         iorails.rails_manager.is_output_safe = AsyncMock()
 
         with caplog_iorails.at_level("WARNING", logger="nemoguardrails.guardrails.iorails"):
-            result = await iorails.generate_async(MESSAGES)
+            result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_output_safe.assert_not_called()
@@ -231,7 +231,7 @@ class TestSpeculativeGeneration:
 
         with caplog_iorails.at_level("WARNING", logger="nemoguardrails.guardrails.iorails"):
             with pytest.raises(RuntimeError):
-                await iorails.generate_async(MESSAGES)
+                await iorails.generate_async(messages=MESSAGES)
 
         assert any("task error discarded during cleanup" in rec.message for rec in caplog_iorails.records)
 
@@ -254,7 +254,7 @@ class TestSpeculativeGeneration:
             iorails.rails_manager.is_output_safe = AsyncMock()
 
             with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_mock:
-                result = await iorails.generate_async(MESSAGES)
+                result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         record_mock.assert_called_once()
@@ -279,7 +279,7 @@ class TestSpeculativeGeneration:
             iorails.rails_manager.is_output_safe = AsyncMock()
 
             with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_mock:
-                result = await iorails.generate_async(MESSAGES)
+                result = await iorails.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         record_mock.assert_called_once()
@@ -306,7 +306,7 @@ class TestSpeculativeGeneration:
         iorails_sequential.engine_registry.model_call = mock_generate
         iorails_sequential.rails_manager.is_output_safe = mock_output
 
-        await iorails_sequential.generate_async(MESSAGES)
+        await iorails_sequential.generate_async(messages=MESSAGES)
         assert call_order == ["input", "generate", "output"]
 
 
@@ -360,7 +360,7 @@ class TestSpeculativeGenerationTelemetry:
         iorails_speculative_tracing.engine_registry.model_call = slow_llm
         iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails_speculative_tracing.generate_async(MESSAGES)
+        result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": "Hello from LLM"}
         spans = span_exporter.get_finished_spans()
@@ -386,7 +386,7 @@ class TestSpeculativeGenerationTelemetry:
         iorails_speculative_tracing.engine_registry.model_call = slow_llm
         iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock()
 
-        result = await iorails_speculative_tracing.generate_async(MESSAGES)
+        result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         spans = span_exporter.get_finished_spans()
@@ -412,7 +412,7 @@ class TestSpeculativeGenerationTelemetry:
         iorails_speculative_tracing.engine_registry.model_call = fast_llm
         iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-        result = await iorails_speculative_tracing.generate_async(MESSAGES)
+        result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": "Fast LLM response"}
         spans = span_exporter.get_finished_spans()
@@ -438,7 +438,7 @@ class TestSpeculativeGenerationTelemetry:
         iorails_speculative_tracing.engine_registry.model_call = fast_llm
         iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock()
 
-        result = await iorails_speculative_tracing.generate_async(MESSAGES)
+        result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         spans = span_exporter.get_finished_spans()
@@ -462,7 +462,7 @@ class TestSpeculativeGenerationTelemetry:
                 iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="response"))
                 iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
-                await iorails.generate_async(MESSAGES)
+                await iorails.generate_async(messages=MESSAGES)
 
         spans = span_exporter.get_finished_spans()
         request_spans = [s for s in spans if s.name == "guardrails.request"]

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -309,20 +309,20 @@ class TestNonStreamingToolCalls:
     async def test_allowed_tool_call_passes(self, iorails):
         _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
         result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert result.tool_calls[0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio
     async def test_undeclared_tool_call_blocked(self, iorails):
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
         result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
     @pytest.mark.asyncio
     async def test_invalid_arguments_blocked(self, iorails):
         # Missing the required "city" argument violates the declared schema.
         _inject_json_response(iorails, _tool_call_payload("get_weather", "{}"))
         result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
 
 class TestSpeculativeToolCalls:
@@ -337,13 +337,13 @@ class TestSpeculativeToolCalls:
     async def test_undeclared_tool_call_blocked(self, speculative_iorails):
         _inject_json_response(speculative_iorails, _tool_call_payload("rm_rf", "{}"))
         result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
     @pytest.mark.asyncio
     async def test_allowed_tool_call_passes(self, speculative_iorails):
         _inject_json_response(speculative_iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
         result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert result.tool_calls[0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio
     async def test_input_toggle_forwarded_to_input_rails(self, speculative_iorails):
@@ -474,7 +474,7 @@ class TestPerRequestToggles:
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
         options = {"llm_params": LLM_PARAMS, "rails": {"tool_output": False}}
         result = await iorails.generate_async(MESSAGES, options=options)
-        assert result["tool_calls"][0]["function"]["name"] == "rm_rf"
+        assert result.tool_calls[0]["function"]["name"] == "rm_rf"
 
     @pytest.mark.asyncio
     async def test_tool_input_disabled_skips_tool_result_rail(self, iorails):
@@ -484,7 +484,7 @@ class TestPerRequestToggles:
             make_tool_conversation(result_call_id="call_999"),
             options={"rails": {"tool_input": False}},
         )
-        assert result == {"role": "assistant", "content": "ok"}
+        assert result.response == [{"role": "assistant", "content": "ok"}]
 
     @pytest.mark.asyncio
     async def test_input_toggle_forwarded_to_input_rails(self, iorails):
@@ -531,7 +531,7 @@ class TestFailClosed:
         _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
         dup_params = {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
         result = await iorails.generate_async(MESSAGES, options={"llm_params": dup_params})
-        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
 
 class TestToolRailBlockMetrics:
@@ -551,7 +551,7 @@ class TestToolRailBlockMetrics:
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
             result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
-        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
         record_blocked.assert_called_once_with(RailDirection.OUTPUT)
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_tool_rails_iorails.py
+++ b/tests/guardrails/test_tool_rails_iorails.py
@@ -308,20 +308,20 @@ class TestNonStreamingToolCalls:
     @pytest.mark.asyncio
     async def test_allowed_tool_call_passes(self, iorails):
         _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
-        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        result = await iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.tool_calls[0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio
     async def test_undeclared_tool_call_blocked(self, iorails):
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
-        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        result = await iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
     @pytest.mark.asyncio
     async def test_invalid_arguments_blocked(self, iorails):
         # Missing the required "city" argument violates the declared schema.
         _inject_json_response(iorails, _tool_call_payload("get_weather", "{}"))
-        result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        result = await iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
 
@@ -336,13 +336,13 @@ class TestSpeculativeToolCalls:
     @pytest.mark.asyncio
     async def test_undeclared_tool_call_blocked(self, speculative_iorails):
         _inject_json_response(speculative_iorails, _tool_call_payload("rm_rf", "{}"))
-        result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        result = await speculative_iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
     @pytest.mark.asyncio
     async def test_allowed_tool_call_passes(self, speculative_iorails):
         _inject_json_response(speculative_iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
-        result = await speculative_iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+        result = await speculative_iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.tool_calls[0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio
@@ -351,7 +351,7 @@ class TestSpeculativeToolCalls:
         spy = AsyncMock(wraps=speculative_iorails.rails_manager.is_input_safe)
         speculative_iorails.rails_manager.is_input_safe = spy
         _inject_json_response(speculative_iorails, _text_payload("ok"))
-        await speculative_iorails.generate_async(MESSAGES, options={"rails": {"input": False}})
+        await speculative_iorails.generate_async(messages=MESSAGES, options={"rails": {"input": False}})
         assert spy.await_args.kwargs.get("enabled") is False
 
 
@@ -368,14 +368,14 @@ class TestConfigDeclaredTools:
     async def test_config_declared_tool_call_passes(self, iorails_config_tools):
         """A call to a config-declared tool passes the rail when the request carries no llm_params."""
         _inject_json_response(iorails_config_tools, _tool_call_payload("get_weather", '{"city": "Paris"}'))
-        result = await iorails_config_tools.generate_async(MESSAGES)
+        result = await iorails_config_tools.generate_async(messages=MESSAGES)
         assert result["tool_calls"][0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio
     async def test_undeclared_tool_call_blocked_against_config_tools(self, iorails_config_tools):
         """A call to a tool absent from the config toolset is blocked when the request carries no llm_params."""
         _inject_json_response(iorails_config_tools, _tool_call_payload("rm_rf", "{}"))
-        result = await iorails_config_tools.generate_async(MESSAGES)
+        result = await iorails_config_tools.generate_async(messages=MESSAGES)
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
 
     @pytest.mark.asyncio
@@ -392,7 +392,7 @@ class TestNonStreamingToolResults:
     @pytest.mark.asyncio
     async def test_linked_tool_result_passes(self, iorails):
         _inject_json_response(iorails, _text_payload("It is sunny."))
-        result = await iorails.generate_async(make_tool_conversation(result_call_id="call_1"))
+        result = await iorails.generate_async(messages=make_tool_conversation(result_call_id="call_1"))
         assert result == {"role": "assistant", "content": "It is sunny."}
 
     @pytest.mark.asyncio
@@ -400,7 +400,7 @@ class TestNonStreamingToolResults:
         # A blocked tool result must short-circuit before the model is ever called:
         # wire a transport that fails if used, and assert it stayed untouched.
         forbidden_post = _inject_forbidden_transport(iorails)
-        result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
+        result = await iorails.generate_async(messages=make_tool_conversation(result_call_id="call_999"))
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         forbidden_post.assert_not_called()
 
@@ -409,14 +409,14 @@ class TestNonStreamingToolResults:
         """Multi-turn conversation reusing the same call_id across turns is valid"""
 
         _inject_json_response(iorails, _text_payload("It's 12C in London."))
-        result = await iorails.generate_async(multi_turn_reused_call_id_messages())
+        result = await iorails.generate_async(messages=multi_turn_reused_call_id_messages())
         assert result == {"role": "assistant", "content": "It's 12C in London."}
 
     @pytest.mark.asyncio
     async def test_malformed_prior_tool_call_does_not_block(self, iorails):
         """Malformed tool-call in prior turns must not block request."""
         _inject_json_response(iorails, _text_payload("It's 12C in London."))
-        result = await iorails.generate_async(malformed_prior_tool_call_messages())
+        result = await iorails.generate_async(messages=malformed_prior_tool_call_messages())
         assert result == {"role": "assistant", "content": "It's 12C in London."}
 
 
@@ -473,7 +473,7 @@ class TestPerRequestToggles:
         # An undeclared tool call would normally block; disabling tool_output lets it through.
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
         options = {"llm_params": LLM_PARAMS, "rails": {"tool_output": False}}
-        result = await iorails.generate_async(MESSAGES, options=options)
+        result = await iorails.generate_async(messages=MESSAGES, options=options)
         assert result.tool_calls[0]["function"]["name"] == "rm_rf"
 
     @pytest.mark.asyncio
@@ -481,7 +481,7 @@ class TestPerRequestToggles:
         # An unlinked tool result would normally block; disabling tool_input lets it through.
         _inject_json_response(iorails, _text_payload("ok"))
         result = await iorails.generate_async(
-            make_tool_conversation(result_call_id="call_999"),
+            messages=make_tool_conversation(result_call_id="call_999"),
             options={"rails": {"tool_input": False}},
         )
         assert result.response == [{"role": "assistant", "content": "ok"}]
@@ -492,7 +492,7 @@ class TestPerRequestToggles:
         spy = AsyncMock(wraps=iorails.rails_manager.is_input_safe)
         iorails.rails_manager.is_input_safe = spy
         _inject_json_response(iorails, _text_payload("ok"))
-        await iorails.generate_async(MESSAGES, options={"rails": {"input": False}})
+        await iorails.generate_async(messages=MESSAGES, options={"rails": {"input": False}})
         assert spy.await_args.kwargs.get("enabled") is False
 
     @pytest.mark.asyncio
@@ -501,7 +501,7 @@ class TestPerRequestToggles:
         spy = AsyncMock(wraps=iorails.rails_manager.is_output_safe)
         iorails.rails_manager.is_output_safe = spy
         _inject_json_response(iorails, _text_payload("ok"))
-        await iorails.generate_async(MESSAGES, options={"rails": {"output": False}})
+        await iorails.generate_async(messages=MESSAGES, options={"rails": {"output": False}})
         assert spy.await_args.kwargs.get("enabled") is False
 
     @pytest.mark.asyncio
@@ -530,7 +530,7 @@ class TestFailClosed:
         # parse_tools raises on a duplicate tool name; the request must fail closed.
         _inject_json_response(iorails, _tool_call_payload("get_weather", '{"city": "Paris"}'))
         dup_params = {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
-        result = await iorails.generate_async(MESSAGES, options={"llm_params": dup_params})
+        result = await iorails.generate_async(messages=MESSAGES, options={"llm_params": dup_params})
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
 
 
@@ -541,7 +541,7 @@ class TestToolRailBlockMetrics:
     async def test_nonstream_tool_result_block_records_input_metric(self, iorails):
         iorails._metrics_enabled = True
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
-            result = await iorails.generate_async(make_tool_conversation(result_call_id="call_999"))
+            result = await iorails.generate_async(messages=make_tool_conversation(result_call_id="call_999"))
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         record_blocked.assert_called_once_with(RailDirection.INPUT)
 
@@ -550,7 +550,7 @@ class TestToolRailBlockMetrics:
         iorails._metrics_enabled = True
         _inject_json_response(iorails, _tool_call_payload("rm_rf", "{}"))
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
-            result = await iorails.generate_async(MESSAGES, options={"llm_params": LLM_PARAMS})
+            result = await iorails.generate_async(messages=MESSAGES, options={"llm_params": LLM_PARAMS})
         assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
         record_blocked.assert_called_once_with(RailDirection.OUTPUT)
 

--- a/tests/guardrails/test_topic_safety_iorails_actions.py
+++ b/tests/guardrails/test_topic_safety_iorails_actions.py
@@ -92,10 +92,14 @@ class TestTopicSafetyPrompt:
 
 class TestTopicSafetyParseResponse:
     def test_on_topic(self, action):
-        assert action._parse_response("on-topic") == RailResult(is_safe=True)
+        result = action._parse_response("on-topic")
+        assert result == RailResult(is_safe=True)
+        assert result.return_value == {"on_topic": True}
 
     def test_off_topic(self, action):
-        assert action._parse_response("off-topic") == RailResult(is_safe=False, reason="Topic safety: off-topic")
+        result = action._parse_response("off-topic")
+        assert result == RailResult(is_safe=False, reason="Topic safety: off-topic")
+        assert result.return_value == {"on_topic": False}
 
     @pytest.mark.parametrize("text", ["Off-Topic", "  off-topic  \n", "OFF-TOPIC"])
     def test_off_topic_variants(self, action, text):


### PR DESCRIPTION
## Description

Adds the [`GenerationResponse`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L377) return argument to non-streaming `generate()` and `generate_sync()` methods. When a [`GenerationOptions`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L161) object is provided, the `GenerationResponse` structured response is returned rather than a dict with `role`/`content`/`tool_calls` keys. 

**BREAKING CHANGE**: Users who passed the `options` named argument in `generate()` and `generate_async()` that used to get a dict will now get a [`GenerationResponse`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L377).

**BREAKING CHANGE**: This PR contains changes to the Guardrails and IORails signatures for these two functions to align them exactly with LLMRails. The signature of `generate()` and `generate_async()` now includes `prompt` as the first parameter, to match LLMRails. It changed from:
```
    def generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
```
to
```
def generate(
        self,
        prompt: Optional[str] = None,
        messages: Optional[LLMMessages] = None,
        options: Optional[Union[dict, GenerationOptions]] = None,
        **kwargs,
    ) -> Union[LLMMessage, GenerationResponse]:
```
This means users who passed a `messages` parameter in the first positional argument of `generate_async()` or `generate()` will now get a `TypeError("prompt must be a string; pass a message list via messages=")`. The `state` and `streaming_handler` arguments LLMRails supports for these functions aren't supported in IORails.


The [`GenerationResponse`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L377) collects many different items of metadata, timestamps and durations into one place. The `GenerationResponse.log` field has a type [`GenerationLog`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L289), which in IORails does not support the `internal_events` and `colang_history` fields. The [`GenerationLogOptions`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L105) class controls which fields in `GenerationLog` are returned. If `GenerationLogOptions.internal_events` or `GenerationLogOptions.colang_history` are set to `True`, an Exception will be raised  since IORails doesn't use a Colang runtime needed for these fields.

Because the `GenerationResponse` is so loosely typed, and depends on the models called in the input and output rails along with the main LLM generation, live end-to-end tests were used to run the same generation with both LLMRails and IORails engines. These won't match exactly due to LLM non-determinism, or natural variation in the time taken for inference, but the schema of the responses should match.

### `GenerationResponse` detailed field support in IORails

**Fully supported**

| Field | Notes |
| --- | --- |
| `response` | The assistant message. IORails takes only `messages`, so always a 1-element `[assistant_msg]` list. |
| `tool_calls` | Canonical `ToolCall.to_dict()` dict-args shape, matching LLMRails' `GenerationResponse.tool_calls`. (Bare/streaming paths keep the JSON-string wire shape, unchanged.) |
| `reasoning_content` | Provider `reasoning` field, or `<think>` extracted from the completion; the structured path keeps `response` content clean (no inline `<think>`). |
| `llm_output` | Always `None` — identical to LLMRails, whose source for this field is never populated either. `llm_output=True` is accepted as a silent no-op. |

**Partially supported**

| Field | What works | What differs / is missing |
| --- | --- | --- |
| `log` | `activated_rails` (one synthetic `ExecutedAction` + `LLMCallInfo` per rail), the flat `llm_calls` list, and aggregate `stats` — all synthesized from per-rail `RailCallRecord`s + the main call. Per-call/aggregate token usage, `id`, `prompt`, `completion`, model/provider, durations, and timestamps all match LLMRails. | `internal_events` and `colang_history` raise `NotImplementedError` (Colang-runtime-only). `activated_rails[].decisions` is always `[]` (a Colang construct). The generation rail's `name`/`action_name` are `generation`/`generate_bot_message` vs LLMRails' Colang `generate user intent`/`generate_user_intent`. `prompt` is a role-labeled serialized-messages string with content parity with LLMRails. |
| `llm_metadata` | Surfaces the main call's `provider_metadata` verbatim (e.g. `response_headers`). | IORails reports the **main** call only; LLMRails reports the **last** call, which is either the last output rail to complete or if no output-rails are configured the main LLM. No `usage` sub-key — all token usage lives in `log` (LLMRails mirror). Often `None` when the provider returns no metadata blob. |

**Not supported**

| Field | Behavior | Why |
| --- | --- | --- |
| `output_data` | Always `None`; passing `options.output_vars` raises `ValueError`. | Populated in LLMRails from Colang output-variable mapping; IORails has no Colang context to return. |
| `state` | Always `None`; passing `options.state` raises `ValueError`. | Colang interaction state; IORails is a stateless input/output-rails engine with nothing to persist or resume. |

### Integration-testing (using [`compare_generate.py`](//gist.github.com/tgasser-nv/ad3695dd55a0344c7c9e153405371d84) )

This script issues the identical request to both IORails and LLMRails, with the `GenerationLogOptions` fields that IORails doesn't support disabled.

It was run as below from the Guardrails uv environment

```
$ uv run --locked python ~/utils/generation_options/compare_generate.py \
    --config examples/configs/nemoguards \
    --output-dir ~/output \
    --message "Hello" 
```

This generated the `llmrails_generation_response.json` and `iorails_generation_response.json` files attached to the PR. 

[iorails_generation_response.json](https://github.com/user-attachments/files/30140825/iorails_generation_response.json)
[llmrails_generation_response.json](https://github.com/user-attachments/files/30140826/llmrails_generation_response.json)

The **Field-by-field Comparison** output is below. For the full log file see here
[generation_compare.log](https://github.com/user-attachments/files/30140993/generation_compare.log) .


```
==============================================================================
FIELD-BY-FIELD COMPARISON
------------------------------------------------------------------------------

response  ->  IDENTICAL
llm_output  ->  IDENTICAL
output_data  ->  IDENTICAL
log  ->  DIFFERENT SHAPE
  LLMRails: dict{activated_rails, colang_history, internal_events, llm_calls, stats}
  IORails:  dict{activated_rails, colang_history, internal_events, llm_calls, stats}
state  ->  IDENTICAL
tool_calls  ->  IDENTICAL
reasoning_content  ->  SAME SHAPE (values differ)
  LLMRails: str[115] "The user said "Hello". This is a standard greeting…"
  IORails:  str[99] "The user said "Hello". This is a standard greeting…"
llm_metadata  ->  DIFFERENT SHAPE
  LLMRails: dict{response_headers}
  IORails:  None
```

## Related Issue(s)

* [NGUARD-818](https://jirasw.nvidia.com/browse/NGUARD-818)

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test

================================================================= test session starts =================================================================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-structured-response
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [5609 items]
ss...s..s....s....s....s...s...s.....s......................................................................................................... [  2%]
.............................................................................................................sss..s............................ [  5%]
............................................................................................................................................... [  7%]
.........................................................s...............s..s.................................................................. [ 10%]
...................................................s.s....s..s...s.s..s................................s....................................... [ 12%]
............................................................................................................................................... [ 15%]
......................s.........................................................................................s.............................. [ 17%]
............................................s.................................................................................................. [ 20%]
............................................................................................................................................... [ 22%]
............................................................................................................................................... [ 25%]
............................................................................................................................................... [ 28%]
............................................................................................................................................... [ 30%]
............................................................................................................................................... [ 33%]
............................................................................................................................................... [ 35%]
.......................................................................................ss.sssss.s.............................................. [ 38%]
..........................................................................................................................ssss..s.s.s.......... [ 40%]
.....ssssssss................................................................................ss................................................ [ 43%]
............................................................................................................................................... [ 45%]
................................................................................................s.s.sssss....................s.s.ss.sss...s.... [ 48%]
............................................................................................................................................... [ 50%]
......................ss....................................................................................................................... [ 53%]
........................................................................................................s...................................... [ 56%]
....................s.....................................................................................ss................................... [ 58%]
..............................................................ss.....s.ssss......ssssssssssssssssss....................s....................... [ 61%]
...................ss............................................sssss.ss...................................................................... [ 63%]
............................................................................................................................................... [ 66%]
...............................sssss........................................................................................................... [ 68%]
.....................................................................................ssssssss.......s.s................................s.ss..s. [ 71%]
s.......................................................................s...................................................................... [ 73%]
............................................................................................................................................... [ 76%]
.............................................................................................................s................................. [ 79%]
......................s.............................................................................................s.......................... [ 81%]
.........................................................................................ssssss................................................ [ 84%]
..........sss.........s..................................................................................................ss......ss............ [ 86%]
............................................................................................................................................... [ 89%]
............sssssss.ssssss...s.....................................s........................................................................... [ 91%]
....................s..........s.......................................s....................................................................ss. [ 94%]
..s.......................sssssssss.........................................................................................s.................. [ 96%]
............................................................................................................................................... [ 99%]
................................                                                                                                                [100%]

═══════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return
x and inline-snapshot will not be able to fix snapshots or generate reports.


========================================================= 5431 passed, 178 skipped in 45.35s ==========================================================

```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-07-17 16:12:38 INFO: Registered model engine: type=main, model=nvidia/nemotron-3-ultra-550b-a55b, base_url=https://integrate.api.nvidia.com
2026-07-17 16:12:38 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-07-17 16:12:38 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-07-17 16:12:38 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-07-17 16:12:38 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-07-17 16:12:40 INFO: [e68a132b75d22ca0] generate_async called
2026-07-17 16:12:40 INFO: [e68a132b75d22ca0] Running tool result rails
2026-07-17 16:12:40 INFO: [e68a132b75d22ca0] Running input rails
2026-07-17 16:12:40 INFO: [e68a132b75d22ca0] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-17 16:12:41 INFO: [e68a132b75d22ca0] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-07-17 16:12:41 INFO: [e68a132b75d22ca0] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-07-17 16:12:42 INFO: [e68a132b75d22ca0] Calling main LLM
2026-07-17 16:12:42 INFO: [e68a132b75d22ca0] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3-ultra-550b-a55b'
2026-07-17 16:12:43 INFO: [e68a132b75d22ca0] Running output rails
2026-07-17 16:12:43 INFO: [e68a132b75d22ca0] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-17 16:12:44 INFO: [e68a132b75d22ca0] generate_async completed time=3514.0ms
<think>The user said "Hello!". This is a standard greeting.
I should respond politely and ask how I can help.</think>
Hello! How can I help you today?

> How can I burn a house down?
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] generate_async called
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] Running tool result rails
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] Running input rails
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] Input flow content safety check input $model=content_safety blocked
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-07-17 16:12:53 INFO: [f3250f4b927e23f3] generate_async completed time=462.3ms
I'm sorry, I can't respond to that.

```
## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional generation settings for synchronous and asynchronous requests.
  * Added structured generation responses with reasoning, tool calls, and provider metadata.
  * Added detailed generation logs covering rail decisions, model calls, token usage, timing, and prompts.
  * Added provider lookup support for configured model engines.
* **Bug Fixes**
  * Safety, jailbreak, and topic checks now consistently return structured verdict details.
  * Blocked requests provide clearer refusal responses and execution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->