### PR TITLE
refactor(self-check): name the rail selector variant end-to-end

### DIFF
--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -46,7 +46,7 @@ async def self_check_input(
     events: Optional[List[dict]] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
-    task: Optional[str] = None,
+    variant: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks the input from the user.
@@ -62,7 +62,7 @@ async def self_check_input(
     user_input = context.get("user_message")
 
     task = resolve_self_check_task(
-        task,
+        variant,
         context,
         events,
         triggered_rail_key="triggered_input_rail",

--- a/nemoguardrails/library/self_check/input_check/flows.co
+++ b/nemoguardrails/library/self_check/input_check/flows.co
@@ -1,5 +1,5 @@
 flow self check input $variant="self_check_input"
-  $response = await SelfCheckInputAction(task=$variant)
+  $response = await SelfCheckInputAction(variant=$variant)
 
   if $response.is_blocked
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -46,7 +46,7 @@ async def self_check_output(
     events: Optional[List[dict]] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
-    task: Optional[str] = None,
+    variant: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks if the output from the bot.
@@ -67,7 +67,7 @@ async def self_check_output(
     bot_thinking = context.get("bot_thinking")
 
     task = resolve_self_check_task(
-        task,
+        variant,
         context,
         events,
         triggered_rail_key="triggered_output_rail",

--- a/nemoguardrails/library/self_check/output_check/flows.co
+++ b/nemoguardrails/library/self_check/output_check/flows.co
@@ -1,5 +1,5 @@
 flow self check output $variant="self_check_output"
-  $response = await SelfCheckOutputAction(task=$variant)
+  $response = await SelfCheckOutputAction(variant=$variant)
 
   if $response.is_blocked
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/self_check/utils.py
+++ b/nemoguardrails/library/self_check/utils.py
@@ -66,7 +66,7 @@ def get_self_check_prompt_task(
 
 
 def resolve_self_check_task(
-    task: Optional[str],
+    variant: Optional[str],
     context: Optional[dict],
     events: Optional[List[dict]],
     triggered_rail_key: str,
@@ -75,8 +75,8 @@ def resolve_self_check_task(
     variant_param: str,
     default_task: str,
 ) -> str:
-    if task and not task.startswith("$"):
-        return task
+    if variant and not variant.startswith("$"):
+        return variant
 
     context = context or {}
     context_task = get_self_check_task_from_rail(

--- a/tests/test_multiple_self_check_rails.py
+++ b/tests/test_multiple_self_check_rails.py
@@ -784,9 +784,9 @@ def test_output_fallback_chain_prefers_task_over_default():
     assert chat.llm.inference_count == 2
 
 
-def _resolve_input_task(task=None, context=None, events=None):
+def _resolve_input_task(variant=None, context=None, events=None):
     return resolve_self_check_task(
-        task,
+        variant,
         context,
         events,
         triggered_rail_key="triggered_input_rail",
@@ -889,7 +889,7 @@ def test_get_self_check_task_from_rail_resolves_custom_and_default_tasks():
 
 def test_resolve_self_check_task_prefers_explicit_task():
     task = _resolve_input_task(
-        task="check_harmful",
+        variant="check_harmful",
         context={"triggered_input_rail": "self check input $variant=check_off_topic"},
     )
 
@@ -898,7 +898,7 @@ def test_resolve_self_check_task_prefers_explicit_task():
 
 def test_resolve_self_check_task_uses_triggered_rail_context():
     task = _resolve_input_task(
-        task="$variant",
+        variant="$variant",
         context={"triggered_input_rail": "self check input $variant=check_harmful"},
     )
 
@@ -907,7 +907,7 @@ def test_resolve_self_check_task_uses_triggered_rail_context():
 
 def test_resolve_self_check_task_uses_latest_start_rail_event():
     task = _resolve_input_task(
-        task="$variant",
+        variant="$variant",
         events=[
             {"type": "StartInputRail", "flow_id": "self check input $variant=check_off_topic"},
             {"type": "SomeOtherEvent", "flow_id": "self check input $variant=ignored"},
@@ -930,14 +930,14 @@ def test_resolve_self_check_task_uses_start_flow_params():
 
 def test_resolve_self_check_task_defaults_unresolved_placeholders():
     assert _resolve_input_task(context={"triggered_input_rail": "self check input"}) == SELF_CHECK_INPUT_DEFAULT_TASK
-    assert _resolve_input_task(task="$variant") == SELF_CHECK_INPUT_DEFAULT_TASK
+    assert _resolve_input_task(variant="$variant") == SELF_CHECK_INPUT_DEFAULT_TASK
     assert _resolve_input_task() == SELF_CHECK_INPUT_DEFAULT_TASK
 
 
 def test_bare_triggered_rail_uses_default_over_event_history():
     """Verify a bare triggered rail selects the default task."""
     task = _resolve_input_task(
-        task="$variant",
+        variant="$variant",
         context={"triggered_input_rail": "self check input"},
         events=[
             {


### PR DESCRIPTION

## Description

The self-check flow passed its $variant value into the action as task=, so the action signature read self_check_input(task=...) while the config-facing selector is $variant=. Rename the carrier to variant across the flow-to-action boundary: both flows.co calls (variant=$variant), both action signatures (task -> variant), and resolve_self_check_task input parameter. The resolved value stays task from resolve_self_check_task return onward, since it keys the prompt template and model routing. The action parameter is unreleased (added with the multiple-self-check feature), so no compatibility path is needed.


follow-up on #2175 

## Related Issue(s)

#2175

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-check configuration so input and output safety checks consistently honor the selected variant.
  * Ensured variant-based task resolution works correctly across configured rails and event-based flows.
  * Preserved existing default behavior when no variant is specified or when a variant cannot be resolved.
  * Updated validation coverage for variant selection, placeholder handling, and fallback task behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->