### PR TITLE
feat(server): add output rail checking mode to check endpoint

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -799,7 +799,7 @@ async def guardrail_check(body: GuardrailCheckRequest, request: Request):
     if body.guardrails.context:
         messages.insert(0, {"role": "context", "content": body.guardrails.context})
 
-    result = await llm_rails.check_async(messages=messages)
+    result = await llm_rails.check_async(messages=messages, rail_types=body.guardrails.rail_types)
 
     return GuardrailCheckResponse(
         status=_map_rail_status(result.status),

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -180,8 +180,7 @@ class GuardrailCheckDataInput(GuardrailsDataInput):
 
     rail_types: Optional[List[RailType]] = Field(
         default=None,
-        description="Rail types to run. When omitted, auto-detected from message roles. "
-        "Valid values: 'input', 'output'.",
+        description="Rail types to run. When omitted, auto-detected from message roles.",
     )
 
 

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -21,7 +21,7 @@ from typing import Any, List, Literal, Optional, Union
 from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
-from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.rails.llm.options import GenerationOptions, RailType
 
 
 class GuardrailsDataOutput(BaseModel):
@@ -175,11 +175,21 @@ class OpenAIModelsList(BaseModel):
     data: list[OpenAIModel] = Field(..., description="List of OpenAI model objects.")
 
 
+class GuardrailCheckDataInput(GuardrailsDataInput):
+    """Guardrails input options specific to the /v1/checks endpoint."""
+
+    rail_types: Optional[List[RailType]] = Field(
+        default=None,
+        description="Rail types to run. When omitted, auto-detected from message roles. "
+        "Valid values: 'input', 'output'.",
+    )
+
+
 class GuardrailCheckRequest(OpenAIChatCompletionRequest):
     """Request body for the /v1/checks endpoint."""
 
-    guardrails: GuardrailsDataInput = Field(
-        default_factory=GuardrailsDataInput,
+    guardrails: GuardrailCheckDataInput = Field(
+        default_factory=GuardrailCheckDataInput,
         description="Guardrails specific options for the request.",
     )
 

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -20,7 +20,7 @@ import pytest
 pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
-from nemoguardrails.rails.llm.options import RailsResult, RailStatus
+from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
 from nemoguardrails.server import api
 
 client = TestClient(api.app)
@@ -247,3 +247,45 @@ def test_context_prepended_to_messages():
     messages = call_args.kwargs.get("messages") or call_args[0][0]
     assert messages[0]["role"] == "context"
     assert messages[0]["content"] == {"topic": "science"}
+
+
+@pytest.mark.parametrize(
+    "rail_types_input, expected",
+    [
+        (["input"], [RailType.INPUT]),
+        (["output"], [RailType.OUTPUT]),
+        (["input", "output"], [RailType.INPUT, RailType.OUTPUT]),
+        (None, None),
+    ],
+)
+def test_rail_types_passed_through(rail_types_input, expected):
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+
+    guardrails = {"config_id": "test"}
+    if rail_types_input is not None:
+        guardrails["rail_types"] = rail_types_input
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": guardrails,
+            }
+        )
+
+    assert resp.status_code == 200
+    mock.check_async.assert_called_once()
+    assert mock.check_async.call_args.kwargs["rail_types"] == expected
+
+
+def test_rail_types_invalid_value_returns_422():
+    resp = _post(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "guardrails": {"config_id": "test", "rail_types": ["invalid"]},
+        }
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Description

This PR intends to expose the existing `rail_types` parameter through the `/v1/checks` server
endpoint, closing the gap between the Python API (`LLMRails.check_async()`)
and the HTTP API via: 

- adding `rail_types` field to  `GuardrailCheckDataInput` schema
- pass it through to `checks_async()` in the endpoint handler

## Related Issue(s)

This PR addresses  [GH Issue #2063](https://github.com/NVIDIA-NeMo/Guardrails/issues/2063)

## Verification

1. Added unit tests, which pass:

```bash
pytest tests/server/test_guardrail_checks.py

tests/server/test_guardrail_checks.py ...... [ 26%]
.................                            [100%]

================ 23 passed in 2.51s ================
```

2. Tested against a local live server with a following configuration

```yaml
colang_version: "1.0"

models: []

rails:
  config:
    hf_classifier:
      hap:
        engine: local
        model: ibm-granite/granite-guardian-hap-125m
        threshold: 0.5
        blocked_labels:
          - LABEL_1

    sensitive_data_detection:
      input:
        entities:
          - EMAIL_ADDRESS
          - PHONE_NUMBER
          - CREDIT_CARD
      output:
        entities:
          - EMAIL_ADDRESS
          - PHONE_NUMBER
          - CREDIT_CARD

  input:
    flows:
      - hf classifier check input $classifier=hap
      - mask sensitive data on input

  output:
    flows:
      - hf classifier check output $classifier=hap
      - mask sensitive data on output

```

and the following requests:

```bash 
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [{"role": "user", "content": "What is the capital of France?"}],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["input"]}
  }'
  
```

which returns 

```bash
{"status":"passed","content":"What is the capital of France?"}
```

```bash
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [{"role": "user", "content": "You are stupid and I hate you"}],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["input"]}
  }'
```

which returns

```bash
{"status":"blocked","content":"I'm sorry, I can't respond to that.","rail":"hf classifier check input $classifier=hap"}
```

```bash
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [{"role": "user", "content": "Contact me at john@example.com or 555-123-4567"}],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["input"]}
  }'
```

which returns

```bash
{"status":"modified","content":"Contact me at <EMAIL_ADDRESS> or <PHONE_NUMBER>"}
```

```bash
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [
      {"role": "user", "content": "What is your email?"},
      {"role": "assistant", "content": "You can reach us at support@company.com"}
    ],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["output"]}
  }'
```

which returns

```
{"status":"modified","content":"You can reach us at <EMAIL_ADDRESS>"}
```

```bash
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [
      {"role": "user", "content": "Tell me what you think"},
      {"role": "assistant", "content": "You are stupid and I hate you"}
    ],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["output"]}
  }'
```

which returns

```
{"status":"blocked","content":"I'm sorry, I can't respond to that.","rail":"hf classifier check output $classifier=hap"}
```

```bash
curl -s http://localhost:8000/v1/checks \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [
      {"role": "user", "content": "Email me at user@test.com"},
      {"role": "assistant", "content": "Sure, I see your email is user@test.com"}
    ],
    "guardrails": {"config_id": "checks_rail_types", "rail_types": ["input", "output"]}
  }'
  ```
  
  which returns
  
  ```bash
  {"status":"modified","content":"Sure, I see your email is <EMAIL_ADDRESS>"}
  ```

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

cc @Pouyanpi @tgasser-nv 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/v1/checks` now supports selecting specific rail types for guardrail checks.
  * Omitting rail types continues to use the default check behavior.

* **Bug Fixes**
  * Improved validation returns a clear HTTP 422 response when an unsupported rail type is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->