### PR TITLE
refactor(library): make context bloat verdict flow-independent

### DIFF
--- a/nemoguardrails/library/context_bloat_detection/actions.py
+++ b/nemoguardrails/library/context_bloat_detection/actions.py
@@ -33,10 +33,11 @@ Wire as retrieval rail (RAG chunks) or input rail.
 import logging
 import math
 from collections import Counter
-from typing import List, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +53,9 @@ class ContextBloatResult(TypedDict):
     reason: Optional[str]
     detections: List[str]
     metrics: dict
+
+
+ContextBloatSource = Literal["input", "retrieval"]
 
 
 def _stratified_sample(text: str, sample_chars: int) -> str:
@@ -162,21 +166,50 @@ def _check_repetition(text: str, cfg, detections: List[str], metrics: dict) -> O
     return None
 
 
+def _context_bloat_outcome(source: ContextBloatSource, original_text: str, result: ContextBloatResult) -> RailOutcome:
+    targets = {
+        "input": TransformTarget.USER_MESSAGE,
+        "retrieval": TransformTarget.RELEVANT_CHUNKS,
+    }
+    if source not in targets:
+        raise ValueError("source must be either 'input' or 'retrieval'")
+
+    metadata = {
+        "is_bloat": result["is_bloat"],
+        "action": result["action"],
+        "detections": result["detections"],
+        "metrics": result["metrics"],
+    }
+    if result["is_bloat"] and result["action"] == "reject":
+        return RailOutcome.block(reason=result["reason"], metadata=metadata)
+    if result["is_bloat"] and result["action"] == "truncate" and result["text"] != original_text:
+        return RailOutcome.transform(
+            [(targets[source], result["text"])],
+            reason=result["reason"],
+            metadata=metadata,
+        )
+    return RailOutcome.allow(reason=result["reason"], metadata=metadata)
+
+
 @action()
-async def context_bloat_detection(text: str, config: RailsConfig) -> ContextBloatResult:
+async def context_bloat_detection(source: ContextBloatSource, text: str, config: RailsConfig) -> RailOutcome:
     """Detect context-bloat / context-manipulation attacks.
     Check order is cheapest first to enable early-exit.
 
     Args:
+        source: Whether the text came from input or retrieved chunks.
         text: The text to inspect (joined chunks or user message).
         config: RailsConfig with rails.config.context_bloat_detection settings.
 
     Returns:
-        ContextBloatResult with is_bloat flag, processed text, reason, metrics.
+        The allow, block, or transform verdict with detection evidence.
     """
+    if source not in ("input", "retrieval"):
+        raise ValueError("source must be either 'input' or 'retrieval'")
     _validate_config(config)
     cfg = config.rails.config.context_bloat_detection
 
+    original_text = text
     char_count = len(text) if text else 0
     detections: List[str] = []
     metrics: dict = {"chars": char_count}
@@ -185,13 +218,17 @@ async def context_bloat_detection(text: str, config: RailsConfig) -> ContextBloa
         detections.append("size_cap_exceeded")
         log.info(f"context bloat detected: size_cap_exceeded | chars={char_count}")
         if cfg.action == "reject":
-            return ContextBloatResult(
-                is_bloat=True,
-                action=cfg.action,
-                text=text,
-                reason="size_cap_exceeded",
-                detections=detections,
-                metrics=metrics,
+            return _context_bloat_outcome(
+                source,
+                original_text,
+                ContextBloatResult(
+                    is_bloat=True,
+                    action=cfg.action,
+                    text=text,
+                    reason="size_cap_exceeded",
+                    detections=detections,
+                    metrics=metrics,
+                ),
             )
         if cfg.action == "truncate":
             text = text[: cfg.max_chars]
@@ -200,17 +237,21 @@ async def context_bloat_detection(text: str, config: RailsConfig) -> ContextBloa
         for check in (_check_entropy, _check_longest_run, _check_repetition):
             result = check(text, cfg, detections, metrics)
             if result is not None:
-                return result
+                return _context_bloat_outcome(source, original_text, result)
 
     is_bloat = bool(detections)
     reason = ", ".join(detections) if detections else None
     if is_bloat:
         log.info(f"context bloat detected: {reason} | metrics={metrics}")
-    return ContextBloatResult(
-        is_bloat=is_bloat,
-        action=cfg.action,
-        text=text,
-        reason=reason,
-        detections=detections,
-        metrics=metrics,
+    return _context_bloat_outcome(
+        source,
+        original_text=original_text,
+        result=ContextBloatResult(
+            is_bloat=is_bloat,
+            action=cfg.action,
+            text=text,
+            reason=reason,
+            detections=detections,
+            metrics=metrics,
+        ),
     )

--- a/nemoguardrails/library/context_bloat_detection/actions.py
+++ b/nemoguardrails/library/context_bloat_detection/actions.py
@@ -171,8 +171,6 @@ def _context_bloat_outcome(source: ContextBloatSource, original_text: str, resul
         "input": TransformTarget.USER_MESSAGE,
         "retrieval": TransformTarget.RELEVANT_CHUNKS,
     }
-    if source not in targets:
-        raise ValueError("source must be either 'input' or 'retrieval'")
 
     metadata = {
         "is_bloat": result["is_bloat"],

--- a/nemoguardrails/library/context_bloat_detection/flows.co
+++ b/nemoguardrails/library/context_bloat_detection/flows.co
@@ -4,12 +4,12 @@
 flow context bloat detection on retrieval
   """Detect bloated or padded content in retrieved RAG chunks."""
   global $relevant_chunks
-  $bloat_result = await ContextBloatDetectionAction(text=$relevant_chunks)
-  if $bloat_result.is_bloat and $bloat_result.action == "reject"
+  $bloat_result = await ContextBloatDetectionAction(source="retrieval", text=$relevant_chunks)
+  if $bloat_result.is_blocked
     bot inform retrieval bloated
     abort
-  if $bloat_result.is_bloat and $bloat_result.action == "truncate"
-    $relevant_chunks = $bloat_result.text
+  if $bloat_result.is_transform
+    $relevant_chunks = $bloat_result.transform_text["relevant_chunks"]
 
 flow bot inform retrieval bloated
   bot say "The retrieved sources for this question appeared oversized or padded. I'm not using them to avoid context manipulation."
@@ -19,12 +19,12 @@ flow bot inform retrieval bloated
 flow context bloat detection on input
   """Detect bloated or padded user-supplied content."""
   global $user_message
-  $bloat_result = await ContextBloatDetectionAction(text=$user_message)
-  if $bloat_result.is_bloat and $bloat_result.action == "reject"
+  $bloat_result = await ContextBloatDetectionAction(source="input", text=$user_message)
+  if $bloat_result.is_blocked
     bot refuse bloated input
     abort
-  if $bloat_result.is_bloat and $bloat_result.action == "truncate"
-    $user_message = $bloat_result.text
+  if $bloat_result.is_transform
+    $user_message = $bloat_result.transform_text["user_message"]
 
 flow bot refuse bloated input
   bot say "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."

--- a/nemoguardrails/library/context_bloat_detection/flows.v1.co
+++ b/nemoguardrails/library/context_bloat_detection/flows.v1.co
@@ -3,12 +3,12 @@
 
 define subflow context bloat detection on retrieval
   """Detect bloated or padded content in retrieved RAG chunks."""
-  $bloat_result = execute context_bloat_detection(text=$relevant_chunks)
-  if $bloat_result.is_bloat and $bloat_result.action == "reject"
+  $bloat_result = execute context_bloat_detection(source="retrieval", text=$relevant_chunks)
+  if $bloat_result.is_blocked
     bot inform retrieval bloated
     stop
-  if $bloat_result.is_bloat and $bloat_result.action == "truncate"
-    $relevant_chunks = $bloat_result.text
+  if $bloat_result.is_transform
+    $relevant_chunks = $bloat_result.transform_text["relevant_chunks"]
 
 define bot inform retrieval bloated
   "The retrieved sources for this question appeared oversized or padded. I'm not using them to avoid context manipulation."
@@ -17,12 +17,12 @@ define bot inform retrieval bloated
 
 define subflow context bloat detection on input
   """Detect bloated or padded user-supplied content."""
-  $bloat_result = execute context_bloat_detection(text=$user_message)
-  if $bloat_result.is_bloat and $bloat_result.action == "reject"
+  $bloat_result = execute context_bloat_detection(source="input", text=$user_message)
+  if $bloat_result.is_blocked
     bot refuse bloated input
     stop
-  if $bloat_result.is_bloat and $bloat_result.action == "truncate"
-    $user_message = $bloat_result.text
+  if $bloat_result.is_transform
+    $user_message = $bloat_result.transform_text["user_message"]
 
 define bot refuse bloated input
   "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."

--- a/tests/test_context_bloat_detection.py
+++ b/tests/test_context_bloat_detection.py
@@ -360,6 +360,26 @@ class TestFlowContract:
             << "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."
         )
 
+    def test_colang_1_input_flow_transforms_from_action_verdict(self):
+        text = "x" * 20
+        config = RailsConfig.from_content(
+            config={
+                "models": [],
+                "rails": {
+                    "input": {"flows": ["context bloat detection on input"]},
+                    "config": {"context_bloat_detection": {"max_chars": 10, "action": "truncate"}},
+                },
+            }
+        )
+        chat = TestChat(config, llm_completions=["normal"])
+
+        response = chat.app.generate(
+            messages=[{"role": "user", "content": text}],
+            options={"output_vars": ["user_message"]},
+        )
+
+        assert response.output_data == {"user_message": text[:10]}
+
     def test_colang_2_input_flow_blocks_from_action_verdict(self):
         config = RailsConfig.from_content(
             yaml_content="""
@@ -393,3 +413,36 @@ class TestFlowContract:
             chat
             << "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."
         )
+
+    def test_colang_2_input_flow_transforms_from_action_verdict(self):
+        text = "x" * 20
+        config = RailsConfig.from_content(
+            yaml_content="""
+                colang_version: 2.x
+                models: []
+                rails:
+                  config:
+                    context_bloat_detection:
+                      max_chars: 10
+                      action: truncate
+            """,
+            colang_content="""
+                import core
+                import llm
+                import guardrails
+                import nemoguardrails.library.context_bloat_detection
+
+                flow input rails $input_text
+                  context bloat detection on input
+
+                flow main
+                  global $user_message
+                  activate llm continuation
+                  user said something
+                  bot say "{$user_message}"
+            """,
+        )
+        chat = TestChat(config, llm_completions=[])
+
+        chat >> text
+        chat << text[:10]

--- a/tests/test_context_bloat_detection.py
+++ b/tests/test_context_bloat_detection.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.library.context_bloat_detection.actions import (
     _longest_run_ratio,
     _repetition_ratio,
@@ -29,6 +31,7 @@ from nemoguardrails.rails.llm.config import (
     ContextBloatDetectionConfig,
     RailsConfigData,
 )
+from tests.utils import TestChat
 
 
 def _make_config(**overrides):
@@ -162,31 +165,34 @@ class TestDetectSizeCap:
     @pytest.mark.asyncio
     async def test_reject_oversized(self):
         config = _make_config(max_chars=100, action="reject")
-        result = await context_bloat_detection("x" * 200, config)
-        assert result["is_bloat"] is True
-        assert "size_cap_exceeded" in result["detections"]
+        result = await context_bloat_detection("input", "x" * 200, config)
+        assert result.is_blocked
+        assert result.metadata["is_bloat"] is True
+        assert "size_cap_exceeded" in result.metadata["detections"]
 
     @pytest.mark.asyncio
     async def test_under_size_passes(self):
         config = _make_config(max_chars=1000, action="reject")
-        result = await context_bloat_detection("short text", config)
-        assert "size_cap_exceeded" not in result["detections"]
+        result = await context_bloat_detection("input", "short text", config)
+        assert not result.is_blocked
+        assert "size_cap_exceeded" not in result.metadata["detections"]
 
 
 class TestDetectEntropy:
     @pytest.mark.asyncio
     async def test_low_entropy_detected(self):
         config = _make_config(max_chars=50000, min_entropy=3.5, action="reject")
-        result = await context_bloat_detection("ab" * 500, config)
-        assert result["is_bloat"] is True
-        assert "low_entropy" in result["detections"]
+        result = await context_bloat_detection("input", "ab" * 500, config)
+        assert result.is_blocked
+        assert result.metadata["is_bloat"] is True
+        assert "low_entropy" in result.metadata["detections"]
 
     @pytest.mark.asyncio
     async def test_normal_entropy_passes(self):
         config = _make_config(max_chars=50000, min_entropy=3.5, action="reject")
         text = "The quick brown fox jumps over the lazy dog. " * 10
-        result = await context_bloat_detection(text, config)
-        assert "low_entropy" not in result["detections"]
+        result = await context_bloat_detection("input", text, config)
+        assert "low_entropy" not in result.metadata["detections"]
 
 
 class TestDetectLongRun:
@@ -194,15 +200,16 @@ class TestDetectLongRun:
     async def test_long_run_detected(self):
         config = _make_config(max_chars=50000, min_entropy=0.1, max_run_ratio=0.1, action="reject")
         padded = "a" * 90 + "hello world"
-        result = await context_bloat_detection(padded, config)
-        assert result["is_bloat"] is True
-        assert "long_run" in result["detections"]
+        result = await context_bloat_detection("input", padded, config)
+        assert result.is_blocked
+        assert result.metadata["is_bloat"] is True
+        assert "long_run" in result.metadata["detections"]
 
     @pytest.mark.asyncio
     async def test_short_run_passes(self):
         config = _make_config(max_chars=50000, min_entropy=0.1, max_run_ratio=0.5, action="reject")
-        result = await context_bloat_detection("hello world", config)
-        assert "long_run" not in result["detections"]
+        result = await context_bloat_detection("input", "hello world", config)
+        assert "long_run" not in result.metadata["detections"]
 
 
 class TestDetectRepetition:
@@ -216,9 +223,10 @@ class TestDetectRepetition:
             action="warn",
         )
         repeated = " ".join(["foo bar baz"] * 50)
-        result = await context_bloat_detection(repeated, config)
-        assert result["is_bloat"] is True
-        assert "high_repetition" in result["detections"]
+        result = await context_bloat_detection("input", repeated, config)
+        assert not result.is_blocked
+        assert result.metadata["is_bloat"] is True
+        assert "high_repetition" in result.metadata["detections"]
 
     @pytest.mark.asyncio
     async def test_unique_text_passes(self):
@@ -230,9 +238,9 @@ class TestDetectRepetition:
             action="reject",
         )
         result = await context_bloat_detection(
-            "every single word here is different and unique in this sentence", config
+            "input", "every single word here is different and unique in this sentence", config
         )
-        assert "high_repetition" not in result["detections"]
+        assert "high_repetition" not in result.metadata["detections"]
 
 
 # ---------------------------------------------------------------------------
@@ -245,19 +253,29 @@ class TestTruncateMode:
     async def test_truncates_to_max_chars(self):
         text = ("The quick brown fox jumps over the lazy dog. " * 10)[:200]
         config = _make_config(max_chars=50, action="truncate")
-        result = await context_bloat_detection(text, config)
-        assert result["is_bloat"] is True
-        assert result["action"] == "truncate"
-        assert len(result["text"]) == 50
+        result = await context_bloat_detection("input", text, config)
+        assert result.is_transform
+        assert result.metadata["is_bloat"] is True
+        assert result.metadata["action"] == "truncate"
+        assert result.transform_text == {TransformTarget.USER_MESSAGE.value: text[:50]}
 
     @pytest.mark.asyncio
     async def test_truncate_early_returns_on_entropy(self):
         config = _make_config(max_chars=50000, min_entropy=5.0, action="truncate")
-        result = await context_bloat_detection("ab" * 500, config)
-        assert result["is_bloat"] is True
-        assert result["action"] == "reject"
-        assert "low_entropy" in result["detections"]
-        assert "longest_run_ratio" not in result["metrics"]
+        result = await context_bloat_detection("input", "ab" * 500, config)
+        assert result.is_blocked
+        assert result.metadata["is_bloat"] is True
+        assert result.metadata["action"] == "reject"
+        assert "low_entropy" in result.metadata["detections"]
+        assert "longest_run_ratio" not in result.metadata["metrics"]
+
+    @pytest.mark.asyncio
+    async def test_retrieval_transform_targets_relevant_chunks(self):
+        text = ("The quick brown fox jumps over the lazy dog. " * 10)[:200]
+        config = _make_config(max_chars=50, action="truncate")
+        result = await context_bloat_detection("retrieval", text, config)
+        assert result.is_transform
+        assert result.transform_text == {TransformTarget.RELEVANT_CHUNKS.value: text[:50]}
 
 
 class TestWarnMode:
@@ -265,10 +283,11 @@ class TestWarnMode:
     async def test_warn_does_not_block(self, caplog):
         config = _make_config(max_chars=10, action="warn")
         with caplog.at_level(logging.INFO):
-            result = await context_bloat_detection("x" * 200, config)
-        assert result["is_bloat"] is True
-        assert result["action"] == "warn"
-        assert result["text"] == "x" * 200
+            result = await context_bloat_detection("input", "x" * 200, config)
+        assert not result.is_blocked
+        assert not result.is_transform
+        assert result.metadata["is_bloat"] is True
+        assert result.metadata["action"] == "warn"
         assert any("context bloat detected" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
@@ -281,10 +300,10 @@ class TestWarnMode:
             action="warn",
         )
         repeated = " ".join(["foo bar baz"] * 50)
-        result = await context_bloat_detection(repeated, config)
-        assert result["is_bloat"] is True
-        assert result["action"] == "warn"
-        assert len(result["detections"]) > 1
+        result = await context_bloat_detection("input", repeated, config)
+        assert result.metadata["is_bloat"] is True
+        assert result.metadata["action"] == "warn"
+        assert len(result.metadata["detections"]) > 1
 
 
 # ---------------------------------------------------------------------------
@@ -296,17 +315,18 @@ class TestNormalTextPasses:
     @pytest.mark.asyncio
     async def test_normal_text_not_flagged(self):
         config = _make_config()
-        result = await context_bloat_detection("Hello, how can I help you today?", config)
-        assert result["is_bloat"] is False
-        assert result["reason"] is None
-        assert result["detections"] == []
+        result = await context_bloat_detection("input", "Hello, how can I help you today?", config)
+        assert not result.is_blocked
+        assert result.metadata["is_bloat"] is False
+        assert result.reason is None
+        assert result.metadata["detections"] == []
 
     @pytest.mark.asyncio
     async def test_short_messages_not_flagged(self):
         config = _make_config()
         for msg in ["Hi", "Hello", "Yes", "Yes please", "No thanks"]:
-            result = await context_bloat_detection(msg, config)
-            assert result["is_bloat"] is False, f"'{msg}' should not be flagged"
+            result = await context_bloat_detection("input", msg, config)
+            assert result.metadata["is_bloat"] is False, f"'{msg}' should not be flagged"
 
     @pytest.mark.asyncio
     async def test_moderate_text_not_flagged(self):
@@ -317,5 +337,59 @@ class TestNormalTextPasses:
             "The stock market closed higher on strong earnings reports from tech companies. "
             "A new study suggests that regular exercise can improve cognitive function. "
         )
-        result = await context_bloat_detection(text, config)
-        assert result["is_bloat"] is False
+        result = await context_bloat_detection("input", text, config)
+        assert result.metadata["is_bloat"] is False
+
+
+class TestFlowContract:
+    def test_colang_1_input_flow_blocks_from_action_verdict(self):
+        config = RailsConfig.from_content(
+            config={
+                "models": [],
+                "rails": {
+                    "input": {"flows": ["context bloat detection on input"]},
+                    "config": {"context_bloat_detection": {"max_chars": 10, "action": "reject"}},
+                },
+            }
+        )
+        chat = TestChat(config)
+
+        chat >> "x" * 20
+        (
+            chat
+            << "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."
+        )
+
+    def test_colang_2_input_flow_blocks_from_action_verdict(self):
+        config = RailsConfig.from_content(
+            yaml_content="""
+                colang_version: 2.x
+                models: []
+                rails:
+                  config:
+                    context_bloat_detection:
+                      max_chars: 10
+                      action: reject
+            """,
+            colang_content="""
+                import core
+                import llm
+                import guardrails
+                import nemoguardrails.library.context_bloat_detection
+
+                flow input rails $input_text
+                  context bloat detection on input
+
+                flow main
+                  activate llm continuation
+                  user said something
+                  bot say "normal"
+            """,
+        )
+        chat = TestChat(config)
+
+        chat >> "x" * 20
+        (
+            chat
+            << "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."
+        )


### PR DESCRIPTION


## Description

Return RailOutcome from context-bloat checks so execution backends can derive the same block, transform, or allow verdict from the configured source and input. Update both Colang dialects and cover the action and flow contracts. Follow-up on #2150 

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context bloat detection now supports both input and retrieved content.
  * Detection outcomes can block content, transform it, or allow it to proceed.
  * Transformations target the appropriate user message or relevant retrieved content.

* **Bug Fixes**
  * Updated context-bloat handling to consistently preserve transformed content and provide detection reasons and metadata.
  * Maintained existing user-facing notices when oversized or bloated content is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->