### PR TITLE
refactor(library): migrate HTTP request helpers

### DIFF
--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -19,7 +19,7 @@ from typing import Literal, Optional
 
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome
-from nemoguardrails.http import HTTPClient, http_call, resolve_http_client
+from nemoguardrails.http import HTTPClient, http_call
 from nemoguardrails.utils import new_uuid
 
 log = logging.getLogger(__name__)
@@ -117,15 +117,14 @@ async def call_activefence_api(
         "content_id": "ng-" + new_uuid(),
     }
 
-    async with resolve_http_client(http_client) as client:
-        response = await http_call(
-            client,
-            "POST",
-            url,
-            headers=headers,
-            json=data,
-            raise_for_status=False,
-        )
+    response = await http_call(
+        http_client,
+        "POST",
+        url,
+        headers=headers,
+        json=data,
+        raise_for_status=False,
+    )
     if response.status_code != 200:
         raise ValueError(f"ActiveFence call failed with status code {response.status_code}.\nDetails: {response.text}")
     response_json = response.json()

--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -17,10 +17,9 @@ import logging
 import os
 from typing import Literal, Optional
 
-import aiohttp
-
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.http import HTTPClient, http_call, resolve_http_client
 from nemoguardrails.utils import new_uuid
 
 log = logging.getLogger(__name__)
@@ -103,6 +102,7 @@ def _activefence_outcome(
 async def call_activefence_api(
     text: Optional[str] = None,
     threshold_mode: Literal["simple", "detailed"] = "simple",
+    http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
     api_key = os.environ.get("ACTIVEFENCE_API_KEY")
@@ -117,25 +117,26 @@ async def call_activefence_api(
         "content_id": "ng-" + new_uuid(),
     }
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
-            url=url,
+    async with resolve_http_client(http_client) as client:
+        response = await http_call(
+            client,
+            "POST",
+            url,
             headers=headers,
             json=data,
-        ) as response:
-            if response.status != 200:
-                raise ValueError(
-                    f"ActiveFence call failed with status code {response.status}.\nDetails: {await response.text()}"
-                )
-            response_json = await response.json()
-            log.info(json.dumps(response_json, indent=True))
-            violations = response_json["violations"]
+            raise_for_status=False,
+        )
+    if response.status_code != 200:
+        raise ValueError(f"ActiveFence call failed with status code {response.status_code}.\nDetails: {response.text}")
+    response_json = response.json()
+    log.info(json.dumps(response_json, indent=True))
+    violations = response_json["violations"]
 
-            violations_dict = {}
-            max_risk_score = 0.0
-            for violation in violations:
-                if violation["risk_score"] > max_risk_score:
-                    max_risk_score = violation["risk_score"]
-                violations_dict[violation["violation_type"]] = violation["risk_score"]
+    violations_dict = {}
+    max_risk_score = 0.0
+    for violation in violations:
+        if violation["risk_score"] > max_risk_score:
+            max_risk_score = violation["risk_score"]
+        violations_dict[violation["violation_type"]] = violation["risk_score"]
 
-            return _activefence_outcome(max_risk_score, violations_dict, threshold_mode)
+    return _activefence_outcome(max_risk_score, violations_dict, threshold_mode)

--- a/nemoguardrails/library/factchecking/align_score/actions.py
+++ b/nemoguardrails/library/factchecking/align_score/actions.py
@@ -19,6 +19,7 @@ from typing import Optional
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.http import HTTPClient
 from nemoguardrails.library.factchecking.align_score.request import alignscore_request
 from nemoguardrails.library.self_check.facts.actions import _fact_check_outcome, self_check_facts
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -33,6 +34,7 @@ async def alignscore_check_facts(
     context: Optional[dict] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
+    http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks the facts for the bot response using an information alignment score."""
@@ -45,7 +47,8 @@ async def alignscore_check_facts(
     evidence = context.get("relevant_chunks", [])
     response = context.get("bot_message")
 
-    alignscore = await alignscore_request(alignscore_api_url, evidence, response)
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
+    alignscore = await alignscore_request(alignscore_api_url, evidence, response, **request_kwargs)
     if alignscore is None:
         log.warning("AlignScore endpoint not set up properly. Falling back to the ask_llm approach for fact-checking.")
         if fallback_to_self_check:

--- a/nemoguardrails/library/factchecking/align_score/actions.py
+++ b/nemoguardrails/library/factchecking/align_score/actions.py
@@ -47,8 +47,12 @@ async def alignscore_check_facts(
     evidence = context.get("relevant_chunks", [])
     response = context.get("bot_message")
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
-    alignscore = await alignscore_request(alignscore_api_url, evidence, response, **request_kwargs)
+    alignscore = await alignscore_request(
+        alignscore_api_url,
+        evidence,
+        response,
+        http_client=http_client,
+    )
     if alignscore is None:
         log.warning("AlignScore endpoint not set up properly. Falling back to the ask_llm approach for fact-checking.")
         if fallback_to_self_check:

--- a/nemoguardrails/library/factchecking/align_score/request.py
+++ b/nemoguardrails/library/factchecking/align_score/request.py
@@ -17,7 +17,7 @@ import logging
 from typing import Optional
 
 from nemoguardrails.actions import action
-from nemoguardrails.http import HTTPClient, http_call, resolve_http_client
+from nemoguardrails.http import HTTPClient, http_call
 
 log = logging.getLogger(__name__)
 
@@ -35,14 +35,13 @@ async def alignscore_request(
 
     payload = {"evidence": evidence, "claim": response}
 
-    async with resolve_http_client(http_client) as client:
-        http_response = await http_call(
-            client,
-            "POST",
-            api_url,
-            json=payload,
-            raise_for_status=False,
-        )
+    http_response = await http_call(
+        http_client,
+        "POST",
+        api_url,
+        json=payload,
+        raise_for_status=False,
+    )
     if http_response.status_code != 200:
         log.error(f"AlignScore API request failed with status {http_response.status_code}")
         return None

--- a/nemoguardrails/library/factchecking/align_score/request.py
+++ b/nemoguardrails/library/factchecking/align_score/request.py
@@ -16,9 +16,8 @@
 import logging
 from typing import Optional
 
-import aiohttp
-
 from nemoguardrails.actions import action
+from nemoguardrails.http import HTTPClient, http_call, resolve_http_client
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +27,7 @@ async def alignscore_request(
     api_url: str = "http://localhost:5000/alignscore_large",
     evidence: Optional[list] = None,
     response: Optional[str] = None,
+    http_client: Optional[HTTPClient] = None,
 ):
     """Checks the facts for the bot response by making a request to the AlignScore API."""
     if not evidence:
@@ -35,17 +35,23 @@ async def alignscore_request(
 
     payload = {"evidence": evidence, "claim": response}
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(api_url, json=payload) as resp:
-            if resp.status != 200:
-                log.error(f"AlignScore API request failed with status {resp.status}")
-                return None
+    async with resolve_http_client(http_client) as client:
+        http_response = await http_call(
+            client,
+            "POST",
+            api_url,
+            json=payload,
+            raise_for_status=False,
+        )
+    if http_response.status_code != 200:
+        log.error(f"AlignScore API request failed with status {http_response.status_code}")
+        return None
 
-            result = await resp.json()
+    result = http_response.json()
 
-            log.info(f"AlignScore was {result}.")
-            try:
-                result = result["alignscore"]
-            except Exception:
-                result = None
-            return result
+    log.info(f"AlignScore was {result}.")
+    try:
+        result = result["alignscore"]
+    except Exception:
+        result = None
+    return result

--- a/nemoguardrails/library/gliner/actions.py
+++ b/nemoguardrails/library/gliner/actions.py
@@ -22,6 +22,7 @@ from typing import List, Optional
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.http import HTTPClient
 from nemoguardrails.library.gliner.request import gliner_request
 from nemoguardrails.rails.llm.config import GLiNERDetection
 
@@ -98,6 +99,7 @@ async def gliner_detect_pii(
     source: str,
     text: str,
     config: RailsConfig,
+    http_client: HTTPClient | None = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks whether the provided text contains any PII using GLiNER.
@@ -128,6 +130,7 @@ async def gliner_detect_pii(
 
     api_key = _resolve_api_key(gliner_config)
 
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     gliner_response = await gliner_request(
         text=text,
         server_endpoint=server_endpoint,
@@ -138,6 +141,7 @@ async def gliner_detect_pii(
         flat_ner=gliner_config.flat_ner,
         api_key=api_key,
         model=gliner_config.model,
+        **request_kwargs,
     )
 
     try:
@@ -148,7 +152,12 @@ async def gliner_detect_pii(
 
 
 @action(is_system_action=False)
-async def gliner_mask_pii(source: str, text: str, config: RailsConfig) -> RailOutcome:
+async def gliner_mask_pii(
+    source: str,
+    text: str,
+    config: RailsConfig,
+    http_client: HTTPClient | None = None,
+) -> RailOutcome:
     """Masks any detected PII in the provided text using GLiNER.
 
     Args:
@@ -177,6 +186,7 @@ async def gliner_mask_pii(source: str, text: str, config: RailsConfig) -> RailOu
 
     api_key = _resolve_api_key(gliner_config)
 
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     gliner_response = await gliner_request(
         text=text,
         server_endpoint=server_endpoint,
@@ -187,6 +197,7 @@ async def gliner_mask_pii(source: str, text: str, config: RailsConfig) -> RailOu
         flat_ner=gliner_config.flat_ner,
         api_key=api_key,
         model=gliner_config.model,
+        **request_kwargs,
     )
 
     if not gliner_response or not isinstance(gliner_response, dict):

--- a/nemoguardrails/library/gliner/actions.py
+++ b/nemoguardrails/library/gliner/actions.py
@@ -130,7 +130,6 @@ async def gliner_detect_pii(
 
     api_key = _resolve_api_key(gliner_config)
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     gliner_response = await gliner_request(
         text=text,
         server_endpoint=server_endpoint,
@@ -141,7 +140,7 @@ async def gliner_detect_pii(
         flat_ner=gliner_config.flat_ner,
         api_key=api_key,
         model=gliner_config.model,
-        **request_kwargs,
+        http_client=http_client,
     )
 
     try:
@@ -186,7 +185,6 @@ async def gliner_mask_pii(
 
     api_key = _resolve_api_key(gliner_config)
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     gliner_response = await gliner_request(
         text=text,
         server_endpoint=server_endpoint,
@@ -197,7 +195,7 @@ async def gliner_mask_pii(
         flat_ner=gliner_config.flat_ner,
         api_key=api_key,
         model=gliner_config.model,
-        **request_kwargs,
+        http_client=http_client,
     )
 
     if not gliner_response or not isinstance(gliner_response, dict):

--- a/nemoguardrails/library/gliner/request.py
+++ b/nemoguardrails/library/gliner/request.py
@@ -19,7 +19,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call, resolve_http_client
+from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call
 from nemoguardrails.library.gliner.models import GLiNERRequest
 
 log = logging.getLogger(__name__)
@@ -107,15 +107,14 @@ async def gliner_request(
     if request.labels:
         payload["labels"] = request.labels
 
-    async with resolve_http_client(http_client) as client:
-        response = await http_call(
-            client,
-            "POST",
-            server_endpoint,
-            json=payload,
-            headers=headers,
-            raise_for_status=False,
-        )
+    response = await http_call(
+        http_client,
+        "POST",
+        server_endpoint,
+        json=payload,
+        headers=headers,
+        raise_for_status=False,
+    )
     if response.status_code != 200:
         raise ValueError(f"GLiNER call failed with status code {response.status_code}.\nDetails: {response.text}")
 

--- a/nemoguardrails/library/gliner/request.py
+++ b/nemoguardrails/library/gliner/request.py
@@ -19,8 +19,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-import aiohttp
-
+from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call, resolve_http_client
 from nemoguardrails.library.gliner.models import GLiNERRequest
 
 log = logging.getLogger(__name__)
@@ -36,6 +35,7 @@ async def gliner_request(
     flat_ner: Optional[bool] = None,
     api_key: Optional[str] = None,
     model: str = "nvidia/gliner-pii",
+    http_client: Optional[HTTPClient] = None,
 ) -> Dict[str, Any]:
     """Send a PII detection request to the GLiNER API.
 
@@ -107,44 +107,48 @@ async def gliner_request(
     if request.labels:
         payload["labels"] = request.labels
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(server_endpoint, json=payload, headers=headers) as resp:
-            if resp.status != 200:
-                raise ValueError(f"GLiNER call failed with status code {resp.status}.\nDetails: {await resp.text()}")
+    async with resolve_http_client(http_client) as client:
+        response = await http_call(
+            client,
+            "POST",
+            server_endpoint,
+            json=payload,
+            headers=headers,
+            raise_for_status=False,
+        )
+    if response.status_code != 200:
+        raise ValueError(f"GLiNER call failed with status code {response.status_code}.\nDetails: {response.text}")
 
-            try:
-                raw = await resp.json()
-            except aiohttp.ContentTypeError as err:
-                raise ValueError(
-                    f"Failed to parse GLiNER response as JSON. Status: {resp.status}, Content: {await resp.text()}"
-                ) from err
+    try:
+        raw = response.json()
+    except HTTPResponseDecodeError as error:
+        raise ValueError(
+            f"Failed to parse GLiNER response as JSON. Status: {response.status_code}, Content: {response.text}"
+        ) from error
 
-            if not use_chat_completions:
-                return raw
+    if not use_chat_completions:
+        return raw
 
-            # Unwrap chat completions envelope and normalize entity field names.
-            # NIM uses: text, label, start, end
-            # Custom server uses: value, suggested_label, start_position, end_position
-            try:
-                nim_data = json.loads(raw["choices"][0]["message"]["content"])
-            except (KeyError, IndexError, json.JSONDecodeError, TypeError) as e:
-                raise ValueError(f"Failed to parse NIM response content: {e}") from e
+    try:
+        nim_data = json.loads(raw["choices"][0]["message"]["content"])
+    except (KeyError, IndexError, json.JSONDecodeError, TypeError) as e:
+        raise ValueError(f"Failed to parse NIM response content: {e}") from e
 
-            if not isinstance(nim_data, dict):
-                raise ValueError(f"Expected NIM response content to be a JSON object, got {type(nim_data).__name__}")
+    if not isinstance(nim_data, dict):
+        raise ValueError(f"Expected NIM response content to be a JSON object, got {type(nim_data).__name__}")
 
-            normalized_entities = [
-                {
-                    "value": e.get("text", e.get("value", "")),
-                    "suggested_label": e.get("label", e.get("suggested_label", "")),
-                    "start_position": e.get("start", e.get("start_position", 0)),
-                    "end_position": e.get("end", e.get("end_position", 0)),
-                    "score": e.get("score", 0.0),
-                }
-                for e in (nim_data.get("entities") or [])
-            ]
-            return {
-                "entities": normalized_entities,
-                "total_entities": nim_data.get("total_entities", len(normalized_entities)),
-                "tagged_text": nim_data.get("tagged_text", ""),
-            }
+    normalized_entities = [
+        {
+            "value": e.get("text", e.get("value", "")),
+            "suggested_label": e.get("label", e.get("suggested_label", "")),
+            "start_position": e.get("start", e.get("start_position", 0)),
+            "end_position": e.get("end", e.get("end_position", 0)),
+            "score": e.get("score", 0.0),
+        }
+        for e in (nim_data.get("entities") or [])
+    ]
+    return {
+        "entities": normalized_entities,
+        "total_entities": nim_data.get("total_entities", len(normalized_entities)),
+        "tagged_text": nim_data.get("tagged_text", ""),
+    }

--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -82,13 +82,12 @@ async def jailbreak_detection_heuristics(
         jailbreak = any([lp_check["jailbreak"], ps_ppl_check["jailbreak"]])
         return RailOutcome.block() if jailbreak else RailOutcome.allow()
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     jailbreak = await jailbreak_detection_heuristics_request(
         prompt,
         jailbreak_api_url,
         lp_threshold,
         ps_ppl_threshold,
-        **request_kwargs,
+        http_client=http_client,
     )
     if jailbreak is None:
         log.warning("Jailbreak endpoint not set up properly.")
@@ -161,20 +160,19 @@ async def jailbreak_detection_model(
             )
             jailbreak_result = False
     else:
-        request_kwargs = {"http_client": http_client} if http_client is not None else {}
         if nim_base_url:
             jailbreak = await jailbreak_nim_request(
                 prompt=prompt,
                 nim_url=nim_base_url,
                 nim_auth_token=nim_auth_token,
                 nim_classification_path=nim_classification_path,
-                **request_kwargs,
+                http_client=http_client,
             )
         elif jailbreak_api_url:
             jailbreak = await jailbreak_detection_model_request(
                 prompt=prompt,
                 api_url=jailbreak_api_url,
-                **request_kwargs,
+                http_client=http_client,
             )
 
         if jailbreak is None:

--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -35,6 +35,7 @@ from typing import Dict, Optional
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.http import HTTPClient
 from nemoguardrails.library.jailbreak_detection.request import (
     jailbreak_detection_heuristics_request,
     jailbreak_detection_model_request,
@@ -57,6 +58,7 @@ log = logging.getLogger(__name__)
 async def jailbreak_detection_heuristics(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks the user's prompt to determine if it is attempt to jailbreak the model."""
@@ -80,7 +82,14 @@ async def jailbreak_detection_heuristics(
         jailbreak = any([lp_check["jailbreak"], ps_ppl_check["jailbreak"]])
         return RailOutcome.block() if jailbreak else RailOutcome.allow()
 
-    jailbreak = await jailbreak_detection_heuristics_request(prompt, jailbreak_api_url, lp_threshold, ps_ppl_threshold)
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
+    jailbreak = await jailbreak_detection_heuristics_request(
+        prompt,
+        jailbreak_api_url,
+        lp_threshold,
+        ps_ppl_threshold,
+        **request_kwargs,
+    )
     if jailbreak is None:
         log.warning("Jailbreak endpoint not set up properly.")
         # If no result, assume not a jailbreak
@@ -94,6 +103,7 @@ async def jailbreak_detection_model(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
     model_caches: Optional[Dict[str, CacheInterface]] = None,
+    http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """Uses a trained classifier to determine if a user input is a jailbreak attempt"""
     prompt: str = ""
@@ -151,15 +161,21 @@ async def jailbreak_detection_model(
             )
             jailbreak_result = False
     else:
+        request_kwargs = {"http_client": http_client} if http_client is not None else {}
         if nim_base_url:
             jailbreak = await jailbreak_nim_request(
                 prompt=prompt,
                 nim_url=nim_base_url,
                 nim_auth_token=nim_auth_token,
                 nim_classification_path=nim_classification_path,
+                **request_kwargs,
             )
         elif jailbreak_api_url:
-            jailbreak = await jailbreak_detection_model_request(prompt=prompt, api_url=jailbreak_api_url)
+            jailbreak = await jailbreak_detection_model_request(
+                prompt=prompt,
+                api_url=jailbreak_api_url,
+                **request_kwargs,
+            )
 
         if jailbreak is None:
             log.warning("Jailbreak endpoint not set up properly.")

--- a/nemoguardrails/library/jailbreak_detection/request.py
+++ b/nemoguardrails/library/jailbreak_detection/request.py
@@ -32,7 +32,7 @@ import logging
 from typing import Optional
 from urllib.parse import urljoin
 
-from nemoguardrails.http import HTTPClient, HTTPClientError, HTTPTimeoutError, http_call, resolve_http_client
+from nemoguardrails.http import HTTPClient, HTTPClientError, HTTPTimeoutError, http_call
 
 log = logging.getLogger(__name__)
 
@@ -67,8 +67,7 @@ async def jailbreak_detection_heuristics_request(
         "ps_ppl_threshold": ps_ppl_threshold,
     }
 
-    async with resolve_http_client(http_client) as client:
-        response = await http_call(client, "POST", api_url, json=payload, raise_for_status=False)
+    response = await http_call(http_client, "POST", api_url, json=payload, raise_for_status=False)
     if response.status_code != 200:
         log.error(f"Jailbreak check API request failed with status {response.status_code}")
         return None
@@ -93,8 +92,7 @@ async def jailbreak_detection_model_request(
         "prompt": prompt,
     }
 
-    async with resolve_http_client(http_client) as client:
-        response = await http_call(client, "POST", api_url, json=payload, raise_for_status=False)
+    response = await http_call(http_client, "POST", api_url, json=payload, raise_for_status=False)
     if response.status_code != 200:
         log.error(f"Jailbreak check API request failed with status {response.status_code}")
         return None
@@ -126,16 +124,15 @@ async def jailbreak_nim_request(
     try:
         if nim_auth_token is not None:
             headers["Authorization"] = f"Bearer {nim_auth_token}"
-        async with resolve_http_client(http_client) as client:
-            response = await http_call(
-                client,
-                "POST",
-                endpoint,
-                json=payload,
-                headers=headers,
-                timeout=30,
-                raise_for_status=False,
-            )
+        response = await http_call(
+            http_client,
+            "POST",
+            endpoint,
+            json=payload,
+            headers=headers,
+            timeout=30,
+            raise_for_status=False,
+        )
         if response.status_code != 200:
             log.error(f"NemoGuard JailbreakDetect NIM request failed with status {response.status_code}")
             return None

--- a/nemoguardrails/library/jailbreak_detection/request.py
+++ b/nemoguardrails/library/jailbreak_detection/request.py
@@ -28,12 +28,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 from typing import Optional
 from urllib.parse import urljoin
 
-import aiohttp
+from nemoguardrails.http import HTTPClient, HTTPClientError, HTTPTimeoutError, http_call, resolve_http_client
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +59,7 @@ async def jailbreak_detection_heuristics_request(
     api_url: str = "http://localhost:1337/heuristics",
     lp_threshold: Optional[float] = None,
     ps_ppl_threshold: Optional[float] = None,
+    http_client: Optional[HTTPClient] = None,
 ):
     payload = {
         "prompt": prompt,
@@ -67,46 +67,47 @@ async def jailbreak_detection_heuristics_request(
         "ps_ppl_threshold": ps_ppl_threshold,
     }
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(api_url, json=payload) as resp:
-            if resp.status != 200:
-                log.error(f"Jailbreak check API request failed with status {resp.status}")
-                return None
+    async with resolve_http_client(http_client) as client:
+        response = await http_call(client, "POST", api_url, json=payload, raise_for_status=False)
+    if response.status_code != 200:
+        log.error(f"Jailbreak check API request failed with status {response.status_code}")
+        return None
 
-            result = await resp.json()
+    result = response.json()
 
-            log.info(f"Prompt jailbreak check: {result}.")
-            try:
-                result = result["jailbreak"]
-            except KeyError:
-                log.exception("No jailbreak field in result.")
-                result = None
-            return result
+    log.info(f"Prompt jailbreak check: {result}.")
+    try:
+        result = result["jailbreak"]
+    except KeyError:
+        log.exception("No jailbreak field in result.")
+        result = None
+    return result
 
 
 async def jailbreak_detection_model_request(
     prompt: str,
     api_url: str = "http://localhost:1337/model",
+    http_client: Optional[HTTPClient] = None,
 ):
     payload = {
         "prompt": prompt,
     }
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(api_url, json=payload) as resp:
-            if resp.status != 200:
-                log.error(f"Jailbreak check API request failed with status {resp.status}")
-                return None
+    async with resolve_http_client(http_client) as client:
+        response = await http_call(client, "POST", api_url, json=payload, raise_for_status=False)
+    if response.status_code != 200:
+        log.error(f"Jailbreak check API request failed with status {response.status_code}")
+        return None
 
-            result = await resp.json()
+    result = response.json()
 
-            log.info(f"Prompt jailbreak check: {result}.")
-            try:
-                result = result["jailbreak"]
-            except KeyError:
-                log.exception("No jailbreak field in result.")
-                result = None
-            return result
+    log.info(f"Prompt jailbreak check: {result}.")
+    try:
+        result = result["jailbreak"]
+    except KeyError:
+        log.exception("No jailbreak field in result.")
+        result = None
+    return result
 
 
 async def jailbreak_nim_request(
@@ -114,6 +115,7 @@ async def jailbreak_nim_request(
     nim_url: str,
     nim_auth_token: Optional[str],
     nim_classification_path: str,
+    http_client: Optional[HTTPClient] = None,
 ):
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
     payload = {
@@ -122,30 +124,37 @@ async def jailbreak_nim_request(
 
     endpoint = join_nim_url(nim_url, nim_classification_path)
     try:
-        async with aiohttp.ClientSession() as session:
-            try:
-                if nim_auth_token is not None:
-                    headers["Authorization"] = f"Bearer {nim_auth_token}"
-                async with session.post(endpoint, json=payload, headers=headers, timeout=30) as resp:
-                    if resp.status != 200:
-                        log.error(f"NemoGuard JailbreakDetect NIM request failed with status {resp.status}")
-                        return None
+        if nim_auth_token is not None:
+            headers["Authorization"] = f"Bearer {nim_auth_token}"
+        async with resolve_http_client(http_client) as client:
+            response = await http_call(
+                client,
+                "POST",
+                endpoint,
+                json=payload,
+                headers=headers,
+                timeout=30,
+                raise_for_status=False,
+            )
+        if response.status_code != 200:
+            log.error(f"NemoGuard JailbreakDetect NIM request failed with status {response.status_code}")
+            return None
 
-                    result = await resp.json()
+        result = response.json()
 
-                    log.info(f"Prompt jailbreak check: {result}.")
-                    try:
-                        result = result["jailbreak"]
-                    except KeyError:
-                        log.exception("No jailbreak field in result.")
-                        result = None
-                    return result
-            except aiohttp.ClientError as e:
-                log.error(f"NemoGuard JailbreakDetect NIM connection error: {str(e)}")
-                return None
-            except asyncio.TimeoutError:
-                log.error("NemoGuard JailbreakDetect NIM request timed out")
-                return None
+        log.info(f"Prompt jailbreak check: {result}.")
+        try:
+            result = result["jailbreak"]
+        except KeyError:
+            log.exception("No jailbreak field in result.")
+            result = None
+        return result
+    except HTTPTimeoutError:
+        log.error("NemoGuard JailbreakDetect NIM request timed out")
+        return None
+    except HTTPClientError as e:
+        log.error(f"NemoGuard JailbreakDetect NIM connection error: {str(e)}")
+        return None
     except Exception as e:
         log.error(f"Unexpected error during NIM request: {str(e)}")
         return None

--- a/nemoguardrails/library/polygraf/actions.py
+++ b/nemoguardrails/library/polygraf/actions.py
@@ -208,13 +208,12 @@ async def polygraf_detect_pii(
     polygraf_config, _source_config, enabled_entities = _resolve_source_config(config, source)
     server_endpoint = polygraf_config.server_endpoint
     api_key = _get_polygraf_api_key()
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     try:
         entities: List[Dict[str, Any]] = await polygraf_request(
             text,
             server_endpoint,
             api_key,
-            **request_kwargs,
+            http_client=http_client,
         )
     except ValueError as err:
         # Fail closed: a provider failure must not allow potentially-PII text
@@ -263,13 +262,12 @@ async def polygraf_mask_pii(
     polygraf_config, _source_config, enabled_entities = _resolve_source_config(config, source)
     server_endpoint = polygraf_config.server_endpoint
     api_key = _get_polygraf_api_key()
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     try:
         entities: List[Dict[str, Any]] = await polygraf_request(
             text,
             server_endpoint,
             api_key,
-            **request_kwargs,
+            http_client=http_client,
         )
     except ValueError as err:
         # Fail closed: if we cannot run masking at all, redact the entire text

--- a/nemoguardrails/library/polygraf/actions.py
+++ b/nemoguardrails/library/polygraf/actions.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.http import HTTPClient
 from nemoguardrails.library.polygraf.request import polygraf_request
 from nemoguardrails.rails.llm.config import PolygrafDetection
 
@@ -185,6 +186,7 @@ async def polygraf_detect_pii(
     source: str,
     text: str,
     config: RailsConfig,
+    http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks whether the provided text contains any PII using Polygraf.
@@ -206,10 +208,14 @@ async def polygraf_detect_pii(
     polygraf_config, _source_config, enabled_entities = _resolve_source_config(config, source)
     server_endpoint = polygraf_config.server_endpoint
     api_key = _get_polygraf_api_key()
-    session = kwargs.get("session")
-
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     try:
-        entities: List[Dict[str, Any]] = await polygraf_request(text, server_endpoint, api_key, session=session)
+        entities: List[Dict[str, Any]] = await polygraf_request(
+            text,
+            server_endpoint,
+            api_key,
+            **request_kwargs,
+        )
     except ValueError as err:
         # Fail closed: a provider failure must not allow potentially-PII text
         # through. Log only the failure category, never the input text or
@@ -232,7 +238,13 @@ async def polygraf_detect_pii(
 
 
 @action(is_system_action=False)
-async def polygraf_mask_pii(source: str, text: str, config: RailsConfig, **kwargs) -> RailOutcome:
+async def polygraf_mask_pii(
+    source: str,
+    text: str,
+    config: RailsConfig,
+    http_client: Optional[HTTPClient] = None,
+    **kwargs,
+) -> RailOutcome:
     """Masks any detected PII in the provided text using Polygraf.
 
     Args:
@@ -251,10 +263,14 @@ async def polygraf_mask_pii(source: str, text: str, config: RailsConfig, **kwarg
     polygraf_config, _source_config, enabled_entities = _resolve_source_config(config, source)
     server_endpoint = polygraf_config.server_endpoint
     api_key = _get_polygraf_api_key()
-    session = kwargs.get("session")
-
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     try:
-        entities: List[Dict[str, Any]] = await polygraf_request(text, server_endpoint, api_key, session=session)
+        entities: List[Dict[str, Any]] = await polygraf_request(
+            text,
+            server_endpoint,
+            api_key,
+            **request_kwargs,
+        )
     except ValueError as err:
         # Fail closed: if we cannot run masking at all, redact the entire text
         # rather than risk forwarding raw PII downstream.

--- a/nemoguardrails/library/polygraf/request.py
+++ b/nemoguardrails/library/polygraf/request.py
@@ -23,7 +23,6 @@ from nemoguardrails.http import (
     HTTPResponseDecodeError,
     HTTPTimeoutError,
     http_call,
-    resolve_http_client,
 )
 
 # Default per-request timeout for Polygraf calls. Matches the timeout pattern
@@ -73,16 +72,15 @@ async def polygraf_request(
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        async with resolve_http_client(http_client) as client:
-            response = await http_call(
-                client,
-                "POST",
-                server_endpoint,
-                json=payload,
-                headers=headers,
-                timeout=timeout,
-                raise_for_status=False,
-            )
+        response = await http_call(
+            http_client,
+            "POST",
+            server_endpoint,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+            raise_for_status=False,
+        )
     except HTTPTimeoutError as err:
         raise ValueError(f"Polygraf call timed out after {timeout} seconds.") from err
     except HTTPClientError as err:

--- a/nemoguardrails/library/polygraf/request.py
+++ b/nemoguardrails/library/polygraf/request.py
@@ -15,10 +15,16 @@
 
 """Module for handling Polygraf PII detection requests."""
 
-import asyncio
 from typing import Any, Dict, List, Optional
 
-import aiohttp
+from nemoguardrails.http import (
+    HTTPClient,
+    HTTPClientError,
+    HTTPResponseDecodeError,
+    HTTPTimeoutError,
+    http_call,
+    resolve_http_client,
+)
 
 # Default per-request timeout for Polygraf calls. Matches the timeout pattern
 # used by other community guardrail integrations and prevents hung rails when
@@ -30,7 +36,7 @@ async def polygraf_request(
     text: str,
     server_endpoint: str,
     api_key: Optional[str] = None,
-    session: Optional[aiohttp.ClientSession] = None,
+    http_client: Optional[HTTPClient] = None,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> List[Dict[str, Any]]:
     """Send a PII detection request to the Polygraf API.
@@ -39,7 +45,7 @@ async def polygraf_request(
         text: The text to analyze.
         server_endpoint: The API endpoint URL.
         api_key: The API key for the Polygraf service.
-        session: Optional shared aiohttp session. Passing a session lets callers
+        http_client: Optional shared HTTP client. Passing a client lets callers
             reuse connections across multiple PII checks.
         timeout: Per-request timeout in seconds. Applied to both caller-provided
             and internally created sessions.
@@ -66,50 +72,31 @@ async def polygraf_request(
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
-    client_timeout = aiohttp.ClientTimeout(total=timeout)
-
-    if session is not None:
-        return await _send_polygraf_request(session, server_endpoint, payload, headers, client_timeout)
-
-    async with aiohttp.ClientSession(timeout=client_timeout) as request_session:
-        return await _send_polygraf_request(request_session, server_endpoint, payload, headers, client_timeout)
-
-
-async def _send_polygraf_request(
-    session: aiohttp.ClientSession,
-    server_endpoint: str,
-    payload: Dict[str, Any],
-    headers: Dict[str, str],
-    timeout: aiohttp.ClientTimeout,
-) -> List[Dict[str, Any]]:
     try:
-        try:
-            post_ctx = session.post(server_endpoint, json=payload, headers=headers, timeout=timeout)
-        except TypeError:
-            # Some test doubles do not accept a `timeout` kwarg; fall back to the
-            # session-level timeout instead.
-            post_ctx = session.post(server_endpoint, json=payload, headers=headers)
-
-        async with post_ctx as resp:
-            if resp.status != 200:
-                raise ValueError(f"Polygraf call failed with status code {resp.status}.\nDetails: {await resp.text()}")
-
-            try:
-                data = await resp.json()
-            except aiohttp.ContentTypeError as err:
-                raise ValueError(
-                    f"Failed to parse Polygraf response as JSON. Status: {resp.status}, Content: {await resp.text()}"
-                ) from err
-    except asyncio.TimeoutError as err:
-        # `aiohttp.ClientTimeout` surfaces timeouts as asyncio.TimeoutError on
-        # both the connect and read paths. Normalize so callers see a single
-        # ValueError contract instead of asyncio plumbing exceptions.
-        raise ValueError(f"Polygraf call timed out after {timeout.total} seconds.") from err
-    except aiohttp.ClientError as err:
-        # DNS failures, connection resets, TLS errors, etc. should also surface
-        # as ValueError so the documented contract holds across all network
-        # failure modes.
+        async with resolve_http_client(http_client) as client:
+            response = await http_call(
+                client,
+                "POST",
+                server_endpoint,
+                json=payload,
+                headers=headers,
+                timeout=timeout,
+                raise_for_status=False,
+            )
+    except HTTPTimeoutError as err:
+        raise ValueError(f"Polygraf call timed out after {timeout} seconds.") from err
+    except HTTPClientError as err:
         raise ValueError(f"Polygraf call failed: {type(err).__name__}: {err}") from err
+
+    if response.status_code != 200:
+        raise ValueError(f"Polygraf call failed with status code {response.status_code}.\nDetails: {response.text}")
+
+    try:
+        data = response.json()
+    except HTTPResponseDecodeError as err:
+        raise ValueError(
+            f"Failed to parse Polygraf response as JSON. Status: {response.status_code}, Content: {response.text}"
+        ) from err
 
     # Polygraf may return either a raw list of entities or a wrapper object.
     if isinstance(data, list):

--- a/nemoguardrails/library/privateai/actions.py
+++ b/nemoguardrails/library/privateai/actions.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.http import HTTPClient
 from nemoguardrails.library.privateai.request import private_ai_request
 from nemoguardrails.rails.llm.config import PrivateAIDetection
 
@@ -55,6 +56,7 @@ async def detect_pii(
     source: str,
     text: str,
     config: RailsConfig,
+    http_client: HTTPClient | None = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks whether the provided text contains any PII.
@@ -86,11 +88,13 @@ async def detect_pii(
             f"The current flow, '{source}', is not allowed."
         )
 
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     private_ai_response = await private_ai_request(
         text,
         enabled_entities,
         server_endpoint,
         pai_api_key,
+        **request_kwargs,
     )
 
     try:
@@ -101,7 +105,12 @@ async def detect_pii(
 
 
 @action(is_system_action=False)
-async def mask_pii(source: str, text: str, config: RailsConfig) -> RailOutcome:
+async def mask_pii(
+    source: str,
+    text: str,
+    config: RailsConfig,
+    http_client: HTTPClient | None = None,
+) -> RailOutcome:
     """Masks any detected PII in the provided text.
 
     Args:
@@ -131,11 +140,13 @@ async def mask_pii(source: str, text: str, config: RailsConfig) -> RailOutcome:
             f"The current flow, '{source}', is not allowed."
         )
 
+    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     private_ai_response = await private_ai_request(
         text,
         enabled_entities,
         server_endpoint,
         pai_api_key,
+        **request_kwargs,
     )
 
     if not private_ai_response or not isinstance(private_ai_response, list):

--- a/nemoguardrails/library/privateai/actions.py
+++ b/nemoguardrails/library/privateai/actions.py
@@ -88,13 +88,12 @@ async def detect_pii(
             f"The current flow, '{source}', is not allowed."
         )
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     private_ai_response = await private_ai_request(
         text,
         enabled_entities,
         server_endpoint,
         pai_api_key,
-        **request_kwargs,
+        http_client=http_client,
     )
 
     try:
@@ -140,13 +139,12 @@ async def mask_pii(
             f"The current flow, '{source}', is not allowed."
         )
 
-    request_kwargs = {"http_client": http_client} if http_client is not None else {}
     private_ai_response = await private_ai_request(
         text,
         enabled_entities,
         server_endpoint,
         pai_api_key,
-        **request_kwargs,
+        http_client=http_client,
     )
 
     if not private_ai_response or not isinstance(private_ai_response, list):

--- a/nemoguardrails/library/privateai/request.py
+++ b/nemoguardrails/library/privateai/request.py
@@ -19,7 +19,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-import aiohttp
+from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call, resolve_http_client
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ async def private_ai_request(
     enabled_entities: List[str],
     server_endpoint: str,
     api_key: Optional[str] = None,
+    http_client: Optional[HTTPClient] = None,
 ):
     """Send a PII detection request to the Private AI API.
 
@@ -66,16 +67,21 @@ async def private_ai_request(
     if enabled_entities:
         payload["entity_detection"]["entity_types"] = [{"type": "ENABLE", "value": enabled_entities}]
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(server_endpoint, json=payload, headers=headers) as resp:
-            if resp.status != 200:
-                raise ValueError(
-                    f"Private AI call failed with status code {resp.status}.\nDetails: {await resp.text()}"
-                )
+    async with resolve_http_client(http_client) as client:
+        response = await http_call(
+            client,
+            "POST",
+            server_endpoint,
+            json=payload,
+            headers=headers,
+            raise_for_status=False,
+        )
+    if response.status_code != 200:
+        raise ValueError(f"Private AI call failed with status code {response.status_code}.\nDetails: {response.text}")
 
-            try:
-                return await resp.json()
-            except aiohttp.ContentTypeError:
-                raise ValueError(
-                    f"Failed to parse Private AI response as JSON. Status: {resp.status}, Content: {await resp.text()}"
-                )
+    try:
+        return response.json()
+    except HTTPResponseDecodeError as error:
+        raise ValueError(
+            f"Failed to parse Private AI response as JSON. Status: {response.status_code}, Content: {response.text}"
+        ) from error

--- a/nemoguardrails/library/privateai/request.py
+++ b/nemoguardrails/library/privateai/request.py
@@ -19,7 +19,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call, resolve_http_client
+from nemoguardrails.http import HTTPClient, HTTPResponseDecodeError, http_call
 
 log = logging.getLogger(__name__)
 
@@ -67,15 +67,14 @@ async def private_ai_request(
     if enabled_entities:
         payload["entity_detection"]["entity_types"] = [{"type": "ENABLE", "value": enabled_entities}]
 
-    async with resolve_http_client(http_client) as client:
-        response = await http_call(
-            client,
-            "POST",
-            server_endpoint,
-            json=payload,
-            headers=headers,
-            raise_for_status=False,
-        )
+    response = await http_call(
+        http_client,
+        "POST",
+        server_endpoint,
+        json=payload,
+        headers=headers,
+        raise_for_status=False,
+    )
     if response.status_code != 200:
         raise ValueError(f"Private AI call failed with status code {response.status_code}.\nDetails: {response.text}")
 

--- a/tests/test_activefence_rail.py
+++ b/tests/test_activefence_rail.py
@@ -13,10 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from aioresponses import aioresponses
-
 from nemoguardrails import RailsConfig
+from nemoguardrails.http import HTTPResponse
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
+
+
+def _response(payload: dict) -> HTTPResponse:
+    import json
+
+    return HTTPResponse(
+        status_code=200,
+        headers={"content-type": "application/json"},
+        content=json.dumps(payload).encode(),
+    )
 
 
 def test_input(monkeypatch):
@@ -53,41 +63,39 @@ def test_input(monkeypatch):
         ],
     )
 
-    with aioresponses() as m:
-        # First call to ActiveFence should flag no violations.
-        m.post(
-            "https://apis.activefence.com/sync/v3/content/text",
-            payload={
-                "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
-                "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
-                "entity_type": "content",
-                "violations": [],
-                "errors": [],
-            },
-        )
+    http_client = RecordingHTTPClient(
+        [
+            _response(
+                {
+                    "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
+                    "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
+                    "entity_type": "content",
+                    "violations": [],
+                    "errors": [],
+                }
+            ),
+            _response(
+                {
+                    "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
+                    "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
+                    "entity_type": "content",
+                    "violations": [
+                        {
+                            "violation_type": "abusive_or_harmful.harassment_or_bullying",
+                            "risk_score": 0.95,
+                        }
+                    ],
+                    "errors": [],
+                }
+            ),
+        ]
+    )
+    chat.app.register_action_param("http_client", http_client)
 
-        chat >> "Hello!"
-        chat << "Hello! How can I assist you today?"
-
-        # Second call will flag an abusive_or_harmful violation.
-        m.post(
-            "https://apis.activefence.com/sync/v3/content/text",
-            payload={
-                "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
-                "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
-                "entity_type": "content",
-                "violations": [
-                    {
-                        "violation_type": "abusive_or_harmful.harassment_or_bullying",
-                        "risk_score": 0.95,
-                    }
-                ],
-                "errors": [],
-            },
-        )
-
-        chat >> "you are stupid!"
-        chat << "I'm sorry, I can't respond to that."
+    chat >> "Hello!"
+    chat << "Hello! How can I assist you today?"
+    chat >> "you are stupid!"
+    chat << "I'm sorry, I can't respond to that."
 
 
 def test_output(monkeypatch):
@@ -113,22 +121,25 @@ def test_output(monkeypatch):
         ],
     )
 
-    with aioresponses() as m:
-        m.post(
-            "https://apis.activefence.com/sync/v3/content/text",
-            payload={
-                "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
-                "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
-                "entity_type": "content",
-                "violations": [
-                    {
-                        "violation_type": "abusive_or_harmful.profanity",
-                        "risk_score": 0.95,
-                    }
-                ],
-                "errors": [],
-            },
-        )
+    http_client = RecordingHTTPClient(
+        [
+            _response(
+                {
+                    "response_id": "36f76a43-ddbe-4308-bc86-1a2b068a00ea",
+                    "entity_id": "59fe8fe0-5036-494f-970c-8e28305a3716",
+                    "entity_type": "content",
+                    "violations": [
+                        {
+                            "violation_type": "abusive_or_harmful.profanity",
+                            "risk_score": 0.95,
+                        }
+                    ],
+                    "errors": [],
+                }
+            )
+        ]
+    )
+    chat.app.register_action_param("http_client", http_client)
 
-        chat >> "Hello!"
-        chat << "I'm sorry, I can't respond to that."
+    chat >> "Hello!"
+    chat << "I'm sorry, I can't respond to that."

--- a/tests/test_activefence_rail.py
+++ b/tests/test_activefence_rail.py
@@ -13,20 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from nemoguardrails import RailsConfig
 from nemoguardrails.http import HTTPResponse
+from nemoguardrails.library.activefence.actions import call_activefence_api
 from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
 
 
-def _response(payload: dict) -> HTTPResponse:
+def _response(payload: dict, *, status: int = 200) -> HTTPResponse:
     import json
 
     return HTTPResponse(
-        status_code=200,
+        status_code=status,
         headers={"content-type": "application/json"},
         content=json.dumps(payload).encode(),
     )
+
+
+@pytest.mark.asyncio
+async def test_activefence_uses_shared_client(monkeypatch):
+    monkeypatch.setenv("ACTIVEFENCE_API_KEY", "secret")
+    client = RecordingHTTPClient([_response({"violations": []})])
+
+    result = await call_activefence_api("Hello", http_client=client)
+
+    assert not result.is_blocked
+    request = client.requests[0]
+    assert request.method == "POST"
+    assert request.url == "https://apis.activefence.com/sync/v3/content/text"
+    assert request.headers == {
+        "af-api-key": "secret",
+        "af-source": "nemo-guardrails",
+    }
+    assert request.json["text"] == "Hello"
+    assert request.json["content_id"].startswith("ng-")
+
+
+@pytest.mark.asyncio
+async def test_activefence_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ACTIVEFENCE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ACTIVEFENCE_API_KEY environment variable not set"):
+        await call_activefence_api("Hello", http_client=RecordingHTTPClient())
+
+
+@pytest.mark.asyncio
+async def test_activefence_raises_for_non_200(monkeypatch):
+    monkeypatch.setenv("ACTIVEFENCE_API_KEY", "secret")
+    client = RecordingHTTPClient([_response({}, status=503)])
+
+    with pytest.raises(ValueError, match="ActiveFence call failed with status code 503"):
+        await call_activefence_api("Hello", http_client=client)
 
 
 def test_input(monkeypatch):

--- a/tests/test_fact_checking.py
+++ b/tests/test_fact_checking.py
@@ -16,7 +16,6 @@
 import os
 
 import pytest
-from aioresponses import aioresponses
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
@@ -69,19 +68,19 @@ async def test_fact_checking_correct(httpx_mock):
     )
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    with aioresponses() as m:
-        # Fact-checking using AlignScore
-        m.post(
-            "http://localhost:5000/alignscore_base",
-            payload={"alignscore": 0.82},
-        )
+    # Fact-checking using AlignScore
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:5000/alignscore_base",
+        json={"alignscore": 0.82},
+    )
 
-        # Succeeded, no more generations needed
-        chat >> "What is NeMo Guardrails?"
+    # Succeeded, no more generations needed
+    chat >> "What is NeMo Guardrails?"
 
-        await chat.bot_async(
-            "NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems."
-        )
+    await chat.bot_async(
+        "NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems."
+    )
 
 
 @pytest.mark.asyncio
@@ -97,16 +96,16 @@ async def test_fact_checking_wrong(httpx_mock):
     )
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    with aioresponses() as m:
-        # Fact-checking using AlignScore
-        m.post(
-            "http://localhost:5000/alignscore_base",
-            payload={"alignscore": 0.01},
-        )
+    # Fact-checking using AlignScore
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:5000/alignscore_base",
+        json={"alignscore": 0.01},
+    )
 
-        chat >> "What is NeMo Guardrails?"
+    chat >> "What is NeMo Guardrails?"
 
-        await chat.bot_async("I don't know the answer to that.")
+    await chat.bot_async("I don't know the answer to that.")
 
 
 @pytest.mark.asyncio
@@ -124,17 +123,17 @@ async def test_fact_checking_fallback_to_self_check_correct(httpx_mock):
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    with aioresponses() as m:
-        # Fact-checking using AlignScore
-        m.post(
-            "http://localhost:5000/alignscore_base",
-            payload="API error 404",
-        )
-        chat >> "What is NeMo Guardrails?"
+    # Fact-checking using AlignScore
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:5000/alignscore_base",
+        json="API error 404",
+    )
+    chat >> "What is NeMo Guardrails?"
 
-        await chat.bot_async(
-            "NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems."
-        )
+    await chat.bot_async(
+        "NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems."
+    )
 
 
 @pytest.mark.asyncio
@@ -152,12 +151,12 @@ async def test_fact_checking_fallback_self_check_wrong(httpx_mock):
     )
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    with aioresponses() as m:
-        # Fact-checking using AlignScore
-        m.post(
-            "http://localhost:5000/alignscore_base",
-            payload="API error 404",
-        )
+    # Fact-checking using AlignScore
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:5000/alignscore_base",
+        json="API error 404",
+    )
 
-        chat >> "What is NeMo Guardrails?"
-        await chat.bot_async("I don't know the answer to that.")
+    chat >> "What is NeMo Guardrails?"
+    await chat.bot_async("I don't know the answer to that.")

--- a/tests/test_fact_checking.py
+++ b/tests/test_fact_checking.py
@@ -13,15 +13,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 
 import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
+from nemoguardrails.http import HTTPResponse
+from nemoguardrails.library.factchecking.align_score.request import alignscore_request
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
 
 CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
+
+
+def _response(payload, *, status: int = 200) -> HTTPResponse:
+    return HTTPResponse(
+        status_code=status,
+        headers={"content-type": "application/json"},
+        content=json.dumps(payload).encode(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_alignscore_request_uses_shared_client():
+    client = RecordingHTTPClient([_response({"alignscore": 0.82})])
+
+    result = await alignscore_request(
+        api_url="http://alignscore.example/score",
+        evidence=["NeMo Guardrails is open source."],
+        response="NeMo Guardrails is open source.",
+        http_client=client,
+    )
+
+    assert result == 0.82
+    request = client.requests[0]
+    assert request.method == "POST"
+    assert request.url == "http://alignscore.example/score"
+    assert request.json == {
+        "evidence": ["NeMo Guardrails is open source."],
+        "claim": "NeMo Guardrails is open source.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_alignscore_request_returns_one_without_evidence():
+    client = RecordingHTTPClient()
+
+    assert await alignscore_request(evidence=[], http_client=client) == 1.0
+    assert client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_alignscore_request_returns_none_for_non_200():
+    client = RecordingHTTPClient([_response({}, status=503)])
+
+    result = await alignscore_request(evidence=["evidence"], response="claim", http_client=client)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_alignscore_request_returns_none_without_score():
+    client = RecordingHTTPClient([_response({"result": "unknown"})])
+
+    result = await alignscore_request(evidence=["evidence"], response="claim", http_client=client)
+
+    assert result is None
 
 
 def build_kb():

--- a/tests/test_gliner.py
+++ b/tests/test_gliner.py
@@ -19,12 +19,13 @@ from typing import Any, Dict, List, Optional, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aioresponses import aioresponses
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.http import HTTPResponse
 from nemoguardrails.rails.llm.config import GLiNERDetection
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
 
 
@@ -737,6 +738,11 @@ def _wrap_in_chat_completions(content) -> dict:
     return {"choices": [{"message": {"content": inner}}]}
 
 
+def _http_response(payload=None, *, status: int = 200, body: str | None = None) -> HTTPResponse:
+    content = body.encode() if body is not None else json.dumps(payload).encode()
+    return HTTPResponse(status_code=status, content=content)
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_gliner_request_chat_completions_normalizes_entities():
@@ -751,9 +757,8 @@ async def test_gliner_request_chat_completions_normalizes_entities():
         "total_entities": 2,
         "tagged_text": "[John](first_name) ... [test@example.com](email)",
     }
-    with aioresponses() as m:
-        m.post(NIM_ENDPOINT, payload=_wrap_in_chat_completions(nim_content))
-        result = await gliner_request(text="Hi I'm John", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(_wrap_in_chat_completions(nim_content))])
+    result = await gliner_request(text="Hi I'm John", server_endpoint=NIM_ENDPOINT, http_client=client)
 
     assert result["total_entities"] == 2
     assert result["tagged_text"] == nim_content["tagged_text"]
@@ -787,9 +792,8 @@ async def test_gliner_request_custom_endpoint_returns_raw():
         "total_entities": 1,
         "tagged_text": "[John](first_name)",
     }
-    with aioresponses() as m:
-        m.post(CUSTOM_ENDPOINT, payload=custom_response)
-        result = await gliner_request(text="John", server_endpoint=CUSTOM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(custom_response)])
+    result = await gliner_request(text="John", server_endpoint=CUSTOM_ENDPOINT, http_client=client)
 
     assert result == custom_response
 
@@ -800,15 +804,17 @@ async def test_gliner_request_forwards_api_key_as_bearer_header():
     """When api_key is set, an Authorization: Bearer <key> header is sent."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(
-            NIM_ENDPOINT,
-            payload=_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}),
-        )
-        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, api_key="nvapi-test-key")
+    client = RecordingHTTPClient(
+        [_http_response(_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}))]
+    )
+    await gliner_request(
+        text="hi",
+        server_endpoint=NIM_ENDPOINT,
+        api_key="nvapi-test-key",
+        http_client=client,
+    )
 
-    sent = next(iter(m.requests.values()))[0]
-    headers = sent.kwargs.get("headers") or {}
+    headers = client.requests[0].headers or {}
     assert headers.get("Authorization") == "Bearer nvapi-test-key"
     assert headers.get("Content-Type") == "application/json"
 
@@ -819,15 +825,12 @@ async def test_gliner_request_no_api_key_omits_authorization_header():
     """When api_key is None, no Authorization header is sent."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(
-            NIM_ENDPOINT,
-            payload=_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}),
-        )
-        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient(
+        [_http_response(_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}))]
+    )
+    await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, http_client=client)
 
-    sent = next(iter(m.requests.values()))[0]
-    headers = sent.kwargs.get("headers") or {}
+    headers = client.requests[0].headers or {}
     assert "Authorization" not in headers
 
 
@@ -837,10 +840,9 @@ async def test_gliner_request_non_200_status_raises():
     """Non-200 responses raise ValueError with the status code in the message."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(NIM_ENDPOINT, status=500, body="Internal Server Error")
-        with pytest.raises(ValueError, match=r"GLiNER call failed with status code 500"):
-            await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(status=500, body="Internal Server Error")])
+    with pytest.raises(ValueError, match=r"GLiNER call failed with status code 500"):
+        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, http_client=client)
 
 
 @pytest.mark.unit
@@ -849,10 +851,9 @@ async def test_gliner_request_non_json_response_raises():
     """If the server returns a 200 with non-JSON Content-Type, ValueError is raised."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(NIM_ENDPOINT, status=200, body="not json", content_type="text/plain")
-        with pytest.raises(ValueError, match=r"Failed to parse GLiNER response as JSON"):
-            await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(body="not json")])
+    with pytest.raises(ValueError, match=r"Failed to parse GLiNER response as JSON"):
+        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, http_client=client)
 
 
 @pytest.mark.unit
@@ -861,10 +862,9 @@ async def test_gliner_request_nim_content_unparseable_raises():
     """Chat completions: when message.content is not valid JSON, ValueError is raised."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(NIM_ENDPOINT, payload=_wrap_in_chat_completions("this is not json {"))
-        with pytest.raises(ValueError, match=r"Failed to parse NIM response content"):
-            await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(_wrap_in_chat_completions("this is not json {"))])
+    with pytest.raises(ValueError, match=r"Failed to parse NIM response content"):
+        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, http_client=client)
 
 
 @pytest.mark.unit
@@ -873,10 +873,9 @@ async def test_gliner_request_nim_content_not_dict_raises():
     """Chat completions: when message.content parses to a non-dict, ValueError is raised."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(NIM_ENDPOINT, payload=_wrap_in_chat_completions(["entities", "as", "list"]))
-        with pytest.raises(ValueError, match=r"Expected NIM response content to be a JSON object"):
-            await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT)
+    client = RecordingHTTPClient([_http_response(_wrap_in_chat_completions(["entities", "as", "list"]))])
+    with pytest.raises(ValueError, match=r"Expected NIM response content to be a JSON object"):
+        await gliner_request(text="hi", server_endpoint=NIM_ENDPOINT, http_client=client)
 
 
 @pytest.mark.unit
@@ -885,23 +884,21 @@ async def test_gliner_request_forwards_all_optional_params_to_payload():
     """All optional params flow into the JSON payload sent to the server."""
     from nemoguardrails.library.gliner.request import gliner_request
 
-    with aioresponses() as m:
-        m.post(
-            NIM_ENDPOINT,
-            payload=_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}),
-        )
-        await gliner_request(
-            text="hello",
-            server_endpoint=NIM_ENDPOINT,
-            enabled_entities=["email", "first_name"],
-            threshold=0.7,
-            chunk_length=512,
-            overlap=64,
-            flat_ner=True,
-        )
+    client = RecordingHTTPClient(
+        [_http_response(_wrap_in_chat_completions({"entities": [], "total_entities": 0, "tagged_text": ""}))]
+    )
+    await gliner_request(
+        text="hello",
+        server_endpoint=NIM_ENDPOINT,
+        enabled_entities=["email", "first_name"],
+        threshold=0.7,
+        chunk_length=512,
+        overlap=64,
+        flat_ner=True,
+        http_client=client,
+    )
 
-    sent = next(iter(m.requests.values()))[0]
-    payload = sent.kwargs.get("json") or {}
+    payload = client.requests[0].json or {}
     assert payload["threshold"] == 0.7
     assert payload["chunk_length"] == 512
     assert payload["overlap"] == 64

--- a/tests/test_jailbreak_actions.py
+++ b/tests/test_jailbreak_actions.py
@@ -19,10 +19,53 @@ import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.testing import RecordingHTTPClient
 
 
 class TestJailbreakDetectionActions:
     """Test suite for jailbreak detection actions with comprehensive coverage of PR changes."""
+
+    @pytest.mark.asyncio
+    async def test_jailbreak_detection_heuristics_forwards_http_client(self, monkeypatch):
+        from nemoguardrails.library.jailbreak_detection.actions import (
+            jailbreak_detection_heuristics,
+        )
+
+        request = mock.AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "nemoguardrails.library.jailbreak_detection.actions.jailbreak_detection_heuristics_request",
+            request,
+        )
+        config = RailsConfig.from_content(
+            """
+            define user express greeting
+              "hello"
+            """,
+            """
+            rails:
+              config:
+                jailbreak_detection:
+                  server_endpoint: "http://localhost:1337/heuristics"
+                  length_per_perplexity_threshold: 1.5
+                  prefix_suffix_perplexity_threshold: 2.5
+            """,
+        )
+        client = RecordingHTTPClient()
+
+        result = await jailbreak_detection_heuristics(
+            LLMTaskManager(config=config),
+            {"user_message": "test prompt"},
+            http_client=client,
+        )
+
+        assert result.is_blocked
+        request.assert_awaited_once_with(
+            "test prompt",
+            "http://localhost:1337/heuristics",
+            1.5,
+            2.5,
+            http_client=client,
+        )
 
     @pytest.mark.asyncio
     async def test_jailbreak_detection_model_with_nim_base_url(self, monkeypatch):

--- a/tests/test_jailbreak_actions.py
+++ b/tests/test_jailbreak_actions.py
@@ -65,6 +65,7 @@ class TestJailbreakDetectionActions:
             nim_url="http://localhost:8000/v1",
             nim_auth_token="test_token_123",
             nim_classification_path="classify",
+            http_client=None,
         )
 
     @pytest.mark.asyncio
@@ -116,6 +117,7 @@ class TestJailbreakDetectionActions:
             nim_url="http://localhost:8000/v1",
             nim_auth_token=None,
             nim_classification_path="classify",
+            http_client=None,
         )
 
     @pytest.mark.asyncio
@@ -156,6 +158,7 @@ class TestJailbreakDetectionActions:
             nim_url="http://localhost:8000/v1",
             nim_auth_token=None,
             nim_classification_path="classify",
+            http_client=None,
         )
 
     @pytest.mark.asyncio
@@ -302,6 +305,7 @@ class TestJailbreakDetectionActions:
             nim_url="http://localhost:8000/v1",
             nim_auth_token=None,
             nim_classification_path="classify",
+            http_client=None,
         )
 
     @pytest.mark.asyncio
@@ -341,6 +345,7 @@ class TestJailbreakDetectionActions:
             nim_url="http://localhost:8000/v1",
             nim_auth_token=None,
             nim_classification_path="classify",
+            http_client=None,
         )
 
     @pytest.mark.asyncio
@@ -375,7 +380,11 @@ class TestJailbreakDetectionActions:
         result = await jailbreak_detection_model(llm_task_manager, context)
         assert result.is_blocked is True
 
-        mock_model_request.assert_called_once_with(prompt="test prompt", api_url="http://legacy-server:1337/model")
+        mock_model_request.assert_called_once_with(
+            prompt="test prompt",
+            api_url="http://legacy-server:1337/model",
+            http_client=None,
+        )
 
     @pytest.mark.asyncio
     async def test_jailbreak_detection_model_none_response_handling(self, monkeypatch, caplog):

--- a/tests/test_jailbreak_cache.py
+++ b/tests/test_jailbreak_cache.py
@@ -158,6 +158,7 @@ async def test_jailbreak_without_cache(mock_nim_request, mock_task_manager):
         nim_url="https://ai.api.nvidia.com",
         nim_auth_token="test-key",
         nim_classification_path="/v1/security/nvidia/nemoguard-jailbreak-detect",
+        http_client=None,
     )
 
 

--- a/tests/test_jailbreak_request.py
+++ b/tests/test_jailbreak_request.py
@@ -17,92 +17,229 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import json
+
 import pytest
 
+from nemoguardrails.http import HTTPConnectionError, HTTPResponse, HTTPTimeoutError
+from nemoguardrails.library.jailbreak_detection.request import (
+    jailbreak_detection_heuristics_request,
+    jailbreak_detection_model_request,
+    jailbreak_nim_request,
+    join_nim_url,
+)
+from nemoguardrails.testing import RecordingHTTPClient
 
-class TestJailbreakRequestChanges:
-    """Test jailbreak request function changes introduced in this PR."""
 
-    def test_url_joining_logic(self):
-        """Test that URL joining works correctly with all slash combinations."""
-        from nemoguardrails.library.jailbreak_detection.request import join_nim_url
+def _response(payload=None, *, status: int = 200, content: bytes | None = None) -> HTTPResponse:
+    return HTTPResponse(
+        status_code=status,
+        headers={"content-type": "application/json"},
+        content=content if content is not None else json.dumps(payload).encode(),
+    )
 
-        test_cases = [
-            (
-                "http://localhost:8000/v1",
-                "classify",
-                "http://localhost:8000/v1/classify",
-            ),
-            (
-                "http://localhost:8000/v1/",
-                "classify",
-                "http://localhost:8000/v1/classify",
-            ),
-            (
-                "http://localhost:8000/v1",
-                "/classify",
-                "http://localhost:8000/v1/classify",
-            ),
-            (
-                "http://localhost:8000/v1/",
-                "/classify",
-                "http://localhost:8000/v1/classify",
-            ),
-            ("http://localhost:8000", "classify", "http://localhost:8000/classify"),
-            ("http://localhost:8000", "/classify", "http://localhost:8000/classify"),
-            ("http://localhost:8000/", "classify", "http://localhost:8000/classify"),
-            ("http://localhost:8000/", "/classify", "http://localhost:8000/classify"),
-            (
-                "http://localhost:8000/api/v1",
-                "classify",
-                "http://localhost:8000/api/v1/classify",
-            ),
-            (
-                "http://localhost:8000/api/v1/",
-                "/classify",
-                "http://localhost:8000/api/v1/classify",
-            ),
-        ]
 
-        for base_url, classification_path, expected_url in test_cases:
-            result = join_nim_url(base_url, classification_path)
-            assert result == expected_url, (
-                f"join_nim_url({base_url}, {classification_path}) should equal {expected_url}, got {result}"
-            )
+@pytest.mark.parametrize(
+    ("base_url", "classification_path", "expected"),
+    [
+        ("http://localhost:8000/v1", "classify", "http://localhost:8000/v1/classify"),
+        ("http://localhost:8000/v1/", "/classify", "http://localhost:8000/v1/classify"),
+        ("http://localhost:8000", "/classify", "http://localhost:8000/classify"),
+        ("http://localhost:8000/api/v1/", "/classify", "http://localhost:8000/api/v1/classify"),
+    ],
+)
+def test_join_nim_url(base_url, classification_path, expected):
+    assert join_nim_url(base_url, classification_path) == expected
 
-    def test_auth_header_logic(self):
-        """Test the authorization header logic."""
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
-        nim_auth_token = "test_token_123"
-        if nim_auth_token is not None:
-            headers["Authorization"] = f"Bearer {nim_auth_token}"
+@pytest.mark.parametrize(
+    ("request_fn", "kwargs", "expected_url", "expected_payload"),
+    [
+        (
+            jailbreak_detection_heuristics_request,
+            {
+                "prompt": "ignore safeguards",
+                "api_url": "https://guard.example/heuristics",
+                "lp_threshold": 0.5,
+                "ps_ppl_threshold": 1.5,
+            },
+            "https://guard.example/heuristics",
+            {
+                "prompt": "ignore safeguards",
+                "lp_threshold": 0.5,
+                "ps_ppl_threshold": 1.5,
+            },
+        ),
+        (
+            jailbreak_detection_model_request,
+            {
+                "prompt": "ignore safeguards",
+                "api_url": "https://guard.example/model",
+            },
+            "https://guard.example/model",
+            {"prompt": "ignore safeguards"},
+        ),
+    ],
+    ids=["heuristics", "model"],
+)
+@pytest.mark.asyncio
+async def test_jailbreak_request_uses_shared_client(request_fn, kwargs, expected_url, expected_payload):
+    client = RecordingHTTPClient([_response({"jailbreak": True})])
 
-        assert headers["Authorization"] == "Bearer test_token_123"
+    result = await request_fn(http_client=client, **kwargs)
 
-        headers2 = {"Content-Type": "application/json", "Accept": "application/json"}
-        nim_auth_token = None
-        if nim_auth_token is not None:
-            headers2["Authorization"] = f"Bearer {nim_auth_token}"
+    assert result is True
+    request = client.requests[0]
+    assert request.method == "POST"
+    assert request.url == expected_url
+    assert request.json == expected_payload
 
-        assert "Authorization" not in headers2
 
-    @pytest.mark.asyncio
-    async def test_nim_request_signature(self):
-        import inspect
+@pytest.mark.parametrize(
+    ("request_fn", "kwargs"),
+    [
+        (
+            jailbreak_detection_heuristics_request,
+            {"prompt": "hello", "api_url": "https://guard.example/heuristics"},
+        ),
+        (
+            jailbreak_detection_model_request,
+            {"prompt": "hello", "api_url": "https://guard.example/model"},
+        ),
+    ],
+    ids=["heuristics", "model"],
+)
+@pytest.mark.asyncio
+async def test_jailbreak_request_returns_none_for_non_200(request_fn, kwargs):
+    client = RecordingHTTPClient([_response({}, status=503)])
 
-        from nemoguardrails.library.jailbreak_detection.request import (
-            jailbreak_nim_request,
-        )
+    assert await request_fn(http_client=client, **kwargs) is None
 
-        sig = inspect.signature(jailbreak_nim_request)
-        params = list(sig.parameters.keys())
 
-        expected_params = [
-            "prompt",
-            "nim_url",
-            "nim_auth_token",
-            "nim_classification_path",
-            "http_client",
-        ]
-        assert params == expected_params, f"Expected {expected_params}, got {params}"
+@pytest.mark.parametrize(
+    ("request_fn", "kwargs"),
+    [
+        (
+            jailbreak_detection_heuristics_request,
+            {"prompt": "hello", "api_url": "https://guard.example/heuristics"},
+        ),
+        (
+            jailbreak_detection_model_request,
+            {"prompt": "hello", "api_url": "https://guard.example/model"},
+        ),
+    ],
+    ids=["heuristics", "model"],
+)
+@pytest.mark.asyncio
+async def test_jailbreak_request_returns_none_without_jailbreak_field(request_fn, kwargs):
+    client = RecordingHTTPClient([_response({"result": "safe"})])
+
+    assert await request_fn(http_client=client, **kwargs) is None
+
+
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_forwards_auth_and_timeout():
+    client = RecordingHTTPClient([_response({"jailbreak": False})])
+
+    result = await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example/v1",
+        nim_auth_token="secret",
+        nim_classification_path="/classify",
+        http_client=client,
+    )
+
+    assert result is False
+    request = client.requests[0]
+    assert request.url == "https://nim.example/v1/classify"
+    assert request.headers == {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": "Bearer secret",
+    }
+    assert request.json == {"input": "hello"}
+    assert request.timeout == 30
+
+
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_omits_auth_without_token():
+    client = RecordingHTTPClient([_response({"jailbreak": False})])
+
+    await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example",
+        nim_auth_token=None,
+        nim_classification_path="classify",
+        http_client=client,
+    )
+
+    assert "Authorization" not in client.requests[0].headers
+
+
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_returns_none_for_non_200():
+    client = RecordingHTTPClient([_response({}, status=503)])
+
+    result = await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example",
+        nim_auth_token=None,
+        nim_classification_path="classify",
+        http_client=client,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_returns_none_without_jailbreak_field():
+    client = RecordingHTTPClient([_response({"result": "safe"})])
+
+    result = await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example",
+        nim_auth_token=None,
+        nim_classification_path="classify",
+        http_client=client,
+    )
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        HTTPTimeoutError("timed out"),
+        HTTPConnectionError("connection failed"),
+        RuntimeError("unexpected failure"),
+    ],
+    ids=["timeout", "client-error", "unexpected-error"],
+)
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_returns_none_for_request_errors(error):
+    client = RecordingHTTPClient([error])
+
+    result = await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example",
+        nim_auth_token=None,
+        nim_classification_path="classify",
+        http_client=client,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_jailbreak_nim_request_returns_none_for_invalid_json():
+    client = RecordingHTTPClient([_response(content=b"not-json")])
+
+    result = await jailbreak_nim_request(
+        prompt="hello",
+        nim_url="https://nim.example",
+        nim_auth_token=None,
+        nim_classification_path="classify",
+        http_client=client,
+    )
+
+    assert result is None

--- a/tests/test_jailbreak_request.py
+++ b/tests/test_jailbreak_request.py
@@ -103,5 +103,6 @@ class TestJailbreakRequestChanges:
             "nim_url",
             "nim_auth_token",
             "nim_classification_path",
+            "http_client",
         ]
         assert params == expected_params, f"Expected {expected_params}, got {params}"

--- a/tests/test_pii_detection_actions.py
+++ b/tests/test_pii_detection_actions.py
@@ -25,6 +25,7 @@ from nemoguardrails.library.privateai import actions as privateai_actions
 from nemoguardrails.library.privateai.actions import detect_pii
 from nemoguardrails.library.sensitive_data_detection import actions as sensitive_data_actions
 from nemoguardrails.library.sensitive_data_detection.actions import detect_sensitive_data
+from nemoguardrails.testing import RecordingHTTPClient
 
 
 def _privateai_config() -> RailsConfig:
@@ -80,12 +81,20 @@ def _sensitive_data_config() -> RailsConfig:
     ],
 )
 async def test_privateai_detect_pii_returns_rail_outcome(monkeypatch, response, expected):
-    async def fake_private_ai_request(text, enabled_entities, server_endpoint, api_key):
+    client = RecordingHTTPClient()
+
+    async def fake_private_ai_request(text, enabled_entities, server_endpoint, api_key, http_client=None):
+        assert http_client is client
         return response
 
     monkeypatch.setattr(privateai_actions, "private_ai_request", fake_private_ai_request)
 
-    outcome = await detect_pii(source="input", text="hello", config=_privateai_config())
+    outcome = await detect_pii(
+        source="input",
+        text="hello",
+        config=_privateai_config(),
+        http_client=client,
+    )
 
     assert outcome == expected
 

--- a/tests/test_polygraf.py
+++ b/tests/test_polygraf.py
@@ -262,6 +262,14 @@ async def test_polygraf_request_raises_for_non_200_response():
 
 
 @pytest.mark.asyncio
+async def test_polygraf_request_raises_for_invalid_json():
+    client = RecordingHTTPClient([_http_response(text="not-json")])
+
+    with pytest.raises(ValueError, match="Failed to parse Polygraf response as JSON"):
+        await polygraf_request("John", "http://polygraf.example/pii", None, http_client=client)
+
+
+@pytest.mark.asyncio
 async def test_polygraf_request_forwards_timeout_to_client():
     client = RecordingHTTPClient([_http_response([])])
 

--- a/tests/test_polygraf.py
+++ b/tests/test_polygraf.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import Any, Dict, List, Optional
 
 import pytest
@@ -20,6 +21,7 @@ import pytest
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.http import HTTPConnectionError, HTTPResponse, HTTPTimeoutError
 from nemoguardrails.library.polygraf.actions import (
     FAILSAFE_MASK_PLACEHOLDER,
     _entity_shape,
@@ -27,6 +29,7 @@ from nemoguardrails.library.polygraf.actions import (
     polygraf_mask_pii,
 )
 from nemoguardrails.library.polygraf.request import polygraf_request
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
 
 
@@ -233,62 +236,69 @@ class _FakeSession:
         return _FakePostContextManager(self.response)
 
 
+def _http_response(payload=None, *, status: int = 200, text: str = "") -> HTTPResponse:
+    content = text.encode() if text else json.dumps(payload if payload is not None else []).encode()
+    return HTTPResponse(status_code=status, content=content)
+
+
 @pytest.mark.asyncio
-async def test_polygraf_request_uses_shared_session_and_bearer_auth():
-    session = _FakeSession(
-        _FakeResponse(
-            payload=[
-                {
-                    "entity_type": "Person",
-                    "entity_text": "John",
-                    "start": 0,
-                    "end": 4,
-                    "score": 0.99,
-                }
-            ]
-        )
+async def test_polygraf_request_uses_shared_client_and_bearer_auth():
+    client = RecordingHTTPClient(
+        [
+            _http_response(
+                [
+                    {
+                        "entity_type": "Person",
+                        "entity_text": "John",
+                        "start": 0,
+                        "end": 4,
+                        "score": 0.99,
+                    }
+                ]
+            )
+        ]
     )
 
-    entities = await polygraf_request("John", "http://polygraf.example/pii", "secret", session=session)
+    entities = await polygraf_request("John", "http://polygraf.example/pii", "secret", http_client=client)
 
     assert entities[0]["entity_type"] == "Person"
-    assert session.requests[0]["headers"]["Authorization"] == "Bearer secret"
-    assert session.requests[0]["json"]["detect_pid"] is True
-    assert session.requests[0]["json"]["aggregate_entities"] is True
+    assert client.requests[0].headers["Authorization"] == "Bearer secret"
+    assert client.requests[0].json["detect_pid"] is True
+    assert client.requests[0].json["aggregate_entities"] is True
 
 
 @pytest.mark.asyncio
 async def test_polygraf_request_accepts_wrapped_entities_response():
-    session = _FakeSession(_FakeResponse(payload={"entities": [{"entity_type": "Email"}]}))
+    client = RecordingHTTPClient([_http_response({"entities": [{"entity_type": "Email"}]})])
 
-    entities = await polygraf_request("test@gmail.com", "http://polygraf.example/pii", None, session=session)
+    entities = await polygraf_request("test@gmail.com", "http://polygraf.example/pii", None, http_client=client)
 
     assert entities == [{"entity_type": "Email"}]
 
 
 @pytest.mark.asyncio
 async def test_polygraf_request_accepts_null_entities_as_empty_response():
-    session = _FakeSession(_FakeResponse(payload={"entities": None}))
+    client = RecordingHTTPClient([_http_response({"entities": None})])
 
-    entities = await polygraf_request("hello", "http://polygraf.example/pii", None, session=session)
+    entities = await polygraf_request("hello", "http://polygraf.example/pii", None, http_client=client)
 
     assert entities == []
 
 
 @pytest.mark.asyncio
 async def test_polygraf_request_raises_for_invalid_response_shape():
-    session = _FakeSession(_FakeResponse(payload={"unexpected": []}))
+    client = RecordingHTTPClient([_http_response({"unexpected": []})])
 
     with pytest.raises(ValueError, match="Invalid response from Polygraf service"):
-        await polygraf_request("John", "http://polygraf.example/pii", None, session=session)
+        await polygraf_request("John", "http://polygraf.example/pii", None, http_client=client)
 
 
 @pytest.mark.asyncio
 async def test_polygraf_request_raises_for_non_200_response():
-    session = _FakeSession(_FakeResponse(status=401, text="missing token"))
+    client = RecordingHTTPClient([_http_response(status=401, text="missing token")])
 
     with pytest.raises(ValueError, match="Polygraf call failed with status code 401"):
-        await polygraf_request("John", "http://polygraf.example/pii", None, session=session)
+        await polygraf_request("John", "http://polygraf.example/pii", None, http_client=client)
 
 
 class _FakeSessionWithTimeoutKwarg:
@@ -302,15 +312,12 @@ class _FakeSessionWithTimeoutKwarg:
 
 
 @pytest.mark.asyncio
-async def test_polygraf_request_forwards_timeout_to_post():
-    import aiohttp
+async def test_polygraf_request_forwards_timeout_to_client():
+    client = RecordingHTTPClient([_http_response([])])
 
-    session = _FakeSessionWithTimeoutKwarg(_FakeResponse(payload=[]))
+    await polygraf_request("hello", "http://polygraf.example/pii", None, http_client=client, timeout=7)
 
-    await polygraf_request("hello", "http://polygraf.example/pii", None, session=session, timeout=7)
-
-    assert isinstance(session.timeouts[0], aiohttp.ClientTimeout)
-    assert session.timeouts[0].total == 7
+    assert client.requests[0].timeout == 7
 
 
 class _FakeRaisingSession:
@@ -338,22 +345,18 @@ class _FakeRaisingSession:
 
 @pytest.mark.asyncio
 async def test_polygraf_request_normalizes_timeout_as_value_error():
-    import asyncio
-
-    session = _FakeRaisingSession(asyncio.TimeoutError())
+    client = RecordingHTTPClient([HTTPTimeoutError("timed out")])
 
     with pytest.raises(ValueError, match="timed out"):
-        await polygraf_request("hello", "http://polygraf.example/pii", None, session=session, timeout=3)
+        await polygraf_request("hello", "http://polygraf.example/pii", None, http_client=client, timeout=3)
 
 
 @pytest.mark.asyncio
 async def test_polygraf_request_normalizes_client_error_as_value_error():
-    import aiohttp
-
-    session = _FakeRaisingSession(aiohttp.ClientConnectionError("dns failure"))
+    client = RecordingHTTPClient([HTTPConnectionError("dns failure")])
 
     with pytest.raises(ValueError, match="Polygraf call failed"):
-        await polygraf_request("hello", "http://polygraf.example/pii", None, session=session)
+        await polygraf_request("hello", "http://polygraf.example/pii", None, http_client=client)
 
 
 def test_polygraf_config_rejects_unknown_keys():
@@ -730,18 +733,24 @@ async def test_polygraf_actions_warn_when_api_key_missing(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-async def test_polygraf_mask_pii_accepts_extra_kwargs_and_shared_session(monkeypatch):
-    sentinel_session = object()
+async def test_polygraf_mask_pii_accepts_extra_kwargs_and_shared_client(monkeypatch):
+    sentinel_client = RecordingHTTPClient()
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         assert api_key == "secret"
-        assert session is sentinel_session
+        assert http_client is sentinel_client
         return [{"entity_type": "Person", "entity_text": "John", "start": 0, "end": 4, "score": 0.99}]
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
     monkeypatch.setattr("nemoguardrails.library.polygraf.actions.polygraf_request", mock_request)
 
-    result = await polygraf_mask_pii("input", "John", _polygraf_config(), session=sentinel_session, extra="ignored")
+    result = await polygraf_mask_pii(
+        "input",
+        "John",
+        _polygraf_config(),
+        http_client=sentinel_client,
+        extra="ignored",
+    )
 
     assert result.transform_text["user_message"] == "<Person>"
 

--- a/tests/test_polygraf.py
+++ b/tests/test_polygraf.py
@@ -196,46 +196,6 @@ async def test_polygraf_mask_pii_allows_when_no_entities(monkeypatch):
     assert not result.transforms
 
 
-class _FakeResponse:
-    def __init__(self, status=200, payload=None, text=""):
-        self.status = status
-        self._payload = payload if payload is not None else []
-        self._text = text
-
-    async def json(self):
-        return self._payload
-
-    async def text(self):
-        return self._text
-
-
-class _FakePostContextManager:
-    def __init__(self, response):
-        self.response = response
-
-    async def __aenter__(self):
-        return self.response
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-
-class _FakeSession:
-    def __init__(self, response):
-        self.response = response
-        self.requests = []
-
-    def post(self, server_endpoint, json, headers):
-        self.requests.append(
-            {
-                "server_endpoint": server_endpoint,
-                "json": json,
-                "headers": headers,
-            }
-        )
-        return _FakePostContextManager(self.response)
-
-
 def _http_response(payload=None, *, status: int = 200, text: str = "") -> HTTPResponse:
     content = text.encode() if text else json.dumps(payload if payload is not None else []).encode()
     return HTTPResponse(status_code=status, content=content)
@@ -301,16 +261,6 @@ async def test_polygraf_request_raises_for_non_200_response():
         await polygraf_request("John", "http://polygraf.example/pii", None, http_client=client)
 
 
-class _FakeSessionWithTimeoutKwarg:
-    def __init__(self, response):
-        self.response = response
-        self.timeouts = []
-
-    def post(self, server_endpoint, json, headers, timeout=None):
-        self.timeouts.append(timeout)
-        return _FakePostContextManager(self.response)
-
-
 @pytest.mark.asyncio
 async def test_polygraf_request_forwards_timeout_to_client():
     client = RecordingHTTPClient([_http_response([])])
@@ -318,29 +268,6 @@ async def test_polygraf_request_forwards_timeout_to_client():
     await polygraf_request("hello", "http://polygraf.example/pii", None, http_client=client, timeout=7)
 
     assert client.requests[0].timeout == 7
-
-
-class _FakeRaisingSession:
-    """Test double whose .post() raises a configurable exception when entered."""
-
-    def __init__(self, exc: BaseException):
-        self.exc = exc
-
-    def post(self, *args, **kwargs):
-        async def _raise():
-            raise self.exc
-
-        class _Ctx:
-            def __init__(self, raise_fn):
-                self._raise_fn = raise_fn
-
-            async def __aenter__(self_inner):
-                await self_inner._raise_fn()
-
-            async def __aexit__(self_inner, *a):
-                return False
-
-        return _Ctx(_raise)
 
 
 @pytest.mark.asyncio

--- a/tests/test_polygraf.py
+++ b/tests/test_polygraf.py
@@ -152,7 +152,7 @@ def test_polygraf_entity_shape_does_not_include_values():
 @pytest.mark.parametrize(("entity_type", "is_blocked"), [("Person", True), ("CreditCard", False)])
 @pytest.mark.asyncio
 async def test_polygraf_detect_pii_filters_valid_entities(monkeypatch, entity_type, is_blocked):
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [{"entity_type": entity_type, "start": 0, "end": 4}]
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -165,7 +165,7 @@ async def test_polygraf_detect_pii_filters_valid_entities(monkeypatch, entity_ty
 
 @pytest.mark.asyncio
 async def test_polygraf_detect_pii_fails_closed_on_non_mapping_entity(monkeypatch):
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return ["secret@example.com"]
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -184,7 +184,7 @@ async def test_polygraf_actions_reject_unknown_source():
 
 @pytest.mark.asyncio
 async def test_polygraf_mask_pii_allows_when_no_entities(monkeypatch):
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return []
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -551,7 +551,7 @@ async def test_polygraf_mask_pii_fails_closed_on_malformed_selected_entity(monke
     sensitive_email = "test@gmail.com"
     sensitive_input = f"John lives here. Email: {sensitive_email}"
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [
             {"entity_type": "Person", "start": 0, "end": 4},
             # Email is in the configured entities and has malformed offsets ->
@@ -578,7 +578,7 @@ async def test_polygraf_mask_pii_fails_closed_on_malformed_selected_entity(monke
 async def test_polygraf_mask_pii_skips_unselected_malformed_entity(monkeypatch, caplog):
     """A *known-type* malformed entity that does NOT match the entity filter is skipped, not failed."""
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [
             {"entity_type": "Person", "start": 0, "end": 4},
             # CreditCard is not in the configured entities for `input`; even though
@@ -601,7 +601,7 @@ async def test_polygraf_mask_pii_fails_closed_on_missing_entity_type(monkeypatch
 
     sensitive = "John lives here"
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [
             {"start": 0, "end": 4, "entity_text": "John"},
         ]
@@ -631,7 +631,7 @@ async def test_polygraf_mask_pii_fails_closed_on_missing_entity_type(monkeypatch
 async def test_polygraf_mask_pii_fails_closed_on_out_of_range_offsets(monkeypatch, bad_offsets):
     """Invalid offsets (bool, negative, reversed, beyond text, empty) must fail closed for a selected entity."""
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [{"entity_type": "Person", **bad_offsets}]
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -646,7 +646,7 @@ async def test_polygraf_mask_pii_fails_closed_on_out_of_range_offsets(monkeypatc
 async def test_polygraf_detect_pii_fails_closed_on_missing_entity_type(monkeypatch):
     """detect must block when an entity has no entity_type (cannot prove it's safe)."""
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [{"start": 0, "end": 4, "entity_text": "John"}]
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -663,7 +663,7 @@ async def test_polygraf_mask_pii_fails_closed_on_provider_error(monkeypatch, cap
 
     sensitive_text = "John lives at 1 Main St; email test@gmail.com"
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         raise ValueError("Polygraf call timed out after 30 seconds.")
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -683,7 +683,7 @@ async def test_polygraf_mask_pii_fails_closed_on_provider_error(monkeypatch, cap
 async def test_polygraf_detect_pii_fails_closed_on_provider_error(monkeypatch, caplog):
     """A request-layer ValueError must cause detect to block (return True)."""
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         raise ValueError("Polygraf call failed: ClientConnectorError: ...")
 
     monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
@@ -700,7 +700,7 @@ async def test_polygraf_detect_pii_fails_closed_on_provider_error(monkeypatch, c
 async def test_polygraf_detect_pii_fails_closed_on_malformed_selected_entity(monkeypatch, caplog):
     """detect must block when a configured entity is reported with bad shape."""
 
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         return [
             # Email is in the configured filter and missing offsets -> fail closed.
             {"entity_type": "Email"},
@@ -718,7 +718,7 @@ async def test_polygraf_detect_pii_fails_closed_on_malformed_selected_entity(mon
 
 @pytest.mark.asyncio
 async def test_polygraf_actions_warn_when_api_key_missing(monkeypatch, caplog):
-    async def mock_request(text, server_endpoint, api_key, session=None):
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
         assert api_key is None
         return []
 
@@ -753,6 +753,28 @@ async def test_polygraf_mask_pii_accepts_extra_kwargs_and_shared_client(monkeypa
     )
 
     assert result.transform_text["user_message"] == "<Person>"
+
+
+@pytest.mark.asyncio
+async def test_polygraf_detect_pii_forwards_shared_client(monkeypatch):
+    sentinel_client = RecordingHTTPClient()
+
+    async def mock_request(text, server_endpoint, api_key, http_client=None):
+        assert api_key == "secret"
+        assert http_client is sentinel_client
+        return []
+
+    monkeypatch.setenv("POLYGRAF_API_KEY", "secret")
+    monkeypatch.setattr("nemoguardrails.library.polygraf.actions.polygraf_request", mock_request)
+
+    result = await polygraf_detect_pii(
+        "input",
+        "Hello",
+        _polygraf_config(),
+        http_client=sentinel_client,
+    )
+
+    assert not result.is_blocked
 
 
 @pytest.mark.unit

--- a/tests/test_privateai.py
+++ b/tests/test_privateai.py
@@ -13,15 +13,149 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 
 import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
+from nemoguardrails.http import HTTPResponse
+from nemoguardrails.library.privateai.actions import detect_pii, mask_pii
+from nemoguardrails.library.privateai.request import private_ai_request
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import TestChat
 
 PAI_API_KEY_PRESENT = os.getenv("PAI_API_KEY") is not None
+
+
+def _response(payload=None, *, status: int = 200, content: bytes | None = None) -> HTTPResponse:
+    return HTTPResponse(
+        status_code=status,
+        headers={"content-type": "application/json"},
+        content=content if content is not None else json.dumps(payload).encode(),
+    )
+
+
+def _privateai_config() -> RailsConfig:
+    return RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                privateai:
+                  server_endpoint: http://privateai.example/process
+                  input:
+                    entities:
+                      - NAME
+                  output:
+                    entities:
+                      - NAME
+        """,
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_ai_request_uses_shared_client():
+    response_payload = [{"processed_text": "Hello [NAME_1].", "entities_present": ["NAME"]}]
+    client = RecordingHTTPClient([_response(response_payload)])
+
+    result = await private_ai_request(
+        "Hello John.",
+        ["NAME"],
+        "https://api.private-ai.com/cloud/v3/process/text",
+        api_key="secret",
+        http_client=client,
+    )
+
+    assert result == response_payload
+    request = client.requests[0]
+    assert request.method == "POST"
+    assert request.url == "https://api.private-ai.com/cloud/v3/process/text"
+    assert request.headers == {
+        "Content-Type": "application/json",
+        "x-api-key": "secret",
+    }
+    assert request.json == {
+        "text": ["Hello John."],
+        "link_batch": False,
+        "entity_detection": {
+            "accuracy": "high_automatic",
+            "return_entity": False,
+            "entity_types": [{"type": "ENABLE", "value": ["NAME"]}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_private_ai_request_omits_optional_cloud_fields():
+    client = RecordingHTTPClient([_response([])])
+
+    await private_ai_request(
+        "Hello.",
+        [],
+        "http://privateai.example/process",
+        http_client=client,
+    )
+
+    request = client.requests[0]
+    assert request.headers == {"Content-Type": "application/json"}
+    assert "entity_types" not in request.json["entity_detection"]
+
+
+@pytest.mark.asyncio
+async def test_private_ai_request_requires_cloud_api_key():
+    with pytest.raises(ValueError, match="'api_key' is required"):
+        await private_ai_request(
+            "Hello.",
+            [],
+            "https://api.private-ai.com/cloud/v3/process/text",
+            http_client=RecordingHTTPClient(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_private_ai_request_raises_for_non_200():
+    client = RecordingHTTPClient([_response({}, status=503)])
+
+    with pytest.raises(ValueError, match="Private AI call failed with status code 503"):
+        await private_ai_request(
+            "Hello.",
+            [],
+            "http://privateai.example/process",
+            http_client=client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_private_ai_request_raises_for_invalid_json():
+    client = RecordingHTTPClient([_response(content=b"not-json")])
+
+    with pytest.raises(ValueError, match="Failed to parse Private AI response as JSON"):
+        await private_ai_request(
+            "Hello.",
+            [],
+            "http://privateai.example/process",
+            http_client=client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_privateai_actions_forward_shared_client():
+    client = RecordingHTTPClient(
+        [
+            _response([{"entities_present": ["NAME"]}]),
+            _response([{"processed_text": "Hello [NAME_1]."}]),
+        ]
+    )
+    config = _privateai_config()
+
+    detection = await detect_pii("input", "Hello John.", config, http_client=client)
+    masking = await mask_pii("output", "Hello John.", config, http_client=client)
+
+    assert detection.is_blocked
+    assert masking.transforms[0].text == "Hello [NAME_1]."
+    assert len(client.requests) == 2
 
 
 @action()

--- a/tests/test_self_check_actions.py
+++ b/tests/test_self_check_actions.py
@@ -26,6 +26,7 @@ from nemoguardrails.library.self_check.facts.actions import _fact_check_outcome,
 from nemoguardrails.library.self_check.input_check.actions import self_check_input
 from nemoguardrails.library.self_check.output_check.actions import self_check_output
 from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.testing import RecordingHTTPClient
 from tests.utils import FakeLLMModel, TestChat
 
 
@@ -189,7 +190,10 @@ async def test_self_check_facts_without_evidence_allows():
     ],
 )
 async def test_alignscore_check_facts_returns_rail_outcome(monkeypatch, score, expected):
-    async def fake_alignscore_request(url, evidence, response):
+    client = RecordingHTTPClient()
+
+    async def fake_alignscore_request(url, evidence, response, http_client=None):
+        assert http_client is client
         return score
 
     task_manager = cast(
@@ -214,6 +218,7 @@ async def test_alignscore_check_facts_returns_rail_outcome(monkeypatch, score, e
         context={"relevant_chunks": ["evidence"], "bot_message": "answer"},
         llm=FakeLLMModel(responses=[]),
         config=_config(),
+        http_client=client,
     )
 
     assert outcome == expected
@@ -222,10 +227,12 @@ async def test_alignscore_check_facts_returns_rail_outcome(monkeypatch, score, e
 @pytest.mark.asyncio
 async def test_alignscore_check_facts_preserves_missing_endpoint(monkeypatch):
     observed_url = None
+    client = RecordingHTTPClient()
 
-    async def fake_alignscore_request(url, evidence, response):
+    async def fake_alignscore_request(url, evidence, response, http_client=None):
         nonlocal observed_url
         observed_url = url
+        assert http_client is client
         return 1.0
 
     task_manager = cast(
@@ -250,6 +257,7 @@ async def test_alignscore_check_facts_preserves_missing_endpoint(monkeypatch):
         context={"relevant_chunks": ["evidence"], "bot_message": "answer"},
         llm=FakeLLMModel(responses=[]),
         config=_config(),
+        http_client=client,
     )
 
     assert observed_url is None


### PR DESCRIPTION
## Description

Migrate shared library request helpers to the canonical HTTP client and request
helper. The affected integrations are ActiveFence, AlignScore, GLiNER,
jailbreak detection, Polygraf, and Private AI.

Each helper accepts an injected `HTTPClient` and sends requests through
`http_call`. When no client is injected, `http_call` creates and closes the
fallback client itself. The action modules no longer repeat an
`async with` resolver around every outbound request.

Existing response parsing, request payloads, timeouts, configuration errors, and
provider-specific exception behavior remain local to each integration. Tests
replace transport-specific mocks with the neutral recording client where
appropriate.

### Impact

- Six shared request paths stop constructing or managing transport-specific
  clients directly.
- Runtime injection and standalone fallback execution use the same helper.
- Response bodies remain readable after the managed client context closes.
- Provider-specific behavior remains unchanged and is covered by the existing
  integration tests.



### Stack

| Layer | Branch | Base | PR |
| --- | --- | --- | --- |
| HTTP foundation | `pouyanpi/rail-library-stack-9-http-contract` | `develop` | #2209 |
| HTTP instrumentation | `pouyanpi/rail-library-stack-10-http-instrumentation` | Stack 9 | #2219 |
| Request lifecycle | `pouyanpi/rail-library-stack-11-http-observability` | Stack 9 | #2210 |
| Request migrations | `pouyanpi/rail-library-stack-12-http-request-migrations` | Stack 11 | #2211 |
| Action and specialized migrations | `pouyanpi/rail-library-stack-13-http-action-migrations` | Stack 12 | #2212 |

## Related Issue(s)

- Fixes #<triaged GitHub issue number>
- Internal tracking: NGUARD-861
- Issue assignee: @<username>

## Verification

- `make test TEST="tests/http tests/test_activefence_rail.py tests/test_fact_checking.py tests/test_gliner.py tests/test_jailbreak_request.py tests/test_polygraf.py"` — 144 passed.
- Pre-commit passed across the complete cascaded HTTP stack.
- All tests were local and made no live provider calls.

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: Codex).

Codex assisted with implementation analysis, validation, stack restructuring,
and this draft. Check the disclosure box after human review.

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared asynchronous HTTP client with configurable timeouts, redirects, response handling, and lifecycle management.
  * Added configurable retries with backoff, retry-after support, and transport-error handling.
  * Added safer URL handling and sanitized error messages.
* **Improvements**
  * External moderation, fact-checking, PII detection, and jailbreak detection services can now reuse a shared HTTP client.
  * Standardized HTTP errors and JSON response decoding across integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->