### PR TITLE
feat(iorails): Support HTTP headers in Guardrails Config

### DIFF
--- a/docs/configure-rails/yaml-schema/model-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/model-configuration.mdx
@@ -280,3 +280,40 @@ models:
 ```
 
 Common parameters vary by provider. For built-in engines, see the OpenAI-compatible client options. For LangChain engines, refer to the corresponding LangChain provider documentation.
+
+### Custom HTTP Headers
+
+Set `parameters.default_headers` to attach custom HTTP headers to every request a model sends to its provider endpoint.
+This is useful for multi-tenant routing, request attribution, or correlation IDs.
+Headers are configured per model: each model sends only the headers declared in its own `parameters` block, so a header you want on several models must be repeated under each one.
+
+```yaml
+models:
+  - type: main
+    engine: nim
+    model: meta/llama-3.3-70b-instruct
+    parameters:
+      default_headers:
+        X-Tenant-Id: acme-corp
+        X-Routing-Pool: main-llm
+        X-Correlation-Source: guardrails-app
+
+  - type: content_safety
+    engine: nim
+    model: nvidia/llama-3.1-nemoguard-8b-content-safety
+    parameters:
+      default_headers:
+        X-Tenant-Id: acme-corp
+        X-Routing-Pool: safety-pool
+        X-Team: trust-and-safety
+```
+
+The configured headers apply on top of the request's base headers, which are `Content-Type` and the `Authorization` bearer token derived from the API key.
+Header names are matched case-insensitively, and a configured header overrides a base header of the same name.
+For example, setting `Authorization` under `default_headers` replaces the token built from the API key, which lets you use a custom authentication scheme.
+Configured headers are sent only as HTTP headers and never appear in the request body.
+
+Header values must be strings; a bare numeric or boolean value in YAML, such as `X-Retry: 3`, is converted to its string form.
+Keep secrets such as API keys in environment variables through `api_key_env_var` rather than hardcoding them in `default_headers` in a checked-in `config.yml`.
+
+This behavior is the same for both the IORails and LLMRails engines.

--- a/nemoguardrails/guardrails/_http.py
+++ b/nemoguardrails/guardrails/_http.py
@@ -15,12 +15,31 @@
 
 """Shared aiohttp helpers for IORails engine HTTP clients."""
 
+from typing import Mapping, Optional
+
 import aiohttp
 
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_TIMEOUT_TOTAL = 30
 DEFAULT_TIMEOUT_CONNECT = 5
 RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def merge_headers_case_insensitive(base: Mapping[str, str], overrides: Optional[Mapping[str, str]]) -> dict[str, str]:
+    """Merge ``overrides`` onto a copy of ``base``, matching header names case-insensitively.
+
+    HTTP header names are case-insensitive, so an override replaces any base
+    header with the same name regardless of case, adopting the override's
+    casing (mirrors ``BaseClient._build_headers``). ``base`` is not mutated;
+    ``None`` or empty ``overrides`` yields a plain copy of ``base``.
+    """
+    merged = dict(base)
+    for name, value in (overrides or {}).items():
+        existing = next((key for key in merged if key.lower() == name.lower()), None)
+        if existing is not None:
+            del merged[existing]
+        merged[name] = value
+    return merged
 
 
 async def safe_read_body(response: aiohttp.ClientResponse, max_chars: int = 500) -> str:

--- a/nemoguardrails/guardrails/_http.py
+++ b/nemoguardrails/guardrails/_http.py
@@ -35,8 +35,7 @@ def merge_headers_case_insensitive(base: Mapping[str, str], overrides: Optional[
     """
     merged = dict(base)
     for name, value in (overrides or {}).items():
-        existing = next((key for key in merged if key.lower() == name.lower()), None)
-        if existing is not None:
+        for existing in [key for key in merged if key.lower() == name.lower()]:
             del merged[existing]
         merged[name] = value
     return merged

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -476,9 +476,9 @@ class ModelEngine(BaseEngine):
             max_attempts=int(params.get("max_attempts") or DEFAULT_MAX_ATTEMPTS),
         )
 
-        # Static per-model HTTP headers from `parameters.default_headers`, applied
-        # to every request by `_prepare_request` (LLMRails parity).
-        self.default_headers: dict[str, str] = dict(params.get("default_headers") or {})
+        self.default_headers: Mapping[str, str] = MappingProxyType(
+            {str(key): str(value) for key, value in (params.get("default_headers") or {}).items()}
+        )
 
         # Default `llm_params` used on inference are the subset of Model.parameters after
         # filtering out keys in _RESERVED_LLM_PARAMETERS.  Exposed as a read-only

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -35,6 +35,7 @@ from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
     DEFAULT_TIMEOUT_TOTAL,
+    merge_headers_case_insensitive,
     safe_read_body,
 )
 from nemoguardrails.guardrails.base_engine import BaseEngine
@@ -87,11 +88,11 @@ _RESERVED_LLM_PARAMETERS = frozenset(
         # be used in streaming or non-streaming mode. `stream_call` sets the
         # streaming default (`include_usage`), overridable via `llm_params`.
         "stream_options",
-        # client-only options — these configure the OpenAI-compatible client
-        # (constructor kwargs), not the chat-completion request body.  IORails
-        # doesn't wire the shared client yet; reserve them so they're never
-        # forwarded as body fields, leaving proper client support to a future
-        # refactor.
+        # client-only options — these configure transport, not the
+        # chat-completion request body, so they are never forwarded as body
+        # fields.  `default_headers` is read into `self.default_headers` and
+        # applied as request headers by `_prepare_request`; `default_query`
+        # is reserved for future client wiring.
         "default_headers",
         "default_query",
     }
@@ -477,6 +478,10 @@ class ModelEngine(BaseEngine):
             max_attempts=int(params.get("max_attempts") or DEFAULT_MAX_ATTEMPTS),
         )
 
+        # Static per-model HTTP headers from `parameters.default_headers`, applied
+        # to every request by `_prepare_request` (LLMRails parity).
+        self.default_headers: dict[str, str] = dict(params.get("default_headers") or {})
+
         # Default `llm_params` used on inference are the subset of Model.parameters after
         # filtering out keys in _RESERVED_LLM_PARAMETERS.  Exposed as a read-only
         # MappingProxyType view so callers can't mutate the shared per-engine defaults.
@@ -550,6 +555,7 @@ class ModelEngine(BaseEngine):
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
+        headers = merge_headers_case_insensitive(headers, self.default_headers)
 
         body: dict[str, Any] = {"model": self.model_name, "messages": messages, **kwargs}
         return _RequestParams(client=client, url=url, headers=headers, body=body)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -90,9 +90,7 @@ _RESERVED_LLM_PARAMETERS = frozenset(
         "stream_options",
         # client-only options — these configure transport, not the
         # chat-completion request body, so they are never forwarded as body
-        # fields.  `default_headers` is read into `self.default_headers` and
-        # applied as request headers by `_prepare_request`; `default_query`
-        # is reserved for future client wiring.
+        # fields.
         "default_headers",
         "default_query",
     }

--- a/tests/guardrails/test__http.py
+++ b/tests/guardrails/test__http.py
@@ -104,6 +104,14 @@ class TestMergeHeadersCaseInsensitive:
         merge_headers_case_insensitive(base, {"authorization": "Bearer override"})
         assert base == {"Authorization": "Bearer base"}
 
+    def test_removes_all_case_equivalent_base_keys(self):
+        """An override collapses every case variant of a name in the base into a single header."""
+        base = {"Authorization": "base-a", "authorization": "base-b"}
+        result = merge_headers_case_insensitive(base, {"Authorization": "override"})
+        auth_keys = [key for key in result if key.lower() == "authorization"]
+        assert auth_keys == ["Authorization"]
+        assert result["Authorization"] == "override"
+
 
 class TestSharedConstants:
     """Test values of shared HTTP constants."""

--- a/tests/guardrails/test__http.py
+++ b/tests/guardrails/test__http.py
@@ -24,6 +24,7 @@ from nemoguardrails.guardrails._http import (
     DEFAULT_TIMEOUT_CONNECT,
     DEFAULT_TIMEOUT_TOTAL,
     RETRYABLE_STATUS_CODES,
+    merge_headers_case_insensitive,
     safe_read_body,
 )
 
@@ -64,6 +65,44 @@ class TestSafeReadBody:
         mock_response.text = AsyncMock(return_value=text)
         result = await safe_read_body(mock_response)
         assert len(result) == 500
+
+
+class TestMergeHeadersCaseInsensitive:
+    """Test case-insensitive header merging (override wins, base preserved)."""
+
+    def test_overrides_added_to_base(self):
+        """Non-colliding override keys are added to the base headers."""
+        base = {"Content-Type": "application/json"}
+        result = merge_headers_case_insensitive(base, {"X-Tenant": "acme"})
+        assert result == {"Content-Type": "application/json", "X-Tenant": "acme"}
+
+    def test_override_replaces_case_insensitive_match(self):
+        """An override replaces a base header that differs only by case, keeping one entry."""
+        base = {"Content-Type": "application/json", "Authorization": "Bearer base"}
+        result = merge_headers_case_insensitive(base, {"authorization": "Bearer override"})
+        auth_keys = [key for key in result if key.lower() == "authorization"]
+        assert auth_keys == ["authorization"]
+        assert result["authorization"] == "Bearer override"
+
+    def test_none_overrides_returns_base_copy(self):
+        """None overrides yields an unchanged copy that does not alias the base."""
+        base = {"Content-Type": "application/json"}
+        result = merge_headers_case_insensitive(base, None)
+        assert result == base
+        assert result is not base
+
+    def test_empty_overrides_returns_base_copy(self):
+        """Empty overrides yields an unchanged copy that does not alias the base."""
+        base = {"Content-Type": "application/json"}
+        result = merge_headers_case_insensitive(base, {})
+        assert result == base
+        assert result is not base
+
+    def test_base_not_mutated(self):
+        """Merging does not mutate the caller's base dict."""
+        base = {"Authorization": "Bearer base"}
+        merge_headers_case_insensitive(base, {"authorization": "Bearer override"})
+        assert base == {"Authorization": "Bearer base"}
 
 
 class TestSharedConstants:

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestServer
 
 from nemoguardrails import Guardrails
 from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
@@ -150,6 +152,54 @@ class TestConfigDefaultHeadersEndToEnd:
         assert main_headers != safety_headers
         assert main_headers.get("X-Main-Route") == "main-pool"
         assert safety_headers.get("X-Safety-Route") == "safety-pool"
+
+
+class TestConfigDefaultHeadersOverHTTP:
+    """True end-to-end: run generate_async over a real loopback HTTP server and
+    assert on the headers the aiohttp client actually put on the wire."""
+
+    @pytest.mark.asyncio
+    async def test_config_default_headers_sent_on_the_wire(self):
+        """A configured default_header reaches the provider request, alongside the
+        api-key Authorization, and never leaks into the JSON body."""
+        captured: dict = {}
+
+        async def handler(request):
+            captured["headers"] = dict(request.headers)
+            captured["body"] = await request.json()
+            return web.json_response({"choices": [{"message": {"role": "assistant", "content": "ok"}}]})
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        server = TestServer(app)
+        await server.start_server()
+        try:
+            config = RailsConfig.from_content(
+                config={
+                    "models": [
+                        {
+                            "type": "main",
+                            "engine": "openai",
+                            "model": "test-model",
+                            "parameters": {
+                                "base_url": str(server.make_url("/")),
+                                "default_headers": {"X-Tenant": "acme"},
+                            },
+                        }
+                    ]
+                }
+            )
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+                iorails = IORails(config)
+            async with iorails:
+                result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
+        finally:
+            await server.close()
+
+        assert result == {"role": "assistant", "content": "ok"}
+        assert captured["headers"]["X-Tenant"] == "acme"
+        assert captured["headers"]["Authorization"] == "Bearer test-key"
+        assert "X-Tenant" not in captured["body"]
 
 
 class TestGenerateAsync:

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -68,6 +68,90 @@ class TestIORailsInit:
         assert iorails_sync.rails_manager.engine_registry is iorails_sync.engine_registry
 
 
+DEFAULT_HEADERS_CONFIG = {
+    "models": [
+        {
+            "type": "main",
+            "engine": "nim",
+            "model": "meta/llama-3.3-70b-instruct",
+            "parameters": {"default_headers": {"X-Main-Route": "main-pool"}},
+        },
+        {
+            "type": "content_safety",
+            "engine": "nim",
+            "model": "nvidia/llama-3.1-nemoguard-8b-content-safety",
+            "parameters": {"default_headers": {"X-Safety-Route": "safety-pool"}},
+        },
+    ],
+}
+
+
+@pytest_asyncio.fixture
+async def iorails_with_header_config():
+    """Build an IORails whose main and content_safety models carry distinct
+    parameters.default_headers, for end-to-end per-model header assertions."""
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        iorails = IORails(RailsConfig.from_content(config=DEFAULT_HEADERS_CONFIG))
+    try:
+        yield iorails
+    finally:
+        await iorails.stop()
+
+
+class TestConfigDefaultHeadersEndToEnd:
+    """End-to-end: IORails built from config routes each model's
+    parameters.default_headers onto that model's outbound request, and the
+    main LLM and a second LLM carry only their own headers."""
+
+    @staticmethod
+    def _mock_client():
+        """Build a mock aiohttp client whose post() records its call args."""
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        return mock_client
+
+    async def _headers_for_model(self, iorails, model_type):
+        """Route a model_call for model_type through a mock client and return the sent headers."""
+        engine = iorails.engine_registry._get_engine(model_type, ModelEngine)
+        engine._client = self._mock_client()
+        engine._running = True
+        await iorails.engine_registry.model_call(model_type, [{"role": "user", "content": "Hi"}])
+        return engine._client.post.call_args[1]["headers"]
+
+    @pytest.mark.asyncio
+    async def test_main_llm_carries_only_its_config_headers(self, iorails_with_header_config):
+        """The main model request carries its own default_header plus base headers, and not the second model's."""
+        headers = await self._headers_for_model(iorails_with_header_config, "main")
+        assert headers["X-Main-Route"] == "main-pool"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Authorization"] == "Bearer test-key"
+        assert "X-Safety-Route" not in headers
+
+    @pytest.mark.asyncio
+    async def test_second_llm_carries_only_its_config_headers(self, iorails_with_header_config):
+        """The content_safety model request carries its own default_header plus base headers, and not the main model's."""
+        headers = await self._headers_for_model(iorails_with_header_config, "content_safety")
+        assert headers["X-Safety-Route"] == "safety-pool"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Authorization"] == "Bearer test-key"
+        assert "X-Main-Route" not in headers
+
+    @pytest.mark.asyncio
+    async def test_main_and_second_llm_get_distinct_headers(self, iorails_with_header_config):
+        """The two models' outbound header sets differ, proving per-model routing."""
+        main_headers = await self._headers_for_model(iorails_with_header_config, "main")
+        safety_headers = await self._headers_for_model(iorails_with_header_config, "content_safety")
+        assert main_headers != safety_headers
+        assert main_headers.get("X-Main-Route") == "main-pool"
+        assert safety_headers.get("X-Safety-Route") == "safety-pool"
+
+
 class TestGenerateAsync:
     """Test the generate_async input-check → LLM → output-check pipeline."""
 

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -763,6 +764,22 @@ class TestModelEngineDefaultHeaders:
 
         headers = self._headers_from(engine._client)
         assert headers == {"Content-Type": "application/json", "Authorization": "Bearer test-key"}
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_config_default_header_values_coerced_to_str(self):
+        """Non-string YAML header values (int, bool) are stored as strings."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"X-Count": 3, "X-Flag": True}}))
+        assert engine.default_headers["X-Count"] == "3"
+        assert engine.default_headers["X-Flag"] == "True"
+        assert all(isinstance(value, str) for value in engine.default_headers.values())
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_default_headers_mapping_is_immutable(self):
+        """default_headers is a read-only mapping so callers cannot mutate shared per-engine state."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"X-Tenant": "acme"}}))
+        headers: Any = engine.default_headers
+        with pytest.raises(TypeError):
+            headers["X-Injected"] = "nope"
 
 
 class TestModelEngineStreamCall:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -686,6 +686,85 @@ class TestModelEngineCall:
             await engine.call([{"role": "user", "content": "Hi"}])
 
 
+class TestModelEngineDefaultHeaders:
+    """Test that config-level parameters.default_headers reach outbound requests."""
+
+    @staticmethod
+    def _mock_client():
+        """Build a mock aiohttp client whose post() records call args."""
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        return mock_client
+
+    @staticmethod
+    def _headers_from(mock_client):
+        """Extract the headers dict passed to the mocked post()."""
+        return mock_client.post.call_args[1]["headers"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_headers_merged_into_request(self):
+        """A configured default_header is sent alongside Content-Type and Authorization."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"X-Tenant": "acme"}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        headers = self._headers_from(engine._client)
+        assert headers["X-Tenant"] == "acme"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Authorization"] == "Bearer test-key"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_header_overrides_authorization_case_insensitive(self):
+        """A configured 'authorization' header replaces the api_key-derived Authorization."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"authorization": "Bearer custom"}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        headers = self._headers_from(engine._client)
+        auth_keys = [key for key in headers if key.lower() == "authorization"]
+        assert auth_keys == ["authorization"]
+        assert headers["authorization"] == "Bearer custom"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_headers_absent_from_body(self):
+        """default_headers configure transport, never the JSON request body."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"X-Tenant": "acme"}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        body = engine._client.post.call_args[1]["json"]
+        assert "default_headers" not in body
+        assert "X-Tenant" not in body
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_no_config_default_headers_leaves_base_headers(self):
+        """Without default_headers the request carries only the base headers."""
+        engine = ModelEngine(_make_model())
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        headers = self._headers_from(engine._client)
+        assert headers == {"Content-Type": "application/json", "Authorization": "Bearer test-key"}
+
+
 class TestModelEngineStreamCall:
     """Test ModelEngine.stream_call() SSE streaming."""
 


### PR DESCRIPTION
## Description

This PR adds support for per-model HTTP headers from the Guardrails configuration, giving feature-parity with LLMRails. Here's an example `config.yml` with sample headers for the main LLM and content-safety LLM. This adds X-Tenant-Id, X-Routing-Pool, X-Team, and  X-Correlation-Source headers to the two model calls.

```
models:
  - type: main
    engine: nim
    model: meta/llama-3.3-70b-instruct
    parameters:
      default_headers:
        X-Tenant-Id: acme-corp
        X-Routing-Pool: main-llm
        X-Correlation-Source: guardrails-app

  - type: content_safety
    engine: nim
    model: nvidia/llama-3.1-nemoguard-8b-content-safety
    parameters:
      default_headers:
        X-Tenant-Id: acme-corp
        X-Routing-Pool: safety-pool
        X-Team: trust-and-safety

rails:
  input:
    flows:
      - content safety check input $model=content_safety
  output:
    flows:
      - content safety check output $model=content_safety
```



## Related Issue(s)

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal
================================================================= test session starts =================================================================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-custom-headers
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [6222 items]
............................................................................................................................................... [  2%]
.................................................s.ss.s........................................................................................ [  4%]
............................................................................................................................................... [  6%]
....................................................................................................s.......................................... [  9%]
...........................................................................................................s..s.ss.s.s.s...s................... [ 11%]
..........................s.ss..s.s.s..........s.s.......s....................................................s.ss...ss...sss.................. [ 13%]
............................................................................................................................................... [ 16%]
............................................................................................................................................... [ 18%]
...............s............................................................................................................................... [ 20%]
............................................................................................................................................... [ 22%]
............................................................................................................................................... [ 25%]
............................................................................................................................................... [ 27%]
............................................................................................................................................... [ 29%]
............................................................................................................................................... [ 32%]
..............................................................................................s.......ss....................................ss. [ 34%]
ss...s..s..s.......................................s........................................................................................... [ 36%]
....................................................................s.ssss.........ssss.sssss.sss.ss.ssss...................................... [ 39%]
............................................................................................................................................... [ 41%]
..................................................................................sssss........................................................ [ 43%]
...................s.............................s..............................................s.....................................ssss.s... [ 45%]
.................................................................................................s............................................. [ 48%]
ssssss................................................................sss.....s...................................................ss....ss..... [ 50%]
............................................................................................................................................... [ 52%]
............................................................ssssss.ssss.sss.................................................................... [ 55%]
............................................................................................................................................... [ 57%]
............................................................................................................................................... [ 59%]
....s.....................s.........s...................................................................................s...................... [ 62%]
..........................................ss................................................................................................... [ 64%]
...............................................................ss................................ss............................................ [ 66%]
...............................................s...............s............................................................................... [ 68%]
............................................................................................................................................... [ 71%]
............................................................................................................................................... [ 73%]
............................................................................................................................................... [ 75%]
..............................................................................................................................sssssssss...s.sss [ 78%]
sss.sss..............................s.................................................................sssss.ss...............sssssss.s........ [ 80%]
............................................................................................................................................... [ 82%]
...........s............................................................................................................................sssss.s [ 85%]
ss........................................................................ss................................................................... [ 87%]
............................................................................................................................................... [ 89%]
............................................................................................................................................... [ 91%]
.s..................s......................ss.........s.................................s...................................................... [ 94%]
..............................s................................................................................................................ [ 96%]
..............................................................................sssssss.......................................................... [ 98%]
.........................................................................                                                                       [100%]

═══════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return
x and inline-snapshot will not be able to fix snapshots or generate reports.

========================================================= 6044 passed, 178 skipped in 47.19s ==========================================================
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring default HTTP headers for each model.
  * Default headers are included in provider requests while remaining separate from request bodies.
  * Header matching is case-insensitive, allowing configured values to override existing headers cleanly.

* **Bug Fixes**
  * Prevented duplicate headers when configured names differ only in capitalization.
  * Ensured model-specific headers are sent only with the applicable model’s requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->