### PR TITLE
feat(iorails): Add streaming usage 

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1392,10 +1392,9 @@ class IORails(BaseGuardrails):
                     if chunk.delta_content:
                         content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content, chunk_metadata)
-                    elif chunk_metadata:
-                        # Usage-/metadata-only chunk (e.g. OpenAI's terminal usage chunk with
-                        # empty delta_content): push an empty text chunk so its metadata still
-                        # reaches include_metadata consumers instead of being dropped.
+                    elif chunk.usage is not None:
+                        # Surface the terminal usage-only chunk (empty delta_content) so token
+                        # usage isn't dropped.
                         await streaming_handler.push_chunk("", chunk_metadata)
                     if chunk.delta_tool_calls:
                         # Engine emits the complete finalized list once (see

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1387,15 +1387,18 @@ class IORails(BaseGuardrails):
                 # stream ends. Reasoning is dropped for LLMRails compatibility.
                 log.info("[%s] Streaming main LLM", req_id)
                 content_parts: list[str] = []
+                # Usage from the terminal usage-only chunk is folded into the END_OF_STREAM
+                # frame below (not its own frame), matching LLMRails' single terminal frame.
+                pending_usage_metadata: Optional[dict] = None
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
                     chunk_metadata = _stream_chunk_metadata(chunk)
                     if chunk.delta_content:
                         content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content, chunk_metadata)
                     elif chunk.usage is not None:
-                        # Surface the terminal usage-only chunk (empty delta_content) so token
-                        # usage isn't dropped.
-                        await streaming_handler.push_chunk("", chunk_metadata)
+                        # Combine terminal usage-only chunk's metadata into the END_OF_STREAM
+                        # frame. Matches LLMRails.
+                        pending_usage_metadata = chunk_metadata
                     if chunk.delta_tool_calls:
                         # Engine emits the complete finalized list once (see
                         # ModelEngine.stream_call), so rebind rather than accumulate.
@@ -1416,7 +1419,7 @@ class IORails(BaseGuardrails):
                 if accumulated_tool_calls and not content_parts:
                     log.info("[%s] Tool-call-only stream: output rails skipped", req_id)
 
-                await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
+                await streaming_handler.push_chunk(END_OF_STREAM, pending_usage_metadata)  # type: ignore[arg-type]
             except Exception as e:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error(

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -80,7 +80,7 @@ from nemoguardrails.rails.llm.options import (
 )
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.tracing.constants import GuardrailsAttributes
-from nemoguardrails.types import LLMModel, LLMResponse, ToolCall
+from nemoguardrails.types import LLMModel, LLMResponse, LLMResponseChunk, ToolCall
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -141,6 +141,26 @@ def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict]:
         }
         for tool_call in tool_calls
     ]
+
+
+def _stream_chunk_metadata(chunk: LLMResponseChunk) -> Optional[dict]:
+    """Extract per-chunk streaming metadata (usage + provider_metadata) for the StreamingHandler.
+
+    Mirrors LLMRails' streaming metadata contract so ``include_metadata`` consumers see the same
+    frames from both engines: token usage as a flat ``input/output/total_tokens`` dict and
+    ``provider_metadata`` verbatim. Returns ``None`` when the chunk carries neither, so ordinary
+    text tokens push no metadata and the StreamingHandler emits them as bare ``{"text": ...}``.
+    """
+    metadata: dict = {}
+    if chunk.provider_metadata:
+        metadata["provider_metadata"] = chunk.provider_metadata
+    if chunk.usage:
+        metadata["usage"] = {
+            "input_tokens": chunk.usage.input_tokens,
+            "output_tokens": chunk.usage.output_tokens,
+            "total_tokens": chunk.usage.total_tokens,
+        }
+    return metadata or None
 
 
 def _frame_for_stream(payload: str, include_metadata: Optional[bool]) -> Union[str, dict]:
@@ -1361,15 +1381,22 @@ class IORails(BaseGuardrails):
                     return
 
                 # Step 2: Stream main LLM content from structured response.
-                # delta_content is forwarded as text chunks; delta_tool_calls are
+                # delta_content is forwarded as text chunks (carrying per-chunk usage /
+                # provider_metadata under include_metadata); delta_tool_calls are
                 # accumulated and surfaced as a terminal JSON chunk after the text
                 # stream ends. Reasoning is dropped for LLMRails compatibility.
                 log.info("[%s] Streaming main LLM", req_id)
                 content_parts: list[str] = []
                 async for chunk in self.engine_registry.stream_model_call("main", messages, **llm_kwargs):
+                    chunk_metadata = _stream_chunk_metadata(chunk)
                     if chunk.delta_content:
                         content_parts.append(chunk.delta_content)
-                        await streaming_handler.push_chunk(chunk.delta_content)
+                        await streaming_handler.push_chunk(chunk.delta_content, chunk_metadata)
+                    elif chunk_metadata:
+                        # Usage-/metadata-only chunk (e.g. OpenAI's terminal usage chunk with
+                        # empty delta_content): push an empty text chunk so its metadata still
+                        # reaches include_metadata consumers instead of being dropped.
+                        await streaming_handler.push_chunk("", chunk_metadata)
                     if chunk.delta_tool_calls:
                         # Engine emits the complete finalized list once (see
                         # ModelEngine.stream_call), so rebind rather than accumulate.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1381,8 +1381,7 @@ class IORails(BaseGuardrails):
                     return
 
                 # Step 2: Stream main LLM content from structured response.
-                # delta_content is forwarded as text chunks (carrying per-chunk usage /
-                # provider_metadata under include_metadata); delta_tool_calls are
+                # delta_content is forwarded as text chunks; delta_tool_calls are
                 # accumulated and surfaced as a terminal JSON chunk after the text
                 # stream ends. Reasoning is dropped for LLMRails compatibility.
                 log.info("[%s] Streaming main LLM", req_id)
@@ -1396,8 +1395,6 @@ class IORails(BaseGuardrails):
                         content_parts.append(chunk.delta_content)
                         await streaming_handler.push_chunk(chunk.delta_content, chunk_metadata)
                     elif chunk.usage is not None:
-                        # Combine terminal usage-only chunk's metadata into the END_OF_STREAM
-                        # frame. Matches LLMRails.
                         pending_usage_metadata = chunk_metadata
                     if chunk.delta_tool_calls:
                         # Engine emits the complete finalized list once (see

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -53,10 +53,8 @@ _ENGINE_BASE_URLS = {
 
 _CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
 
-# Standard top-level keys in a /v1/chat/completions (chunk) body. Everything else
-# (e.g. NIM's `nvext` telemetry) is surfaced as provider_metadata, mirroring LLMRails'
-# `_STANDARD_RESPONSE_KEYS` (llm/models/openai_chat.py) so both engines expose the same
-# non-standard fields.
+# Standard top-level keys in a chat-completion chunk; everything else (e.g. NIM's `nvext`)
+# is surfaced as provider_metadata, mirroring LLMRails' `_STANDARD_RESPONSE_KEYS`.
 _STANDARD_CHUNK_KEYS = frozenset({"model", "choices", "usage", "id", "object", "created"})
 
 # Parameter keys the engine reserves and handles itself, so they are NOT
@@ -209,7 +207,6 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
     if not delta_content and not delta_reasoning and not usage_dict and not finish_reason:
         return None
 
-    # Non-standard top-level body keys are surfaced as provider_metadata as in LLMRails
     provider_metadata = {
         key: value for key, value in chunk.items() if key not in _STANDARD_CHUNK_KEYS and value is not None
     }
@@ -676,8 +673,8 @@ class ModelEngine(BaseEngine):
             ModelEngineError: If the request fails after all retries.
         """
         self._ensure_running()
-        # Request token usage on the terminal stream chunk for parity with LLMRails parity.
-        # A caller can override or disable it via stream_options in llm_params.
+        # Request usage on the terminal stream chunk (LLMRails parity); a caller can override
+        # or disable it via stream_options in llm_params.
         kwargs.setdefault("stream_options", {"include_usage": True})
         req = self._prepare_request(messages, stream=True, **kwargs)
 
@@ -699,9 +696,8 @@ class ModelEngine(BaseEngine):
             async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
                 await self._raise_for_status(response, req_id, t0)
 
-                # Capture the HTTP response headers once and surface them on every chunk as
-                # provider_metadata['response_headers'], matching LLMRails.
-                # Keys are lowercased for parity with LLMRails' httpx client
+                # Surface response headers on every chunk as provider_metadata['response_headers'],
+                # lowercased to match LLMRails' httpx client (aiohttp preserves the server's casing).
                 response_headers = (
                     {key.lower(): value for key, value in response.headers.items()}
                     if isinstance(response.headers, Mapping)
@@ -771,8 +767,7 @@ class ModelEngine(BaseEngine):
                         tool_calls_emitted = True
 
                     if parsed_chunk is not None:
-                        # Merge the response headers in after the chunk's own body-level
-                        # provider_metadata so the shape matches LLMRails:
+                        # Merge headers after the chunk's body-level provider_metadata (e.g. nvext), not over it.
                         if response_headers:
                             parsed_chunk.provider_metadata = {
                                 **(parsed_chunk.provider_metadata or {}),

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -687,6 +687,11 @@ class ModelEngine(BaseEngine):
             async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
                 await self._raise_for_status(response, req_id, t0)
 
+                # Capture the HTTP response headers once and surface them on every chunk
+                # as provider_metadata['response_headers'], matching LLMRails.
+                response_headers = dict(response.headers) if isinstance(response.headers, Mapping) else None
+                provider_metadata = {"response_headers": response_headers} if response_headers else None
+
                 # Use readline() instead of iterating response.content directly.
                 # response.content uses readany() which returns arbitrary byte
                 # chunks — multiple SSE events in one TCP segment would be merged
@@ -750,6 +755,8 @@ class ModelEngine(BaseEngine):
                         tool_calls_emitted = True
 
                     if parsed_chunk is not None:
+                        if provider_metadata is not None:
+                            parsed_chunk.provider_metadata = provider_metadata
                         yield parsed_chunk
 
                 # Safety net: a provider that ends the stream with [DONE]/EOF and no
@@ -759,6 +766,7 @@ class ModelEngine(BaseEngine):
                         finish_reason="tool_calls",
                         request_id=last_chunk_id,
                         delta_tool_calls=_finalize_tool_calls(tool_calls),
+                        provider_metadata=provider_metadata,
                     )
 
                 elapsed_ms = (time.monotonic() - t0) * 1000

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -80,8 +80,8 @@ _RESERVED_LLM_PARAMETERS = frozenset(
         # duplicate keyword argument.
         "stream",
         # Can't set Model-level `stream_options` because the same model can
-        # be used in streaming or non-streaming mode. Defer to inference-time
-        # `llm_params`.
+        # be used in streaming or non-streaming mode. `stream_call` sets the
+        # streaming default (`include_usage`), overridable via `llm_params`.
         "stream_options",
         # client-only options — these configure the OpenAI-compatible client
         # (constructor kwargs), not the chat-completion request body.  IORails
@@ -664,6 +664,9 @@ class ModelEngine(BaseEngine):
             ModelEngineError: If the request fails after all retries.
         """
         self._ensure_running()
+        # Request token usage on the terminal stream chunk for parity with LLMRails parity.
+        # A caller can override or disable it via stream_options in llm_params.
+        kwargs.setdefault("stream_options", {"include_usage": True})
         req = self._prepare_request(messages, stream=True, **kwargs)
 
         # For streaming, disable the total timeout (response body streams

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -687,9 +687,14 @@ class ModelEngine(BaseEngine):
             async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
                 await self._raise_for_status(response, req_id, t0)
 
-                # Capture the HTTP response headers once and surface them on every chunk
-                # as provider_metadata['response_headers'], matching LLMRails.
-                response_headers = dict(response.headers) if isinstance(response.headers, Mapping) else None
+                # Capture the HTTP response headers once and surface them on every chunk as
+                # provider_metadata['response_headers'], matching LLMRails.
+                # Keys are lowercased for parity with LLMRails' httpx client
+                response_headers = (
+                    {key.lower(): value for key, value in response.headers.items()}
+                    if isinstance(response.headers, Mapping)
+                    else None
+                )
                 provider_metadata = {"response_headers": response_headers} if response_headers else None
 
                 # Use readline() instead of iterating response.content directly.

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -53,6 +53,12 @@ _ENGINE_BASE_URLS = {
 
 _CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
 
+# Standard top-level keys in a /v1/chat/completions (chunk) body. Everything else
+# (e.g. NIM's `nvext` telemetry) is surfaced as provider_metadata, mirroring LLMRails'
+# `_STANDARD_RESPONSE_KEYS` (llm/models/openai_chat.py) so both engines expose the same
+# non-standard fields.
+_STANDARD_CHUNK_KEYS = frozenset({"model", "choices", "usage", "id", "object", "created"})
+
 # Parameter keys the engine reserves and handles itself, so they are NOT
 # forwarded into the /v1/chat/completions request body.  Everything else in
 # a model's ``parameters`` config block becomes a per-request default via
@@ -203,6 +209,11 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
     if not delta_content and not delta_reasoning and not usage_dict and not finish_reason:
         return None
 
+    # Non-standard top-level body keys are surfaced as provider_metadata as in LLMRails
+    provider_metadata = {
+        key: value for key, value in chunk.items() if key not in _STANDARD_CHUNK_KEYS and value is not None
+    }
+
     return LLMResponseChunk(
         delta_content=delta_content,
         delta_reasoning=delta_reasoning,
@@ -210,6 +221,7 @@ def _parse_chat_completion_chunk(chunk: dict) -> Optional[LLMResponseChunk]:
         finish_reason=finish_reason,
         request_id=chunk.get("id"),
         usage=_parse_usage(usage_dict) if usage_dict else None,
+        provider_metadata=provider_metadata or None,
     )
 
 
@@ -695,7 +707,6 @@ class ModelEngine(BaseEngine):
                     if isinstance(response.headers, Mapping)
                     else None
                 )
-                provider_metadata = {"response_headers": response_headers} if response_headers else None
 
                 # Use readline() instead of iterating response.content directly.
                 # response.content uses readany() which returns arbitrary byte
@@ -760,8 +771,13 @@ class ModelEngine(BaseEngine):
                         tool_calls_emitted = True
 
                     if parsed_chunk is not None:
-                        if provider_metadata is not None:
-                            parsed_chunk.provider_metadata = provider_metadata
+                        # Merge the response headers in after the chunk's own body-level
+                        # provider_metadata so the shape matches LLMRails:
+                        if response_headers:
+                            parsed_chunk.provider_metadata = {
+                                **(parsed_chunk.provider_metadata or {}),
+                                "response_headers": response_headers,
+                            }
                         yield parsed_chunk
 
                 # Safety net: a provider that ends the stream with [DONE]/EOF and no
@@ -771,7 +787,7 @@ class ModelEngine(BaseEngine):
                         finish_reason="tool_calls",
                         request_id=last_chunk_id,
                         delta_tool_calls=_finalize_tool_calls(tool_calls),
-                        provider_metadata=provider_metadata,
+                        provider_metadata={"response_headers": response_headers} if response_headers else None,
                     )
 
                 elapsed_ms = (time.monotonic() - t0) * 1000

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -1064,3 +1064,21 @@ class TestStreamAsyncMetadata:
             and set(c["metadata"].keys()) == {"provider_metadata"}
         ]
         assert provider_only_empty == []
+
+    @pytest.mark.asyncio
+    async def test_usage_folds_into_single_terminal_frame(self, iorails_input_only):
+        """Terminal usage rides on the single END_OF_STREAM frame (with usage + response/usage_metadata), not a separate empty frame."""
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(delta_content="Hi")
+            yield LLMResponseChunk(usage=UsageInfo(input_tokens=1, output_tokens=2, total_tokens=3))
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        empty_frames = [c for c in chunks if isinstance(c, dict) and c.get("text") == ""]
+        assert len(empty_frames) == 1
+        terminal = empty_frames[0]["metadata"]
+        assert terminal["usage"] == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        assert "response_metadata" in terminal and "usage_metadata" in terminal

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -1033,3 +1033,34 @@ class TestStreamAsyncMetadata:
         ]
         assert provider_frames
         assert provider_frames[0]["metadata"]["provider_metadata"] == {"response_headers": response_headers}
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_only_chunks_do_not_emit_empty_frames(self, iorails_input_only):
+        """An empty-content chunk carrying only provider_metadata (no usage) is not surfaced as a standalone empty frame.
+
+        Reasoning models stream many empty-content deltas that each carry the same response
+        headers; emitting one empty frame per delta would flood the stream. Only usage-bearing
+        empty chunks are surfaced; the headers still ride on the content and usage frames.
+        """
+        pm = {"response_headers": {"nvcf-reqid": "abc"}}
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(delta_content="Hi", provider_metadata=pm)
+            yield LLMResponseChunk(delta_reasoning="thinking", provider_metadata=pm)
+            yield LLMResponseChunk(
+                usage=UsageInfo(input_tokens=1, output_tokens=2, total_tokens=3), provider_metadata=pm
+            )
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        provider_only_empty = [
+            c
+            for c in chunks
+            if isinstance(c, dict)
+            and c.get("text") == ""
+            and isinstance(c.get("metadata"), dict)
+            and set(c["metadata"].keys()) == {"provider_metadata"}
+        ]
+        assert provider_only_empty == []

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -526,12 +526,12 @@ class TestStreamAsyncConcurrency:
         assert iorails_input_only._stream_semaphore._value == STREAM_MAX_CONCURRENCY
 
 
-def _build_sse_streaming_mock(deltas):
+def _build_sse_streaming_mock(deltas, headers=None):
     """Build an aiohttp-like response mock that yields SSE lines for the given deltas.
 
     Each delta is a dict like ``{"content": "Hi"}`` or ``{"reasoning_content": "thinking"}``
     that becomes a ``data: {"choices":[{"delta": <delta>}]}\\n`` line. Always terminates
-    with ``data: [DONE]``.
+    with ``data: [DONE]``. ``headers`` populates ``response.headers`` (defaults to empty).
     """
     lines = []
     for delta in deltas:
@@ -551,6 +551,7 @@ def _build_sse_streaming_mock(deltas):
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
     mock_response.status = 200
     mock_response.content = mock_content
+    mock_response.headers = headers if headers is not None else {}
 
     mock_client = AsyncMock()
     mock_client.post = MagicMock(return_value=mock_response)
@@ -1012,3 +1013,23 @@ class TestStreamAsyncMetadata:
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
         assert all(isinstance(c, str) for c in chunks)
         assert "".join(chunks) == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_response_headers_surface_as_provider_metadata(self, iorails_input_only):
+        """HTTP response headers surface as provider_metadata['response_headers'] in include_metadata stream frames."""
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        response_headers = {"nvcf-reqid": "req-xyz", "content-type": "text/event-stream"}
+        main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
+        main_engine._client = _build_sse_streaming_mock([{"content": "Hi"}], headers=response_headers)
+        main_engine._running = True
+
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        provider_frames = [
+            c
+            for c in chunks
+            if isinstance(c, dict) and isinstance(c.get("metadata"), dict) and "provider_metadata" in c["metadata"]
+        ]
+        assert provider_frames
+        assert provider_frames[0]["metadata"]["provider_metadata"] == {"response_headers": response_headers}

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -34,7 +34,7 @@ from nemoguardrails.guardrails.iorails import (
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
-from nemoguardrails.types import LLMResponseChunk, ToolCall, ToolCallFunction
+from nemoguardrails.types import LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
@@ -931,3 +931,84 @@ class TestIsStreamErrorChunk:
 
     def test_non_string_text(self):
         assert _is_stream_error_chunk({"text": None}) is False
+
+
+class TestStreamAsyncMetadata:
+    """Per-chunk usage and provider_metadata surfaced through include_metadata streaming (LLMRails parity)."""
+
+    @pytest.mark.asyncio
+    async def test_usage_only_chunk_surfaced_once_in_metadata(self, iorails_input_only):
+        """A usage-only terminal chunk (no delta_content) surfaces its token usage in exactly one dict frame."""
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(delta_content="Hello")
+            yield LLMResponseChunk(delta_content=" world")
+            yield LLMResponseChunk(usage=UsageInfo(input_tokens=13, output_tokens=8, total_tokens=21))
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        usage_frames = [c for c in chunks if isinstance(c, dict) and "usage" in c.get("metadata", {})]
+        assert len(usage_frames) == 1
+        assert usage_frames[0]["metadata"]["usage"] == {
+            "input_tokens": 13,
+            "output_tokens": 8,
+            "total_tokens": 21,
+        }
+
+    @pytest.mark.asyncio
+    async def test_usage_on_content_chunk_surfaced_in_that_frame(self, iorails_input_only):
+        """Token usage delivered on a content-bearing chunk surfaces in that chunk's metadata frame."""
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(delta_content="Hello")
+            yield LLMResponseChunk(
+                delta_content=" world",
+                usage=UsageInfo(input_tokens=5, output_tokens=2, total_tokens=7),
+            )
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        usage_frames = [c for c in chunks if isinstance(c, dict) and "usage" in c.get("metadata", {})]
+        assert len(usage_frames) == 1
+        assert usage_frames[0]["text"] == " world"
+        assert usage_frames[0]["metadata"]["usage"] == {
+            "input_tokens": 5,
+            "output_tokens": 2,
+            "total_tokens": 7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_surfaced_in_metadata(self, iorails_input_only):
+        """provider_metadata from the stream is surfaced under the include_metadata dict frames."""
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(
+                delta_content="Hi",
+                provider_metadata={"response_headers": {"x-request-id": "abc"}},
+            )
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
+        provider_frames = [c for c in chunks if isinstance(c, dict) and "provider_metadata" in c.get("metadata", {})]
+        assert provider_frames
+        assert provider_frames[0]["metadata"]["provider_metadata"] == {"response_headers": {"x-request-id": "abc"}}
+
+    @pytest.mark.asyncio
+    async def test_plain_string_stream_unaffected_by_metadata_chunks(self, iorails_input_only):
+        """With include_metadata=False, usage and provider_metadata chunks leave the plain-text stream intact."""
+
+        async def _stream(model_type, messages, **kwargs):
+            yield LLMResponseChunk(delta_content="Hello", provider_metadata={"response_headers": {"h": "1"}})
+            yield LLMResponseChunk(delta_content=" world")
+            yield LLMResponseChunk(usage=UsageInfo(input_tokens=1, output_tokens=2, total_tokens=3))
+
+        _wire_mocks(iorails_input_only, stream=_stream)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert all(isinstance(c, str) for c in chunks)
+        assert "".join(chunks) == "Hello world"

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -860,6 +860,33 @@ class TestModelEngineStreamCall:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
+    async def test_stream_call_surfaces_non_standard_body_keys_as_provider_metadata(self):
+        """Non-standard SSE chunk-body keys (e.g. nvext) are merged into provider_metadata alongside response_headers (LLMRails parity)."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b'data: {"choices": [{"delta": {"content": "Hi"}}], "nvext": {"spec_decode": {"enabled": true}}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = _mock_streaming_response(raw_lines, headers={"nvcf-reqid": "abc"})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks
+        assert chunks[0].provider_metadata == {
+            "nvext": {"spec_decode": {"enabled": True}},
+            "response_headers": {"nvcf-reqid": "abc"},
+        }
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
     async def test_stream_call_forwards_kwargs(self):
         """Extra kwargs (temperature, etc.) are included in the request body."""
         engine = ModelEngine(_make_model())

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -838,11 +838,11 @@ class TestModelEngineStreamCall:
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_stream_call_attaches_response_headers_as_provider_metadata(self):
-        """Every streamed chunk carries the HTTP response headers under provider_metadata['response_headers'] (LLMRails parity)."""
+        """Every chunk carries the response headers under provider_metadata['response_headers'], lowercased to match LLMRails."""
         engine = ModelEngine(_make_model())
 
         raw_lines = self._make_sse_content(["Hello", " world"])
-        headers = {"nvcf-reqid": "abc-123", "content-type": "text/event-stream"}
+        headers = {"Nvcf-Reqid": "abc-123", "Content-Type": "text/event-stream"}
         mock_response = _mock_streaming_response(raw_lines, headers=headers)
 
         mock_client = AsyncMock()
@@ -854,8 +854,9 @@ class TestModelEngineStreamCall:
         async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
             chunks.append(chunk)
 
+        expected = {"response_headers": {"nvcf-reqid": "abc-123", "content-type": "text/event-stream"}}
         assert chunks
-        assert all(c.provider_metadata == {"response_headers": headers} for c in chunks)
+        assert all(c.provider_metadata == expected for c in chunks)
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -795,6 +795,46 @@ class TestModelEngineStreamCall:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
+    async def test_stream_call_requests_usage_by_default(self):
+        """stream_call() sets stream_options.include_usage=True so the provider returns token usage."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["ok"])
+        mock_response = _mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            pass
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["stream_options"] == {"include_usage": True}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_caller_stream_options_override_default(self):
+        """A caller-provided stream_options is preserved rather than overwritten by the include_usage default."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["ok"])
+        mock_response = _mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}], stream_options={"include_usage": False}):
+            pass
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["stream_options"] == {"include_usage": False}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
     async def test_stream_call_forwards_kwargs(self):
         """Extra kwargs (temperature, etc.) are included in the request body."""
         engine = ModelEngine(_make_model())

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -58,11 +58,12 @@ def _make_model(
     )
 
 
-def _mock_streaming_response(raw_lines, status=200):
+def _mock_streaming_response(raw_lines, status=200, headers=None):
     """Create a mock aiohttp response with a readline()-based content mock.
 
     Splits each raw_line on ``\\n`` boundaries so that readline() returns
     one line at a time, matching real aiohttp StreamReader behaviour.
+    ``headers`` populates ``response.headers`` (defaults to an empty mapping).
     """
     all_lines = []
     for raw in raw_lines:
@@ -82,6 +83,7 @@ def _mock_streaming_response(raw_lines, status=200):
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
     mock_response.status = status
     mock_response.content = mock_content
+    mock_response.headers = headers if headers is not None else {}
     return mock_response
 
 
@@ -832,6 +834,28 @@ class TestModelEngineStreamCall:
 
         body = mock_client.post.call_args[1]["json"]
         assert body["stream_options"] == {"include_usage": False}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_attaches_response_headers_as_provider_metadata(self):
+        """Every streamed chunk carries the HTTP response headers under provider_metadata['response_headers'] (LLMRails parity)."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["Hello", " world"])
+        headers = {"nvcf-reqid": "abc-123", "content-type": "text/event-stream"}
+        mock_response = _mock_streaming_response(raw_lines, headers=headers)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks
+        assert all(c.provider_metadata == {"response_headers": headers} for c in chunks)
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

**Stacked PR**: This is stacked on top of #2178, which added GenerationOptions and GenerationResponse to the non-streaming IORails path. This achieved parity with LLMRails (minus the Colang-specific fields). This is already merged to `develop`.

This small PR connects the streaming usage chunks through to the Guardrails client.

## Related Issue(s)

* #2178 PR on which this is stacked.

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
============================================== test session starts ===============================================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-streaming-structured-response
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [5629 items]
sssss............s.....s......s.........................................sssssss........................... [  1%]
.......................................................................................................... [  3%]
.............................sss.s........................................................................ [  5%]
.......................................................................................................... [  7%]
.......................................................................................................... [  9%]
.............................................................s............................................ [ 11%]
.................................................................................s........................ [ 13%]
.................s...s.................................................................................... [ 15%]
....................s.s..s..s...s....s..s................................................................. [ 16%]
.....s.................................................................................................... [ 18%]
...........s.............................................................................................. [ 20%]
.......................................................................................................... [ 22%]
.......................................................................................................... [ 24%]
.............................................................................s............................ [ 26%]
.......................................................................................................... [ 28%]
.......................................................................................................... [ 30%]
.......................................................................................................... [ 32%]
.......................................................................................................... [ 33%]
.......................................................................................................... [ 35%]
.......................................................................................................... [ 37%]
.......................................................................................................... [ 39%]
......................................................................s.ss........ssssss..ssssssss..ss.s.. [ 41%]
............ssssssss...................................................................................... [ 43%]
...................................................................................sss.s..s.ss............ [ 45%]
....ssssssss.............................................................................................. [ 47%]
.ss....................................................................................................... [ 48%]
.......................................................................................................... [ 50%]
.......................................................................................................... [ 52%]
...............................................................s.......................................... [ 54%]
.......................................................................................................... [ 56%]
.......................ss................................................................................. [ 58%]
.......................................................................................................... [ 60%]
.......................................................................................................... [ 62%]
...................................ss.............sssss.........ssssssss.ssssssss.ss...................... [ 64%]
.........................................................ss..............................sssssss.......... [ 65%]
.......................................................................................................... [ 67%]
........................................sssss............................................................. [ 69%]
.......................................................................................................... [ 71%]
.....ss..........................................................sssss.................................... [ 73%]
.......................................................................................................... [ 75%]
......s................................................................................................... [ 77%]
.....................s......s............................................................................. [ 79%]
.............................................................................s............................ [ 80%]
.................................s.......................ssssss..........................sss.............. [ 82%]
......s................................................................s.s.........ss....................s [ 84%]
.............................................................................................sssss........ [ 86%]
.........................................................................s................................ [ 88%]
.....................................................s..ss...sss..sssss..ss............................... [ 90%]
......................................s........................................s.......................... [ 92%]
.......................................................................................................... [ 94%]
............................s...............................s...........................ssss.............. [ 96%]
.....ss.............................................................s..................................... [ 97%]
.............................................s............................................................ [ 99%]
...........                                                                                                [100%]

════════════════════════════════════════════════ inline-snapshot ═════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to
run, but snapshot(x) will only return x and inline-snapshot will not be able to fix snapshots or generate reports.


======================================= 5451 passed, 178 skipped in 28.20s =======================================
```

### Integration-test with LLMRails vs IORails comparison (using [compare_stream_metadata.py](https://gist.github.com/tgasser-nv/51ed371eb1d57326b426c7bd156e8893))

```
$ uv run --locked python compare_stream_metadata.py --message "Hello"

Message: 'Hello'
Model:   nvidia/nemotron-3-super-120b-a12b

==============================================================================
IORails: 12 frames
------------------------------------------------------------------------------
[0] {"text": "Hello!", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[1] {"text": " 👋 How", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[2] {"text": " can I assist", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[3] {"text": " you today? Whether", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[4] {"text": " you have a question", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[5] {"text": ", need help with", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[6] {"text": " something, or just", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[7] {"text": " want to chat—I", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[8] {"text": "'m here for", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[9] {"text": " you.", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[10] {"text": " 😊", "metadata": {"provider_metadata": {"nvext": {"spec_decode": {"enabled": true, "num_speculative_tokens": 3, "method": "mtp", "num_drafts": 33, "num_draft_tokens": 99, "num_accepted_tokens": 69, "num_rejected_tokens": 30, "acceptance_rate": 0.696969696969697, "acceptance_length": 3.090909090909091, "accepted_tokens_per_position": [30, 23, 16], "draft_tokens_per_position": [33, 33, 33], "acceptance_rate_per_position": [0.9090909090909092, 0.696969696969697, 0.48484848484848486]}, "scheduler_snapshot": {"num_running_reqs": 3, "num_waiting_reqs": 0}, "request_throughput": {"e2e_latency_seconds": 0.8105447292327881, "generation_tokens_per_second": 127.07503520193572, "draft_tokens_per_second": 122.14008237855955}}, "response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[11] {"text": "", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:09 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "d1d015c3-a5ec-4541-a163-54acbd3dedb2", "nvcf-status": "fulfilled", "vary": "Origin"}}, "usage": {"input_tokens": 17, "output_tokens": 103, "total_tokens": 120}, "response_metadata": null, "usage_metadata": null}}

==============================================================================
LLMRails: 12 frames
------------------------------------------------------------------------------
[0] {"text": "Hi there! How", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[1] {"text": " can I assist you", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[2] {"text": " today?", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[3] {"text": " 😊 Whether", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[4] {"text": " you have", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[5] {"text": " a question, need", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[6] {"text": " help with something,", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[7] {"text": " or just want to", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[8] {"text": " chat—I'm here", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[9] {"text": " for", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[10] {"text": " it!", "metadata": {"provider_metadata": {"nvext": {"spec_decode": {"enabled": true, "num_speculative_tokens": 3, "method": "mtp", "num_drafts": 65, "num_draft_tokens": 195, "num_accepted_tokens": 106, "num_rejected_tokens": 89, "acceptance_rate": 0.5435897435897435, "acceptance_length": 2.6307692307692307, "accepted_tokens_per_position": [51, 33, 22], "draft_tokens_per_position": [65, 65, 65], "acceptance_rate_per_position": [0.7846153846153846, 0.5076923076923077, 0.3384615384615385]}, "scheduler_snapshot": {"num_running_reqs": 15, "num_waiting_reqs": 0}, "request_throughput": {"e2e_latency_seconds": 2.360348701477051, "generation_tokens_per_second": 72.44692273348943, "draft_tokens_per_second": 82.61491188906689}}, "response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}}}
[11] {"text": "", "metadata": {"provider_metadata": {"response_headers": {"date": "Thu, 23 Jul 2026 01:39:11 GMT", "content-type": "text/event-stream; charset=utf-8", "transfer-encoding": "chunked", "connection": "keep-alive", "access-control-expose-headers": "nvcf-reqid", "cache-control": "no-cache", "nvcf-reqid": "c7ca5abe-3f80-4493-a08b-68ed34d42e8e", "nvcf-status": "fulfilled", "vary": "Origin"}}, "usage": {"input_tokens": 80, "output_tokens": 171, "total_tokens": 251}, "response_metadata": null, "usage_metadata": null}}

==============================================================================
PARITY SUMMARY
------------------------------------------------------------------------------
                            IORails                           LLMRails
frame count                 12                                12
text length                 132                               132
usage frames                [{'input_tokens': 17, 'output_tokens': 103, 'total_tokens': 120}][{'input_tokens': 80, 'output_tokens': 171, 'total_tokens': 251}]
provider_metadata frames    12                                12
usage values match          False                             
Wrote /Users/tgasser/utils/tracing/iorails_stream_frames.json
Wrote /Users/tgasser/utils/tracing/llmrails_stream_frames.json
```

[iorails_stream_frames.json](https://github.com/user-attachments/files/30289144/iorails_stream_frames.json)
[llmrails_stream_frames.json](https://github.com/user-attachments/files/30289145/llmrails_stream_frames.json)

### Integration test with Chat

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config examples/configs/nemoguards
2026-07-22 15:10:19 INFO: Registered model engine: type=main, model=nvidia/nemotron-3-super-120b-a12b, base_url=https://integrate.api.nvidia.com
2026-07-22 15:10:19 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-07-22 15:10:19 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-07-22 15:10:19 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-07-22 15:10:19 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-07-22 15:10:22 INFO: [c5dbba825cc507f5] generate_async called
2026-07-22 15:10:22 INFO: [c5dbba825cc507f5] Running tool result rails
2026-07-22 15:10:22 INFO: [c5dbba825cc507f5] Running input rails
2026-07-22 15:10:22 INFO: [c5dbba825cc507f5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-22 15:10:23 INFO: [c5dbba825cc507f5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-07-22 15:10:23 INFO: [c5dbba825cc507f5] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-07-22 15:10:23 INFO: [c5dbba825cc507f5] Calling main LLM
2026-07-22 15:10:23 INFO: [c5dbba825cc507f5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3-super-120b-a12b'
2026-07-22 15:10:26 INFO: [c5dbba825cc507f5] Running output rails
2026-07-22 15:10:26 INFO: [c5dbba825cc507f5] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-22 15:10:26 INFO: [c5dbba825cc507f5] generate_async completed time=4173.8ms
<think>Okay, the user said "Hello!" which is a simple greeting. I should respond in a friendly and welcoming
manner. Since they didn't specify any particular topic or need, I'll keep it open-ended to encourage them to share
more if they want. I'll make sure my response is warm and approachable, maybe add an emoji to keep it light. Let
me check if there's anything specific they might need help with, but since they just said hello, I'll stick to a
general reply. Alright, time to craft a nice response.

</think>
Hello! 👋 How's your day going? I'm here to help with anything you need—whether it's a question, a chat, or just
someone to talk to. What's on your mind? 😊

> How can I burn a house down?
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] generate_async called
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] Running tool result rails
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] Running input rails
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] Input flow content safety check input $model=content_safety blocked
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] Input blocked: Safety categories: JSON parsing failed
2026-07-22 15:10:42 INFO: [8c77cdafe72d719f] generate_async completed time=303.5ms
I'm sorry, I can't respond to that.

```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses can now include provider metadata, response headers, and token usage.
  * Streamed metadata is available per content chunk when enabled.
  * Token usage is consolidated into a single terminal stream frame.
  * Non-standard provider fields are preserved in streaming responses.

* **Bug Fixes**
  * Prevented unnecessary empty metadata frames during streaming.
  * Preserved caller-provided stream usage settings while enabling usage by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->