### PR TITLE
refactor(actions): resolve manifest actions lazily

### DIFF
--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -231,7 +231,7 @@ class ActionDispatcher:
             for action_ref in manifest.actions.refs:
                 self._register_action_ref(action_ref)
             if manifest.origin:
-                module = __import__(manifest.origin, fromlist=["__file__"])
+                module = importlib.import_module(manifest.origin)
                 module_file = getattr(module, "__file__", None)
                 if module_file:
                     self._manifested_library_paths.add(Path(module_file).parent.resolve())

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -86,6 +86,7 @@ class ActionDispatcher:
 
         self._registered_actions: Dict[str, RegisteredAction] = {}
         self._lazy_action_refs: Dict[str, ActionRef] = {}
+        self._manifest_action_names: set[str] = set()
         self._manifested_library_paths: set[Path] = set()
         self._rail_catalog = rail_catalog
         self._registered_actions_view = _RegisteredActions(self)
@@ -152,6 +153,7 @@ class ActionDispatcher:
             self._registered_actions.update(actions)
             for action_name in actions:
                 self._lazy_action_refs.pop(action_name, None)
+                self._manifest_action_names.discard(action_name)
 
         actions_py_path = os.path.join(path, "actions.py")
         if os.path.exists(actions_py_path):
@@ -159,6 +161,7 @@ class ActionDispatcher:
             self._registered_actions.update(actions)
             for action_name in actions:
                 self._lazy_action_refs.pop(action_name, None)
+                self._manifest_action_names.discard(action_name)
 
     def register_action(self, action: RegisteredAction, name: Optional[str] = None, override: bool = True):
         """Registers an action with the given name.
@@ -182,6 +185,7 @@ class ActionDispatcher:
                 return
 
         self._lazy_action_refs.pop(action_name, None)
+        self._manifest_action_names.discard(action_name)
         self._registered_actions[action_name] = action
 
     def _has_action_name(self, action_name: str) -> bool:
@@ -197,6 +201,7 @@ class ActionDispatcher:
             return
         self._registered_actions.pop(action_ref.name, None)
         self._lazy_action_refs[action_ref.name] = action_ref
+        self._manifest_action_names.add(action_ref.name)
 
     def register_actions(self, actions_obj: Any, override: bool = True):
         """Registers all the actions from the given object.
@@ -266,6 +271,10 @@ class ActionDispatcher:
         """Check if an action is registered."""
         name = self._normalize_action_name(name)
         return self._has_action_name(name)
+
+    def is_manifest_action(self, name: str) -> bool:
+        name = self._normalize_action_name(name)
+        return name in self._manifest_action_names
 
     def get_action(self, name: str) -> Optional[RegisteredAction]:
         """Get the registered action by name.

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -262,6 +262,11 @@ class ActionDispatcher:
 
         return action
 
+    @staticmethod
+    def _sanitize_for_log(value: Any) -> str:
+        """Sanitize values before logging to prevent log injection."""
+        return str(value).replace("\r", "\\r").replace("\n", "\\n")
+
     def _normalize_action_name(self, name: str) -> str:
         """Normalize the action name to the required format."""
         if not self._has_action_name(name):
@@ -292,7 +297,7 @@ class ActionDispatcher:
         try:
             return self._resolve_registered_action(name)
         except Exception:
-            log.exception("Failed to resolve action '%s'.", name)
+            log.exception("Failed to resolve action '%s'.", self._sanitize_for_log(name))
             return None
 
     async def execute_action(
@@ -315,7 +320,7 @@ class ActionDispatcher:
             try:
                 maybe_fn = self._resolve_registered_action(action_name)
             except Exception:
-                log.exception("Failed to resolve action '%s'.", action_name)
+                log.exception("Failed to resolve action '%s'.", self._sanitize_for_log(action_name))
                 return None, "failed"
             if not maybe_fn:
                 raise Exception(f"Action '{action_name}' is not registered.")

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -63,6 +63,9 @@ class _RegisteredActions(Mapping[str, RegisteredAction]):
     def __len__(self) -> int:
         return len(self._dispatcher._action_names())
 
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and self._dispatcher._has_action_name(name)
+
 
 class ActionDispatcher:
     def __init__(

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -19,12 +19,14 @@ import importlib.util
 import inspect
 import logging
 import os
+from collections.abc import Iterator, Mapping
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol, Tuple, Type, TypeAlias, Union, cast
 
 from nemoguardrails import utils
 from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.manifests import ActionRef, RailCatalog, default_rail_catalog, resolve_import_ref
 
 log = logging.getLogger(__name__)
 
@@ -45,12 +47,30 @@ RegisteredAction: TypeAlias = Union[
 ]
 
 
+class _RegisteredActions(Mapping[str, RegisteredAction]):
+    def __init__(self, dispatcher: "ActionDispatcher") -> None:
+        self._dispatcher = dispatcher
+
+    def __getitem__(self, name: str) -> RegisteredAction:
+        action = self._dispatcher.get_action(name)
+        if action is None:
+            raise KeyError(name)
+        return action
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._dispatcher._action_names())
+
+    def __len__(self) -> int:
+        return len(self._dispatcher._action_names())
+
+
 class ActionDispatcher:
     def __init__(
         self,
         load_all_actions: bool = True,
         config_path: Optional[str] = None,
         import_paths: Optional[List[str]] = None,
+        rail_catalog: Optional[RailCatalog] = None,
     ):
         """
         Initializes an actions dispatcher.
@@ -65,8 +85,14 @@ class ActionDispatcher:
         log.info("Initializing action dispatcher")
 
         self._registered_actions: Dict[str, RegisteredAction] = {}
+        self._lazy_action_refs: Dict[str, ActionRef] = {}
+        self._manifested_library_paths: set[Path] = set()
+        self._rail_catalog = rail_catalog
+        self._registered_actions_view = _RegisteredActions(self)
 
         if load_all_actions:
+            if self._rail_catalog is None:
+                self._rail_catalog = default_rail_catalog()
             # TODO: check for better way to find actions dir path or use constants.py
             current_file_path = Path(__file__).resolve()
             parent_directory_path = current_file_path.parents[1]
@@ -75,14 +101,9 @@ class ActionDispatcher:
             self.load_actions_from_path(parent_directory_path)
             # self.load_actions_from_path(os.path.join(os.path.dirname(__file__), ".."))
 
-            # Next, we load all actions from the library folder
             library_path = parent_directory_path / "library"
-
-            for root, dirs, files in os.walk(library_path):
-                # We only load the actions if there is an `actions` sub-folder or
-                # an `actions.py` file.
-                if "actions" in dirs or "actions.py" in files:
-                    self.load_actions_from_path(Path(root))
+            self._register_manifest_action_refs()
+            self._load_unmanifested_library_actions(library_path)
 
             # Next, we load all actions from the current working directory
             # TODO: add support for an explicit ACTIONS_PATH
@@ -103,7 +124,7 @@ class ActionDispatcher:
                 for import_path in import_paths:
                     self.load_actions_from_path(Path(import_path.strip()))
 
-        log.info(f"Registered Actions :: {sorted(self._registered_actions.keys())}")
+        log.info(f"Registered Actions :: {sorted(self.get_registered_actions())}")
         log.info("Action dispatcher initialized")
 
     @property
@@ -113,7 +134,7 @@ class ActionDispatcher:
         Returns:
             dict: A dictionary where keys are action names and values are callable action functions.
         """
-        return self._registered_actions
+        return self._registered_actions_view
 
     def load_actions_from_path(self, path: Path):
         """Loads all actions from the specified path.
@@ -127,11 +148,17 @@ class ActionDispatcher:
         """
         actions_path = path / "actions"
         if os.path.exists(actions_path):
-            self._registered_actions.update(self._find_actions(actions_path))
+            actions = self._find_actions(actions_path)
+            self._registered_actions.update(actions)
+            for action_name in actions:
+                self._lazy_action_refs.pop(action_name, None)
 
         actions_py_path = os.path.join(path, "actions.py")
         if os.path.exists(actions_py_path):
-            self._registered_actions.update(self._load_actions_from_module(actions_py_path))
+            actions = self._load_actions_from_module(actions_py_path)
+            self._registered_actions.update(actions)
+            for action_name in actions:
+                self._lazy_action_refs.pop(action_name, None)
 
     def register_action(self, action: RegisteredAction, name: Optional[str] = None, override: bool = True):
         """Registers an action with the given name.
@@ -150,10 +177,26 @@ class ActionDispatcher:
             action_name = name
 
         # If we're not allowed to override, we stop.
-        if action_name in self._registered_actions and not override:
-            return
+        if action_name in self._registered_actions or action_name in self._lazy_action_refs:
+            if not override:
+                return
 
+        self._lazy_action_refs.pop(action_name, None)
         self._registered_actions[action_name] = action
+
+    def _has_action_name(self, action_name: str) -> bool:
+        return action_name in self._registered_actions or action_name in self._lazy_action_refs
+
+    def _action_names(self) -> tuple[str, ...]:
+        return tuple(self._registered_actions) + tuple(
+            name for name in self._lazy_action_refs if name not in self._registered_actions
+        )
+
+    def _register_action_ref(self, action_ref: ActionRef, override: bool = True) -> None:
+        if self._has_action_name(action_ref.name) and not override:
+            return
+        self._registered_actions.pop(action_ref.name, None)
+        self._lazy_action_refs[action_ref.name] = action_ref
 
     def register_actions(self, actions_obj: Any, override: bool = True):
         """Registers all the actions from the given object.
@@ -170,9 +213,50 @@ class ActionDispatcher:
             if hasattr(val, "action_meta"):
                 self.register_action(val, override=override)
 
+    def _register_manifest_action_refs(self) -> None:
+        if self._rail_catalog is None:
+            return
+        for record in self._rail_catalog.records.values():
+            manifest = record.manifest
+            if manifest.actions is None:
+                continue
+            for action_ref in manifest.actions.refs:
+                self._register_action_ref(action_ref)
+            if manifest.origin:
+                module = __import__(manifest.origin, fromlist=["__file__"])
+                module_file = getattr(module, "__file__", None)
+                if module_file:
+                    self._manifested_library_paths.add(Path(module_file).parent.resolve())
+
+    def _load_unmanifested_library_actions(self, library_path: Path) -> None:
+        for root, dirs, files in os.walk(library_path):
+            if Path(root).resolve() in self._manifested_library_paths:
+                continue
+            if "actions" in dirs or "actions.py" in files:
+                self.load_actions_from_path(Path(root))
+
+    def _resolve_registered_action(self, action_name: str) -> Optional[RegisteredAction]:
+        action = self._registered_actions.get(action_name)
+        if action is None:
+            action_ref = self._lazy_action_refs.get(action_name)
+            if action_ref is None:
+                return None
+            resolved_action = resolve_import_ref(action_ref)
+            action_meta = getattr(resolved_action, "action_meta", {})
+            if action_meta and action_meta.get("name") != action_ref.name:
+                raise ValueError(
+                    f"Lazy action ref {action_ref.name!r} resolved to action "
+                    f"{action_meta.get('name')!r} from {action_ref.target!r}."
+                )
+            self._registered_actions[action_name] = resolved_action
+            self._lazy_action_refs.pop(action_name, None)
+            return cast(RegisteredAction, resolved_action)
+
+        return action
+
     def _normalize_action_name(self, name: str) -> str:
         """Normalize the action name to the required format."""
-        if name not in self.registered_actions:
+        if not self._has_action_name(name):
             if name.endswith("Action"):
                 name = name.replace("Action", "")
             name = utils.camelcase_to_snakecase(name)
@@ -181,7 +265,7 @@ class ActionDispatcher:
     def has_registered(self, name: str) -> bool:
         """Check if an action is registered."""
         name = self._normalize_action_name(name)
-        return name in self.registered_actions
+        return self._has_action_name(name)
 
     def get_action(self, name: str) -> Optional[RegisteredAction]:
         """Get the registered action by name.
@@ -193,7 +277,7 @@ class ActionDispatcher:
             callable: The registered action.
         """
         name = self._normalize_action_name(name)
-        return self._registered_actions.get(name, None)
+        return self._resolve_registered_action(name)
 
     async def execute_action(
         self, action_name: str, params: Dict[str, Any]
@@ -210,9 +294,9 @@ class ActionDispatcher:
 
         action_name = self._normalize_action_name(action_name)
 
-        if action_name in self._registered_actions:
+        if self._has_action_name(action_name):
             log.info("Executing registered action: %s", action_name)
-            maybe_fn: Optional[RegisteredAction] = self._registered_actions.get(action_name, None)
+            maybe_fn = self._resolve_registered_action(action_name)
             if not maybe_fn:
                 raise Exception(f"Action '{action_name}' is not registered.")
 
@@ -274,7 +358,7 @@ class ActionDispatcher:
         Returns:
             List[str]: List of available actions.
         """
-        return list(self._registered_actions.keys())
+        return list(self._action_names())
 
     @staticmethod
     def _load_actions_from_module(filepath: str):
@@ -324,10 +408,6 @@ class ActionDispatcher:
             if not module.__file__:
                 raise RuntimeError(f"No file found for module {module} at {filepath}.")
 
-            try:
-                relative_filepath = Path(module.__file__).relative_to(Path.cwd())
-            except ValueError:
-                relative_filepath = Path(module.__file__).resolve()
             log.error(f"Failed to register {filename} in action dispatcher due to exception: {e}")
 
         return action_objects
@@ -349,7 +429,7 @@ class ActionDispatcher:
             return action_objects
 
         # Loop through all files in the directory and its subdirectories
-        for root, dirs, files in os.walk(directory):
+        for root, _dirs, files in os.walk(directory):
             for filename in files:
                 if filename.endswith(".py"):
                     filepath = os.path.join(root, filename)

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -53,11 +53,11 @@ class _RegisteredActions(Mapping[str, RegisteredAction]):
     """Read-only view over registered and lazily declared actions.
 
     Iteration, ``in``, and ``len`` reflect every registered and lazily declared
-    action name. Subscripting resolves a single lazy action on demand (importing
-    its module) and raises ``KeyError`` if it cannot be resolved. Bulk value
-    access (``values``/``items``) intentionally returns only actions that are
-    already resolved so that materializing the view never triggers lazy imports
-    or fails on an action whose optional dependency is missing.
+    action name. Subscripting (and therefore ``dict(view)``) resolves a lazy
+    action on demand, importing its module and raising ``KeyError`` if it cannot
+    be resolved. ``values`` and ``items`` deliberately expose only actions that
+    are already resolved, so iterating them never triggers a lazy import or
+    fails on an action whose optional dependency is missing.
     """
 
     def __init__(self, dispatcher: "ActionDispatcher") -> None:

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -277,7 +277,11 @@ class ActionDispatcher:
             callable: The registered action.
         """
         name = self._normalize_action_name(name)
-        return self._resolve_registered_action(name)
+        try:
+            return self._resolve_registered_action(name)
+        except Exception:
+            log.exception("Failed to resolve action '%s'.", name)
+            return None
 
     async def execute_action(
         self, action_name: str, params: Dict[str, Any]
@@ -296,7 +300,11 @@ class ActionDispatcher:
 
         if self._has_action_name(action_name):
             log.info("Executing registered action: %s", action_name)
-            maybe_fn = self._resolve_registered_action(action_name)
+            try:
+                maybe_fn = self._resolve_registered_action(action_name)
+            except Exception:
+                log.exception("Failed to resolve action '%s'.", action_name)
+                return None, "failed"
             if not maybe_fn:
                 raise Exception(f"Action '{action_name}' is not registered.")
 

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -19,7 +19,7 @@ import importlib.util
 import inspect
 import logging
 import os
-from collections.abc import Iterator, Mapping
+from collections.abc import ItemsView, Iterator, Mapping, ValuesView
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol, Tuple, Type, TypeAlias, Union, cast
@@ -48,6 +48,16 @@ RegisteredAction: TypeAlias = Union[
 
 
 class _RegisteredActions(Mapping[str, RegisteredAction]):
+    """Read-only view over registered and lazily declared actions.
+
+    Iteration, ``in``, and ``len`` reflect every registered and lazily declared
+    action name. Subscripting resolves a single lazy action on demand (importing
+    its module) and raises ``KeyError`` if it cannot be resolved. Bulk value
+    access (``values``/``items``) intentionally returns only actions that are
+    already resolved so that materializing the view never triggers lazy imports
+    or fails on an action whose optional dependency is missing.
+    """
+
     def __init__(self, dispatcher: "ActionDispatcher") -> None:
         self._dispatcher = dispatcher
 
@@ -65,6 +75,12 @@ class _RegisteredActions(Mapping[str, RegisteredAction]):
 
     def __contains__(self, name: object) -> bool:
         return isinstance(name, str) and self._dispatcher._has_action_name(name)
+
+    def values(self) -> ValuesView[RegisteredAction]:
+        return self._dispatcher._registered_actions.values()
+
+    def items(self) -> ItemsView[str, RegisteredAction]:
+        return self._dispatcher._registered_actions.items()
 
 
 class ActionDispatcher:

--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -30,6 +30,8 @@ from nemoguardrails.manifests import ActionRef, RailCatalog, default_rail_catalo
 
 log = logging.getLogger(__name__)
 
+LEGACY_UNMANIFESTED_LIBRARY_PACKAGES: Tuple[str, ...] = ("attention", "utils")
+
 
 class AsyncInvokableAction(Protocol):
     def ainvoke(self, *args: Any, **kwargs: Any) -> Awaitable[Any]: ...
@@ -106,7 +108,6 @@ class ActionDispatcher:
         self._registered_actions: Dict[str, RegisteredAction] = {}
         self._lazy_action_refs: Dict[str, ActionRef] = {}
         self._manifest_action_names: set[str] = set()
-        self._manifested_library_paths: set[Path] = set()
         self._rail_catalog = rail_catalog
         self._registered_actions_view = _RegisteredActions(self)
 
@@ -246,18 +247,16 @@ class ActionDispatcher:
                 continue
             for action_ref in manifest.actions.refs:
                 self._register_action_ref(action_ref)
-            if manifest.origin:
-                module = importlib.import_module(manifest.origin)
-                module_file = getattr(module, "__file__", None)
-                if module_file:
-                    self._manifested_library_paths.add(Path(module_file).parent.resolve())
 
     def _load_unmanifested_library_actions(self, library_path: Path) -> None:
-        for root, dirs, files in os.walk(library_path):
-            if Path(root).resolve() in self._manifested_library_paths:
-                continue
-            if "actions" in dirs or "actions.py" in files:
-                self.load_actions_from_path(Path(root))
+        """Load pre-manifest library packages that register actions directly.
+
+        Manifested library actions are indexed as lazy refs by
+        `_register_manifest_action_refs`; only the packages in
+        `LEGACY_UNMANIFESTED_LIBRARY_PACKAGES` still register eagerly.
+        """
+        for package_name in LEGACY_UNMANIFESTED_LIBRARY_PACKAGES:
+            self.load_actions_from_path(library_path / package_name)
 
     def _resolve_registered_action(self, action_name: str) -> Optional[RegisteredAction]:
         action = self._registered_actions.get(action_name)

--- a/nemoguardrails/colang/runtime.py
+++ b/nemoguardrails/colang/runtime.py
@@ -15,7 +15,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from nemoguardrails.actions.action_dispatcher import ActionDispatcher
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -34,27 +34,18 @@ class Runtime:
         # Register the actions with the dispatcher.
         self.action_dispatcher = ActionDispatcher(
             config_path=config.config_path,
-            import_paths=list(config.imported_paths.values()),
+            import_paths=list((config.imported_paths or {}).values()),
         )
 
-        if hasattr(self, "_run_output_rails_in_parallel_streaming"):
-            self.action_dispatcher.register_action(
-                self._run_output_rails_in_parallel_streaming,
-                name="run_output_rails_in_parallel_streaming",
-            )
-
-        if hasattr(self, "_run_flows_in_parallel"):
-            self.action_dispatcher.register_action(self._run_flows_in_parallel, name="run_flows_in_parallel")
-
-        if hasattr(self, "_run_input_rails_in_parallel"):
-            self.action_dispatcher.register_action(
-                self._run_input_rails_in_parallel, name="run_input_rails_in_parallel"
-            )
-
-        if hasattr(self, "_run_output_rails_in_parallel"):
-            self.action_dispatcher.register_action(
-                self._run_output_rails_in_parallel, name="run_output_rails_in_parallel"
-            )
+        for action_name in (
+            "run_output_rails_in_parallel_streaming",
+            "run_flows_in_parallel",
+            "run_input_rails_in_parallel",
+            "run_output_rails_in_parallel",
+        ):
+            action = getattr(self, f"_{action_name}", None)
+            if action is not None:
+                self.action_dispatcher.register_action(action, name=action_name)
 
         # The list of additional parameters that can be passed to the actions.
         self.registered_action_params: dict = {}
@@ -89,7 +80,7 @@ class Runtime:
         self.action_dispatcher.register_actions(actions_obj, override=override)
 
     @property
-    def registered_actions(self) -> dict:
+    def registered_actions(self) -> Mapping[str, Any]:
         """Return registered actions."""
         return self.action_dispatcher.registered_actions
 

--- a/nemoguardrails/colang/runtime.py
+++ b/nemoguardrails/colang/runtime.py
@@ -17,7 +17,7 @@ import logging
 from abc import abstractmethod
 from typing import Any, Callable, List, Mapping, Optional, Tuple
 
-from nemoguardrails.actions.action_dispatcher import ActionDispatcher
+from nemoguardrails.actions.action_dispatcher import ActionDispatcher, RegisteredAction
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
 
@@ -80,7 +80,7 @@ class Runtime:
         self.action_dispatcher.register_actions(actions_obj, override=override)
 
     @property
-    def registered_actions(self) -> Mapping[str, Any]:
+    def registered_actions(self) -> Mapping[str, RegisteredAction]:
         """Return registered actions."""
         return self.action_dispatcher.registered_actions
 

--- a/nemoguardrails/colang/v2_x/runtime/runtime.py
+++ b/nemoguardrails/colang/v2_x/runtime/runtime.py
@@ -298,6 +298,7 @@ class RuntimeV2_x(Runtime):
     @staticmethod
     def _get_action_finished_event(result: dict, **kwargs) -> Dict[str, Any]:
         """Helper to return the ActionFinished event from the result of running a local action."""
+        rail_action_marker = {"is_rail_action": True} if result.get("is_rail_action") else {}
         return new_event_dict(
             f"{result['action_name']}Finished",
             action_uid=result["start_action_event"]["action_uid"],
@@ -306,6 +307,7 @@ class RuntimeV2_x(Runtime):
             is_success=True,
             return_value=result["return_value"],
             events=result["new_events"],
+            **rail_action_marker,
             **kwargs,
             # is_system_action=action_meta.get("is_system_action", False),
         )
@@ -615,6 +617,7 @@ class RuntimeV2_x(Runtime):
         # we ignore all the keys from "an empty event" of the same type.
         ignore_keys = new_event_dict(start_action_event["type"]).keys()
         action_params = {k: v for k, v in start_action_event.items() if k not in ignore_keys}
+        is_rail_action = self.action_dispatcher.is_manifest_action(action_name)
 
         return_value, new_events, context_updates = await self._process_start_action(
             action_name,
@@ -632,6 +635,7 @@ class RuntimeV2_x(Runtime):
             "new_events": new_events,
             "context_updates": context_updates,
             "start_action_event": start_action_event,
+            "is_rail_action": is_rail_action,
         }
 
 

--- a/nemoguardrails/llm/filters.py
+++ b/nemoguardrails/llm/filters.py
@@ -45,7 +45,7 @@ def co_v2(
     if not events:
         return history
 
-    system_actions = [
+    excluded_actions = [
         "retrieve_relevant_chunks",
         "create_event",
         "wolfram alpha request",
@@ -59,17 +59,6 @@ def co_v2(
         "wikipedia_query",
         "wolframalpha_query",
         "zapier_nla_query",
-        "CallActivefenceApiAction",
-        "CallGcpnlpApiAction",
-        "jailbreak_detection_heuristics",
-        "self_check_hallucination",
-        "llama_guard_check_input",
-        "llama_guard_check_output",
-        "alignscore_check_facts",
-        "alignscore request",
-        "self_check_facts",
-        "self_check_input",
-        "self_check_output",
         "AddFlowsAction",
         "RemoveFlowsAction",
         "CheckForActiveEventMatchAction",
@@ -115,7 +104,8 @@ def co_v2(
                 elif (
                     event["type"].endswith("ActionFinished")
                     and event.get("action_name")
-                    and event["action_name"] not in system_actions
+                    and not event.get("is_rail_action", False)
+                    and event["action_name"] not in excluded_actions
                 ):
                     # history += f"  await {str(event['action_name'])}()\n"
                     history += f"  # {str(event.get('return_value'))}\n"

--- a/tests/rails/llm/test_builtin_rail_manifests.py
+++ b/tests/rails/llm/test_builtin_rail_manifests.py
@@ -126,6 +126,52 @@ def test_builtin_action_refs_match_decorated_names_and_bindings():
                 assert binding.action_param in parameters
 
 
+def test_every_manifested_action_is_declared_in_its_manifest():
+    """Every `@action` in a manifested package must be declared in a manifest.
+
+    The dispatcher registers manifested library actions solely from their
+    declared refs; the package itself is no longer scanned. An `@action` in a
+    manifested package that is missing from every manifest's refs would silently
+    never register, so this asserts the reverse of
+    `test_builtin_action_refs_match_decorated_names_and_bindings`.
+    """
+    library_root = Path("nemoguardrails/library")
+    declared_targets = {
+        action_ref.target
+        for manifest in all_rail_manifests().values()
+        if manifest.actions is not None
+        for action_ref in manifest.actions.refs
+    }
+
+    def _is_action_decorator(decorator: ast.expr) -> bool:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            return target.id == "action"
+        if isinstance(target, ast.Attribute):
+            return target.attr == "action"
+        return False
+
+    undeclared = []
+    for path in sorted(library_root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        if path.relative_to(library_root).parts[0] in LEGACY_UNMANIFESTED_PACKAGES:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "@action" not in source:
+            continue
+        relative_module = path.relative_to(library_root).with_suffix("")
+        module_name = ".".join(("nemoguardrails", "library", *relative_module.parts))
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if any(_is_action_decorator(decorator) for decorator in node.decorator_list):
+                if f"{module_name}:{node.name}" not in declared_targets:
+                    undeclared.append(f"{module_name}:{node.name}")
+
+    assert not undeclared, "Manifested actions missing from every manifest's refs:\n" + "\n".join(undeclared)
+
+
 def test_self_check_surfaces_bind_optional_variant():
     manifests = all_rail_manifests()
 

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -225,6 +225,33 @@ async def test_lazy_action_resolution_logs_escape_line_breaks(caplog):
     assert caplog.messages == [expected, expected]
 
 
+def test_registered_actions_view_does_not_import_lazy_actions():
+    dispatcher = ActionDispatcher(load_all_actions=False)
+    dispatcher._register_action_ref(
+        ActionRef(name="lazy_test_action", target="tests.test_action_dispatcher:_lazy_test_action")
+    )
+    dispatcher._register_action_ref(ActionRef(name="broken_action", target="tests.missing_lazy_action_module:action"))
+    view = dispatcher.registered_actions
+
+    # Membership and iteration expose the full declared namespace.
+    assert set(view) == {"lazy_test_action", "broken_action"}
+    assert "lazy_test_action" in view and "broken_action" in view
+    assert len(view) == 2
+
+    # Materializing the view resolves nothing, so an unresolvable ref cannot
+    # raise and no module is imported yet.
+    assert dict(view.items()) == {}
+    assert tuple(view.values()) == ()
+
+    # Subscripting still resolves a single action and caches it.
+    assert view["lazy_test_action"] is _lazy_test_action
+    assert dict(view.items()) == {"lazy_test_action": _lazy_test_action}
+
+    # The failure contract for direct access is preserved.
+    with pytest.raises(KeyError, match="broken_action"):
+        view["broken_action"]
+
+
 def test_load_actions_from_nonexistent_module():
     """Test loading actions from a non-existent module"""
 

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -199,6 +199,24 @@ async def test_lazy_action_resolution_failures_follow_dispatcher_contract(action
     assert await dispatcher.execute_action(action_ref.name, params={}) == (None, "failed")
 
 
+@pytest.mark.asyncio
+async def test_lazy_action_resolution_logs_escape_line_breaks(caplog):
+    action_name = "unsafe\r\naction"
+    dispatcher = ActionDispatcher(load_all_actions=False)
+    dispatcher._register_action_ref(
+        ActionRef(
+            name=action_name,
+            target="tests.missing_lazy_action_module:action",
+        )
+    )
+
+    assert dispatcher.get_action(action_name) is None
+    assert await dispatcher.execute_action(action_name, params={}) == (None, "failed")
+
+    expected = "Failed to resolve action 'unsafe\\r\\naction'."
+    assert caplog.messages == [expected, expected]
+
+
 def test_load_actions_from_nonexistent_module():
     """Test loading actions from a non-existent module"""
 

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -21,7 +21,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from nemoguardrails.actions.action_dispatcher import ActionDispatcher
+import nemoguardrails
+from nemoguardrails.actions.action_dispatcher import (
+    LEGACY_UNMANIFESTED_LIBRARY_PACKAGES,
+    ActionDispatcher,
+)
 from nemoguardrails.manifests import ActionRef, default_rail_catalog
 
 
@@ -139,6 +143,30 @@ def test_load_all_actions_preserves_unmanifested_library_actions():
     assert "GetAttentionPercentageAction" in dispatcher.get_registered_actions()
     assert not isinstance(dispatcher.registered_actions["GetCurrentDateTimeAction"], ActionRef)
     assert not dispatcher.is_manifest_action("GetCurrentDateTimeAction")
+
+
+def test_legacy_unmanifested_packages_match_library_layout():
+    """Eagerly loaded packages must equal the library packages without a manifest.
+
+    The dispatcher only loads `LEGACY_UNMANIFESTED_LIBRARY_PACKAGES` eagerly; a
+    new library action package without a rail.py manifest would otherwise never
+    be registered, so this locks the constant to the actual library layout.
+    """
+    library_root = Path(nemoguardrails.__file__).parent / "library"
+
+    unmanifested_packages = set()
+    for path in library_root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        if "@action(" not in path.read_text(encoding="utf-8"):
+            continue
+        package_dir = path.parent
+        while package_dir != library_root and not (package_dir / "rail.py").exists():
+            package_dir = package_dir.parent
+        if package_dir == library_root:
+            unmanifested_packages.add(path.relative_to(library_root).parts[0])
+
+    assert unmanifested_packages == set(LEGACY_UNMANIFESTED_LIBRARY_PACKAGES)
 
 
 @pytest.mark.asyncio

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -32,6 +32,13 @@ def _lazy_test_action(value: str = "ok") -> str:
 setattr(_lazy_test_action, "action_meta", {"name": "lazy_test_action"})
 
 
+def _mismatched_lazy_test_action() -> None:
+    return None
+
+
+setattr(_mismatched_lazy_test_action, "action_meta", {"name": "different_lazy_action"})
+
+
 @pytest.fixture
 def temp_module():
     """Temporary module with actions for testing"""
@@ -142,6 +149,36 @@ async def test_lazy_action_ref_resolves_and_caches():
     assert result == ("done", "success")
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action_ref",
+    [
+        ActionRef(
+            name="missing_module_action",
+            target="tests.missing_lazy_action_module:action",
+        ),
+        ActionRef(
+            name="missing_attribute_action",
+            target="tests.test_action_dispatcher:missing_lazy_action",
+        ),
+        ActionRef(
+            name="mismatched_lazy_action",
+            target="tests.test_action_dispatcher:_mismatched_lazy_test_action",
+        ),
+    ],
+    ids=("missing-module", "missing-attribute", "name-mismatch"),
+)
+async def test_lazy_action_resolution_failures_follow_dispatcher_contract(action_ref):
+    """Lazy resolution failures remain contained by dispatcher APIs."""
+    dispatcher = ActionDispatcher(load_all_actions=False)
+    dispatcher._register_action_ref(action_ref)
+
+    assert dispatcher.get_action(action_ref.name) is None
+    with pytest.raises(KeyError, match=action_ref.name):
+        dispatcher.registered_actions[action_ref.name]
+    assert await dispatcher.execute_action(action_ref.name, params={}) == (None, "failed")
+
+
 def test_load_actions_from_nonexistent_module():
     """Test loading actions from a non-existent module"""
 
@@ -169,8 +206,8 @@ def test_load_actions_from_invalid_module():
         assert actions == {}
 
 
-def test_load_actions_from_module_relative_path_exception(monkeypatch):
-    """Test loading actions from a module with invalid code"""
+def test_load_actions_from_module_logs_invalid_syntax(monkeypatch):
+    """Test that invalid action module syntax is logged."""
 
     with tempfile.TemporaryDirectory() as temp_dir:
         filename = "invalid_actions.py"
@@ -180,21 +217,10 @@ def test_load_actions_from_module_relative_path_exception(monkeypatch):
 
         dispatcher = ActionDispatcher(load_all_actions=False)
 
-        # Mock the logger to capture the log messages
         mock_logger = MagicMock()
         monkeypatch.setattr("nemoguardrails.actions.action_dispatcher.log", mock_logger)
 
-        # Mock Path.cwd() to raise ValueError when calling relative_to
-        original_cwd = Path.cwd
-        monkeypatch.setattr(
-            "nemoguardrails.actions.action_dispatcher.Path.cwd",
-            lambda: (_ for _ in ()).throw(ValueError),
-        )
-
-        try:
-            actions = dispatcher._load_actions_from_module(str(module_path))
-        finally:
-            monkeypatch.setattr("nemoguardrails.actions.action_dispatcher.Path.cwd", original_cwd)
+        actions = dispatcher._load_actions_from_module(str(module_path))
 
         assert actions == {}
         mock_logger.error.assert_called()

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -117,6 +117,8 @@ def test_load_all_actions_registers_builtin_library_action_refs_lazily():
     assert dispatcher.is_manifest_action("ContentSafetyCheckInputAction")
     assert action_module not in sys.modules
     registered_actions = dispatcher.registered_actions
+    assert "content_safety_check_input" in registered_actions
+    assert "unknown_action" not in registered_actions
     assert action_module not in sys.modules
     assert callable(registered_actions["content_safety_check_input"])
     assert action_module in sys.modules

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails.actions.action_dispatcher import ActionDispatcher
-from nemoguardrails.manifests import ActionRef
+from nemoguardrails.manifests import ActionRef, default_rail_catalog
 
 
 def _lazy_test_action(value: str = "ok") -> str:
@@ -108,11 +108,19 @@ async def test_execute_action_with_async_invoke():
 
 
 def test_load_all_actions_registers_builtin_library_action_refs_lazily():
+    catalog = default_rail_catalog()
+    action_modules = {
+        action_ref.target.partition(":")[0]
+        for record in catalog.records.values()
+        for action_ref in (record.manifest.actions.refs if record.manifest.actions is not None else ())
+    }
     action_module = "nemoguardrails.library.content_safety.actions"
     sys.modules.pop(action_module, None)
+    loaded_modules = set(sys.modules)
 
     dispatcher = ActionDispatcher(load_all_actions=True)
 
+    assert action_modules.isdisjoint(set(sys.modules) - loaded_modules)
     assert "content_safety_check_input" in dispatcher.get_registered_actions()
     assert dispatcher.is_manifest_action("ContentSafetyCheckInputAction")
     assert action_module not in sys.modules

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -114,6 +114,7 @@ def test_load_all_actions_registers_builtin_library_action_refs_lazily():
     dispatcher = ActionDispatcher(load_all_actions=True)
 
     assert "content_safety_check_input" in dispatcher.get_registered_actions()
+    assert dispatcher.is_manifest_action("ContentSafetyCheckInputAction")
     assert action_module not in sys.modules
     registered_actions = dispatcher.registered_actions
     assert action_module not in sys.modules
@@ -127,6 +128,7 @@ def test_load_all_actions_preserves_unmanifested_library_actions():
     assert "GetCurrentDateTimeAction" in dispatcher.get_registered_actions()
     assert "GetAttentionPercentageAction" in dispatcher.get_registered_actions()
     assert not isinstance(dispatcher.registered_actions["GetCurrentDateTimeAction"], ActionRef)
+    assert not dispatcher.is_manifest_action("GetCurrentDateTimeAction")
 
 
 @pytest.mark.asyncio
@@ -140,13 +142,29 @@ async def test_lazy_action_ref_resolves_and_caches():
     )
 
     assert dispatcher.has_registered("lazy_test_action")
+    assert dispatcher.is_manifest_action("lazy_test_action")
     assert isinstance(dispatcher._lazy_action_refs["lazy_test_action"], ActionRef)
     assert dispatcher.get_action("lazy_test_action") is _lazy_test_action
+    assert dispatcher.is_manifest_action("lazy_test_action")
     assert dispatcher.registered_actions["lazy_test_action"] is _lazy_test_action
 
     result = await dispatcher.execute_action("lazy_test_action", params={"value": "done"})
 
     assert result == ("done", "success")
+
+
+def test_registered_action_override_clears_manifest_ownership():
+    dispatcher = ActionDispatcher(load_all_actions=False)
+    dispatcher._register_action_ref(
+        ActionRef(
+            name="lazy_test_action",
+            target="tests.test_action_dispatcher:_lazy_test_action",
+        )
+    )
+
+    dispatcher.register_action(_lazy_test_action)
+
+    assert not dispatcher.is_manifest_action("lazy_test_action")
 
 
 @pytest.mark.asyncio

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import inspect
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -21,6 +22,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails.actions.action_dispatcher import ActionDispatcher
+from nemoguardrails.manifests import ActionRef
+
+
+def _lazy_test_action(value: str = "ok") -> str:
+    return value
+
+
+setattr(_lazy_test_action, "action_meta", {"name": "lazy_test_action"})
 
 
 @pytest.fixture
@@ -87,6 +96,48 @@ async def test_execute_action_with_async_invoke():
     dispatcher.register_action(AsyncInvokeAction(), name="async_invoke")
 
     result = await dispatcher.execute_action("async_invoke", params={"value": "done"})
+
+    assert result == ("done", "success")
+
+
+def test_load_all_actions_registers_builtin_library_action_refs_lazily():
+    action_module = "nemoguardrails.library.content_safety.actions"
+    sys.modules.pop(action_module, None)
+
+    dispatcher = ActionDispatcher(load_all_actions=True)
+
+    assert "content_safety_check_input" in dispatcher.get_registered_actions()
+    assert action_module not in sys.modules
+    registered_actions = dispatcher.registered_actions
+    assert action_module not in sys.modules
+    assert callable(registered_actions["content_safety_check_input"])
+    assert action_module in sys.modules
+
+
+def test_load_all_actions_preserves_unmanifested_library_actions():
+    dispatcher = ActionDispatcher(load_all_actions=True)
+
+    assert "GetCurrentDateTimeAction" in dispatcher.get_registered_actions()
+    assert "GetAttentionPercentageAction" in dispatcher.get_registered_actions()
+    assert not isinstance(dispatcher.registered_actions["GetCurrentDateTimeAction"], ActionRef)
+
+
+@pytest.mark.asyncio
+async def test_lazy_action_ref_resolves_and_caches():
+    dispatcher = ActionDispatcher(load_all_actions=False)
+    dispatcher._register_action_ref(
+        ActionRef(
+            name="lazy_test_action",
+            target="tests.test_action_dispatcher:_lazy_test_action",
+        )
+    )
+
+    assert dispatcher.has_registered("lazy_test_action")
+    assert isinstance(dispatcher._lazy_action_refs["lazy_test_action"], ActionRef)
+    assert dispatcher.get_action("lazy_test_action") is _lazy_test_action
+    assert dispatcher.registered_actions["lazy_test_action"] is _lazy_test_action
+
+    result = await dispatcher.execute_action("lazy_test_action", params={"value": "done"})
 
     assert result == ("done", "success")
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -24,19 +24,32 @@ from nemoguardrails.llm.filters import (
 )
 
 
-def test_co_v2_hides_vendor_system_actions():
-    """Colang 2 history excludes internal vendor action results."""
-    for action_name in ("CallActivefenceApiAction", "CallGcpnlpApiAction"):
-        events = [
-            {
-                "type": f"{action_name}Finished",
-                "uid": action_name,
-                "action_name": action_name,
-                "return_value": "internal result",
-            }
-        ]
+def test_co_v2_hides_rail_action_results():
+    events = [
+        {
+            "type": "AnyRailActionFinished",
+            "uid": "rail-action",
+            "action_name": "AnyRailAction",
+            "return_value": "internal result",
+            "is_rail_action": True,
+        }
+    ]
 
-        assert co_v2(events) == ""
+    assert co_v2(events) == ""
+
+
+def test_co_v2_keeps_non_rail_action_results():
+    events = [
+        {
+            "type": "CustomActionFinished",
+            "uid": "custom-action",
+            "action_name": "CustomAction",
+            "return_value": "custom result",
+            "is_rail_action": False,
+        }
+    ]
+
+    assert co_v2(events) == "  # custom result\n"
 
 
 def test_first_turns():

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -740,7 +740,8 @@ async def test_malformed_inline_yara_rule_fails_gracefully(caplog):
 
     some_text_that_would_be_injection = "This is a test string."
 
-    caplog.set_level(logging.ERROR, logger="actions.py")
+    logger_name = "nemoguardrails.library.injection_detection.actions"
+    caplog.set_level(logging.ERROR, logger=logger_name)
 
     chat = TestChat(config, llm_completions=[some_text_that_would_be_injection])
     rails = chat.app
@@ -754,7 +755,7 @@ async def test_malformed_inline_yara_rule_fails_gracefully(caplog):
 
     # verify the error log was created with the expected content
     assert any(
-        record.name == "actions.py"
+        record.name == logger_name
         and record.levelno == logging.ERROR
         # minor variations in the error message are expected
         and "Failed to initialize injection detection" in record.message

--- a/tests/test_jailbreak_nim.py
+++ b/tests/test_jailbreak_nim.py
@@ -106,7 +106,7 @@ JAILBREAK_SETUP_PRESENT, JAILBREAK_SKIP_REASON = check_jailbreak_nim_availabilit
     not JAILBREAK_SETUP_PRESENT,
     reason=JAILBREAK_SKIP_REASON or "JailbreakDetect NIM not running or endpoint is not in config.",
 )
-@patch("nemoguardrails.library.jailbreak_detection.request.jailbreak_nim_request")
+@patch("nemoguardrails.library.jailbreak_detection.actions.jailbreak_nim_request")
 def test_jb_detect_nim_unsafe(mock_jailbreak_nim):
     """Test that the NIM correctly identifies unsafe jailbreak input.
 
@@ -136,7 +136,7 @@ def test_jb_detect_nim_unsafe(mock_jailbreak_nim):
     not JAILBREAK_SETUP_PRESENT,
     reason=JAILBREAK_SKIP_REASON or "JailbreakDetect NIM not running or endpoint is not in config.",
 )
-@patch("nemoguardrails.library.jailbreak_detection.request.jailbreak_nim_request")
+@patch("nemoguardrails.library.jailbreak_detection.actions.jailbreak_nim_request")
 def test_jb_detect_nim_safe(mock_jailbreak_nim):
     """Test that the NIM correctly allows safe input.
 

--- a/tests/v2_x/test_run_actions.py
+++ b/tests/v2_x/test_run_actions.py
@@ -14,10 +14,15 @@
 # limitations under the License.
 
 import logging
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from rich.logging import RichHandler
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
+from nemoguardrails.llm.filters import co_v2
+from nemoguardrails.utils import new_event_dict
 from tests.utils import TestChat
 
 FORMAT = "%(message)s"
@@ -127,6 +132,23 @@ def test_3():
 
     chat >> "hi"
     chat << "I couldn't find any items matching your request!"
+
+
+@pytest.mark.asyncio
+async def test_manifest_owned_action_result_is_hidden_from_history():
+    runtime = object.__new__(RuntimeV2_x)
+    runtime.action_dispatcher = MagicMock()
+    runtime.action_dispatcher.is_manifest_action.return_value = True
+    runtime._process_start_action = AsyncMock(return_value=("result", [], {}))
+    state = MagicMock()
+    state.context = {}
+    start_action_event = new_event_dict("StartExampleAction")
+
+    result = await runtime._run_action("ExampleAction", start_action_event, [], state)
+    event = runtime._get_action_finished_event(result)
+
+    assert event["is_rail_action"] is True
+    assert co_v2([event]) == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Resolve manifest-declared action references only when an action is dispatched.
This keeps catalog and configuration discovery independent of action-module
imports and optional rail dependencies while preserving explicitly registered
actions and existing dispatcher behavior.

Directly importing action symbols from `rail.py` would make discovery execute
the runtime modules the manifest boundary is intended to isolate. structured
`ActionRef` values let the catalog index public action names first and resolve
their Python targets only when execution reaches that action. Decorator-based
registration remains supported for user and custom actions; manifest-backed
resolution is the built-in library path, not its replacement.

teach both action dispatch and the Colang runtime to load the owning manifest
action on demand, cache the resulting registration through the existing action
registry, and retain clear unknown-action and import-failure behavior. Add
dispatcher coverage for successful lazy resolution, explicit registrations,
unknown actions, and failed imports.

two focused test fixes patch the action-bound injection logger and jailbreak
NIM request rather than stale definition-module symbols. Lazy import timing made
those incorrect patch targets observable; production behavior is unchanged.


| Path | develop (eager walk) | this branch (lazy) |
| --- | --- | --- |
| Dispatcher construct / first config load | ~812 ms, +117 modules, ~4.9 MB Python objects | ~25 ms, +0 action modules |
| First dispatch of a given action | already imported | ~20 ms (that one action's module) |
| Repeat dispatch of the same action | dict lookup | dict lookup (~6 us) |
| Rail catalog discovery (`default_rail_catalog`) | 29.7 ms / 33 `rail.py` | 29.7 ms / 33 `rail.py` |
| `LLMRails` init with one rail enabled | imports all ~34 library action modules | imports 0 library action modules |



### Impact

- Loading configuration or inspecting the rail catalog no longer imports every
  built-in action module or its optional runtime dependencies.
- Applications pay an action's import cost only when that action is first
  dispatched, after which the existing registry caches it.
- Explicitly registered custom actions retain precedence and behavior.
- Unknown actions, invalid lazy targets, and import failures remain visible at
  the execution boundary with focused test coverage.
- The observable timing of built-in action imports changes, but action results
  and dispatcher semantics remain unchanged.


### Stack

| Layer | Branch | Base | PR |
| --- | --- | --- | --- |
| Stack 3 | `pouyanpi/rail-library-stack-3-manifest-contract` | `develop` | #2157 |
| Stack 4 | `pouyanpi/rail-library-stack-4-builtins` | Stack 3 | #2181 |
| Stack 4b | `pouyanpi/rail-library-stack-4b-flow-gate` | Stack 4 | #2185 |
| **Stack 5** | `pouyanpi/rail-library-stack-5-lazy-actions` | Stack 4b | **#2186** |




## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive GCP text moderation flows, including detailed violation-specific responses.
  * Added configurable blocking messages for retrieval safety and context-bloat detections.
  * Added a generated Rails configuration schema snapshot.

* **Bug Fixes**
  * Corrected guardrail action references and flow syntax across Cleanlab, GCP moderation, and Fiddler integrations.
  * Improved lazy action loading and failure handling.
  * Updated regex and injection-detection behavior for more consistent blocking outcomes.

* **Tests**
  * Added broad validation for rail configuration, flow portability, action declarations, and runtime equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->