### PR TITLE
fix(railoutcome): make RailDecision JSON serializable

### DIFF
--- a/nemoguardrails/actions/rail_outcome.py
+++ b/nemoguardrails/actions/rail_outcome.py
@@ -45,7 +45,7 @@ from typing import Any
 __all__ = ["RailDecision", "TransformTarget", "TransformSpec", "RailOutcome", "require_rail_outcome"]
 
 
-class RailDecision(Enum):
+class RailDecision(str, Enum):
     """The three mutually exclusive things a rail can decide."""
 
     ALLOW = "allow"

--- a/tests/test_generation_options.py
+++ b/tests/test_generation_options.py
@@ -18,12 +18,77 @@ import os.path
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.rails.llm.options import (
     GenerationLog,
     GenerationResponse,
     GenerationStats,
 )
 from tests.utils import TestChat
+
+_RAIL_OUTCOME_CASES = [
+    pytest.param(
+        RailOutcome.allow(reason="allowed", metadata={"score": 0.9}),
+        id="allow",
+    ),
+    pytest.param(
+        RailOutcome.block(reason="blocked", metadata={"categories": ["unsafe"]}),
+        id="block",
+    ),
+    pytest.param(
+        RailOutcome.transform(
+            [
+                (TransformTarget.USER_MESSAGE, "masked input"),
+                (TransformTarget.BOT_MESSAGE, "masked output"),
+                (TransformTarget.RELEVANT_CHUNKS, "masked chunks"),
+            ],
+            reason="transformed",
+            metadata={"entities": ["name"]},
+        ),
+        id="transform",
+    ),
+]
+
+
+def _generate_with_rail_outcome(outcome, *, log=None, output_vars=None):
+    config = RailsConfig.from_content(
+        colang_content="""
+            define subflow outcome input rail
+              $response = execute outcome_action
+        """,
+        yaml_content="""
+            rails:
+              input:
+                flows:
+                  - outcome input rail
+        """,
+    )
+    chat = TestChat(config, llm_completions=[])
+
+    async def outcome_action():
+        return outcome
+
+    chat.app.register_action(outcome_action)
+    options = {"rails": ["input"]}
+    if log is not None:
+        options["log"] = log
+    if output_vars is not None:
+        options["output_vars"] = output_vars
+
+    return chat.app.generate("Hello!", options=options)
+
+
+def _json_round_trip(model):
+    return json.loads(json.dumps(model.model_dump()))
+
+
+def _expected_serialized_outcome(outcome):
+    return {
+        "decision": outcome.decision.value,
+        "reason": outcome.reason,
+        "metadata": dict(outcome.metadata),
+        "transforms": [{"target": spec.target.value, "text": spec.text} for spec in outcome.transforms],
+    }
 
 
 def test_output_vars_1():
@@ -181,6 +246,61 @@ def test_triggered_abc_bot():
     print(json.dumps(res.log.dict(), indent=True))
 
     res.log.print_summary()
+
+
+@pytest.mark.parametrize("outcome", _RAIL_OUTCOME_CASES)
+@pytest.mark.parametrize("log_field", ["activated_rails", "internal_events"])
+def test_generation_log_with_rail_outcome_is_json_serializable(outcome, log_field):
+    res = _generate_with_rail_outcome(outcome, log={log_field: True})
+
+    data = _json_round_trip(res.log)
+
+    if log_field == "activated_rails":
+        serialized_outcome = data["activated_rails"][0]["executed_actions"][0]["return_value"]
+    else:
+        action_event = next(
+            event
+            for event in data["internal_events"]
+            if event["type"] == "InternalSystemActionFinished" and event["action_name"] == "outcome_action"
+        )
+        serialized_outcome = action_event["return_value"]
+
+    assert serialized_outcome == _expected_serialized_outcome(outcome)
+
+
+@pytest.mark.parametrize("outcome", _RAIL_OUTCOME_CASES)
+@pytest.mark.parametrize(
+    "surface",
+    [
+        "activated_rails",
+        "internal_events",
+        "selected_output_vars",
+        "all_output_vars",
+    ],
+)
+def test_generation_response_with_rail_outcome_is_json_serializable(outcome, surface):
+    if surface in {"activated_rails", "internal_events"}:
+        res = _generate_with_rail_outcome(outcome, log={surface: True})
+    elif surface == "selected_output_vars":
+        res = _generate_with_rail_outcome(outcome, output_vars=["response"])
+    else:
+        res = _generate_with_rail_outcome(outcome, output_vars=True)
+
+    data = _json_round_trip(res)
+
+    if surface == "activated_rails":
+        serialized_outcome = data["log"]["activated_rails"][0]["executed_actions"][0]["return_value"]
+    elif surface == "internal_events":
+        action_event = next(
+            event
+            for event in data["log"]["internal_events"]
+            if event["type"] == "InternalSystemActionFinished" and event["action_name"] == "outcome_action"
+        )
+        serialized_outcome = action_event["return_value"]
+    else:
+        serialized_outcome = data["output_data"]["response"]
+
+    assert serialized_outcome == _expected_serialized_outcome(outcome)
 
 
 @pytest.mark.skip(reason="Run manually.")

--- a/tests/test_generation_options.py
+++ b/tests/test_generation_options.py
@@ -91,6 +91,16 @@ def _expected_serialized_outcome(outcome):
     }
 
 
+def _get_outcome_action_event(events):
+    action_events = [
+        event
+        for event in events
+        if event["type"] == "InternalSystemActionFinished" and event["action_name"] == "outcome_action"
+    ]
+    assert len(action_events) == 1, f"Expected one outcome_action completion event, found {len(action_events)}"
+    return action_events[0]
+
+
 def test_output_vars_1():
     config = RailsConfig.from_content(
         colang_content="""
@@ -258,11 +268,7 @@ def test_generation_log_with_rail_outcome_is_json_serializable(outcome, log_fiel
     if log_field == "activated_rails":
         serialized_outcome = data["activated_rails"][0]["executed_actions"][0]["return_value"]
     else:
-        action_event = next(
-            event
-            for event in data["internal_events"]
-            if event["type"] == "InternalSystemActionFinished" and event["action_name"] == "outcome_action"
-        )
+        action_event = _get_outcome_action_event(data["internal_events"])
         serialized_outcome = action_event["return_value"]
 
     assert serialized_outcome == _expected_serialized_outcome(outcome)
@@ -291,11 +297,7 @@ def test_generation_response_with_rail_outcome_is_json_serializable(outcome, sur
     if surface == "activated_rails":
         serialized_outcome = data["log"]["activated_rails"][0]["executed_actions"][0]["return_value"]
     elif surface == "internal_events":
-        action_event = next(
-            event
-            for event in data["log"]["internal_events"]
-            if event["type"] == "InternalSystemActionFinished" and event["action_name"] == "outcome_action"
-        )
+        action_event = _get_outcome_action_event(data["log"]["internal_events"])
         serialized_outcome = action_event["return_value"]
     else:
         serialized_outcome = data["output_data"]["response"]


### PR DESCRIPTION
## Description

Make `RailDecision` string-backed so `RailOutcome` values in generation logs and responses remain JSON-serializable. Add regression coverage for all decisions across activated rails, internal events, and output variables.


## Verification

- `make test TEST=tests/test_generation_options.py WORKERS=1` (`31 passed, 2 skipped`)
- `make test TEST=tests/test_rail_outcome.py WORKERS=1` (`28 passed`)
- Verified `json.dumps(response.log.dict())` emits the decision as a string.
- Pre-commit passed on both changed files.
- Full test suite not run; CI will provide broader coverage.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when rail outcomes are serialized, allowing decisions such as allow, block, and transform to be represented as standard strings.
  - Ensured rail outcome details in generation logs and responses can be safely converted to and restored from JSON without losing information.

- **Tests**
  - Added coverage for JSON serialization across supported rail outcome types and output surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->