### PR TITLE
docs: clarify agent guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,22 @@ skill discovery.
 
 ## Quick Rules
 
-- Agent-specific rule: do not submit issues, PRs, or draft PRs through browser
-  automation, the GitHub API, `gh`, or similar tooling. Draft text for a human to
-  review and submit, following the repo's issue/PR templates so it can be
-  submitted as-is.
-- Do not push branches or prepare public-submission-ready PR materials unless
-  the linked issue is triaged and assigned to the human contributor.
+- Default to drafting issue/PR text for a human to review and submit, following
+  the repo's issue/PR templates so it can be submitted as-is. The agent is not
+  the access-control boundary and does not adjudicate identity: authorization
+  rests with the directing human under `AI_POLICY.md` and with the GitHub
+  credentials in the environment.
+- Open or submit an issue directly (using `gh` or the GitHub API, not browser
+  automation) only when the operator explicitly directs it; a new issue has
+  nothing to pre-check, so no triage or assignment gate applies.
+- Push a branch, or open or submit a PR, directly (using `gh` or the GitHub API,
+  not browser automation) only when the operator explicitly directs it and a
+  read-only API check confirms the linked issue is triaged and assigned to you:
+  its `labels` mark it triaged and its `assignees` include your authenticated
+  login (compare `gh api repos/{owner}/{repo}/issues/{number}` against
+  `gh api user --jq .login`). Otherwise stop at draft text. When submitting,
+  still follow the issue/PR templates, title conventions, DCO sign-off, and
+  review-readiness rules.
 - Opportunistic refactoring in service of an assigned change is welcome: keep
   it small, local, and within that change's scope. Standalone refactor PRs and
   broad restructuring (module reshuffles, sweeping renames, architectural
@@ -128,7 +138,7 @@ as package coverage.
   implementation plan (an issue comment, or a throwaway `PLAN.md` PR maintainers
   can review) rather than implementing.
 - Before preparing PR-shaped work, check for duplicate or in-flight effort with
-  read-only `gh` (distinct from the no-`gh`-submission rule above):
+  read-only `gh` (always allowed, independent of the submission rules above):
   `gh issue view <issue> --comments`, `gh pr list --state open --search "<issue>
   in:body"`, and `gh pr list --state open --search "<area keywords>"`. If an open
   PR already covers the change, do not prepare a duplicate; if your approach

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,11 @@ skill discovery.
   submitted as-is.
 - Do not push branches or prepare public-submission-ready PR materials unless
   the linked issue is triaged and assigned to the human contributor.
-- Do not implement refactors unless a maintainer has approved the plan and
-  assigned the work.
+- Opportunistic refactoring in service of an assigned change is welcome: keep
+  it small, local, and within that change's scope. Standalone refactor PRs and
+  broad restructuring (module reshuffles, sweeping renames, architectural
+  overhauls) are maintainer-led; do not implement them without an approved
+  proposal and assignment. See `CONTRIBUTING.md`.
 - Never edit `CHANGELOG.md` or `CHANGELOG-Colang.md` manually.
 - Do not commit secrets, credentials, or sensitive provider data, and do not
   fabricate results, approvals, or citations. See `AI_POLICY.md` Safety and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,13 @@ skill discovery.
   without clear provenance and maintainer alignment.
 - Unit tests must not call live LLM or provider services.
 - Do not add license headers manually. Pre-commit handles license insertion.
-- Do not add comments unless explicitly requested; keep existing comments,
-  docstrings, and license headers unless your change makes them inaccurate.
+- Comments are welcome, not banned. When you feel the urge to comment what a
+  block does, first try to make the comment superfluous: extract a function,
+  rename for clarity, or add an assertion for a required state. Reach for a
+  comment when the code cannot carry the meaning: to explain why (rationale,
+  tradeoff, constraint), warn of a consequence, or flag where you are unsure.
+  Keep existing comments, docstrings, and license headers unless your change
+  makes them inaccurate.
 - Use uv for Python commands: `uv run --locked python ...`,
   `uv run --locked pytest ...`, `uv run --locked pre-commit ...`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ as package coverage.
 
 - For PR-ready code changes, pre-commit is the authoritative lint, format,
   license-header, and type-checking path.
-- Standalone Ruff, Ruff format, and Pyright runs are local diagnosis only; run
+- Standalone Ruff, Ruff format, and ty runs are local diagnosis only; run
   pre-commit on changed files before handoff and report if it is skipped.
 - `make test` runs every `pytest.ini` testpath, so it includes `benchmark/tests`,
   not just `tests/`; scope with `TEST=`. The default suite needs no network:

--- a/nemoguardrails/AGENTS.md
+++ b/nemoguardrails/AGENTS.md
@@ -49,9 +49,12 @@ provider-integration specifics that matter when editing this package.
 - Avoid broad filesystem walks, import-time side effects, and global state
   changes in runtime paths unless the surrounding code already establishes that
   pattern.
-- Wrap provider/LLM failures in the domain exceptions in
-  `nemoguardrails/exceptions.py` (`LLMCallException`, `LLMClientError`
-  subclasses) and re-raise with `from`; do not raise bare exceptions.
+- Wrap failures from LLM model and LLM-provider calls in the domain exceptions
+  in `nemoguardrails/exceptions.py` (`LLMCallException` and `LLMClientError`
+  subclasses), preserving the original cause with `from`. Do not use the
+  `LLM*` exception hierarchy for non-LLM integrations such as external
+  guardrail, moderation, or scanning APIs unless their established contract
+  explicitly requires it.
 - Use a module-level `log = logging.getLogger(__name__)`; never `print`.
 - Sync public methods delegate to their `_async` twin via
   `get_or_create_event_loop()` and must raise if called inside a running loop;


### PR DESCRIPTION
## Description

Tightens the agent-facing guidance in the AGENTS.md files so it reflects how the
repo actually works and stops a few rules from being read as blanket bans.

- Fix a stale reference: the type-checker is `ty`, not Pyright.
- Reframe comment guidance around intent (explain *why*, refactor away *what*)
  instead of "do not add comments," which led agents to strip useful comments.
- Distinguish opportunistic, in-scope refactoring (welcome) from standalone
  refactor PRs and broad restructuring (maintainer-led), matching CONTRIBUTING.md.
- Make branch/PR submission operator-directed: default to drafting for a human;
  push or submit directly only on explicit direction when the authenticated
  account is the issue assignee (or local config authorizes it), rather than
  keying on an unverifiable maintainer claim.
- Scope the `LLM*` exception-wrapping rule to LLM model/provider calls only.

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance for issue and pull request submissions, authorization, branch management, and refactoring.
  * Clarified when to add code comments and how to preserve useful existing documentation.
  * Updated validation guidance to use the current type-checking tool.
  * Added specific guidance for handling LLM-related failures and exceptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->