### PR TITLE
Clear error when injections references an unknown inline YARA rule

### DIFF
--- a/nemoguardrails/library/injection_detection/actions.py
+++ b/nemoguardrails/library/injection_detection/actions.py
@@ -175,6 +175,7 @@ def _load_rules(
         or None if no rule names are provided.
 
     Raises:
+        ValueError: If a requested rule name is not present in the inline `yara_rules`.
         yara.SyntaxError: If there is a syntax error in the YARA rules.
         ImportError: If the yara module is not installed.
     """
@@ -185,6 +186,17 @@ def _load_rules(
 
     try:
         if yara_rules:
+            # Validate requested names against the inline rules up front so we raise a
+            # clear, actionable error instead of a bare KeyError when indexing below.
+            missing_rules = [rule_name for rule_name in rule_names if rule_name not in yara_rules]
+            if missing_rules:
+                available_rules = ", ".join(sorted(yara_rules.keys())) or "<none>"
+                msg = (
+                    "Provided set of `injections` %r references rule name(s) %r not present in the inline "
+                    "`yara_rules`. Available inline rules are: %s."
+                ) % (tuple(rule_names), tuple(missing_rules), available_rules)
+                log.error(msg)
+                raise ValueError(msg)
             rules_source = {name: rule for name, rule in yara_rules.items() if name in rule_names}
             rules = yara.compile(sources={rule_name: rules_source[rule_name] for rule_name in rule_names})
         else:

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -30,6 +30,7 @@
 
 import logging
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -283,6 +284,26 @@ def test_load_inline_yara_rules():
     assert len(matches) == 1
     assert matches[0].rule == "test_inline"
     assert matches[0].namespace == inline_rule_name
+
+
+def test_load_inline_yara_rules_missing_name_raises_clear_error():
+    """Requesting a rule name absent from inline `yara_rules` should raise a clear
+    ValueError naming the missing rule, not an opaque KeyError."""
+    inline_rule_name = "custom_rule"
+    inline_rule_content = 'rule custom_rule { strings: $a = "foo" condition: $a }'
+    missing_rule_name = "sqli"
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_rules(
+            Path("."),
+            (missing_rule_name, inline_rule_name),
+            {inline_rule_name: inline_rule_content},
+        )
+
+    message = str(exc_info.value)
+    # The error must name the missing rule and list the available inline rules.
+    assert missing_rule_name in message
+    assert inline_rule_name in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #2170.

Raise a descriptive `ValueError` when an inline YARA rule referenced by `injections` isn't present in `yara_rules`.

Previously the missing rule surfaced as a bare `KeyError`, which made the misconfiguration hard to diagnose.

Adds a regression test for the missing-rule case.
