### PR TITLE
test(frameworks): prevent default-framework leak between tests

### DIFF
--- a/tests/llm/frameworks/test_registry.py
+++ b/tests/llm/frameworks/test_registry.py
@@ -39,9 +39,13 @@ from nemoguardrails.types import LLMModel
 
 @pytest.fixture(autouse=True)
 def clean_registry():
+    from nemoguardrails.llm.frameworks import registry
+
     _reset_frameworks()
+    saved_default_framework = registry._default_framework
     yield
     _reset_frameworks()
+    registry._default_framework = saved_default_framework
 
 
 class FakeFramework:


### PR DESCRIPTION
## Description


`test_default_from_env_var` sets `NEMOGUARDRAILS_LLM_FRAMEWORK` through `monkeypatch` and calls `_reset_frameworks()`, which re-derives the module-global `_default_framework` from that environment variable. The autouse `clean_registry` teardown also calls `_reset_frameworks()`, but it runs before `monkeypatch` restores the environment, so the reset re-reads "litellm" and pins it as the global default.

The stale default then leaks into any test that runs later in the same xdist worker. When `test_compat_check_runs_against_main_when_no_constructor_llm` constructs `LLMRails`, it reads the default framework "litellm", which `get_framework()` cannot build because only "langchain" and "default" are lazily registerable, and fails with
`KeyError: Unknown framework 'litellm'. Available frameworks: []`. The failure surfaces intermittently because it depends on worker assignment and collection order, which vary by Python version.

Snapshot the real `_default_framework` value in the `clean_registry` fixture and restore it on teardown so isolation no longer depends on `monkeypatch` finalization ordering. This is a test-only change; "litellm" remains an arbitrary env value used solely to exercise env-var parsing and is not a supported framework.



<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preserving and restoring the default framework configuration between tests.
  * Prevented test runs from unintentionally affecting one another through shared registry state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->