### PR TITLE
ci: separate PR coverage from test matrix

### DIFF
--- a/.github/workflows/_coverage.yml
+++ b/.github/workflows/_coverage.yml
@@ -1,0 +1,21 @@
+name: Reusable Coverage
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    uses: ./.github/workflows/_test.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      os: Ubuntu
+      image: ubuntu-latest
+      python-version: "3.11"
+      with-coverage: true

--- a/.github/workflows/develop-coverage.yml
+++ b/.github/workflows/develop-coverage.yml
@@ -12,11 +12,6 @@ permissions:
 
 jobs:
   develop-coverage:
-    uses: ./.github/workflows/_test.yml
+    uses: ./.github/workflows/_coverage.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    with:
-      os: Ubuntu
-      image: ubuntu-latest
-      python-version: "3.11"
-      with-coverage: true

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,0 +1,28 @@
+name: PR Coverage
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  pr-coverage:
+    uses: ./.github/workflows/_test.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      os: Ubuntu
+      image: ubuntu-latest
+      python-version: "3.11"
+      with-coverage: true
+  pr-coverage-summary:
+    name: PR Coverage Summary
+    needs: pr-coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm PR coverage passed
+        run: echo "PR coverage completed successfully"

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -9,16 +9,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-coverage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-coverage:
-    uses: ./.github/workflows/_test.yml
+    uses: ./.github/workflows/_coverage.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    with:
-      os: Ubuntu
-      image: ubuntu-latest
-      python-version: "3.11"
-      with-coverage: true
   pr-coverage-summary:
     name: PR Coverage Summary
     needs: pr-coverage

--- a/.github/workflows/pr-tests-skip.yml
+++ b/.github/workflows/pr-tests-skip.yml
@@ -14,3 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Tests skipped (no code changes)"
+  pr-coverage-summary:
+    name: PR Coverage Summary
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Coverage skipped (no code changes)"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,17 +18,12 @@ jobs:
         include:
           - os: Ubuntu
             image: ubuntu-latest
-          - python-version: "3.11"
-            with-coverage: true
       fail-fast: false
     uses: ./.github/workflows/_test.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       os: ${{ matrix.os }}
       image: ${{ matrix.image }}
       python-version: ${{ matrix.python-version }}
-      with-coverage: ${{ matrix.with-coverage || false }}
   pr-tests-summary:
     name: PR Tests Summary
     needs: pr-tests-matrix


### PR DESCRIPTION
## Description

Separates Python 3.11 coverage from the PR test matrix so test timing and coverage reporting are tracked independently.



## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request coverage checks with concurrency controls.
  * Added reusable coverage workflow support for consistent testing environments.
  * Added clear completion summaries for coverage checks.

* **Improvements**
  * Separated coverage execution from standard pull request tests.
  * Added skip summaries when pull requests contain no code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->