### PR TITLE
feat(llm): add shared model telemetry and instrumented decorator

### DIFF
--- a/nemoguardrails/__init__.py
+++ b/nemoguardrails/__init__.py
@@ -63,6 +63,7 @@ from nemoguardrails.llm.frameworks import (  # noqa: E402
     register_framework,
     set_default_framework,
 )
+from nemoguardrails.llm.models.instrumented import InstrumentedLLMModel  # noqa: E402
 from nemoguardrails.llm.providers import register_provider  # noqa: E402
 from nemoguardrails.types import (  # noqa: E402
     ChatMessage,
@@ -82,6 +83,7 @@ __all__ = [
     "ChatMessage",
     "FinishReason",
     "Guardrails",
+    "InstrumentedLLMModel",
     "LLMFramework",
     "LLMModel",
     "LLMRails",

--- a/nemoguardrails/llm/models/instrumented.py
+++ b/nemoguardrails/llm/models/instrumented.py
@@ -37,6 +37,17 @@ from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponse
 
 
 class InstrumentedLLMModel:
+    """Decorate an ``LLMModel`` with tracing, metrics, and content capture.
+
+    Requests and responses are delegated to the wrapped model without changing
+    their runtime contract. Wrapping an existing ``InstrumentedLLMModel`` is
+    idempotent and returns the existing decorator.
+
+    The tracer controls client-span creation, while metrics and content capture
+    are independently opt-in. ``default_request_params`` contributes provider
+    defaults to telemetry without changing the parameters sent to the model.
+    """
+
     def __new__(cls, model: LLMModel, *args: Any, **kwargs: Any):
         if isinstance(model, cls):
             return model
@@ -84,6 +95,7 @@ class InstrumentedLLMModel:
 
     @property
     def wrapped_model(self) -> LLMModel:
+        """Return the underlying model for direct access or re-instrumentation."""
         return self._model
 
     def _request_params(self, stop: Optional[list[str]], kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -105,6 +117,11 @@ class InstrumentedLLMModel:
         stop: Optional[list[str]] = None,
         **kwargs: Any,
     ) -> LLMResponse:
+        """Generate one response while recording the LLM call telemetry.
+
+        The prompt, stop sequences, and provider-specific keyword arguments are
+        forwarded unchanged to the wrapped model.
+        """
         operation_name = OperationNames.CHAT
         provider_name = self.provider_name or SystemConstants.UNKNOWN
         params = self._request_params(stop, kwargs)
@@ -137,6 +154,12 @@ class InstrumentedLLMModel:
         stop: Optional[list[str]] = None,
         **kwargs: Any,
     ) -> AsyncIterator[LLMResponseChunk]:
+        """Stream response chunks while recording one LLM call lifecycle.
+
+        Metrics and response attributes are finalized when the stream completes
+        or closes, and the wrapped stream is always closed when it supports
+        ``aclose``.
+        """
         operation_name = OperationNames.CHAT
         provider_name = self.provider_name or SystemConstants.UNKNOWN
         params = self._request_params(stop, kwargs)
@@ -212,6 +235,11 @@ def instrument_llm_model(
     content_capture_enabled: bool = False,
     default_request_params: Optional[Mapping[str, Any]] = None,
 ) -> LLMModel:
+    """Return ``model`` decorated with the requested telemetry.
+
+    The original model is returned when neither tracing nor metrics are enabled.
+    Existing ``InstrumentedLLMModel`` instances are returned unchanged.
+    """
     if isinstance(model, InstrumentedLLMModel):
         return model
     if tracer is None and not metrics_enabled:

--- a/nemoguardrails/llm/models/instrumented.py
+++ b/nemoguardrails/llm/models/instrumented.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import warnings
+from collections.abc import AsyncIterator, Mapping
+from contextlib import nullcontext
+from typing import Any, Optional, Union
+
+from nemoguardrails.llm.telemetry import (
+    llm_call_span,
+    set_llm_call_content,
+    set_llm_request_attributes,
+    set_llm_response_attributes,
+)
+from nemoguardrails.tracing.constants import (
+    OperationNames,
+    SystemConstants,
+    llm_operation_duration,
+    record_time_per_output_chunk,
+    record_time_to_first_chunk,
+    record_token_usage,
+)
+from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
+
+
+class InstrumentedLLMModel:
+    def __new__(cls, model: LLMModel, *args: Any, **kwargs: Any):
+        if isinstance(model, cls):
+            return model
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        model: LLMModel,
+        *,
+        tracer: Optional[Any] = None,
+        metrics_enabled: bool = False,
+        content_capture_enabled: bool = False,
+        default_request_params: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        if model is self:
+            if (
+                tracer is not self._tracer
+                or metrics_enabled != self._metrics_enabled
+                or content_capture_enabled != self._content_capture_enabled
+                or dict(default_request_params or {}) != self._default_request_params
+            ):
+                warnings.warn(
+                    "InstrumentedLLMModel is already instrumented; new instrumentation "
+                    "settings are ignored. Re-instrument the underlying wrapped_model instead.",
+                    stacklevel=2,
+                )
+            return
+        self._model = model
+        self._tracer = tracer
+        self._metrics_enabled = metrics_enabled
+        self._content_capture_enabled = content_capture_enabled
+        self._default_request_params = dict(default_request_params or {})
+
+    @property
+    def model_name(self) -> str:
+        return self._model.model_name
+
+    @property
+    def provider_name(self) -> Optional[str]:
+        return self._model.provider_name
+
+    @property
+    def provider_url(self) -> Optional[str]:
+        return self._model.provider_url
+
+    @property
+    def wrapped_model(self) -> LLMModel:
+        return self._model
+
+    def _request_params(self, stop: Optional[list[str]], kwargs: dict[str, Any]) -> dict[str, Any]:
+        params = {**self._default_request_params, **kwargs}
+        if stop is not None:
+            params["stop"] = stop
+        return params
+
+    @staticmethod
+    def _input_messages(prompt: Union[str, list[ChatMessage]]) -> list[dict[str, Any]]:
+        if isinstance(prompt, str):
+            return [{"role": "user", "content": prompt}]
+        return [message.to_dict() if isinstance(message, ChatMessage) else message for message in prompt]
+
+    async def generate_async(
+        self,
+        prompt: Union[str, list[ChatMessage]],
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        operation_name = OperationNames.CHAT
+        provider_name = self.provider_name or SystemConstants.UNKNOWN
+        params = self._request_params(stop, kwargs)
+        with llm_call_span(self._tracer, self.model_name, provider_name, operation_name) as span:
+            set_llm_request_attributes(span, params)
+            duration = (
+                llm_operation_duration(self.model_name, provider_name, operation_name)
+                if self._metrics_enabled
+                else nullcontext()
+            )
+            with duration:
+                response = await self._model.generate_async(prompt, stop=stop, **kwargs)
+            set_llm_response_attributes(
+                span,
+                model=response.model,
+                response_id=response.request_id,
+                finish_reason=response.finish_reason,
+                usage=response.usage,
+            )
+            if self._content_capture_enabled:
+                set_llm_call_content(span, self._input_messages(prompt), response.content)
+        if self._metrics_enabled:
+            record_token_usage(self.model_name, provider_name, operation_name, response.usage)
+        return response
+
+    async def stream_async(
+        self,
+        prompt: Union[str, list[ChatMessage]],
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[LLMResponseChunk]:
+        operation_name = OperationNames.CHAT
+        provider_name = self.provider_name or SystemConstants.UNKNOWN
+        params = self._request_params(stop, kwargs)
+        captured_usage: Optional[UsageInfo] = None
+        captured_model: Optional[str] = None
+        captured_response_id: Optional[str] = None
+        captured_finish_reason: Optional[str] = None
+        content_parts: list[str] = []
+        stream = self._model.stream_async(prompt, stop=stop, **kwargs)
+        with llm_call_span(self._tracer, self.model_name, provider_name, operation_name) as span:
+            set_llm_request_attributes(span, params, stream=True)
+            duration = (
+                llm_operation_duration(self.model_name, provider_name, operation_name)
+                if self._metrics_enabled
+                else nullcontext()
+            )
+            try:
+                with duration:
+                    started_at = time.monotonic() if self._metrics_enabled else 0.0
+                    last_chunk_at: Optional[float] = None
+                    async for chunk in stream:
+                        if self._metrics_enabled and (chunk.delta_content or chunk.delta_reasoning):
+                            now = time.monotonic()
+                            if last_chunk_at is None:
+                                record_time_to_first_chunk(
+                                    self.model_name,
+                                    provider_name,
+                                    operation_name,
+                                    now - started_at,
+                                )
+                            else:
+                                record_time_per_output_chunk(
+                                    self.model_name,
+                                    provider_name,
+                                    operation_name,
+                                    now - last_chunk_at,
+                                )
+                            last_chunk_at = now
+                        if chunk.model is not None:
+                            captured_model = chunk.model
+                        if chunk.request_id is not None:
+                            captured_response_id = chunk.request_id
+                        if chunk.finish_reason is not None:
+                            captured_finish_reason = chunk.finish_reason
+                        if chunk.usage is not None:
+                            captured_usage = chunk.usage
+                        if self._content_capture_enabled and chunk.delta_content:
+                            content_parts.append(chunk.delta_content)
+                        yield chunk
+            finally:
+                close = getattr(stream, "aclose", None)
+                if close is not None:
+                    await close()
+            set_llm_response_attributes(
+                span,
+                model=captured_model,
+                response_id=captured_response_id,
+                finish_reason=captured_finish_reason,
+                usage=captured_usage,
+            )
+            if self._content_capture_enabled:
+                output_text = "".join(content_parts) if content_parts else None
+                set_llm_call_content(span, self._input_messages(prompt), output_text)
+        if self._metrics_enabled:
+            record_token_usage(self.model_name, provider_name, operation_name, captured_usage)
+
+
+def instrument_llm_model(
+    model: LLMModel,
+    *,
+    tracer: Optional[Any] = None,
+    metrics_enabled: bool = False,
+    content_capture_enabled: bool = False,
+    default_request_params: Optional[Mapping[str, Any]] = None,
+) -> LLMModel:
+    if isinstance(model, InstrumentedLLMModel):
+        return model
+    if tracer is None and not metrics_enabled:
+        return model
+    return InstrumentedLLMModel(
+        model,
+        tracer=tracer,
+        metrics_enabled=metrics_enabled,
+        content_capture_enabled=content_capture_enabled,
+        default_request_params=default_request_params,
+    )
+
+
+__all__ = ["InstrumentedLLMModel", "instrument_llm_model"]

--- a/nemoguardrails/llm/telemetry.py
+++ b/nemoguardrails/llm/telemetry.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import json
 import os
 from contextlib import contextmanager, suppress
@@ -204,8 +205,11 @@ def llm_call_span(
 ) -> Generator[Optional["Span"], None, None]:
     """Create a GenAI client span for one LLM call.
 
-    Yields ``None`` when no tracer is configured. Exceptions from the wrapped
-    call are recorded on the span and re-raised unchanged.
+    Yields ``None`` when no tracer is configured. Provider exceptions from the
+    wrapped call are recorded on the span and re-raised unchanged. Early stream
+    closure (``GeneratorExit``) and task cancellation (``CancelledError``) are
+    control flow, not provider failures, so they are re-raised without marking
+    the span as an error.
     """
     if tracer is None:
         yield None
@@ -222,6 +226,8 @@ def llm_call_span(
             span.set_attribute(GenAIAttributes.GEN_AI_PROVIDER_NAME, provider_name)
         try:
             yield span
+        except (GeneratorExit, asyncio.CancelledError):
+            raise
         except BaseException as exc:
             record_span_error(span, exc)
             raise

--- a/nemoguardrails/llm/telemetry.py
+++ b/nemoguardrails/llm/telemetry.py
@@ -107,6 +107,12 @@ def set_llm_call_content(
     input_messages: list[dict[str, Any]],
     output_text: Optional[str] = None,
 ) -> None:
+    """Record LLM input and output content on a span when available.
+
+    The configured OpenTelemetry content format determines whether content is
+    stored as JSON attributes or legacy events. Telemetry failures are ignored
+    so they cannot affect the model call.
+    """
     if span is None:
         return
     with suppress(Exception):
@@ -128,6 +134,10 @@ def _stop_sequences(params: dict) -> Optional[list]:
 
 
 def set_llm_request_attributes(span: Optional["Span"], params: dict, *, stream: bool = False) -> None:
+    """Record supported GenAI request parameters on a span.
+
+    Unknown parameters are ignored, as are telemetry failures.
+    """
     if span is None:
         return
     with suppress(Exception):
@@ -150,6 +160,7 @@ def set_llm_response_attributes(
     finish_reason: Optional[str] = None,
     usage: Optional["UsageInfo"] = None,
 ) -> None:
+    """Record available model response metadata and token usage on a span."""
     if span is None:
         return
     with suppress(Exception):
@@ -170,6 +181,7 @@ def set_llm_response_attributes(
 
 
 def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
+    """Record an exception and error status without changing call behavior."""
     if span is None:
         return
     with suppress(Exception):
@@ -185,6 +197,11 @@ def llm_call_span(
     provider_name: str,
     operation_name: str = "chat",
 ) -> Generator[Optional["Span"], None, None]:
+    """Create a GenAI client span for one LLM call.
+
+    Yields ``None`` when no tracer is configured. Exceptions from the wrapped
+    call are recorded on the span and re-raised unchanged.
+    """
     if tracer is None:
         yield None
         return

--- a/nemoguardrails/llm/telemetry.py
+++ b/nemoguardrails/llm/telemetry.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any, Generator, Optional
+
+from nemoguardrails.tracing.constants import EventNames, GenAIAttributes, OtelContentCapture
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span, Tracer
+
+    from nemoguardrails.types import UsageInfo
+else:
+    try:
+        from opentelemetry.trace import SpanKind, StatusCode
+    except ImportError:
+        SpanKind = None
+        StatusCode = None
+
+
+_LEGACY_EVENT_BY_ROLE = {
+    "system": EventNames.GEN_AI_SYSTEM_MESSAGE,
+    "user": EventNames.GEN_AI_USER_MESSAGE,
+    "assistant": EventNames.GEN_AI_ASSISTANT_MESSAGE,
+    "tool": EventNames.GEN_AI_TOOL_MESSAGE,
+}
+
+_GENAI_REQUEST_PARAMS = {
+    "temperature": GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE,
+    "max_tokens": GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS,
+    "max_completion_tokens": GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS,
+    "top_p": GenAIAttributes.GEN_AI_REQUEST_TOP_P,
+    "top_k": GenAIAttributes.GEN_AI_REQUEST_TOP_K,
+    "frequency_penalty": GenAIAttributes.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+    "presence_penalty": GenAIAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY,
+}
+
+
+def _use_json_span_format() -> bool:
+    tokens = {token.strip() for token in os.environ.get(OtelContentCapture.STABILITY_OPT_IN_ENV, "").split(",")}
+    return OtelContentCapture.STABILITY_OPT_IN_LATEST in tokens
+
+
+def _system_parts_from_messages(messages: list[dict[str, Any]]) -> list[dict]:
+    return [
+        {"type": "text", "content": message["content"]}
+        for message in messages
+        if message.get("role") == "system" and message.get("content") is not None
+    ]
+
+
+def _non_system_input_messages(messages: list[dict[str, Any]]) -> list[dict]:
+    return [
+        {
+            "role": message["role"],
+            "parts": [{"type": "text", "content": message["content"]}],
+        }
+        for message in messages
+        if message.get("role") is not None and message.get("role") != "system" and message.get("content") is not None
+    ]
+
+
+def _set_llm_call_content_json(span: "Span", input_messages: list[dict[str, Any]], output_text: Optional[str]) -> None:
+    system_parts = _system_parts_from_messages(input_messages)
+    if system_parts:
+        span.set_attribute(GenAIAttributes.GEN_AI_SYSTEM_INSTRUCTIONS, json.dumps(system_parts))
+    non_system = _non_system_input_messages(input_messages)
+    if non_system:
+        span.set_attribute(GenAIAttributes.GEN_AI_INPUT_MESSAGES, json.dumps(non_system))
+    if output_text is not None:
+        output_messages = [{"role": "assistant", "parts": [{"type": "text", "content": output_text}]}]
+        span.set_attribute(GenAIAttributes.GEN_AI_OUTPUT_MESSAGES, json.dumps(output_messages))
+
+
+def _set_llm_call_content_events(
+    span: "Span", input_messages: list[dict[str, Any]], output_text: Optional[str]
+) -> None:
+    for message in input_messages:
+        role = message.get("role")
+        content = message.get("content")
+        event_name = _LEGACY_EVENT_BY_ROLE.get(role)
+        if event_name is not None and isinstance(role, str) and isinstance(content, str):
+            span.add_event(event_name, attributes={"role": role, "content": content})
+    if output_text is not None:
+        span.add_event(
+            EventNames.GEN_AI_CHOICE,
+            attributes={"index": 0, "message.role": "assistant", "message.content": output_text},
+        )
+
+
+def set_llm_call_content(
+    span: Optional["Span"],
+    input_messages: list[dict[str, Any]],
+    output_text: Optional[str] = None,
+) -> None:
+    if span is None:
+        return
+    with suppress(Exception):
+        if _use_json_span_format():
+            _set_llm_call_content_json(span, input_messages, output_text)
+        else:
+            _set_llm_call_content_events(span, input_messages, output_text)
+
+
+def _stop_sequences(params: dict) -> Optional[list]:
+    value = params.get("stop")
+    if value is None:
+        value = params.get("stop_sequences")
+    if isinstance(value, str) and value:
+        return [value]
+    if isinstance(value, list) and value:
+        return value
+    return None
+
+
+def set_llm_request_attributes(span: Optional["Span"], params: dict, *, stream: bool = False) -> None:
+    if span is None:
+        return
+    with suppress(Exception):
+        for key, attribute in _GENAI_REQUEST_PARAMS.items():
+            value = params.get(key)
+            if value is not None:
+                span.set_attribute(attribute, value)
+        stop_sequences = _stop_sequences(params)
+        if stop_sequences is not None:
+            span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES, stop_sequences)
+        if stream:
+            span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_STREAM, True)
+
+
+def set_llm_response_attributes(
+    span: Optional["Span"],
+    *,
+    model: Optional[str] = None,
+    response_id: Optional[str] = None,
+    finish_reason: Optional[str] = None,
+    usage: Optional["UsageInfo"] = None,
+) -> None:
+    if span is None:
+        return
+    with suppress(Exception):
+        if model is not None:
+            span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_MODEL, model)
+        if response_id is not None:
+            span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_ID, response_id)
+        if finish_reason is not None:
+            span.set_attribute(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS, [finish_reason])
+        if usage is not None:
+            span.set_attribute(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, usage.input_tokens)
+            span.set_attribute(GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, usage.output_tokens)
+            if usage.reasoning_tokens is not None:
+                span.set_attribute(
+                    GenAIAttributes.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+                    usage.reasoning_tokens,
+                )
+
+
+def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
+    if span is None:
+        return
+    with suppress(Exception):
+        span.set_attribute("error.type", type(exc).__name__)
+        span.record_exception(exc)
+        span.set_status(StatusCode.ERROR, str(exc))
+
+
+@contextmanager
+def llm_call_span(
+    tracer: Optional["Tracer"],
+    model_name: str,
+    provider_name: str,
+    operation_name: str = "chat",
+) -> Generator[Optional["Span"], None, None]:
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(
+        f"{operation_name} {model_name}",
+        kind=SpanKind.CLIENT,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        with suppress(Exception):
+            span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, operation_name)
+            span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_MODEL, model_name)
+            span.set_attribute(GenAIAttributes.GEN_AI_PROVIDER_NAME, provider_name)
+        try:
+            yield span
+        except BaseException as exc:
+            record_span_error(span, exc)
+            raise
+
+
+__all__ = [
+    "llm_call_span",
+    "record_span_error",
+    "set_llm_call_content",
+    "set_llm_request_attributes",
+    "set_llm_response_attributes",
+]

--- a/nemoguardrails/llm/telemetry.py
+++ b/nemoguardrails/llm/telemetry.py
@@ -181,13 +181,18 @@ def set_llm_response_attributes(
 
 
 def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
-    """Record an exception and error status without changing call behavior."""
+    """Record error status and the exception type on a span.
+
+    The exception message and stack trace are deliberately omitted: a provider
+    error can embed request content, which must not reach telemetry unless
+    content capture is explicitly enabled. Only the low-cardinality error type
+    is recorded.
+    """
     if span is None:
         return
     with suppress(Exception):
         span.set_attribute("error.type", type(exc).__name__)
-        span.record_exception(exc)
-        span.set_status(StatusCode.ERROR, str(exc))
+        span.set_status(StatusCode.ERROR)
 
 
 @contextmanager

--- a/tests/llm/models/test_instrumented.py
+++ b/tests/llm/models/test_instrumented.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import warnings
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from nemoguardrails.actions.llm.utils import llm_call
+from nemoguardrails.guardrails import telemetry
+from nemoguardrails.llm.models.instrumented import InstrumentedLLMModel, instrument_llm_model
+from nemoguardrails.tracing import constants as tracing_constants
+from nemoguardrails.tracing.constants import SystemConstants
+from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
+from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
+
+
+class RecordingModel:
+    model_name = "test-model"
+    provider_name = "test-provider"
+    provider_url = "https://example.test/v1"
+
+    def __init__(self, response=None, chunks=None, error=None):
+        self.response = response or LLMResponse(content="response")
+        self.chunks = chunks or []
+        self.error = error
+        self.calls = []
+        self.stream_closed = False
+
+    async def generate_async(self, prompt, *, stop=None, **kwargs):
+        self.calls.append((prompt, stop, kwargs))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+    async def stream_async(self, prompt, *, stop=None, **kwargs):
+        self.calls.append((prompt, stop, kwargs))
+        try:
+            for chunk in self.chunks:
+                yield chunk
+            if self.error is not None:
+                raise self.error
+        finally:
+            self.stream_closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry():
+    telemetry._meter = None
+    tracing_constants._llm_instruments = None
+    yield
+    telemetry._meter = None
+    tracing_constants._llm_instruments = None
+
+
+@pytest.fixture
+def span_exporter():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("test"), exporter
+
+
+@pytest.fixture
+def metric_reader():
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    telemetry._meter = provider.get_meter(SystemConstants.SYSTEM_NAME)
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_generate_delegates_and_returns_exact_response(span_exporter):
+    tracer, exporter = span_exporter
+    response = LLMResponse(
+        content="answer",
+        model="response-model",
+        request_id="request-id",
+        finish_reason="stop",
+        usage=UsageInfo(input_tokens=3, output_tokens=2),
+    )
+    model = RecordingModel(response=response)
+    instrumented = InstrumentedLLMModel(model, tracer=tracer)
+    prompt = [ChatMessage(role="user", content="question")]
+
+    result = await instrumented.generate_async(prompt, stop=["END"], temperature=0.2)
+
+    assert isinstance(instrumented, LLMModel)
+    assert result is response
+    assert model.calls == [(prompt, ["END"], {"temperature": 0.2})]
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["gen_ai.request.model"] == "test-model"
+    assert attrs["gen_ai.provider.name"] == "test-provider"
+    assert attrs["gen_ai.request.temperature"] == 0.2
+    assert list(attrs["gen_ai.request.stop_sequences"]) == ["END"]
+    assert attrs["gen_ai.response.model"] == "response-model"
+    assert attrs["gen_ai.response.id"] == "request-id"
+    assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+    assert attrs["gen_ai.usage.input_tokens"] == 3
+    assert attrs["gen_ai.usage.output_tokens"] == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_preserves_exception_identity(span_exporter):
+    tracer, exporter = span_exporter
+    error = RuntimeError("provider failed")
+    model = InstrumentedLLMModel(RecordingModel(error=error), tracer=tracer)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await model.generate_async("question")
+
+    assert exc_info.value is error
+    traceback = exc_info.value.__traceback__
+    while traceback and traceback.tb_next:
+        traceback = traceback.tb_next
+    assert traceback is not None
+    assert traceback.tb_frame.f_code is RecordingModel.generate_async.__code__
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["error.type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_llm_call_uses_instrumented_custom_model(span_exporter):
+    tracer, exporter = span_exporter
+    model = InstrumentedLLMModel(RecordingModel(), tracer=tracer)
+
+    result = await llm_call(model, "question")
+
+    assert result.content == "response"
+    assert len(exporter.get_finished_spans()) == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_chunks_and_latest_non_null_metadata(span_exporter):
+    tracer, exporter = span_exporter
+    chunks = [
+        LLMResponseChunk(delta_content="a", model="first", request_id="id-1"),
+        LLMResponseChunk(delta_reasoning="thinking", model="second"),
+        LLMResponseChunk(delta_content="b", finish_reason="stop"),
+        LLMResponseChunk(usage=UsageInfo(input_tokens=4, output_tokens=2)),
+    ]
+    underlying = RecordingModel(chunks=chunks)
+    model = InstrumentedLLMModel(underlying, tracer=tracer)
+
+    received = [chunk async for chunk in model.stream_async("question")]
+
+    assert received == chunks
+    assert all(received_chunk is source_chunk for received_chunk, source_chunk in zip(received, chunks))
+    assert underlying.stream_closed
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["gen_ai.request.stream"] is True
+    assert attrs["gen_ai.response.model"] == "second"
+    assert attrs["gen_ai.response.id"] == "id-1"
+    assert list(attrs["gen_ai.response.finish_reasons"]) == ["stop"]
+    assert attrs["gen_ai.usage.input_tokens"] == 4
+    assert attrs["gen_ai.usage.output_tokens"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_error_has_no_final_response_telemetry(span_exporter):
+    tracer, exporter = span_exporter
+    error = RuntimeError("stream failed")
+    source = RecordingModel(
+        chunks=[LLMResponseChunk(delta_content="partial", model="partial-model")],
+        error=error,
+    )
+    model = InstrumentedLLMModel(source, tracer=tracer)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        async for _ in model.stream_async("question"):
+            pass
+
+    assert exc_info.value is error
+    traceback = exc_info.value.__traceback__
+    while traceback and traceback.tb_next:
+        traceback = traceback.tb_next
+    assert traceback is not None
+    assert traceback.tb_frame.f_code is RecordingModel.stream_async.__code__
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["error.type"] == "RuntimeError"
+    assert "gen_ai.response.model" not in attrs
+    assert "gen_ai.usage.input_tokens" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_close_has_no_final_response_telemetry(span_exporter):
+    tracer, exporter = span_exporter
+    source = RecordingModel(
+        chunks=[
+            LLMResponseChunk(delta_content="partial", model="partial-model"),
+            LLMResponseChunk(usage=UsageInfo(input_tokens=1, output_tokens=1)),
+        ]
+    )
+    model = InstrumentedLLMModel(source, tracer=tracer)
+    stream = model.stream_async("question")
+
+    assert await anext(stream) is source.chunks[0]
+    await stream.aclose()
+
+    assert source.stream_closed
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["error.type"] == "GeneratorExit"
+    assert "gen_ai.response.model" not in attrs
+    assert "gen_ai.usage.input_tokens" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_stream_task_cancellation_preserves_cancelled_error(span_exporter):
+    tracer, exporter = span_exporter
+    started = asyncio.Event()
+
+    class BlockingModel(RecordingModel):
+        async def stream_async(self, prompt, *, stop=None, **kwargs):
+            try:
+                started.set()
+                await asyncio.Event().wait()
+                yield LLMResponseChunk(delta_content="unreachable")
+            finally:
+                self.stream_closed = True
+
+    source = BlockingModel()
+    model = InstrumentedLLMModel(source, tracer=tracer)
+
+    async def consume():
+        async for _ in model.stream_async("question"):
+            pass
+
+    task = asyncio.create_task(consume())
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert source.stream_closed
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert attrs["error.type"] == "CancelledError"
+    assert "gen_ai.response.model" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_content_capture_is_disabled_by_default(span_exporter):
+    tracer, exporter = span_exporter
+    model = InstrumentedLLMModel(RecordingModel(response=LLMResponse(content="secret output")), tracer=tracer)
+
+    await model.generate_async("secret input")
+
+    span = exporter.get_finished_spans()[0]
+    assert all("secret" not in str(value) for value in span.attributes.values())
+    assert all("secret" not in str(event.attributes) for event in span.events)
+
+
+@pytest.mark.asyncio
+async def test_content_capture_uses_existing_format_switch(span_exporter):
+    tracer, exporter = span_exporter
+    model = InstrumentedLLMModel(
+        RecordingModel(response=LLMResponse(content="captured output")),
+        tracer=tracer,
+        content_capture_enabled=True,
+    )
+
+    with patch.dict("os.environ", {"OTEL_SEMCONV_STABILITY_OPT_IN": "gen_ai_latest_experimental"}):
+        await model.generate_async("captured input")
+
+    attrs = dict(exporter.get_finished_spans()[0].attributes)
+    assert json.loads(attrs["gen_ai.input.messages"])[0]["parts"][0]["content"] == "captured input"
+    assert json.loads(attrs["gen_ai.output.messages"])[0]["parts"][0]["content"] == "captured output"
+
+
+@pytest.mark.asyncio
+async def test_metrics_and_chunk_timing(metric_reader):
+    usage = UsageInfo(input_tokens=5, output_tokens=2)
+    chunks = [
+        LLMResponseChunk(delta_reasoning="think"),
+        LLMResponseChunk(delta_content="answer"),
+        LLMResponseChunk(usage=usage),
+    ]
+    model = InstrumentedLLMModel(RecordingModel(chunks=chunks), metrics_enabled=True)
+
+    async for _ in model.stream_async("question"):
+        pass
+
+    points = collect_metric_points(metric_reader)
+    assert len(points["gen_ai.client.token.usage"]) == 2
+    assert points["gen_ai.client.operation.time_to_first_chunk"][0].value == 1
+    assert points["gen_ai.client.operation.time_per_output_chunk"][0].value == 1
+    assert points["gen_ai.client.operation.duration"][0].value == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_telemetry_returns_original_model(metric_reader):
+    model = RecordingModel()
+
+    result = instrument_llm_model(model)
+    response = await result.generate_async("question")
+
+    assert result is model
+    assert response is model.response
+    assert collect_metric_points(metric_reader) == {}
+
+
+@pytest.mark.asyncio
+async def test_instrumentation_is_idempotent_and_does_not_own_model(span_exporter):
+    tracer, exporter = span_exporter
+    model = RecordingModel()
+    first = InstrumentedLLMModel(model, tracer=tracer)
+    second = InstrumentedLLMModel(first, metrics_enabled=True)
+    third = instrument_llm_model(second, tracer=tracer)
+
+    await third.generate_async("question")
+
+    assert second is first
+    assert third is first
+    assert len(exporter.get_finished_spans()) == 1
+    assert first.wrapped_model is model
+    assert not hasattr(first, "close")
+    assert not hasattr(first, "aclose")
+
+
+@pytest.mark.asyncio
+async def test_stream_cleanup_runs_outside_duration_metric(metric_reader):
+    close_delay = 0.2
+
+    class SlowClosingModel(RecordingModel):
+        async def stream_async(self, prompt, *, stop=None, **kwargs):
+            try:
+                yield LLMResponseChunk(delta_content="a")
+                yield LLMResponseChunk(delta_content="b")
+            finally:
+                await asyncio.sleep(close_delay)
+                self.stream_closed = True
+
+    source = SlowClosingModel()
+    model = InstrumentedLLMModel(source, metrics_enabled=True)
+    stream = model.stream_async("question")
+
+    assert await anext(stream) is not None
+    await stream.aclose()
+
+    assert source.stream_closed
+    points = collect_metric_points(metric_reader)
+    assert len(points["gen_ai.client.operation.duration"]) == 1
+    recorded_duration = collect_histogram_sum(metric_reader, "gen_ai.client.operation.duration")
+    assert recorded_duration < close_delay / 2
+
+
+def test_reinstrument_with_changed_settings_warns_and_keeps_original():
+    instrumented = InstrumentedLLMModel(RecordingModel(), metrics_enabled=True)
+
+    with pytest.warns(UserWarning, match="already instrumented"):
+        again = InstrumentedLLMModel(instrumented, content_capture_enabled=True)
+
+    assert again is instrumented
+    assert again._content_capture_enabled is False
+
+
+def test_reinstrument_with_identical_settings_does_not_warn():
+    instrumented = InstrumentedLLMModel(RecordingModel(), metrics_enabled=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        again = InstrumentedLLMModel(instrumented, metrics_enabled=True)
+
+    assert again is instrumented

--- a/tests/llm/models/test_instrumented.py
+++ b/tests/llm/models/test_instrumented.py
@@ -235,8 +235,10 @@ async def test_stream_consumer_close_has_no_final_response_telemetry(span_export
     await stream.aclose()
 
     assert source.stream_closed
-    attrs = dict(exporter.get_finished_spans()[0].attributes)
-    assert attrs["error.type"] == "GeneratorExit"
+    span = exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert "error.type" not in attrs
+    assert span.status.status_code != StatusCode.ERROR
     assert "gen_ai.response.model" not in attrs
     assert "gen_ai.usage.input_tokens" not in attrs
 
@@ -270,8 +272,10 @@ async def test_stream_task_cancellation_preserves_cancelled_error(span_exporter)
         await task
 
     assert source.stream_closed
-    attrs = dict(exporter.get_finished_spans()[0].attributes)
-    assert attrs["error.type"] == "CancelledError"
+    span = exporter.get_finished_spans()[0]
+    attrs = dict(span.attributes)
+    assert "error.type" not in attrs
+    assert span.status.status_code != StatusCode.ERROR
     assert "gen_ai.response.model" not in attrs
 
 

--- a/tests/llm/models/test_instrumented.py
+++ b/tests/llm/models/test_instrumented.py
@@ -24,6 +24,7 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 from nemoguardrails.actions.llm.utils import llm_call
 from nemoguardrails.guardrails import telemetry
@@ -136,6 +137,23 @@ async def test_generate_preserves_exception_identity(span_exporter):
     assert traceback.tb_frame.f_code is RecordingModel.generate_async.__code__
     attrs = dict(exporter.get_finished_spans()[0].attributes)
     assert attrs["error.type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_error_span_excludes_exception_content(span_exporter):
+    tracer, exporter = span_exporter
+    secret = "secret-prompt-text-9f31"
+    model = InstrumentedLLMModel(RecordingModel(error=RuntimeError(f"boom {secret}")), tracer=tracer)
+
+    with pytest.raises(RuntimeError):
+        await model.generate_async("question")
+
+    span = exporter.get_finished_spans()[0]
+    assert span.attributes["error.type"] == "RuntimeError"
+    assert span.status.status_code == StatusCode.ERROR
+    assert all(secret not in str(value) for value in span.attributes.values())
+    assert all(secret not in str(event.attributes) for event in span.events)
+    assert secret not in (span.status.description or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Adds shared, engine-neutral OpenTelemetry GenAI instrumentation for model calls.

**Commit 1 (the deliverable):** `feat(llm): add shared model telemetry and instrumented decorator`2b680f0f2e29eecd045443a760afa2f0b9654401
- `nemoguardrails/llm/telemetry.py`: engine-neutral helpers for GenAI CLIENT spans and request/response/usage attributes.
- `InstrumentedLLMModel`: a transparent decorator wrapping any `LLMModel` to emit GenAI spans and client metrics. No-op when tracing and metrics are both off.
- No engine is wired to it. Self-contained, unit-tested, changes no existing behavior.

**Commit 2 (temporary):** `refactor(guardrails): route IORails model calls through the shared decorator`
- Switches IORails to the shared decorator to show its tracing/metrics are preserved.
- Not for merge here; I will drop it before merging. Review as a preservation proof.

## Related Issue(s)

<!-- Replace with the triaged issue assigned to the PR author before submitting. -->
- Fixes #<issue_number>
- Issue assignee: @Pouyanpi

## Verification

- Live IORails (OpenAI `gpt-4o-mini`): unchanged spans plus both `guardrails.*` and `gen_ai.client.*` metrics. Examples were run against every IORails telemetry doc:
  - `docs/observability/metrics/`: `enable-metrics.mdx`, `index.mdx`, `opentelemetry-integration.mdx`, `reference.mdx`
  - `docs/observability/tracing/`: `content-capture.mdx`, `span-reference.mdx`, `index.mdx`


## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
