### PR TITLE
docs: add Out of Scope section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,20 @@ To report a potential security vulnerability in any NVIDIA product:
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
 
+## Out of Scope
+
+NeMo Guardrails is designed to be deployed as a component behind an authenticating network layer (for example, an API gateway, reverse proxy, service mesh sidecar such as `kube-rbac-proxy`, or load balancer) that is expected to provide authentication, authorization, TLS termination, and rate limiting before traffic reaches the library. See [Horizontal Scaling and Caching](docs/configure-rails/caching/model-memory-cache.mdx) and the [Actions Server deployment considerations](docs/run-rails/using-fastapi-server/actions-server.mdx) for the documented deployment model.
+
+Because of this, the following are considered intentional design decisions rather than security vulnerabilities, and should not be reported through the security channels above. If in doubt, or if you have found a way to defeat the documented deployment model itself, please still report it so we can confirm:
+
+- **No built-in authentication or authorization on the Guardrails server (`nemoguardrails server`) or the optional Actions Server API endpoints.** Authentication/authorization is expected to be enforced by the API gateway, reverse proxy, or sidecar in front of the deployment, not by the library itself.
+- **No built-in TLS/mTLS termination on the FastAPI server.** TLS termination and certificate management are the responsibility of the ingress/gateway/proxy fronting the deployment.
+- **No built-in rate limiting or request throttling on server endpoints.** These controls are expected to be enforced by the API gateway or load balancer layer.
+- **No network isolation between the Guardrails server and the optional Actions Server by default.** Operators are responsible for placing the Actions Server on a separate network segment and adding authentication between the two services, as called out in the Actions Server deployment guidance.
+- **Any already-authenticated/authorized caller being able to invoke any Guardrails API endpoint or any registered action.** Once a caller has passed the deployer's authentication/authorization layer, NeMo Guardrails does not currently perform additional fine-grained, per-endpoint or per-action authorization. Reports that only demonstrate this, without a way to bypass or escalate beyond what the deployer's own access-control layer already grants, are treated as hardening suggestions rather than vulnerabilities. Please open a regular GitHub issue for such hardening/feature requests instead of a security report.
+
+We continue to welcome defense-in-depth hardening proposals (for example, an optional in-process authentication layer) as regular feature requests.
+
 ## NVIDIA Product Security
 
 For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security


### PR DESCRIPTION
## Summary

Adds an **Out of Scope** section to `SECURITY.md` clarifying that authentication, authorization, TLS termination, rate limiting, and network isolation between the Guardrails server and the optional Actions Server are expected to be provided by the deployment's own network layer (API gateway, reverse proxy, sidecar such as `kube-rbac-proxy`, or load balancer) rather than by the library itself.

This is consistent with the deployment model already documented elsewhere in this repo:

- [Horizontal Scaling and Caching](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/docs/configure-rails/caching/model-memory-cache.mdx#L180-L191) — "A typical deployment has multiple Guardrails instances running in parallel behind an API gateway and load balancer. The API gateway implements authentication and authorization, rate limiting and throttling..."
- [Actions Server deployment considerations](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/docs/run-rails/using-fastapi-server/actions-server.mdx#L305-L313) — lists network isolation and adding authentication as production deployment responsibilities.

## Motivation

Downstream security audits of NeMo Guardrails deployments have repeatedly filed "missing authentication on the server/Actions Server" as security vulnerabilities, only for maintainers/triagers to conclude these are expected behavior rather than bugs, since the library intentionally delegates authN/authZ, TLS, and rate limiting to the deployer's network layer. Documenting this explicitly in `SECURITY.md` should reduce duplicate reports and give reporters clear guidance on what to check before filing (e.g., confirm the deployment itself isn't missing its expected gateway/proxy layer) and where to route non-security hardening ideas instead (regular GitHub issues).

## What's out of scope (as proposed)

- No built-in authentication/authorization on the Guardrails server or Actions Server endpoints
- No built-in TLS/mTLS termination on the FastAPI server
- No built-in rate limiting/throttling on server endpoints
- No network isolation between the Guardrails server and the optional Actions Server by default
- Any already-authenticated/authorized caller being able to invoke any Guardrails endpoint or registered action (no additional in-process, per-endpoint/per-action authorization)

## Test plan

- [ ] Docs-only change; no code/tests affected
- [ ] Maintainers confirm this framing matches the intended security/deployment model

Made with [Cursor](https://cursor.com)