### PR TITLE
refactor(library): make moderation outcomes flow-independent

### DIFF
--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -35,16 +35,30 @@ ACTIVEFENCE_DETAILED_THRESHOLDS = {
     "adult_content.general": 0.3,
     "privacy_violation.pii": 0.8,
 }
+ACTIVEFENCE_DETAILED_REASONS = {
+    "abusive_or_harmful.harassment_or_bullying": "ActiveFence moderation triggered. The harassment or bullying risk score exceeded the threshold.",
+    "abusive_or_harmful.profanity": "ActiveFence moderation triggered. The profanity risk score exceeded the threshold.",
+    "abusive_or_harmful.hate_speech": "ActiveFence moderation triggered. The hate speech risk score exceeded the threshold.",
+    "abusive_or_harmful.child_grooming": "ActiveFence moderation triggered. The child grooming risk score exceeded the threshold.",
+    "abusive_or_harmful.general_violence": "ActiveFence moderation triggered. The general violence risk score exceeded the threshold.",
+    "self_harm.general": "ActiveFence moderation triggered. The self harm risk score exceeded the threshold.",
+    "adult_content.general": "ActiveFence moderation triggered. The adult content risk score exceeded the threshold.",
+    "privacy_violation.pii": "ActiveFence moderation triggered. The privacy violation risk score exceeded the threshold.",
+}
 
 
 def _activefence_simple_blocked(max_risk_score: float) -> bool:
     return max_risk_score > 0.7
 
 
-def _activefence_detailed_blocked(violations: dict[str, float]) -> bool:
-    return any(
-        violations.get(violation_type, 0) > threshold
-        for violation_type, threshold in ACTIVEFENCE_DETAILED_THRESHOLDS.items()
+def _activefence_triggered_violation(violations: dict[str, float]) -> Optional[str]:
+    return next(
+        (
+            violation_type
+            for violation_type, threshold in ACTIVEFENCE_DETAILED_THRESHOLDS.items()
+            if violations.get(violation_type, 0) > threshold
+        ),
+        None,
     )
 
 
@@ -53,19 +67,20 @@ def _activefence_outcome(
     violations: dict[str, float],
     threshold_mode: Literal["simple", "detailed"] = "simple",
 ) -> RailOutcome:
+    triggered_violation = _activefence_triggered_violation(violations) if threshold_mode == "detailed" else None
     metadata = {
         "max_risk_score": max_risk_score,
         "violations": violations,
         "threshold_mode": threshold_mode,
+        "triggered_violation": triggered_violation,
     }
-    blocked = (
-        _activefence_detailed_blocked(violations)
-        if threshold_mode == "detailed"
-        else _activefence_simple_blocked(max_risk_score)
-    )
-
-    if blocked:
-        return RailOutcome.block(metadata=metadata)
+    if triggered_violation is not None:
+        return RailOutcome.block(reason=ACTIVEFENCE_DETAILED_REASONS[triggered_violation], metadata=metadata)
+    if threshold_mode != "detailed" and _activefence_simple_blocked(max_risk_score):
+        return RailOutcome.block(
+            reason="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.",
+            metadata=metadata,
+        )
     return RailOutcome.allow(metadata=metadata)
 
 

--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -25,25 +25,39 @@ from nemoguardrails.utils import new_uuid
 
 log = logging.getLogger(__name__)
 
-ACTIVEFENCE_DETAILED_THRESHOLDS = {
-    "abusive_or_harmful.harassment_or_bullying": 0.8,
-    "abusive_or_harmful.profanity": 0.7,
-    "abusive_or_harmful.hate_speech": 0.6,
-    "abusive_or_harmful.child_grooming": 0.4,
-    "abusive_or_harmful.general_violence": 0.7,
-    "self_harm.general": 0.8,
-    "adult_content.general": 0.3,
-    "privacy_violation.pii": 0.8,
-}
-ACTIVEFENCE_DETAILED_REASONS = {
-    "abusive_or_harmful.harassment_or_bullying": "ActiveFence moderation triggered. The harassment or bullying risk score exceeded the threshold.",
-    "abusive_or_harmful.profanity": "ActiveFence moderation triggered. The profanity risk score exceeded the threshold.",
-    "abusive_or_harmful.hate_speech": "ActiveFence moderation triggered. The hate speech risk score exceeded the threshold.",
-    "abusive_or_harmful.child_grooming": "ActiveFence moderation triggered. The child grooming risk score exceeded the threshold.",
-    "abusive_or_harmful.general_violence": "ActiveFence moderation triggered. The general violence risk score exceeded the threshold.",
-    "self_harm.general": "ActiveFence moderation triggered. The self harm risk score exceeded the threshold.",
-    "adult_content.general": "ActiveFence moderation triggered. The adult content risk score exceeded the threshold.",
-    "privacy_violation.pii": "ActiveFence moderation triggered. The privacy violation risk score exceeded the threshold.",
+ACTIVEFENCE_DETAILED_RULES = {
+    "abusive_or_harmful.harassment_or_bullying": (
+        0.8,
+        "ActiveFence moderation triggered. The harassment or bullying risk score exceeded the threshold.",
+    ),
+    "abusive_or_harmful.profanity": (
+        0.7,
+        "ActiveFence moderation triggered. The profanity risk score exceeded the threshold.",
+    ),
+    "abusive_or_harmful.hate_speech": (
+        0.6,
+        "ActiveFence moderation triggered. The hate speech risk score exceeded the threshold.",
+    ),
+    "abusive_or_harmful.child_grooming": (
+        0.4,
+        "ActiveFence moderation triggered. The child grooming risk score exceeded the threshold.",
+    ),
+    "abusive_or_harmful.general_violence": (
+        0.7,
+        "ActiveFence moderation triggered. The general violence risk score exceeded the threshold.",
+    ),
+    "self_harm.general": (
+        0.8,
+        "ActiveFence moderation triggered. The self harm risk score exceeded the threshold.",
+    ),
+    "adult_content.general": (
+        0.3,
+        "ActiveFence moderation triggered. The adult content risk score exceeded the threshold.",
+    ),
+    "privacy_violation.pii": (
+        0.8,
+        "ActiveFence moderation triggered. The privacy violation risk score exceeded the threshold.",
+    ),
 }
 
 
@@ -55,7 +69,7 @@ def _activefence_triggered_violation(violations: dict[str, float]) -> Optional[s
     return next(
         (
             violation_type
-            for violation_type, threshold in ACTIVEFENCE_DETAILED_THRESHOLDS.items()
+            for violation_type, (threshold, _) in ACTIVEFENCE_DETAILED_RULES.items()
             if violations.get(violation_type, 0) > threshold
         ),
         None,
@@ -75,7 +89,8 @@ def _activefence_outcome(
         "triggered_violation": triggered_violation,
     }
     if triggered_violation is not None:
-        return RailOutcome.block(reason=ACTIVEFENCE_DETAILED_REASONS[triggered_violation], metadata=metadata)
+        reason = ACTIVEFENCE_DETAILED_RULES[triggered_violation][1]
+        return RailOutcome.block(reason=reason, metadata=metadata)
     if threshold_mode != "detailed" and _activefence_simple_blocked(max_risk_score):
         return RailOutcome.block(
             reason="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.",

--- a/nemoguardrails/library/activefence/flows.co
+++ b/nemoguardrails/library/activefence/flows.co
@@ -19,7 +19,7 @@ flow activefence moderation on input
 
   if $result.is_blocked
     if $system.config.enable_rails_exceptions
-      send ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+      send ActiveFenceModerationRailException(message=$result.reason)
     else
       bot refuse to respond
     abort
@@ -30,7 +30,7 @@ flow activefence moderation on output
 
   if $result.is_blocked
     if $system.config.enable_rails_exceptions
-      send ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+      send ActiveFenceModerationRailException(message=$result.reason)
     else
       bot refuse to respond
     abort
@@ -39,60 +39,54 @@ flow activefence moderation on input detailed
   """Guardrail based on individual risk scores."""
   $result = await  CallActivefenceApiAction(text=$user_message, threshold_mode="detailed")
 
-  if $result.metadata["violations"].get("abusive_or_harmful.harassment_or_bullying", 0) > 0.8
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceHarassmentRailException(message="ActiveFence moderation triggered. The harassment or bullying risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive_or_harmful behavior
-    abort
+  if $result.is_blocked
+    $triggered_violation = $result.metadata["triggered_violation"]
 
-  if $result.metadata["violations"].get("abusive_or_harmful.profanity", 0) > 0.7
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceProfanityRailException(message="ActiveFence moderation triggered. The profanity risk score exceeded the threshold.")
+    if $triggered_violation == "abusive_or_harmful.harassment_or_bullying"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceHarassmentRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive_or_harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.profanity"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceProfanityRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive_or_harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.hate_speech"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceHateSpeechRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive_or_harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.child_grooming"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceChildGroomingRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive_or_harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.general_violence"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceGeneralViolenceRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive_or_harmful behavior
+    else if $triggered_violation == "self_harm.general"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceSelfHarmRailException(message=$result.reason)
+      else
+        bot inform cannot engage in self harm behavior
+    else if $triggered_violation == "adult_content.general"
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceAdultContentRailException(message=$result.reason)
+      else
+        bot inform cannot engage with inappropriate content
+    else if $triggered_violation == "privacy_violation.pii"
+      if $system.config.enable_rails_exceptions
+        send ActiveFencePrivacyViolationRailException(message=$result.reason)
+      else
+        bot inform cannot engage with sensitive content
     else
-      bot inform cannot engage in abusive_or_harmful behavior
-    abort
-
-  if $result.metadata["violations"].get("abusive_or_harmful.hate_speech", 0) > 0.6
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceHateSpeechRailException(message="ActiveFence moderation triggered. The hate speech risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive_or_harmful behavior
-    abort
-
-  if $result.metadata["violations"].get("abusive_or_harmful.child_grooming", 0) > 0.4
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceChildGroomingRailException(message="ActiveFence moderation triggered. The child grooming risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive_or_harmful behavior
-    abort
-
-  if $result.metadata["violations"].get("abusive_or_harmful.general_violence", 0) > 0.7
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceGeneralViolenceRailException(message="ActiveFence moderation triggered. The general violence risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive_or_harmful behavior
-    abort
-
-  if $result.metadata["violations"].get("self_harm.general", 0) > 0.8
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceSelfHarmRailException(message="ActiveFence moderation triggered. The self harm risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in self harm behavior
-    abort
-
-  if $result.metadata["violations"].get("adult_content.general", 0) > 0.3
-    if $system.config.enable_rails_exceptions
-      send ActiveFenceAdultContentRailException(message="ActiveFence moderation triggered. The adult content risk score exceeded the threshold.")
-    else
-      bot inform cannot engage with inappropriate content
-    abort
-
-  if $result.metadata["violations"].get("privacy_violation.pii", 0) > 0.8
-    if $system.config.enable_rails_exceptions
-      send ActiveFencePrivacyViolationRailException(message="ActiveFence moderation triggered. The privacy violation risk score exceeded the threshold.")
-    else
-      bot inform cannot engage with sensitive content
+      if $system.config.enable_rails_exceptions
+        send ActiveFenceModerationRailException(message=$result.reason)
+      else
+        bot refuse to respond
     abort
 
 flow bot inform cannot engage in abusive_or_harmful behavior

--- a/nemoguardrails/library/activefence/flows.co
+++ b/nemoguardrails/library/activefence/flows.co
@@ -40,7 +40,7 @@ flow activefence moderation on input detailed
   $result = await  CallActivefenceApiAction(text=$user_message, threshold_mode="detailed")
 
   if $result.is_blocked
-    $triggered_violation = $result.metadata["triggered_violation"]
+    $triggered_violation = $result.metadata.get("triggered_violation")
 
     if $triggered_violation == "abusive_or_harmful.harassment_or_bullying"
       if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/activefence/flows.v1.co
+++ b/nemoguardrails/library/activefence/flows.v1.co
@@ -41,7 +41,7 @@ define subflow activefence moderation on input detailed
   $result = execute call_activefence_api(text=$user_message, threshold_mode="detailed")
 
   if $result.is_blocked
-    $triggered_violation = $result.metadata["triggered_violation"]
+    $triggered_violation = $result.metadata.get("triggered_violation")
 
     if $triggered_violation == "abusive_or_harmful.harassment_or_bullying"
       if $config.enable_rails_exceptions

--- a/nemoguardrails/library/activefence/flows.v1.co
+++ b/nemoguardrails/library/activefence/flows.v1.co
@@ -19,7 +19,7 @@ define subflow activefence moderation on input
 
   if $result.is_blocked
     if $config.enable_rails_exceptions
-      create event ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+      create event ActiveFenceModerationRailException(message=$result.reason)
     else
       bot refuse to respond
     stop
@@ -30,7 +30,7 @@ define subflow activefence moderation on input
 
   if $result.is_blocked
     if $config.enable_rails_exceptions
-      create event ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+      create event ActiveFenceModerationRailException(message=$result.reason)
     else
       bot refuse to respond
     stop
@@ -40,60 +40,54 @@ define subflow activefence moderation on input detailed
   """Guardrail based on individual risk scores."""
   $result = execute call_activefence_api(text=$user_message, threshold_mode="detailed")
 
-  if $result.metadata["violations"].get("abusive_or_harmful.harassment_or_bullying", 0) > 0.8
-    if $config.enable_rails_exceptions
-      create event ActiveFenceHarassmentRailException(message="ActiveFence moderation triggered. The harassment or bullying risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive or harmful behavior
-    stop
+  if $result.is_blocked
+    $triggered_violation = $result.metadata["triggered_violation"]
 
-  if $result.metadata["violations"].get("abusive_or_harmful.profanity", 0) > 0.7
-    if $config.enable_rails_exceptions
-      create event ActiveFenceProfanityRailException(message="ActiveFence moderation triggered. The profanity risk score exceeded the threshold.")
+    if $triggered_violation == "abusive_or_harmful.harassment_or_bullying"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceHarassmentRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.profanity"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceProfanityRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.hate_speech"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceHateSpeechRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.child_grooming"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceChildGroomingRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "abusive_or_harmful.general_violence"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceGeneralViolenceRailException(message=$result.reason)
+      else
+        bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "self_harm.general"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceSelfHarmRailException(message=$result.reason)
+      else
+        bot inform cannot engage in self harm behavior
+    else if $triggered_violation == "adult_content.general"
+      if $config.enable_rails_exceptions
+        create event ActiveFenceAdultContentRailException(message=$result.reason)
+      else
+        bot inform cannot engage with inappropriate content
+    else if $triggered_violation == "privacy_violation.pii"
+      if $config.enable_rails_exceptions
+        create event ActiveFencePrivacyViolationRailException(message=$result.reason)
+      else
+        bot inform cannot engage with sensitive content
     else
-      bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("abusive_or_harmful.hate_speech", 0) > 0.6
-    if $config.enable_rails_exceptions
-      create event ActiveFenceHateSpeechRailException(message="ActiveFence moderation triggered. The hate speech risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("abusive_or_harmful.child_grooming", 0) > 0.4
-    if $config.enable_rails_exceptions
-      create event ActiveFenceChildGroomingRailException(message="ActiveFence moderation triggered. The child grooming risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("abusive_or_harmful.general_violence", 0) > 0.7
-    if $config.enable_rails_exceptions
-      create event ActiveFenceGeneralViolenceRailException(message="ActiveFence moderation triggered. The general violence risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("self_harm.general", 0) > 0.8
-    if $config.enable_rails_exceptions
-      create event ActiveFenceSelfHarmRailException(message="ActiveFence moderation triggered. The self harm risk score exceeded the threshold.")
-    else
-      bot inform cannot engage in self harm behavior
-    stop
-
-  if $result.metadata["violations"].get("adult_content.general", 0) > 0.3
-    if $config.enable_rails_exceptions
-      create event ActiveFenceAdultContentRailException(message="ActiveFence moderation triggered. The adult content risk score exceeded the threshold.")
-    else
-      bot inform cannot engage with inappropriate content
-    stop
-
-  if $result.metadata["violations"].get("privacy_violation.pii", 0) > 0.8
-    if $config.enable_rails_exceptions
-      create event ActiveFencePrivacyViolationRailException(message="ActiveFence moderation triggered. The privacy violation risk score exceeded the threshold.")
-    else
-      bot inform cannot engage with sensitive content
+      if $config.enable_rails_exceptions
+        create event ActiveFenceModerationRailException(message=$result.reason)
+      else
+        bot refuse to respond
     stop
 
 define bot inform cannot engage in abusive or harmful behavior

--- a/nemoguardrails/library/gcp_moderate_text/actions.py
+++ b/nemoguardrails/library/gcp_moderate_text/actions.py
@@ -45,8 +45,11 @@ def _gcp_text_simple_blocked(max_risk_score: float) -> bool:
     return max_risk_score > 0.8
 
 
-def _gcp_text_detailed_blocked(violations: dict[str, float]) -> bool:
-    return any(violations.get(name, 0) > threshold for name, threshold in GCP_TEXT_DETAILED_THRESHOLDS.items())
+def _gcp_text_triggered_violation(violations: dict[str, float]) -> Optional[str]:
+    return next(
+        (name for name, threshold in GCP_TEXT_DETAILED_THRESHOLDS.items() if violations.get(name, 0) > threshold),
+        None,
+    )
 
 
 def _gcp_text_moderation_outcome(
@@ -54,18 +57,23 @@ def _gcp_text_moderation_outcome(
     violations: dict[str, float],
     threshold_mode: Literal["simple", "detailed"] = "simple",
 ) -> RailOutcome:
+    triggered_violation = _gcp_text_triggered_violation(violations) if threshold_mode == "detailed" else None
     metadata = {
         "max_risk_score": max_risk_score,
         "violations": violations,
         "threshold_mode": threshold_mode,
+        "triggered_violation": triggered_violation,
     }
-    blocked = (
-        _gcp_text_detailed_blocked(violations)
-        if threshold_mode == "detailed"
-        else _gcp_text_simple_blocked(max_risk_score)
-    )
-    if blocked:
-        return RailOutcome.block(metadata=metadata)
+    if triggered_violation is not None:
+        return RailOutcome.block(
+            reason=f"GCP text moderation triggered. {triggered_violation} exceeded the threshold.",
+            metadata=metadata,
+        )
+    if threshold_mode != "detailed" and _gcp_text_simple_blocked(max_risk_score):
+        return RailOutcome.block(
+            reason="GCP text moderation triggered. The maximum risk score exceeded the threshold.",
+            metadata=metadata,
+        )
     return RailOutcome.allow(metadata=metadata)
 
 

--- a/nemoguardrails/library/gcp_moderate_text/flows.co
+++ b/nemoguardrails/library/gcp_moderate_text/flows.co
@@ -38,7 +38,7 @@ define subflow gcpnlp moderation detailed
   $result = execute call gcpnlp api(threshold_mode="detailed")
 
   if $result.is_blocked
-    $triggered_violation = $result.metadata["triggered_violation"]
+    $triggered_violation = $result.metadata.get("triggered_violation")
 
     if $triggered_violation == "Toxic"
       bot inform cannot engage in abusive or harmful behavior

--- a/nemoguardrails/library/gcp_moderate_text/flows.co
+++ b/nemoguardrails/library/gcp_moderate_text/flows.co
@@ -37,68 +37,43 @@ define subflow gcpnlp moderation detailed
   """Guardrail based on individual risk scores."""
   $result = execute call gcpnlp api(threshold_mode="detailed")
 
-  if $result.metadata["violations"].get("Toxic", 0) > 0.8
-    bot inform cannot engage in abusive or harmful behavior
-    stop
+  if $result.is_blocked
+    $triggered_violation = $result.metadata["triggered_violation"]
 
-  if $result.metadata["violations"].get("Insult", 0) > 0.7
-    bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("Profanity", 0) > 0.6
-    bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("Derogatory", 0) > 0.4
-    bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("Violent", 0) > 0.8
-    bot inform cannot engage in abusive or harmful behavior
-    stop
-
-  if $result.metadata["violations"].get("Sexual", 0) > 0.7
-    bot inform cannot engage in inappropriate content
-    stop
-
-  if $result.metadata["violations"].get("Death, Harm & Tragedy", 0) > 0.8
-    bot inform cannot engage in inappropriate content
-    stop
-
-  if $result.metadata["violations"].get("Firearms & Weapons", 0) > 0.8
-    bot inform cannot engage in inappropriate content
-    stop
-
-  if $result.metadata["violations"].get("Illicit Drugs", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Public Safety", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Health", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Religion & Belief", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("War & Conflict", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Politics", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Finance", 0) > 0.8
-    bot inform cannot engage with sensitive content
-    stop
-
-  if $result.metadata["violations"].get("Legal", 0) > 0.8
-    bot inform cannot engage with sensitive content
+    if $triggered_violation == "Toxic"
+      bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "Insult"
+      bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "Profanity"
+      bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "Derogatory"
+      bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "Violent"
+      bot inform cannot engage in abusive or harmful behavior
+    else if $triggered_violation == "Sexual"
+      bot inform cannot engage in inappropriate content
+    else if $triggered_violation == "Death, Harm & Tragedy"
+      bot inform cannot engage in inappropriate content
+    else if $triggered_violation == "Firearms & Weapons"
+      bot inform cannot engage in inappropriate content
+    else if $triggered_violation == "Illicit Drugs"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Public Safety"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Health"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Religion & Belief"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "War & Conflict"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Politics"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Finance"
+      bot inform cannot engage with sensitive content
+    else if $triggered_violation == "Legal"
+      bot inform cannot engage with sensitive content
+    else
+      bot refuse to respond
     stop
 
 

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -370,6 +370,18 @@ class TestIORailsUnsupportedReason:
         reason = IORails.unsupported_reason(config, llm=None)
         assert reason == "config has unsupported output flows: ['self check output']"
 
+    @pytest.mark.parametrize(
+        "flow",
+        ["activefence moderation on input detailed", "gcpnlp moderation detailed"],
+    )
+    def test_detailed_flow_without_iorails_adapter_reports_offender(self, flow):
+        """Detailed flows remain unsupported until IORails has an adapter for them."""
+        config = _make_iorails_config(rails={"input": {"flows": [flow]}})
+
+        reason = IORails.unsupported_reason(config, llm=None)
+
+        assert reason == f"config has unsupported input flows: ['{flow}']"
+
     def test_llm_takes_precedence_over_config_issues(self):
         """When both llm is provided and the config has unsupported flows, the llm
         reason is reported first so the user fixes one issue at a time."""

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -2131,7 +2131,10 @@ FIXTURES = [
     _case(
         "activefence_input_detailed_fails_closed_without_trigger_metadata",
         ACTIVEFENCE_INPUT_DETAILED,
-        _risk_outcome(0.31, blocked=True, threshold_mode="detailed"),
+        RailOutcome.block(
+            reason="Moderation threshold exceeded.",
+            metadata={"max_risk_score": 0.31, "violations": {}, "threshold_mode": "detailed"},
+        ),
         ObservableOutcome.REFUSAL,
         FlowDecision.BLOCK,
     ),
@@ -2173,7 +2176,10 @@ FIXTURES = [
     _case(
         "gcp_moderation_output_detailed_fails_closed_without_trigger_metadata",
         GCP_MODERATION_OUTPUT_DETAILED,
-        _risk_outcome(0.41, blocked=True, threshold_mode="detailed"),
+        RailOutcome.block(
+            reason="Moderation threshold exceeded.",
+            metadata={"max_risk_score": 0.41, "violations": {}, "threshold_mode": "detailed"},
+        ),
         ObservableOutcome.REFUSAL,
         FlowDecision.BLOCK,
     ),
@@ -2470,6 +2476,16 @@ def test_runtime_flow_gate_matches_rail_outcome(case: FlowEquivalenceCase):
                 triggered_violation="adult_content.general",
             ),
             "I will not engage with inappropriate content.",
+        ),
+        (
+            "activefence",
+            "activefence moderation on input detailed",
+            "call_activefence_api",
+            RailOutcome.block(
+                reason="Moderation threshold exceeded.",
+                metadata={"max_risk_score": 0.31, "violations": {}, "threshold_mode": "detailed"},
+            ),
+            REFUSAL,
         ),
     ],
 )

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -624,17 +624,17 @@ ACTIVEFENCE_INPUT_DETAILED = RailSpec(
     action="call_activefence_api",
 )
 
-GCP_MODERATION_OUTPUT = RailSpec(
-    name="gcp_moderation_output",
+GCP_MODERATION_INPUT = RailSpec(
+    name="gcp_moderation_input",
     flow="gcpnlp moderation",
-    direction="output",
+    direction="input",
     action="call gcpnlp api",
 )
 
-GCP_MODERATION_OUTPUT_DETAILED = RailSpec(
-    name="gcp_moderation_output_detailed",
+GCP_MODERATION_INPUT_DETAILED = RailSpec(
+    name="gcp_moderation_input_detailed",
     flow="gcpnlp moderation detailed",
-    direction="output",
+    direction="input",
     action="call gcpnlp api",
 )
 
@@ -2139,29 +2139,29 @@ FIXTURES = [
         FlowDecision.BLOCK,
     ),
     _case(
-        "gcp_moderation_output_allows_at_simple_threshold",
-        GCP_MODERATION_OUTPUT,
+        "gcp_moderation_input_allows_at_simple_threshold",
+        GCP_MODERATION_INPUT,
         _risk_outcome(0.8, blocked=False, threshold_mode="simple"),
         ObservableOutcome.ALLOW,
         FlowDecision.ALLOW,
     ),
     _case(
-        "gcp_moderation_output_blocks_above_simple_threshold",
-        GCP_MODERATION_OUTPUT,
+        "gcp_moderation_input_blocks_above_simple_threshold",
+        GCP_MODERATION_INPUT,
         _risk_outcome(0.81, blocked=True, threshold_mode="simple"),
         ObservableOutcome.REFUSAL,
         FlowDecision.BLOCK,
     ),
     _case(
-        "gcp_moderation_output_detailed_allows_at_derogatory_threshold",
-        GCP_MODERATION_OUTPUT_DETAILED,
+        "gcp_moderation_input_detailed_allows_at_derogatory_threshold",
+        GCP_MODERATION_INPUT_DETAILED,
         _risk_outcome(0.4, blocked=False, threshold_mode="detailed", violations={"Derogatory": 0.4}),
         ObservableOutcome.ALLOW,
         FlowDecision.ALLOW,
     ),
     _case(
-        "gcp_moderation_output_detailed_blocks_above_derogatory_threshold",
-        GCP_MODERATION_OUTPUT_DETAILED,
+        "gcp_moderation_input_detailed_blocks_above_derogatory_threshold",
+        GCP_MODERATION_INPUT_DETAILED,
         _risk_outcome(
             0.41,
             blocked=True,
@@ -2174,8 +2174,8 @@ FIXTURES = [
         expected_content="I will not engage in any abusive or harmful behavior.",
     ),
     _case(
-        "gcp_moderation_output_detailed_fails_closed_without_trigger_metadata",
-        GCP_MODERATION_OUTPUT_DETAILED,
+        "gcp_moderation_input_detailed_fails_closed_without_trigger_metadata",
+        GCP_MODERATION_INPUT_DETAILED,
         RailOutcome.block(
             reason="Moderation threshold exceeded.",
             metadata={"max_risk_score": 0.41, "violations": {}, "threshold_mode": "detailed"},

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -115,8 +115,6 @@ HF_CLASSIFIER_RAILS_CONFIG = {
 INJECTION_DETECTION_REJECT_RAILS_CONFIG = {"injection_detection": {"action": "reject"}}
 INJECTION_DETECTION_OMIT_RAILS_CONFIG = {"injection_detection": {"action": "omit"}}
 GUARDRAILS_AI_RAILS_CONFIG = {"guardrails_ai": {"validators": [{"name": "regex_match"}]}}
-ACTIVEFENCE_DETAILED_THRESHOLDS = {"adult_content.general": 0.3}
-GCP_DETAILED_THRESHOLDS = {"Derogatory": 0.4}
 
 
 def _blocked_if_regex_match(raw_return: Any) -> FlowDecision:
@@ -137,26 +135,6 @@ def _transform_if_false(raw_return: Any) -> FlowDecision:
 
 def _blocked_if_is_blocked(raw_return: Any) -> FlowDecision:
     return FlowDecision.BLOCK if raw_return["is_blocked"] else FlowDecision.ALLOW
-
-
-def _blocked_if_activefence_simple(raw_return: Any) -> FlowDecision:
-    return FlowDecision.BLOCK if raw_return["max_risk_score"] > 0.7 else FlowDecision.ALLOW
-
-
-def _blocked_if_activefence_detailed(raw_return: Any) -> FlowDecision:
-    violations = raw_return.get("violations", {})
-    blocked = any(violations.get(name, 0) > threshold for name, threshold in ACTIVEFENCE_DETAILED_THRESHOLDS.items())
-    return FlowDecision.BLOCK if blocked else FlowDecision.ALLOW
-
-
-def _blocked_if_gcp_simple(raw_return: Any) -> FlowDecision:
-    return FlowDecision.BLOCK if raw_return["max_risk_score"] > 0.8 else FlowDecision.ALLOW
-
-
-def _blocked_if_gcp_detailed(raw_return: Any) -> FlowDecision:
-    violations = raw_return.get("violations", {})
-    blocked = any(violations.get(name, 0) > threshold for name, threshold in GCP_DETAILED_THRESHOLDS.items())
-    return FlowDecision.BLOCK if blocked else FlowDecision.ALLOW
 
 
 def _transform_if_changed_from_normal_output(raw_return: Any) -> FlowDecision:
@@ -1116,14 +1094,17 @@ def _risk_outcome(
     blocked: bool,
     threshold_mode: str,
     violations: dict[str, float] | None = None,
+    triggered_violation: str | None = None,
+    reason: str | None = None,
 ) -> RailOutcome:
     metadata = {
         "max_risk_score": max_risk_score,
         "violations": violations or {},
         "threshold_mode": threshold_mode,
+        "triggered_violation": triggered_violation,
     }
     if blocked:
-        return RailOutcome.block(metadata=metadata)
+        return RailOutcome.block(reason=reason or "Moderation threshold exceeded.", metadata=metadata)
     return RailOutcome.allow(metadata=metadata)
 
 
@@ -2127,6 +2108,7 @@ FIXTURES = [
             blocked=True,
             threshold_mode="detailed",
             violations={"adult_content.general": 0.31},
+            triggered_violation="adult_content.general",
         ),
         ObservableOutcome.REFUSAL,
         FlowDecision.BLOCK,
@@ -2140,10 +2122,18 @@ FIXTURES = [
             blocked=True,
             threshold_mode="detailed",
             violations={"adult_content.general": 0.31},
+            triggered_violation="adult_content.general",
         ),
         ObservableOutcome.EXCEPTION,
         FlowDecision.BLOCK,
         enable_rails_exceptions=True,
+    ),
+    _case(
+        "activefence_input_detailed_fails_closed_without_trigger_metadata",
+        ACTIVEFENCE_INPUT_DETAILED,
+        _risk_outcome(0.31, blocked=True, threshold_mode="detailed"),
+        ObservableOutcome.REFUSAL,
+        FlowDecision.BLOCK,
     ),
     _case(
         "gcp_moderation_output_allows_at_simple_threshold",
@@ -2169,10 +2159,23 @@ FIXTURES = [
     _case(
         "gcp_moderation_output_detailed_blocks_above_derogatory_threshold",
         GCP_MODERATION_OUTPUT_DETAILED,
-        _risk_outcome(0.41, blocked=True, threshold_mode="detailed", violations={"Derogatory": 0.41}),
+        _risk_outcome(
+            0.41,
+            blocked=True,
+            threshold_mode="detailed",
+            violations={"Derogatory": 0.41},
+            triggered_violation="Derogatory",
+        ),
         ObservableOutcome.REFUSAL,
         FlowDecision.BLOCK,
         expected_content="I will not engage in any abusive or harmful behavior.",
+    ),
+    _case(
+        "gcp_moderation_output_detailed_fails_closed_without_trigger_metadata",
+        GCP_MODERATION_OUTPUT_DETAILED,
+        _risk_outcome(0.41, blocked=True, threshold_mode="detailed"),
+        ObservableOutcome.REFUSAL,
+        FlowDecision.BLOCK,
     ),
     _case(
         "guardrails_ai_input_allows_valid",
@@ -2450,3 +2453,54 @@ def test_runtime_flow_gate_matches_rail_outcome(case: FlowEquivalenceCase):
         assert response == {"role": "assistant", "content": case.expected_content}
     if case.expected_output_data is not None:
         assert output_data == case.expected_output_data
+
+
+@pytest.mark.parametrize(
+    ("module", "flow", "action_name", "outcome", "expected"),
+    [
+        (
+            "activefence",
+            "activefence moderation on input detailed",
+            "call_activefence_api",
+            _risk_outcome(
+                0.31,
+                blocked=True,
+                threshold_mode="detailed",
+                violations={"adult_content.general": 0.31},
+                triggered_violation="adult_content.general",
+            ),
+            "I will not engage with inappropriate content.",
+        ),
+    ],
+)
+def test_colang_2_detailed_moderation_renders_action_verdict(module, flow, action_name, outcome, expected):
+    """Colang 2 uses the action verdict while preserving its legacy response."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            colang_version: 2.x
+            models: []
+        """,
+        colang_content=f"""
+            import core
+            import llm
+            import guardrails
+            import nemoguardrails.library.{module}
+
+            flow input rails $input_text
+              {flow}
+
+            flow main
+              activate llm continuation
+              user said something
+              bot say "{NORMAL_OUTPUT}"
+        """,
+    )
+    chat = TestChat(config)
+
+    async def stub_action(**kwargs):
+        return outcome
+
+    chat.app.register_action(stub_action, action_name)
+
+    chat >> USER_INPUT
+    chat << expected

--- a/tests/test_vendor_block_actions.py
+++ b/tests/test_vendor_block_actions.py
@@ -16,12 +16,15 @@
 import pytest
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
-from nemoguardrails.library.activefence.actions import _activefence_outcome
+from nemoguardrails.library.activefence.actions import ACTIVEFENCE_DETAILED_THRESHOLDS, _activefence_outcome
 from nemoguardrails.library.ai_defense.actions import _ai_defense_outcome
 from nemoguardrails.library.clavata.actions import _clavata_outcome
 from nemoguardrails.library.cleanlab.actions import _cleanlab_outcome
 from nemoguardrails.library.fiddler.actions import _fiddler_outcome
-from nemoguardrails.library.gcp_moderate_text.actions import _gcp_text_moderation_outcome
+from nemoguardrails.library.gcp_moderate_text.actions import (
+    GCP_TEXT_DETAILED_THRESHOLDS,
+    _gcp_text_moderation_outcome,
+)
 from nemoguardrails.library.trend_micro.actions import GuardResult, _trend_micro_outcome
 
 
@@ -109,6 +112,10 @@ def test_activefence_outcome_pins_simple_and_detailed_thresholds(
     assert outcome.metadata["max_risk_score"] == max_risk_score
     assert outcome.metadata["violations"] == violations
     assert outcome.metadata["threshold_mode"] == threshold_mode
+    assert outcome.metadata["triggered_violation"] == (
+        "adult_content.general" if threshold_mode == "detailed" and expected_blocked else None
+    )
+    assert bool(outcome.reason) is expected_blocked
 
 
 @pytest.mark.parametrize(
@@ -133,3 +140,62 @@ def test_gcp_text_moderation_outcome_pins_simple_and_detailed_thresholds(
     assert outcome.metadata["max_risk_score"] == max_risk_score
     assert outcome.metadata["violations"] == violations
     assert outcome.metadata["threshold_mode"] == threshold_mode
+    assert outcome.metadata["triggered_violation"] == (
+        "Derogatory" if threshold_mode == "detailed" and expected_blocked else None
+    )
+    assert bool(outcome.reason) is expected_blocked
+
+
+@pytest.mark.parametrize(("violation", "threshold"), ACTIVEFENCE_DETAILED_THRESHOLDS.items())
+def test_activefence_detailed_outcome_owns_each_threshold(violation, threshold):
+    at_threshold = _activefence_outcome(threshold, {violation: threshold}, "detailed")
+    above_threshold = _activefence_outcome(threshold + 0.01, {violation: threshold + 0.01}, "detailed")
+
+    assert at_threshold == RailOutcome.allow(
+        metadata={
+            "max_risk_score": threshold,
+            "violations": {violation: threshold},
+            "threshold_mode": "detailed",
+            "triggered_violation": None,
+        }
+    )
+    assert above_threshold.is_blocked
+    assert above_threshold.metadata["triggered_violation"] == violation
+    assert above_threshold.reason
+
+
+@pytest.mark.parametrize(("violation", "threshold"), GCP_TEXT_DETAILED_THRESHOLDS.items())
+def test_gcp_detailed_outcome_owns_each_threshold(violation, threshold):
+    at_threshold = _gcp_text_moderation_outcome(threshold, {violation: threshold}, "detailed")
+    above_threshold = _gcp_text_moderation_outcome(threshold + 0.01, {violation: threshold + 0.01}, "detailed")
+
+    assert at_threshold == RailOutcome.allow(
+        metadata={
+            "max_risk_score": threshold,
+            "violations": {violation: threshold},
+            "threshold_mode": "detailed",
+            "triggered_violation": None,
+        }
+    )
+    assert above_threshold.is_blocked
+    assert above_threshold.metadata["triggered_violation"] == violation
+    assert above_threshold.reason
+
+
+def test_detailed_outcomes_preserve_legacy_first_match_order():
+    activefence = _activefence_outcome(
+        0.91,
+        {
+            "adult_content.general": 0.91,
+            "abusive_or_harmful.harassment_or_bullying": 0.91,
+        },
+        "detailed",
+    )
+    gcp = _gcp_text_moderation_outcome(
+        0.91,
+        {"Derogatory": 0.91, "Toxic": 0.91},
+        "detailed",
+    )
+
+    assert activefence.metadata["triggered_violation"] == "abusive_or_harmful.harassment_or_bullying"
+    assert gcp.metadata["triggered_violation"] == "Toxic"

--- a/tests/test_vendor_block_actions.py
+++ b/tests/test_vendor_block_actions.py
@@ -16,7 +16,7 @@
 import pytest
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
-from nemoguardrails.library.activefence.actions import ACTIVEFENCE_DETAILED_THRESHOLDS, _activefence_outcome
+from nemoguardrails.library.activefence.actions import ACTIVEFENCE_DETAILED_RULES, _activefence_outcome
 from nemoguardrails.library.ai_defense.actions import _ai_defense_outcome
 from nemoguardrails.library.clavata.actions import _clavata_outcome
 from nemoguardrails.library.cleanlab.actions import _cleanlab_outcome
@@ -146,8 +146,11 @@ def test_gcp_text_moderation_outcome_pins_simple_and_detailed_thresholds(
     assert bool(outcome.reason) is expected_blocked
 
 
-@pytest.mark.parametrize(("violation", "threshold"), ACTIVEFENCE_DETAILED_THRESHOLDS.items())
-def test_activefence_detailed_outcome_owns_each_threshold(violation, threshold):
+@pytest.mark.parametrize(
+    ("violation", "threshold", "reason"),
+    [(violation, threshold, reason) for violation, (threshold, reason) in ACTIVEFENCE_DETAILED_RULES.items()],
+)
+def test_activefence_detailed_outcome_owns_each_rule(violation, threshold, reason):
     at_threshold = _activefence_outcome(threshold, {violation: threshold}, "detailed")
     above_threshold = _activefence_outcome(threshold + 0.01, {violation: threshold + 0.01}, "detailed")
 
@@ -161,7 +164,7 @@ def test_activefence_detailed_outcome_owns_each_threshold(violation, threshold):
     )
     assert above_threshold.is_blocked
     assert above_threshold.metadata["triggered_violation"] == violation
-    assert above_threshold.reason
+    assert above_threshold.reason == reason
 
 
 @pytest.mark.parametrize(("violation", "threshold"), GCP_TEXT_DETAILED_THRESHOLDS.items())


### PR DESCRIPTION
## Description

follow-up on #2151 and https://github.com/NVIDIA-NeMo/Guardrails/pull/2151/changes#r3578955885 , https://github.com/NVIDIA-NeMo/Guardrails/pull/2151/changes#r3578957884


## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detailed moderation now identifies the specific policy category that triggered a block.
  - Blocked content receives clearer, category-specific explanations and refusal messages.
  - Moderation exceptions now include the applicable reason instead of a generic threshold message.
  - Updated moderation flows provide consistent behavior across ActiveFence and Google Cloud moderation.

- **Bug Fixes**
  - Detailed moderation now safely refuses content when violation details are unavailable or unrecognized.
  - Improved handling of multiple simultaneous policy violations while preserving predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->