### PR TITLE
ci: upgrade PyPI publish action to v1.14.1

### DIFF
--- a/.github/workflows/publish-pypi-approval.yml
+++ b/.github/workflows/publish-pypi-approval.yml
@@ -78,7 +78,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           verbose: true
           packages-dir: dist/

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -27,7 +27,7 @@ jobs:
         # zizmor: ignore[use-trusted-publishing] -- publishes with a PyPI API
         # token by design; migrating to OIDC trusted publishing is tracked
         # separately.
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           verbose: true
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description

upgrade PyPI publish action to v1.14.1
## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI publishing workflow to use a specific pinned revision of the publishing action.
  * Applied the same publishing action update across approval and wheel release workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->