### PR TITLE
fix(output_parsers): parse trailing category tokens for safe verdicts in is_content_safe

### DIFF
--- a/nemoguardrails/llm/output_parsers.py
+++ b/nemoguardrails/llm/output_parsers.py
@@ -74,6 +74,16 @@ def verbose_v1_parser(s: str):
 
     return "\n".join(lines)
 
+def _parse_safe_violations(response_text):
+    """Helper function to parse trailing category tokens from safe response."""
+    lower_response = response_text.lower()
+    safe_pos = lower_response.find("safe")
+    if safe_pos != -1:
+        after_safe = response_text[safe_pos + len("safe"):].strip()
+        if after_safe:
+            violations = [v.strip() for v in after_safe.split() if v.strip()]
+            return violations
+    return []
 
 def _parse_unsafe_violations(response_text):
     """Helper function to parse violations from unsafe response."""
@@ -125,7 +135,7 @@ def is_content_safe(response: str) -> Sequence[Union[bool, str]]:
     splited_response = response_lower.split(" ")[:2]
 
     response_actions = {
-        "safe": lambda: [True],
+        "safe": lambda: [True] + _parse_safe_violations(original_response),
         "unsafe": lambda: [False] + _parse_unsafe_violations(original_response),
         "yes": lambda: [False],
         "no": lambda: [True],

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -109,9 +109,7 @@ class TestContentSafetyParserIntegration:
         )
 
         assert result.is_blocked is False
-        # following assertion fails
-        # assert result.metadata["policy_violations"] == ["S1", "S8"]
-        assert result.metadata["policy_violations"] == []
+        assert result.metadata["policy_violations"] == ["S1", "S8"]
 
     @pytest.mark.parametrize(
         "response,expected_allowed,expected_violations",


### PR DESCRIPTION
## Summary
Fixes #2174

## Problem
`is_content_safe()` in `nemoguardrails/llm/output_parsers.py` only extracted 
trailing policy-category tokens (e.g., `S1`, `S8`) when the response prefix 
was `"unsafe"`. The `"safe"` branch unconditionally returned `[True]`, silently 
dropping any trailing category information.

## Fix
- Added `_parse_safe_violations()` helper that mirrors the existing 
  `_parse_unsafe_violations()` logic
- Updated the `"safe"` branch in `is_content_safe()` to call it
- Re-enabled the previously commented-out assertion in 
  `test_content_safety_input_with_is_content_safe_parser_safe_with_violations`

## Testing
All 36 tests in `tests/test_content_safety_integration.py` pass.