### PR TITLE
fix(server)!: remove inline config from /v1/checks endpoint

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -699,35 +699,20 @@ async def guardrail_check(body: GuardrailCheckRequest, request: Request):
     if not body.messages:
         raise HTTPException(status_code=422, detail="messages must be non-empty")
 
-    config_ids = None
-    config = body.guardrails.config
-
-    if isinstance(config, dict):
-        try:
-            rails_config = RailsConfig.from_content(config=config)
-            if body.model:
-                rails_config = _inject_model(rails_config, body.model)
-            llm_rails = LLMRails(config=rails_config, verbose=True)
-        except Exception as ex:
-            log.exception(ex)
-            raise HTTPException(status_code=422, detail=f"Invalid inline config: {ex}")
-    else:
-        if isinstance(config, str):
-            config_ids = [config]
-        elif body.guardrails.config_ids:
-            config_ids = list(body.guardrails.config_ids)
-        elif app.default_config_id:
+    config_ids = body.guardrails.config_ids
+    if not config_ids:
+        if app.default_config_id:
             config_ids = [app.default_config_id]
         else:
             raise HTTPException(
                 status_code=422,
                 detail="No guardrails config_id provided and server has no default configuration",
             )
-        try:
-            llm_rails = await _get_rails(config_ids, model_name=body.model)
-        except ValueError as ex:
-            log.exception(ex)
-            raise HTTPException(status_code=422, detail=str(ex))
+    try:
+        llm_rails = await _get_rails(config_ids, model_name=body.model)
+    except ValueError as ex:
+        log.exception(ex)
+        raise HTTPException(status_code=422, detail=str(ex))
 
     if llm_rails.config.colang_version != "1.0":
         raise HTTPException(

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -175,28 +175,11 @@ class OpenAIModelsList(BaseModel):
     data: list[OpenAIModel] = Field(..., description="List of OpenAI model objects.")
 
 
-class GuardrailCheckDataInput(GuardrailsDataInput):
-    """Guardrails input options specific to the checks endpoint."""
-
-    config: Optional[Union[str, dict]] = Field(
-        default=None,
-        description="The id of the configuration or its dict representation to be used.",
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_config_exclusivity(cls, data: Any) -> Any:
-        if isinstance(data, dict) and data.get("config") is not None:
-            if data.get("config_id") is not None or data.get("config_ids") is not None:
-                raise ValueError("config is mutually exclusive with config_id and config_ids")
-        return data
-
-
 class GuardrailCheckRequest(OpenAIChatCompletionRequest):
     """Request body for the /v1/checks endpoint."""
 
-    guardrails: GuardrailCheckDataInput = Field(
-        default_factory=GuardrailCheckDataInput,
+    guardrails: GuardrailsDataInput = Field(
+        default_factory=GuardrailsDataInput,
         description="Guardrails specific options for the request.",
     )
 

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -130,44 +130,6 @@ def test_config_id_resolves():
     mock_get.assert_called_once_with(["my_config"], model_name="test")
 
 
-def test_config_string_resolves_via_get_rails():
-    result = RailsResult(status=RailStatus.PASSED, content="hi")
-    mock = _mock_rails(result)
-
-    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock) as mock_get:
-        resp = _post(
-            {
-                "model": "test",
-                "messages": [{"role": "user", "content": "hi"}],
-                "guardrails": {"config": "my_config"},
-            }
-        )
-
-    assert resp.status_code == 200
-    mock_get.assert_called_once_with(["my_config"], model_name="test")
-
-
-def test_inline_config():
-    result = RailsResult(status=RailStatus.PASSED, content="hi")
-    mock_llm_rails = _mock_rails(result)
-
-    with (
-        patch("nemoguardrails.server.api.RailsConfig") as mock_config_cls,
-        patch("nemoguardrails.server.api.LLMRails", return_value=mock_llm_rails),
-    ):
-        mock_config_cls.from_content.return_value = MagicMock()
-        resp = _post(
-            {
-                "model": "test",
-                "messages": [{"role": "user", "content": "hi"}],
-                "guardrails": {"config": {"models": [], "rails": {}}},
-            }
-        )
-
-    assert resp.status_code == 200
-    mock_config_cls.from_content.assert_called_once()
-
-
 def test_default_config_used_when_none_specified():
     api.app.default_config_id = "my_default"
     result = RailsResult(status=RailStatus.PASSED, content="hi")
@@ -194,17 +156,6 @@ def test_empty_messages_returns_422():
             "model": "test",
             "messages": [],
             "guardrails": {"config_id": "test"},
-        }
-    )
-    assert resp.status_code == 422
-
-
-def test_config_and_config_id_mutually_exclusive():
-    resp = _post(
-        {
-            "model": "test",
-            "messages": [{"role": "user", "content": "hi"}],
-            "guardrails": {"config": "a", "config_id": "b"},
         }
     )
     assert resp.status_code == 422


### PR DESCRIPTION
## Description

The inline config specification should be dropped from `v1/checks` endpoint as it mixes control and data planes. This impacts [PR#2205](https://github.com/NVIDIA-NeMo/Guardrails/pull/2205), so it's probably prudent to review this first and then I will subsequently revise the aforementioned PR

## Related Issue(s)

No issue was filed, but this was discussed previously

## Verification

Revised tests pass:

```bash
 uv run --locked pytest tests/server/test_guardrail_checks.py -v

tests/server/test_guardrail_checks.py::test_status_mapping[passed-passed] PASSED [  6%]
tests/server/test_guardrail_checks.py::test_status_mapping[modified-modified] PASSED [ 13%]
tests/server/test_guardrail_checks.py::test_status_mapping[blocked-blocked] PASSED [ 20%]
tests/server/test_guardrail_checks.py::test_content_returned_on_passed PASSED [ 26%]
tests/server/test_guardrail_checks.py::test_content_returned_on_modified PASSED [ 33%]
tests/server/test_guardrail_checks.py::test_content_returned_on_blocked PASSED [ 40%]
tests/server/test_guardrail_checks.py::test_rail_null_on_passed PASSED   [ 46%]
tests/server/test_guardrail_checks.py::test_config_id_resolves PASSED    [ 53%]
tests/server/test_guardrail_checks.py::test_default_config_used_when_none_specified PASSED [ 60%]
tests/server/test_guardrail_checks.py::test_empty_messages_returns_422 PASSED [ 66%]
tests/server/test_guardrail_checks.py::test_no_config_no_default_returns_422 PASSED [ 73%]
tests/server/test_guardrail_checks.py::test_colang_v2_returns_422 PASSED [ 80%]
tests/server/test_guardrail_checks.py::test_get_rails_failure_returns_422 PASSED [ 86%]
tests/server/test_guardrail_checks.py::test_check_async_failure_returns_500 PASSED [ 93%]
tests/server/test_guardrail_checks.py::test_context_prepended_to_messages PASSED [100%]

============================== 15 passed in 2.12s ==============================
```

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
