### PR TITLE
refactor(iorails): Add LLMModel and HTTP Client support to ModelEngine

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -161,27 +161,31 @@ class EngineRegistry:
         if self._running:
             return
 
-        started: list[BaseEngine] = []
+        started: list[tuple[str, BaseEngine]] = []
         self._http_client = create_http_client()
 
         for name, engine in self._engines.items():
             try:
                 await engine.start()
-                started.append(engine)
+                started.append((name, engine))
             except Exception as e:
                 log.error("Error starting engine %s: %s", name, e)
-                for eng in started:
-                    try:
-                        await eng.stop()
-                    except Exception:
-                        pass
-                try:
-                    await self._close_http_client()
-                except Exception:
-                    pass
+                await self._rollback_start(started)
                 raise RuntimeError(f"Failed to start engine: Engine {name}: exception {e}") from e
 
         self._running = True
+
+    async def _rollback_start(self, started: list[tuple[str, BaseEngine]]) -> None:
+        """Release everything a partial ``start`` brought up."""
+        for name, engine in started:
+            try:
+                await engine.stop()
+            except Exception as stop_error:
+                log.warning("Error stopping engine %s during start rollback: %s", name, stop_error)
+        try:
+            await self._close_http_client()
+        except Exception as close_error:
+            log.warning("Error closing the managed HTTP client during start rollback: %s", close_error)
 
     async def stop(self) -> None:
         """Stop all engine clients and the managed HTTP client.

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -20,31 +20,19 @@ model type. Each engine owns its own RetryClient with per-model settings.
 """
 
 import logging
-import time
 from collections.abc import AsyncGenerator
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from nemoguardrails.guardrails.api_engine import APIEngine
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
-from nemoguardrails.guardrails.telemetry import (
-    api_call_span,
-    llm_call_span,
-    set_llm_call_content,
-    set_llm_request_attributes,
-    set_llm_response_attributes,
-)
+from nemoguardrails.guardrails.telemetry import api_call_span
 from nemoguardrails.guardrails.tool_schema import ToolExchange, ToolResult, Toolset
+from nemoguardrails.http.client import ClosableHTTPClient
+from nemoguardrails.http.runtime import create_http_client
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
-from nemoguardrails.tracing.constants import (
-    llm_operation_duration,
-    record_time_per_output_chunk,
-    record_time_to_first_chunk,
-    record_token_usage,
-)
-from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
+from nemoguardrails.types import LLMModel, LLMResponse, LLMResponseChunk
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -86,16 +74,27 @@ class EngineRegistry:
         contract.  Defaults to False; should only be True when
         ``tracer`` is also set, since capture on a no-op span is wasted
         work.
+
+        All three telemetry settings are handed to each ``ModelEngine``,
+        which owns the instrumentation so that rails reaching the model
+        through ``generate_async`` are instrumented identically to main
+        generation reaching it through ``model_call``.
         """
         self._engines: dict[str, BaseEngine] = {}
+        self._llms: dict[str, LLMModel] = {}
+        self._http_client: Optional[ClosableHTTPClient] = None
         self._running = False
         self._tracer = tracer
-        self._metrics_enabled = metrics_enabled
-        self._content_capture_enabled = content_capture_enabled
 
         for model_config in models:
-            engine = ModelEngine(model_config)
+            engine = ModelEngine(
+                model_config,
+                tracer=tracer,
+                metrics_enabled=metrics_enabled,
+                content_capture_enabled=content_capture_enabled,
+            )
             self._engines[model_config.type] = engine
+            self._llms[model_config.type] = engine
             log.info(
                 "Registered model engine: type=%s, model=%s, base_url=%s",
                 model_config.type,
@@ -118,12 +117,52 @@ class EngineRegistry:
                 api_engine.url,
             )
 
+    @property
+    def llms(self) -> dict[str, LLMModel]:
+        """The configured model engines keyed by ``Model.type``.
+
+        This is the ``Dict[str, LLMModel]`` that library rail actions index by
+        model type (``llms["content_safety"]``).  API engines are not LLMs and
+        are excluded.
+        """
+        return self._llms
+
+    @property
+    def http_client(self) -> ClosableHTTPClient:
+        """The process-wide HTTP client shared by vendor rail actions.
+
+        One managed client replaces the per-request client each vendor action
+        would otherwise create and close, so connections are pooled across
+        requests.
+
+        Raises:
+            RuntimeError: If the registry has not been started.
+        """
+        if self._http_client is None:
+            raise RuntimeError("EngineRegistry has not been started. Call start() first.")
+        return self._http_client
+
+    async def _close_http_client(self) -> None:
+        """Close the managed HTTP client, if one is open.
+
+        The reference is cleared before the await so a failing ``close()``
+        still leaves the registry without a half-closed client.
+        """
+        client, self._http_client = self._http_client, None
+        if client is not None:
+            await client.close()
+
     async def start(self) -> None:
-        """Start all engine clients. Call this during service startup."""
+        """Start all engine clients and the managed HTTP client.
+
+        Call this during service startup.  A failure part-way through rolls
+        everything already started back, so a failed start leaks nothing.
+        """
         if self._running:
             return
 
         started: list[BaseEngine] = []
+        self._http_client = create_http_client()
 
         for name, engine in self._engines.items():
             try:
@@ -136,31 +175,42 @@ class EngineRegistry:
                         await eng.stop()
                     except Exception:
                         pass
+                try:
+                    await self._close_http_client()
+                except Exception:
+                    pass
                 raise RuntimeError(f"Failed to start engine: Engine {name}: exception {e}") from e
 
         self._running = True
 
     async def stop(self) -> None:
-        """Stop all engine clients. Call this during service shutdown."""
+        """Stop all engine clients and the managed HTTP client.
+
+        Call this during service shutdown.  Every component is stopped even if
+        an earlier one fails; the failures are reported together afterwards.
+        """
         if not self._running:
             return
 
-        engine_errors: dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         try:
             for name, engine in self._engines.items():
                 try:
                     await engine.stop()
                 except Exception as e:
-                    engine_errors[name] = e
+                    errors[f"Engine {name}"] = e
                     log.error("Error stopping engine %s: %s", name, e)
+            try:
+                await self._close_http_client()
+            except Exception as e:
+                errors["HTTP client"] = e
+                log.error("Error closing the managed HTTP client: %s", e)
         finally:
             self._running = False
 
-        if engine_errors:
-            engine_error_string = ", ".join(
-                f"Engine {name}: exception {exception}" for name, exception in engine_errors.items()
-            )
-            raise RuntimeError(f"Failed to stop engines: {engine_error_string}")
+        if errors:
+            error_string = ", ".join(f"{component}: exception {exception}" for component, exception in errors.items())
+            raise RuntimeError(f"Failed to stop engines: {error_string}")
 
     def _get_engine(self, name: str, expected_type: type[_EngineT]) -> _EngineT:
         """Look up an engine by name, verifying its type."""
@@ -174,7 +224,7 @@ class EngineRegistry:
 
     def provider_name(self, model_type: str) -> str:
         """Return the provider/engine name (e.g. 'nim', 'openai') for a model engine."""
-        return self._get_engine(model_type, ModelEngine).model_config.engine or "unknown"
+        return self._get_engine(model_type, ModelEngine).provider_name
 
     async def model_call(self, model_type: str, messages: list[dict], **kwargs: Any) -> LLMResponse:
         """Route a chat completion request to the named model engine.
@@ -183,10 +233,12 @@ class EngineRegistry:
         reasoning (when the provider exposes it), usage, finish reason.
         Callers that only want the assistant text should access ``.content``.
 
-        When metrics are enabled, emits ``gen_ai.client.operation.duration``
-        (with ``error.type`` on exception) and ``gen_ai.client.token.usage``
-        (one observation each for ``input`` and ``output`` token types,
-        only when ``LLMResponse.usage`` is populated).
+        Parameter merging and OTEL instrumentation live in
+        ``ModelEngine.generate_from_messages`` so that rails, which reach the
+        model through ``llm_call`` rather than through this method, emit the
+        same spans and metrics.  *messages* is already in wire form here — every
+        IORails entry point normalizes through ``IORails._convert_to_messages``
+        — so this skips the ``generate_async`` protocol adapter.
 
         Raises:
             KeyError: If no engine is registered with the given name.
@@ -196,46 +248,7 @@ class EngineRegistry:
         log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_engine(model_type, ModelEngine)
-        # TODO: Replace with LLMModel.provider_name after refactoring
-        provider_name = engine.model_config.engine or "unknown"
-        operation_name = "chat"
-
-        # Merge the model's config parameters with per-call kwargs (GenerationOptions.llm_params)
-        # Per-call kwargs have priority.
-        merged_params = {**engine.body_param_defaults, **kwargs}
-
-        # Compose: span (always created — no-op when tracer is None) and
-        # duration metric (only when metrics enabled).  Token usage is
-        # emitted after the call returns since it depends on
-        # ``result.usage`` — exception path skips it because control
-        # never reaches the line below.
-        duration_ctx = (
-            llm_operation_duration(engine.model_name, provider_name, operation_name)
-            if self._metrics_enabled
-            else nullcontext()
-        )
-        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
-            # Request params are known before the call, so set them first —
-            # they land on the span even if the call raises.
-            set_llm_request_attributes(span, merged_params)
-            with duration_ctx:
-                result = await engine.chat_completion(messages, **merged_params)
-            # Set response/usage and content attrs inside the span context so
-            # the helpers see the live LLM CLIENT span and the attributes land
-            # before it closes.  Both are skipped on exception, which never
-            # reaches here.
-            set_llm_response_attributes(
-                span,
-                model=result.model,
-                response_id=result.request_id,
-                finish_reason=result.finish_reason,
-                usage=result.usage,
-            )
-            if self._content_capture_enabled:
-                set_llm_call_content(span, messages, result.content)
-
-        if self._metrics_enabled:
-            record_token_usage(engine.model_name, provider_name, operation_name, result.usage)
+        result = await engine.generate_from_messages(messages, **kwargs)
 
         log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))
         return result
@@ -245,27 +258,11 @@ class EngineRegistry:
     ) -> AsyncGenerator[LLMResponseChunk, None]:
         """Stream chat completion chunks from the named model engine.
 
-        Yields ``LLMResponseChunk`` objects. The surrounding
-        ``llm_call_span`` wraps the full generator lifetime: it opens
-        before the first chunk and closes when the generator exhausts or
-        raises.
-
-        When metrics are enabled, emits ``gen_ai.client.operation.duration``
-        for the full stream lifetime (with ``error.type`` on exception)
-        and ``gen_ai.client.token.usage`` after stream completion using
-        the ``UsageInfo`` carried on the terminal SSE chunk (when the
-        provider returns one — controlled by ``include_usage_in_stream``,
-        defaults to True for OpenAI-compatible engines).  No token
-        observation is emitted on early consumer cancellation or on
-        provider error mid-stream.
-
-        The LLM CLIENT span receives ``gen_ai.request.*`` attributes
-        (including ``gen_ai.request.stream=True``) before the first chunk,
-        and ``gen_ai.response.*`` / ``gen_ai.usage.*`` attributes
-        accumulated across the chunks after natural exhaustion.  Like the
-        token metric, the response attrs are skipped on cancellation or a
-        mid-stream provider error.  These span attrs are independent of
-        whether metrics are enabled.
+        Yields ``LLMResponseChunk`` objects.  Parameter merging, the LLM
+        CLIENT span, and the metrics live in
+        ``ModelEngine.stream_from_messages`` — see that method for the span and
+        metric contract.  As in ``model_call``, *messages* is already in wire
+        form, so this skips the ``stream_async`` protocol adapter.
 
         Raises:
             KeyError: If no engine is registered with the given name.
@@ -275,105 +272,16 @@ class EngineRegistry:
         log.debug("[%s] Model engine '%s' stream messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_engine(model_type, ModelEngine)
-        # TODO: Change to LLMModel.provider_name after refactor
-        provider_name = engine.model_config.engine or "unknown"
-        operation_name = "chat"
-
-        # Merge the model's configured parameter defaults with the per-call
-        # kwargs (per-call wins), above set_llm_request_attributes, so the span
-        # reflects the request body.  Excluding "stream"/"stream_options" from
-        # body_param_defaults also prevents a duplicate-keyword TypeError when
-        # stream_call() passes its own stream=True into _prepare_request().
-        merged_params = {**engine.body_param_defaults, **kwargs}
-
-        # Capture the latest non-None response fields from the stream so we
-        # can set the LLM span's response/usage attrs and emit the token
-        # metric after the stream completes.  Providers spread these across
-        # the SSE chunks — OpenAI-compatible engines only populate ``usage``
-        # on the terminal chunk (when ``stream_options.include_usage=true``)
-        # and finish_reason likewise arrives last — so each field keeps its
-        # latest non-None value.
-        captured_usage: Optional["UsageInfo"] = None
-        captured_model: Optional[str] = None
-        captured_response_id: Optional[str] = None
-        captured_finish_reason: Optional[str] = None
-        # Accumulate streamed delta_content here when content capture is on;
-        # joined and recorded onto the LLM span at stream end.  The list is
-        # allocated unconditionally (cost: one empty list per stream); the
-        # per-chunk appends are gated on the flag so the disabled path
-        # doesn't carry chunk strings in memory.
-        content_parts: list[str] = []
-        duration_ctx = (
-            llm_operation_duration(engine.model_name, provider_name, operation_name)
-            if self._metrics_enabled
-            else nullcontext()
-        )
-        with llm_call_span(self._tracer, engine.model_name, provider_name, operation_name) as span:
-            # Set request params + stream=True before the first chunk so they
-            # land on the span even if the stream errors mid-flight.
-            set_llm_request_attributes(span, merged_params, stream=True)
-            with duration_ctx:
-                # Gate timing-state setup on ``_metrics_enabled`` so the
-                # cold path skips ``time.monotonic()`` and the per-chunk
-                # bookkeeping entirely.  ``t0`` defaults to ``0.0`` in
-                # the disabled path so the type stays a plain ``float``
-                # — it's never read in that branch.
-                t0 = time.monotonic() if self._metrics_enabled else 0.0
-                last_chunk_time: Optional[float] = None
-                async for chunk in engine.stream_chat_completion(messages, **merged_params):
-                    if self._metrics_enabled:
-                        # Per OTEL semconv, "first chunk" / "output chunk"
-                        # mean content-bearing chunks — gate on
-                        # ``delta_content`` / ``delta_reasoning`` to skip
-                        # the terminal usage frame and any other cosmetic
-                        # SSE events that the parser leaves in place.
-                        if chunk.delta_content or chunk.delta_reasoning:
-                            now = time.monotonic()
-                            if last_chunk_time is None:
-                                record_time_to_first_chunk(engine.model_name, provider_name, operation_name, now - t0)
-                            else:
-                                record_time_per_output_chunk(
-                                    engine.model_name, provider_name, operation_name, now - last_chunk_time
-                                )
-                            last_chunk_time = now
-                    # Keep the latest non-None response field from each chunk.
-                    # Captured regardless of ``_metrics_enabled`` because they
-                    # feed the span's response/usage attrs (set after the loop)
-                    # as well as the token-usage metric.
-                    if chunk.model is not None:
-                        captured_model = chunk.model
-                    if chunk.request_id is not None:
-                        captured_response_id = chunk.request_id
-                    if chunk.finish_reason is not None:
-                        captured_finish_reason = chunk.finish_reason
-                    if chunk.usage is not None:
-                        captured_usage = chunk.usage
-                    if self._content_capture_enabled and chunk.delta_content:
-                        content_parts.append(chunk.delta_content)
-                    yield chunk
-            # Set response/usage attrs and (when enabled) content inside the
-            # span context so the helpers see the live LLM CLIENT span before
-            # it closes.  Reached only on natural exhaustion — consumer
-            # cancellation or provider error raises out of the ``with`` blocks
-            # above, so partial response data is intentionally not recorded.
-            set_llm_response_attributes(
-                span,
-                model=captured_model,
-                response_id=captured_response_id,
-                finish_reason=captured_finish_reason,
-                usage=captured_usage,
-            )
-            # Empty ``content_parts`` -> output_text=None so we don't claim
-            # an empty assistant response (matches iorails.py's request-span
-            # streaming path).
-            if self._content_capture_enabled:
-                output_text = "".join(content_parts) if content_parts else None
-                set_llm_call_content(span, messages, output_text)
-
-        # Reached only on natural exhaustion (not on consumer cancellation
-        # or provider error — those raise out of the ``with`` blocks above).
-        if self._metrics_enabled:
-            record_token_usage(engine.model_name, provider_name, operation_name, captured_usage)
+        stream = engine.stream_from_messages(messages, **kwargs)
+        try:
+            async for chunk in stream:
+                yield chunk
+        finally:
+            # Close the delegate explicitly.  A consumer that abandons this
+            # generator only unwinds *this* one; without the aclose the
+            # instrumented core stays suspended at its yield until garbage
+            # collection, so the duration metric's `finally` never runs.
+            await stream.aclose()
 
     def parse_tools(self, model_type: str, llm_params: Optional[dict]) -> Toolset:
         """Parse the tool block in ``llm_params`` for the named model engine.

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -25,8 +25,9 @@ import logging
 import os
 import time
 from collections.abc import AsyncGenerator, Mapping
+from contextlib import nullcontext
 from types import MappingProxyType
-from typing import Any, NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, cast
 
 import aiohttp
 from aiohttp_retry import RetryClient
@@ -40,11 +41,30 @@ from nemoguardrails.guardrails._http import (
 )
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, get_request_id, truncate
+from nemoguardrails.guardrails.telemetry import (
+    llm_call_span,
+    set_llm_call_content,
+    set_llm_request_attributes,
+    set_llm_response_attributes,
+)
 from nemoguardrails.guardrails.tool_schema import Tool, ToolExchange, ToolResult, Toolset
 from nemoguardrails.rails.llm.config import Model
+from nemoguardrails.tracing.constants import (
+    llm_operation_duration,
+    record_time_per_output_chunk,
+    record_time_to_first_chunk,
+    record_token_usage,
+)
 from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+
 log = logging.getLogger(__name__)
+
+# The OTEL GenAI operation name for every call this engine makes; it only speaks
+# /v1/chat/completions.
+_OPERATION_NAME = "chat"
 
 # Default base URLs by engine type
 _ENGINE_BASE_URLS = {
@@ -104,6 +124,41 @@ class _RequestParams(NamedTuple):
     url: str
     headers: dict[str, str]
     body: dict[str, Any]
+
+
+# TODO: duplicates OpenAIChatModel._to_messages in
+# nemoguardrails/llm/models/openai_chat.py . Needs consolidating.
+def _to_wire_messages(prompt: str | list) -> LLMMessages:
+    """Normalize an ``LLMModel`` prompt into OpenAI-format message dicts.
+
+    This is the ``LLMModel`` protocol boundary. Library rail actions render a
+    task prompt with ``LLMTaskManager.render_task_prompt``, which returns either
+    a string or a list of ``{"type": ..., "content": ...}`` dicts depending on
+    whether the task prompt was configured with ``content:`` or ``messages:``;
+    ``llm_call`` then hands over a string or a list of ``ChatMessage``. Both
+    shapes are converted here. A list of dicts that is already in wire form
+    passes through untouched.
+
+    ``ChatMessage`` conversion drops ``provider_metadata`` — it is an internal
+    field the completions endpoint would reject — and re-encodes tool-call
+    arguments as a JSON string, which is the wire shape the API expects. It also
+    maps the task manager's ``type`` key onto ``role``, which the API requires.
+    """
+    if isinstance(prompt, str):
+        return [{"role": "user", "content": prompt}]
+    if not prompt or not isinstance(prompt[0], ChatMessage):
+        return prompt
+
+    messages: LLMMessages = []
+    for message in prompt:
+        wire_message = message.to_dict()
+        wire_message.pop("provider_metadata", None)
+        for tool_call in wire_message.get("tool_calls", []):
+            function = tool_call.get("function", {})
+            if isinstance(function.get("arguments"), dict):
+                function["arguments"] = json.dumps(function["arguments"])
+        messages.append(wire_message)
+    return messages
 
 
 def _parse_usage(usage_dict: dict) -> UsageInfo:
@@ -454,20 +509,54 @@ class ModelEngineError(Exception):
         self.status = status
         super().__init__(message)
 
+    @property
+    def status_code(self) -> int | None:
+        """The upstream HTTP status, under the name status extractors look for.
+
+        A rail reaching the model through ``llm_call`` has this error wrapped into
+        ``LLMCallException``, and ``nemoguardrails.llm.call._extract_http_status``
+        duck-types on ``status_code`` — the OpenAI SDK and httpx spelling.  Without
+        this alias the upstream status is dropped and the server reports 500 for
+        what was really a 429 or 503, which SDKs retry differently.  Callers that
+        hold the concrete type can keep reading ``status``.
+        """
+        return self.status
+
 
 class ModelEngine(BaseEngine):
     """Wraps a single Model config and makes HTTP calls to its endpoint.
 
     Each ModelEngine owns its own RetryClient with per-model timeout,
     retry, and connection pool settings.
+
+    Implements the :class:`~nemoguardrails.types.LLMModel` protocol through
+    ``generate_async`` / ``stream_async``, so library rail actions can reach an
+    IORails-configured model through ``nemoguardrails.llm.call.llm_call`` the
+    same way they reach any other backend.
     """
 
-    def __init__(self, model_config: Model) -> None:
-        """Resolve base URL, API key, and retry settings from the model config."""
+    def __init__(
+        self,
+        model_config: Model,
+        *,
+        tracer: Optional["Tracer"] = None,
+        metrics_enabled: bool = False,
+        content_capture_enabled: bool = False,
+    ) -> None:
+        """Resolve base URL, API key, and retry settings from the model config.
+
+        The telemetry arguments carry the OTEL instrumentation for every call
+        this engine makes.  They live here rather than one level up in
+        ``EngineRegistry`` because rails reach the model through
+        ``generate_async``, not through ``EngineRegistry.model_call``.
+        """
         self.model_config = model_config
         self.model_name: str = model_config.model or ""
         self.base_url: str = self._resolve_base_url()
         self.api_key: Optional[str] = self._resolve_api_key(model_config.engine)
+        self._tracer = tracer
+        self._metrics_enabled = metrics_enabled
+        self._content_capture_enabled = content_capture_enabled
 
         params = model_config.parameters or {}
         super().__init__(
@@ -486,6 +575,25 @@ class ModelEngine(BaseEngine):
         self.body_param_defaults: Mapping[str, Any] = MappingProxyType(
             {key: value for key, value in params.items() if key not in _RESERVED_LLM_PARAMETERS}
         )
+
+    @property
+    def provider_name(self) -> str:
+        """The provider this model is served by ('nim', 'openai', ...).
+
+        Falls back to ``"unknown"`` so telemetry always carries a
+        ``gen_ai.provider.name`` label rather than dropping the attribute.
+        """
+        return self.model_config.engine or "unknown"
+
+    @property
+    def provider_url(self) -> str:
+        """The OpenAI-compatible API root for this model.
+
+        ``base_url`` is stored without the ``/v1`` suffix (see
+        ``_resolve_base_url``), so it is re-appended here to match what
+        ``OpenAIChatModel.provider_url`` reports for the same endpoint.
+        """
+        return f"{self.base_url}/v1"
 
     def _resolve_base_url(self) -> str:
         """Resolve the base URL from model parameters or engine type.
@@ -831,6 +939,201 @@ class ModelEngine(BaseEngine):
         """
         async for chunk in self.stream_call(messages, **kwargs):
             yield chunk
+
+    def _merge_params(self, stop: Optional[list[str]], kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Merge the model's configured body defaults under the per-call kwargs.
+
+        ``stop=None`` means "not specified by this call", so a model-level
+        ``stop`` default survives rather than being overwritten with ``None``.
+        """
+        merged = {**self.body_param_defaults, **kwargs}
+        if stop is not None:
+            merged["stop"] = stop
+        return merged
+
+    def _duration_metric(self):
+        """Return the operation-duration metric context, or a no-op when metrics are off."""
+        if not self._metrics_enabled:
+            return nullcontext()
+        return llm_operation_duration(self.model_name, self.provider_name, _OPERATION_NAME)
+
+    async def generate_async(
+        self,
+        prompt: str | list,
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Generate a completion, implementing the ``LLMModel`` protocol.
+
+        Adapter only: it normalizes *prompt* — a plain string or a list of
+        ``ChatMessage``, which is what ``llm_call`` passes on behalf of library
+        rail actions — into wire messages and delegates.  All the work is in
+        ``generate_from_messages``.
+
+        Raises:
+            ModelEngineError: If the request fails or the response format is unexpected.
+        """
+        return await self.generate_from_messages(_to_wire_messages(prompt), stop=stop, **kwargs)
+
+    async def generate_from_messages(
+        self,
+        messages: LLMMessages,
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Generate a completion from OpenAI-format messages.
+
+        The instrumented entry point every caller ends up at: rails through
+        ``generate_async``, main generation directly from
+        ``EngineRegistry.model_call``, which already holds wire messages and so
+        does not need the protocol adapter.  The model's configured
+        ``parameters`` supply request-body defaults which *kwargs* override.
+
+        Raises:
+            ModelEngineError: If the request fails or the response format is unexpected.
+        """
+        params = self._merge_params(stop, kwargs)
+
+        # Request params are known before the call, so they land on the span
+        # even if the call raises.  Response, usage, and content attrs are set
+        # inside the span context so the helpers see the live span; all three
+        # are skipped on exception, which never reaches them.
+        with llm_call_span(self._tracer, self.model_name, self.provider_name, _OPERATION_NAME) as span:
+            set_llm_request_attributes(span, params)
+            with self._duration_metric():
+                result = await self.chat_completion(messages, **params)
+            set_llm_response_attributes(
+                span,
+                model=result.model,
+                response_id=result.request_id,
+                finish_reason=result.finish_reason,
+                usage=result.usage,
+            )
+            if self._content_capture_enabled:
+                set_llm_call_content(span, messages, result.content)
+
+        if self._metrics_enabled:
+            record_token_usage(self.model_name, self.provider_name, _OPERATION_NAME, result.usage)
+
+        return result
+
+    async def stream_async(
+        self,
+        prompt: str | list,
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[LLMResponseChunk, None]:
+        """Stream a completion, implementing the ``LLMModel`` protocol.
+
+        The streaming counterpart of ``generate_async``: normalize *prompt* into
+        wire messages, then delegate to ``stream_from_messages``.
+
+        Raises:
+            ModelEngineError: If the request fails after all retries.
+        """
+        stream = self.stream_from_messages(_to_wire_messages(prompt), stop=stop, **kwargs)
+        try:
+            async for chunk in stream:
+                yield chunk
+        finally:
+            # Close the delegate explicitly.  A consumer that abandons this
+            # generator only unwinds *this* one; without the aclose the
+            # instrumented core stays suspended at its yield until garbage
+            # collection, so the duration metric's `finally` never runs.
+            await stream.aclose()
+
+    async def stream_from_messages(
+        self,
+        messages: LLMMessages,
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[LLMResponseChunk, None]:
+        """Stream a completion from OpenAI-format messages.
+
+        The streaming counterpart of ``generate_from_messages``.  Parameter
+        merging matches it; the chunk contract is ``stream_call``'s, including
+        the terminal usage-only chunk.
+
+        Raises:
+            ModelEngineError: If the request fails after all retries.
+        """
+        params = self._merge_params(stop, kwargs)
+
+        # Providers spread the response fields across the SSE chunks —
+        # OpenAI-compatible engines only populate ``usage`` on the terminal
+        # chunk (when ``stream_options.include_usage=true``) and finish_reason
+        # likewise arrives last — so each field keeps its latest non-None value.
+        captured_usage: Optional[UsageInfo] = None
+        captured_model: Optional[str] = None
+        captured_response_id: Optional[str] = None
+        captured_finish_reason: Optional[str] = None
+        # Accumulate streamed delta_content here when content capture is on;
+        # joined and recorded onto the LLM span at stream end.  The list is
+        # allocated unconditionally (cost: one empty list per stream); the
+        # per-chunk appends are gated on the flag so the disabled path
+        # doesn't carry chunk strings in memory.
+        content_parts: list[str] = []
+
+        with llm_call_span(self._tracer, self.model_name, self.provider_name, _OPERATION_NAME) as span:
+            set_llm_request_attributes(span, params, stream=True)
+            with self._duration_metric():
+                # Gate timing-state setup on ``_metrics_enabled`` so the cold
+                # path skips ``time.monotonic()`` and the per-chunk bookkeeping
+                # entirely.  ``t0`` defaults to ``0.0`` in the disabled path so
+                # the type stays a plain ``float`` — it's never read there.
+                t0 = time.monotonic() if self._metrics_enabled else 0.0
+                last_chunk_time: Optional[float] = None
+                async for chunk in self.stream_chat_completion(messages, **params):
+                    if self._metrics_enabled:
+                        # Per OTEL semconv, "first chunk" / "output chunk" mean
+                        # content-bearing chunks — gate on ``delta_content`` /
+                        # ``delta_reasoning`` to skip the terminal usage frame
+                        # and any other cosmetic SSE events the parser leaves in
+                        # place.
+                        if chunk.delta_content or chunk.delta_reasoning:
+                            now = time.monotonic()
+                            if last_chunk_time is None:
+                                record_time_to_first_chunk(
+                                    self.model_name, self.provider_name, _OPERATION_NAME, now - t0
+                                )
+                            else:
+                                record_time_per_output_chunk(
+                                    self.model_name, self.provider_name, _OPERATION_NAME, now - last_chunk_time
+                                )
+                            last_chunk_time = now
+                    # Captured regardless of ``_metrics_enabled`` because they
+                    # feed the span's response/usage attrs as well as the metric.
+                    if chunk.model is not None:
+                        captured_model = chunk.model
+                    if chunk.request_id is not None:
+                        captured_response_id = chunk.request_id
+                    if chunk.finish_reason is not None:
+                        captured_finish_reason = chunk.finish_reason
+                    if chunk.usage is not None:
+                        captured_usage = chunk.usage
+                    if self._content_capture_enabled and chunk.delta_content:
+                        content_parts.append(chunk.delta_content)
+                    yield chunk
+            set_llm_response_attributes(
+                span,
+                model=captured_model,
+                response_id=captured_response_id,
+                finish_reason=captured_finish_reason,
+                usage=captured_usage,
+            )
+            # Empty ``content_parts`` -> output_text=None so we don't claim an
+            # empty assistant response (matches iorails.py's request-span
+            # streaming path).
+            if self._content_capture_enabled:
+                output_text = "".join(content_parts) if content_parts else None
+                set_llm_call_content(span, messages, output_text)
+
+        if self._metrics_enabled:
+            record_token_usage(self.model_name, self.provider_name, _OPERATION_NAME, captured_usage)
 
     def parse_tools(self, llm_params: Optional[dict]) -> Toolset:
         """Parse the provider tool block in ``llm_params`` into a ``Toolset``.

--- a/tests/guardrails/conftest.py
+++ b/tests/guardrails/conftest.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixtures shared across the IORails guardrails tests."""
+
+import pytest
+
+from nemoguardrails.context import llm_call_info_var, llm_response_metadata_var, llm_stats_var
+
+
+@pytest.fixture
+def reset_llm_call_context():
+    """Reset the context variables ``llm_call`` writes, before and after a test.
+
+    ``reasoning_trace_var``, ``tool_calls_var``, and ``explain_info_var`` already
+    have autouse resets in ``tests/conftest.py``; these three do not.
+    """
+    call_info_token = llm_call_info_var.set(None)
+    stats_token = llm_stats_var.set(None)
+    metadata_token = llm_response_metadata_var.set(None)
+    yield
+    llm_call_info_var.reset(call_info_token)
+    llm_stats_var.reset(stats_token)
+    llm_response_metadata_var.reset(metadata_token)

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -26,15 +26,18 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from nemoguardrails.context import llm_call_info_var, llm_response_metadata_var, llm_stats_var
+from nemoguardrails.guardrails import engine_registry as engine_registry_module
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.api_engine import APIEngine
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.tool_schema import Toolset
+from nemoguardrails.llm.call import llm_call
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing import constants as tracing_constants
 from nemoguardrails.tracing.constants import SystemConstants
-from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
+from nemoguardrails.types import LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
 from tests.guardrails.metric_helpers import collect_histogram_sum, collect_metric_points
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
@@ -1582,3 +1585,387 @@ class TestEngineRegistryToolDelegation:
             mgr = EngineRegistry(config.models, config.rails.config)
         toolset = mgr.parse_tools("main", None)
         assert [t.key for t in toolset.tools] == ["get_weather"]
+
+
+class TestEngineRegistryLLMs:
+    """``llms`` exposes the model engines as the ``Dict[str, LLMModel]`` that library
+    rail actions index by model type."""
+
+    def test_maps_every_model_type(self, manager):
+        """One entry per configured model, keyed by Model.type."""
+        assert set(manager.llms) == {"main", "content_safety", "topic_control"}
+
+    def test_excludes_api_engines(self, manager):
+        """jailbreak_detection is an APIEngine, not an LLM, so it is not an entry."""
+        assert "jailbreak_detection" not in manager.llms
+
+    def test_values_are_the_registered_engines(self, manager):
+        """Entries are the registry's own engines, not copies, so they share lifecycle."""
+        assert manager.llms["main"] is manager._get_engine("main", ModelEngine)
+
+    def test_values_satisfy_the_llm_model_protocol(self, manager):
+        """Every entry is usable wherever a library action declares ``LLMModel``."""
+        assert all(isinstance(model, LLMModel) for model in manager.llms.values())
+
+
+class TestEngineRegistryMessagesEntryPoint:
+    """The registry always holds wire messages — every IORails entry point normalizes
+    through ``IORails._convert_to_messages`` — so it calls the messages-typed core
+    directly instead of routing back through the ``LLMModel`` prompt adapter."""
+
+    _MESSAGES = [{"role": "user", "content": "Hi"}]
+
+    @pytest.mark.asyncio
+    async def test_model_call_skips_the_prompt_adapter(self, manager):
+        """model_call reaches generate_from_messages with its messages and kwargs intact."""
+        engine = manager._get_engine("main", ModelEngine)
+        engine.generate_from_messages = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await manager.model_call("main", self._MESSAGES, temperature=0.5)
+
+        engine.generate_from_messages.assert_called_once_with(self._MESSAGES, temperature=0.5)
+
+    @pytest.mark.asyncio
+    async def test_stream_model_call_skips_the_prompt_adapter(self, manager):
+        """stream_model_call reaches stream_from_messages and yields its chunks."""
+        engine = manager._get_engine("main", ModelEngine)
+        captured = {}
+
+        async def _fake_stream(messages, **kwargs):
+            captured["messages"] = messages
+            captured["kwargs"] = kwargs
+            yield LLMResponseChunk(delta_content="ok")
+
+        engine.stream_from_messages = _fake_stream
+
+        chunks = [chunk async for chunk in manager.stream_model_call("main", self._MESSAGES, temperature=0.5)]
+
+        assert captured == {"messages": self._MESSAGES, "kwargs": {"temperature": 0.5}}
+        assert [chunk.delta_content for chunk in chunks] == ["ok"]
+
+
+class TestEngineRegistryProviderName:
+    """``provider_name`` reads the engine's own property rather than its model config."""
+
+    def test_returns_the_engine_provider_name(self, manager):
+        """The registry and the engine agree on the provider name."""
+        engine = manager._get_engine("main", ModelEngine)
+        assert manager.provider_name("main") == engine.provider_name == "nim"
+
+    def test_unknown_model_type_raises_key_error(self, manager):
+        """An unconfigured model type raises rather than reporting 'unknown'."""
+        with pytest.raises(KeyError):
+            manager.provider_name("nonexistent")
+
+
+class _FakeHTTPClient:
+    """Minimal ``ClosableHTTPClient`` stand-in that records ``close()`` calls."""
+
+    def __init__(self, close_error: Optional[Exception] = None) -> None:
+        self.close_count = 0
+        self.close_error = close_error
+
+    async def request(self, method, url, **kwargs):
+        raise NotImplementedError("the fake client does not send requests")
+
+    async def close(self) -> None:
+        self.close_count += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+@pytest.fixture
+def fake_http_client(monkeypatch):
+    """Replace the managed HTTP client factory with a recording fake."""
+    client = _FakeHTTPClient()
+    monkeypatch.setattr(engine_registry_module, "create_http_client", lambda: client)
+    return client
+
+
+@pytest.fixture
+def mocked_engine_lifecycle(manager):
+    """Stub start/stop on every engine so lifecycle tests exercise only the registry."""
+    for engine in manager._engines.values():
+        engine.start = AsyncMock()
+        engine.stop = AsyncMock()
+    return manager
+
+
+class TestEngineRegistryHTTPClient:
+    """The registry owns one managed HTTP client for the whole process, started and
+    stopped with the engines, so vendor rail actions stop creating one per request."""
+
+    def test_client_is_unavailable_before_start(self, manager):
+        """Reaching for the client before start() fails loudly instead of handing back None."""
+        with pytest.raises(RuntimeError, match="has not been started"):
+            _ = manager.http_client
+
+    @pytest.mark.asyncio
+    async def test_client_is_created_on_start(self, mocked_engine_lifecycle, fake_http_client):
+        """start() builds the managed client through create_http_client()."""
+        await mocked_engine_lifecycle.start()
+        assert mocked_engine_lifecycle.http_client is fake_http_client
+
+    @pytest.mark.asyncio
+    async def test_same_client_across_accesses(self, mocked_engine_lifecycle, fake_http_client):
+        """Every access returns the one shared client, so connections are pooled."""
+        await mocked_engine_lifecycle.start()
+        assert mocked_engine_lifecycle.http_client is mocked_engine_lifecycle.http_client
+
+    @pytest.mark.asyncio
+    async def test_second_start_does_not_replace_the_client(self, mocked_engine_lifecycle, fake_http_client):
+        """start() is idempotent: a repeat call leaves the existing client in place."""
+        await mocked_engine_lifecycle.start()
+        first = mocked_engine_lifecycle.http_client
+
+        await mocked_engine_lifecycle.start()
+
+        assert mocked_engine_lifecycle.http_client is first
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_the_client(self, mocked_engine_lifecycle, fake_http_client):
+        """stop() releases the client's connection pool."""
+        await mocked_engine_lifecycle.start()
+        await mocked_engine_lifecycle.stop()
+        assert fake_http_client.close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_client_is_unavailable_after_stop(self, mocked_engine_lifecycle, fake_http_client):
+        """A closed client is not handed out again."""
+        await mocked_engine_lifecycle.start()
+        await mocked_engine_lifecycle.stop()
+
+        with pytest.raises(RuntimeError, match="has not been started"):
+            _ = mocked_engine_lifecycle.http_client
+
+    @pytest.mark.asyncio
+    async def test_second_stop_does_not_close_again(self, mocked_engine_lifecycle, fake_http_client):
+        """stop() is idempotent: the client is closed exactly once."""
+        await mocked_engine_lifecycle.start()
+        await mocked_engine_lifecycle.stop()
+        await mocked_engine_lifecycle.stop()
+        assert fake_http_client.close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_engine_start_failure_closes_the_client(self, manager, fake_http_client):
+        """A failed start rolls the client back with the engines rather than leaking it."""
+        for name, engine in manager._engines.items():
+            engine.stop = AsyncMock()
+            engine.start = AsyncMock(side_effect=RuntimeError("boom") if name == "topic_control" else None)
+
+        with pytest.raises(RuntimeError, match="Failed to start engine"):
+            await manager.start()
+
+        assert fake_http_client.close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_reports_a_failing_client_close(self, mocked_engine_lifecycle, monkeypatch):
+        """A close() failure is surfaced, not swallowed, and still clears running state."""
+        monkeypatch.setattr(
+            engine_registry_module,
+            "create_http_client",
+            lambda: _FakeHTTPClient(close_error=RuntimeError("socket stuck")),
+        )
+        await mocked_engine_lifecycle.start()
+
+        with pytest.raises(RuntimeError, match="socket stuck"):
+            await mocked_engine_lifecycle.stop()
+
+        assert not mocked_engine_lifecycle._running
+
+
+@pytest.fixture
+def reset_llm_call_context():
+    """Reset the context variables ``llm_call`` writes, before and after a test.
+
+    ``reasoning_trace_var``, ``tool_calls_var``, and ``explain_info_var`` already
+    have autouse resets in ``tests/conftest.py``; these three do not.
+    """
+    call_info_token = llm_call_info_var.set(None)
+    stats_token = llm_stats_var.set(None)
+    metadata_token = llm_response_metadata_var.set(None)
+    yield
+    llm_call_info_var.reset(call_info_token)
+    llm_stats_var.reset(stats_token)
+    llm_response_metadata_var.reset(metadata_token)
+
+
+class TestRailCallTelemetryParity:
+    """A rail-shaped ``llm_call(engine, ...)`` produces the same telemetry as
+    ``EngineRegistry.model_call``.
+
+    Library rail actions reach the model through ``llm_call`` -> ``generate_async``,
+    not through ``model_call``. If the LLM span and the GenAI metrics stayed in the
+    registry wrapper, every migrated rail would silently stop emitting them — no
+    error, no failing test, just missing telemetry in production. These tests pin the
+    instrumentation to the engine so both entry points stay equivalent.
+    """
+
+    _MESSAGES = [{"role": "user", "content": "Is this safe?"}]
+
+    @staticmethod
+    def _response() -> LLMResponse:
+        return LLMResponse(
+            content="safe",
+            model="meta/llama-3.3-70b-instruct",
+            finish_reason="stop",
+            request_id="chatcmpl-1",
+            usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+
+    @pytest.mark.asyncio
+    async def test_span_matches_model_call(self, manager_with_tracer, span_exporter, reset_llm_call_context):
+        """Both entry points emit one LLM CLIENT span with identical name, kind, and attributes."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=self._response())
+
+        await manager_with_tracer.model_call("main", self._MESSAGES, temperature=0.2, stop=["END"])
+        registry_span = exporter.get_finished_spans()[-1]
+        exporter.clear()
+
+        await llm_call(engine, self._MESSAGES, stop=["END"], llm_params={"temperature": 0.2})
+        rail_span = exporter.get_finished_spans()[-1]
+
+        assert rail_span.name == registry_span.name
+        assert rail_span.kind == registry_span.kind
+        assert dict(rail_span.attributes) == dict(registry_span.attributes)
+
+    @pytest.mark.asyncio
+    async def test_error_span_matches_model_call(self, manager_with_tracer, span_exporter, reset_llm_call_context):
+        """A provider failure marks the span the same way on both paths."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        with pytest.raises(RuntimeError, match="provider down"):
+            await manager_with_tracer.model_call("main", self._MESSAGES)
+        registry_span = exporter.get_finished_spans()[-1]
+        exporter.clear()
+
+        with pytest.raises(Exception, match="provider down"):
+            await llm_call(engine, self._MESSAGES)
+        rail_span = exporter.get_finished_spans()[-1]
+
+        assert rail_span.status.status_code == registry_span.status.status_code
+        assert dict(rail_span.attributes)["error.type"] == dict(registry_span.attributes)["error.type"]
+
+    @pytest.mark.asyncio
+    async def test_content_capture_matches_model_call(self, rails_config, span_exporter, reset_llm_call_context):
+        """With capture on, the rail path records the same message content."""
+        tracer, exporter = span_exporter
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            registry = EngineRegistry(
+                rails_config.models,
+                rails_config.rails.config,
+                tracer=tracer,
+                content_capture_enabled=True,
+            )
+        engine = registry._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=self._response())
+
+        await registry.model_call("main", self._MESSAGES)
+        registry_attrs = dict(exporter.get_finished_spans()[-1].attributes)
+        exporter.clear()
+
+        await llm_call(engine, self._MESSAGES)
+        rail_attrs = dict(exporter.get_finished_spans()[-1].attributes)
+
+        assert rail_attrs == registry_attrs
+
+    @pytest.mark.asyncio
+    async def test_rail_call_emits_token_usage_and_duration(
+        self, manager_with_metrics, metric_reader, reset_llm_call_context
+    ):
+        """The GenAI metrics fire on the rail path, labelled by model, provider, and operation."""
+        engine = manager_with_metrics._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=self._response())
+
+        await llm_call(engine, self._MESSAGES)
+
+        points = collect_metric_points(metric_reader)
+        assert {p.attributes["gen_ai.token.type"] for p in points["gen_ai.client.token.usage"]} == {"input", "output"}
+        assert points["gen_ai.client.operation.duration"][0].value == 1
+        for point in points["gen_ai.client.token.usage"] + points["gen_ai.client.operation.duration"]:
+            assert point.attributes["gen_ai.operation.name"] == "chat"
+            assert point.attributes["gen_ai.provider.name"] == "nim"
+            assert point.attributes["gen_ai.request.model"] == "meta/llama-3.3-70b-instruct"
+
+    @pytest.mark.asyncio
+    async def test_rail_call_records_error_type_on_failure(
+        self, manager_with_metrics, metric_reader, reset_llm_call_context
+    ):
+        """A failed rail call still emits duration, labelled with the failure type."""
+        engine = manager_with_metrics._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        with pytest.raises(Exception, match="provider down"):
+            await llm_call(engine, self._MESSAGES)
+
+        points = collect_metric_points(metric_reader)
+        assert "gen_ai.client.token.usage" not in points
+        assert points["gen_ai.client.operation.duration"][0].attributes["error.type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_no_metrics_when_metrics_disabled(self, manager, metric_reader, reset_llm_call_context):
+        """Metrics stay gated on the config flag, not on meter availability."""
+        engine = manager._get_engine("main", ModelEngine)
+        engine.chat_completion = AsyncMock(return_value=self._response())
+
+        await llm_call(engine, self._MESSAGES)
+
+        points = collect_metric_points(metric_reader)
+        assert "gen_ai.client.token.usage" not in points
+        assert "gen_ai.client.operation.duration" not in points
+
+    @pytest.mark.asyncio
+    async def test_stream_duration_recorded_on_consumer_early_break(self, manager_with_metrics, metric_reader):
+        """Abandoning ``stream_async`` mid-stream must still record the duration.
+
+        The adapter and the instrumented core are separate generators, so closing
+        the adapter only unwinds the adapter — it has to close the core too, or
+        the metric's ``finally`` waits on garbage collection.
+        """
+        engine = manager_with_metrics._get_engine("main", ModelEngine)
+        engine.stream_chat_completion = _mock_stream(
+            LLMResponseChunk(delta_content="sa"),
+            LLMResponseChunk(delta_content="fe"),
+            LLMResponseChunk(usage=UsageInfo(input_tokens=10, output_tokens=5)),
+        )
+
+        stream = engine.stream_async(self._MESSAGES)
+        first = await anext(stream)
+        assert first.delta_content == "sa"
+        await stream.aclose()
+
+        points = collect_metric_points(metric_reader)
+        assert "gen_ai.client.token.usage" not in points
+        assert points["gen_ai.client.operation.duration"][0].value == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_span_matches_stream_model_call(self, manager_with_tracer, span_exporter):
+        """The streaming rail path emits the same span as ``stream_model_call``."""
+        _, exporter = span_exporter
+        engine = manager_with_tracer._get_engine("main", ModelEngine)
+        chunks = (
+            LLMResponseChunk(delta_content="sa", model="meta/llama-3.3-70b-instruct", request_id="chatcmpl-1"),
+            LLMResponseChunk(
+                delta_content="fe",
+                finish_reason="stop",
+                usage=UsageInfo(input_tokens=10, output_tokens=5),
+            ),
+        )
+
+        engine.stream_chat_completion = _mock_stream(*chunks)
+        async for _ in manager_with_tracer.stream_model_call("main", self._MESSAGES, temperature=0.2):
+            pass
+        registry_span = exporter.get_finished_spans()[-1]
+        exporter.clear()
+
+        engine.stream_chat_completion = _mock_stream(*chunks)
+        async for _ in engine.stream_async(self._MESSAGES, temperature=0.2):
+            pass
+        rail_span = exporter.get_finished_spans()[-1]
+
+        assert rail_span.name == registry_span.name
+        assert dict(rail_span.attributes) == dict(registry_span.attributes)

--- a/tests/guardrails/test_engine_registry.py
+++ b/tests/guardrails/test_engine_registry.py
@@ -16,6 +16,7 @@
 """Unit tests for engine_registry module."""
 
 import json
+import logging
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,7 +27,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from nemoguardrails.context import llm_call_info_var, llm_response_metadata_var, llm_stats_var
 from nemoguardrails.guardrails import engine_registry as engine_registry_module
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.api_engine import APIEngine
@@ -1140,7 +1140,13 @@ class TestEngineRegistryStreamModelCallMetrics:
         ``record_token_usage`` line after the ``with`` block doesn't
         run (GeneratorExit unwinds the with-stack but skips trailing
         code).  Duration still records via the ``finally`` in
-        ``llm_operation_duration``."""
+        ``llm_operation_duration``.
+
+        This also pins ``stream_model_call``'s ``finally: await stream.aclose()``.
+        The metric context lives one generator down, in
+        ``ModelEngine.stream_from_messages``; closing this generator only unwinds
+        this one, so without that explicit close the delegate stays suspended at
+        its yield and the duration is not recorded until garbage collection."""
         engine = manager_with_metrics._get_engine("main", ModelEngine)
         engine.stream_chat_completion = _mock_stream(
             LLMResponseChunk(delta_content="Hello"),
@@ -1759,6 +1765,46 @@ class TestEngineRegistryHTTPClient:
         assert fake_http_client.close_count == 1
 
     @pytest.mark.asyncio
+    async def test_start_rollback_logs_a_failing_client_close(self, manager, monkeypatch, caplog):
+        """A close() failure during rollback is logged, not silently swallowed.
+
+        The engine-start error must still be what propagates — a cleanup failure
+        raised from the rollback would replace the reason the start failed — so the
+        log line is the only signal that the client leaked.
+        """
+        monkeypatch.setattr(
+            engine_registry_module,
+            "create_http_client",
+            lambda: _FakeHTTPClient(close_error=RuntimeError("socket stuck")),
+        )
+        for name, engine in manager._engines.items():
+            engine.stop = AsyncMock()
+            engine.start = AsyncMock(side_effect=RuntimeError("boom") if name == "topic_control" else None)
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(RuntimeError, match="Failed to start engine"):
+                await manager.start()
+
+        assert "socket stuck" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_start_rollback_logs_a_failing_engine_stop(self, manager, fake_http_client, caplog):
+        """A stop() failure during rollback names the engine that failed to release.
+
+        Rollback continues past it (pinned by ``test_start_rollback_swallows_stop_errors``);
+        this pins that the failure is reported rather than lost.
+        """
+        for name, engine in manager._engines.items():
+            engine.start = AsyncMock(side_effect=RuntimeError("boom") if name == "topic_control" else None)
+            engine.stop = AsyncMock(side_effect=RuntimeError("close failed") if name == "main" else None)
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(RuntimeError, match="Failed to start engine"):
+                await manager.start()
+
+        assert "Error stopping engine main during start rollback" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_stop_reports_a_failing_client_close(self, mocked_engine_lifecycle, monkeypatch):
         """A close() failure is surfaced, not swallowed, and still clears running state."""
         monkeypatch.setattr(
@@ -1772,22 +1818,6 @@ class TestEngineRegistryHTTPClient:
             await mocked_engine_lifecycle.stop()
 
         assert not mocked_engine_lifecycle._running
-
-
-@pytest.fixture
-def reset_llm_call_context():
-    """Reset the context variables ``llm_call`` writes, before and after a test.
-
-    ``reasoning_trace_var``, ``tool_calls_var``, and ``explain_info_var`` already
-    have autouse resets in ``tests/conftest.py``; these three do not.
-    """
-    call_info_token = llm_call_info_var.set(None)
-    stats_token = llm_stats_var.set(None)
-    metadata_token = llm_response_metadata_var.set(None)
-    yield
-    llm_call_info_var.reset(call_info_token)
-    llm_stats_var.reset(stats_token)
-    llm_response_metadata_var.reset(metadata_token)
 
 
 class TestRailCallTelemetryParity:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-from nemoguardrails.context import llm_call_info_var, llm_response_metadata_var, llm_stats_var
+from nemoguardrails.context import llm_call_info_var, llm_stats_var
 from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
@@ -132,22 +132,6 @@ def _started_engine(client, **model_kwargs) -> ModelEngine:
 def _posted_body(mock_client) -> dict:
     """Return the JSON body of the single request made through ``mock_client``."""
     return mock_client.post.call_args[1]["json"]
-
-
-@pytest.fixture
-def reset_llm_call_context():
-    """Reset the context variables ``llm_call`` writes, before and after a test.
-
-    ``reasoning_trace_var``, ``tool_calls_var``, and ``explain_info_var`` already
-    have autouse resets in ``tests/conftest.py``; these three do not.
-    """
-    call_info_token = llm_call_info_var.set(None)
-    stats_token = llm_stats_var.set(None)
-    metadata_token = llm_response_metadata_var.set(None)
-    yield
-    llm_call_info_var.reset(call_info_token)
-    llm_stats_var.reset(stats_token)
-    llm_response_metadata_var.reset(metadata_token)
 
 
 class TestModelEngineError:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -23,6 +23,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from nemoguardrails.context import llm_call_info_var, llm_response_metadata_var, llm_stats_var
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
@@ -37,8 +39,18 @@ from nemoguardrails.guardrails.model_engine import (
     _parse_chat_completion_chunk,
 )
 from nemoguardrails.guardrails.tool_schema import Toolset
+from nemoguardrails.llm.call import llm_call
 from nemoguardrails.rails.llm.config import Model
-from nemoguardrails.types import LLMResponse, LLMResponseChunk, UsageInfo
+from nemoguardrails.types import (
+    ChatMessage,
+    LLMModel,
+    LLMResponse,
+    LLMResponseChunk,
+    Role,
+    ToolCall,
+    ToolCallFunction,
+    UsageInfo,
+)
 from tests.guardrails.tool_helpers import make_tool_conversation, multi_turn_reused_call_id_messages
 
 
@@ -88,6 +100,56 @@ def _mock_streaming_response(raw_lines, status=200, headers=None):
     return mock_response
 
 
+_OK_COMPLETION = {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+
+def _mock_chat_client(payload: dict | None = None, status: int = 200):
+    """Create a mock aiohttp client whose post() returns a chat-completion payload.
+
+    The returned mock records the outbound request, so tests read the body back
+    with ``_posted_body``.
+    """
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = status
+    mock_response.json = AsyncMock(return_value=payload if payload is not None else _OK_COMPLETION)
+    mock_response.text = AsyncMock(return_value='{"error": "boom"}')
+
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    mock_client.closed = False
+    return mock_client
+
+
+def _started_engine(client, **model_kwargs) -> ModelEngine:
+    """Create a ModelEngine wired to ``client`` and marked as started."""
+    engine = ModelEngine(_make_model(**model_kwargs))
+    engine._client = client
+    engine._running = True
+    return engine
+
+
+def _posted_body(mock_client) -> dict:
+    """Return the JSON body of the single request made through ``mock_client``."""
+    return mock_client.post.call_args[1]["json"]
+
+
+@pytest.fixture
+def reset_llm_call_context():
+    """Reset the context variables ``llm_call`` writes, before and after a test.
+
+    ``reasoning_trace_var``, ``tool_calls_var``, and ``explain_info_var`` already
+    have autouse resets in ``tests/conftest.py``; these three do not.
+    """
+    call_info_token = llm_call_info_var.set(None)
+    stats_token = llm_stats_var.set(None)
+    metadata_token = llm_response_metadata_var.set(None)
+    yield
+    llm_call_info_var.reset(call_info_token)
+    llm_stats_var.reset(stats_token)
+    llm_response_metadata_var.reset(metadata_token)
+
+
 class TestModelEngineError:
     """Test the ModelEngineError Exception type fields."""
 
@@ -107,6 +169,14 @@ class TestModelEngineError:
     def test_is_exception(self):
         """ModelEngineError is a subclass of Exception."""
         assert issubclass(ModelEngineError, Exception)
+
+    def test_status_code_mirrors_status(self):
+        """status_code is the spelling error-status extractors duck-type on."""
+        assert ModelEngineError("bad request", model_name="my-model", status=400).status_code == 400
+
+    def test_status_code_is_none_without_a_status(self):
+        """A failure with no HTTP response reports no status under either name."""
+        assert ModelEngineError("connection dropped", model_name="my-model").status_code is None
 
 
 class TestModelEngineBaseUrl:
@@ -2337,3 +2407,437 @@ class TestExtractToolExchanges:
     def test_unknown_engine_falls_back_to_openai_extractor(self):
         engine = ModelEngine(_make_model(engine="vllm", parameters={"base_url": "http://localhost:8000"}))
         assert self._ids(engine.extract_tool_exchanges(_TOOL_MESSAGES)) == [(["call_1"], ["call_1"])]
+
+
+class TestModelEngineLLMModelProtocol:
+    """ModelEngine implements LLMModel, the interface library rail actions call through."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_engine_is_an_llm_model(self):
+        """A ModelEngine instance satisfies the runtime-checkable LLMModel protocol."""
+        assert isinstance(ModelEngine(_make_model()), LLMModel)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_model_name_is_the_configured_model(self):
+        """model_name reports the configured model, the gen_ai.request.model label value."""
+        assert ModelEngine(_make_model(model="my-llm")).model_name == "my-llm"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_provider_name_is_the_configured_engine(self):
+        """provider_name reports the engine type, the gen_ai.provider.name label value."""
+        assert ModelEngine(_make_model(engine="openai")).provider_name == "openai"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_provider_url_is_the_openai_compatible_api_root(self):
+        """provider_url is the /v1 API root rather than the bare host."""
+        engine = ModelEngine(_make_model(engine="nim"))
+        assert engine.provider_url == _ENGINE_BASE_URLS["nim"] + "/v1"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_provider_url_is_not_doubled_when_base_url_already_ends_in_v1(self):
+        """A base_url configured with a trailing /v1 yields exactly one /v1."""
+        engine = ModelEngine(_make_model(parameters={"base_url": "http://localhost:8000/v1"}))
+        assert engine.provider_url == "http://localhost:8000/v1"
+
+
+class TestModelEngineGenerateAsync:
+    """generate_async adapts chat_completion to the LLMModel protocol signature."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_string_prompt_becomes_one_user_message(self):
+        """A plain string prompt is sent as a single user message."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await engine.generate_async("Hello")
+
+        assert _posted_body(client)["messages"] == [{"role": "user", "content": "Hello"}]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_chat_messages_are_serialized_for_the_wire(self):
+        """ChatMessage input is converted to OpenAI dicts: provider_metadata is dropped
+        and tool-call arguments are JSON-encoded, so the body stays a valid request."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        prompt = [
+            ChatMessage(role=Role.SYSTEM, content="be safe", provider_metadata={"internal": True}),
+            ChatMessage(
+                role=Role.ASSISTANT,
+                tool_calls=[ToolCall(id="call-1", function=ToolCallFunction(name="lookup", arguments={"q": "x"}))],
+            ),
+        ]
+        await engine.generate_async(prompt)
+
+        assert _posted_body(client)["messages"] == [
+            {"role": "system", "content": "be safe"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call-1", "type": "function", "function": {"name": "lookup", "arguments": '{"q": "x"}'}}
+                ],
+            },
+        ]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_dict_messages_pass_through_unchanged(self):
+        """Raw OpenAI-format dicts, which EngineRegistry.model_call forwards, are sent as-is."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        messages = [{"role": "user", "content": "Hi", "name": "caller"}]
+        await engine.generate_async(messages)
+
+        assert _posted_body(client)["messages"] == messages
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_empty_prompt_list_sends_an_empty_messages_array(self):
+        """An empty prompt list is forwarded as an empty messages array, not a string prompt."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await engine.generate_async([])
+
+        assert _posted_body(client)["messages"] == []
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stop_is_forwarded_into_the_request_body(self):
+        """The keyword-only stop argument lands in the request body as `stop`."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await engine.generate_async("Hi", stop=["END"])
+
+        assert _posted_body(client)["stop"] == ["END"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stop_none_leaves_a_configured_default_in_place(self):
+        """stop=None means "unspecified", so a model-level stop default survives."""
+        client = _mock_chat_client()
+        engine = _started_engine(client, parameters={"stop": ["CONFIGURED"]})
+
+        await engine.generate_async("Hi")
+
+        assert _posted_body(client)["stop"] == ["CONFIGURED"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_defaults_merge_under_per_call_kwargs(self):
+        """Model parameters supply defaults; per-call kwargs win on collision."""
+        client = _mock_chat_client()
+        engine = _started_engine(client, parameters={"temperature": 0.1, "top_p": 0.9})
+
+        await engine.generate_async("Hi", temperature=0.9)
+
+        body = _posted_body(client)
+        assert body["temperature"] == 0.9
+        assert body["top_p"] == 0.9
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_returns_the_parsed_llm_response(self):
+        """The provider payload is parsed into an LLMResponse with usage and finish reason."""
+        client = _mock_chat_client(
+            {
+                "id": "chatcmpl-1",
+                "model": "meta/llama-3.3-70b-instruct",
+                "choices": [{"message": {"role": "assistant", "content": "safe"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+            }
+        )
+        engine = _started_engine(client)
+
+        response = await engine.generate_async("Hi")
+
+        assert response == LLMResponse(
+            content="safe",
+            model="meta/llama-3.3-70b-instruct",
+            finish_reason="stop",
+            request_id="chatcmpl-1",
+            usage=UsageInfo(input_tokens=7, output_tokens=2, total_tokens=9),
+        )
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_http_error_raises_model_engine_error(self):
+        """A provider error surfaces as ModelEngineError carrying the HTTP status."""
+        engine = _started_engine(_mock_chat_client(status=400))
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.generate_async("Hi")
+
+        assert exc_info.value.status == 400
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_raises_when_the_engine_has_not_been_started(self):
+        """generate_async enforces the same lifecycle guard as call()."""
+        engine = ModelEngine(_make_model())
+
+        with pytest.raises(ModelEngineError, match="has not been started"):
+            await engine.generate_async("Hi")
+
+
+class TestModelEngineStreamAsync:
+    """stream_async adapts stream_chat_completion to the LLMModel protocol signature."""
+
+    @staticmethod
+    def _sse_lines(*texts: str):
+        lines = [f"data: {json.dumps({'choices': [{'delta': {'content': text}}]})}\n\n".encode() for text in texts]
+        lines.append(b"data: [DONE]\n\n")
+        return lines
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_yields_chunks_from_the_stream(self):
+        """stream_async yields the same LLMResponseChunk sequence as stream_call."""
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(self._sse_lines("Hello", " world")))
+        engine = _started_engine(mock_client)
+
+        chunks = [chunk async for chunk in engine.stream_async("Hi")]
+
+        assert [chunk.delta_content for chunk in chunks] == ["Hello", " world"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_string_prompt_becomes_one_user_message(self):
+        """A plain string prompt is sent as a single user message, as in generate_async."""
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(self._sse_lines("Hi")))
+        engine = _started_engine(mock_client)
+
+        [chunk async for chunk in engine.stream_async("Hello")]
+
+        assert _posted_body(mock_client)["messages"] == [{"role": "user", "content": "Hello"}]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stop_and_config_defaults_reach_the_request_body(self):
+        """stop and model parameter defaults are merged into the streaming request body."""
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(self._sse_lines("Hi")))
+        engine = _started_engine(mock_client, parameters={"temperature": 0.1})
+
+        [chunk async for chunk in engine.stream_async("Hello", stop=["END"])]
+
+        body = _posted_body(mock_client)
+        assert body["stop"] == ["END"]
+        assert body["temperature"] == 0.1
+        assert body["stream"] is True
+
+
+class TestModelEngineMessagesEntryPoint:
+    """``generate_async`` / ``stream_async`` are protocol adapters over the
+    messages-typed core.  Callers that already hold wire messages — every IORails
+    entry point, which normalizes through ``IORails._convert_to_messages`` — go
+    straight to the core instead of back through prompt normalization."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_generate_from_messages_sends_messages_unchanged(self):
+        """The messages-typed core forwards its messages verbatim."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        messages = [{"role": "system", "content": "be safe"}, {"role": "user", "content": "hi"}]
+        await engine.generate_from_messages(messages)
+
+        assert _posted_body(client)["messages"] == messages
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_generate_async_normalizes_then_delegates(self):
+        """The adapter converts the prompt to wire messages and passes stop and
+        kwargs through untouched."""
+        engine = ModelEngine(_make_model())
+        engine.generate_from_messages = AsyncMock(return_value=LLMResponse(content="ok"))
+
+        await engine.generate_async("Hi", stop=["END"], temperature=0.5)
+
+        engine.generate_from_messages.assert_called_once_with(
+            [{"role": "user", "content": "Hi"}], stop=["END"], temperature=0.5
+        )
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_from_messages_sends_messages_unchanged(self):
+        """The streaming core forwards its messages verbatim."""
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(
+            return_value=_mock_streaming_response([b'data: {"choices": [{"delta": {"content": "Hi"}}]}\n\n'])
+        )
+        engine = _started_engine(mock_client)
+
+        messages = [{"role": "user", "content": "hi"}]
+        [chunk async for chunk in engine.stream_from_messages(messages)]
+
+        assert _posted_body(mock_client)["messages"] == messages
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_async_normalizes_then_delegates(self):
+        """The streaming adapter mirrors generate_async: normalize, then delegate."""
+        engine = ModelEngine(_make_model())
+        captured: dict[str, Any] = {}
+
+        async def _fake_stream(messages, *, stop=None, **kwargs):
+            captured["messages"] = messages
+            captured["stop"] = stop
+            captured["kwargs"] = kwargs
+            yield LLMResponseChunk(delta_content="ok")
+
+        engine.stream_from_messages = _fake_stream
+
+        chunks = [chunk async for chunk in engine.stream_async("Hi", stop=["END"], temperature=0.5)]
+
+        assert captured == {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stop": ["END"],
+            "kwargs": {"temperature": 0.5},
+        }
+        assert [chunk.delta_content for chunk in chunks] == ["ok"]
+
+
+class TestModelEngineLLMCallRoundTrip:
+    """``llm_call`` drives a ModelEngine end to end — the path library rail actions take."""
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_returns_the_model_response(self, reset_llm_call_context):
+        """llm_call returns the LLMResponse produced by the engine."""
+        client = _mock_chat_client({"choices": [{"message": {"role": "assistant", "content": "safe"}}]})
+        engine = _started_engine(client)
+
+        response = await llm_call(engine, [{"role": "user", "content": "Is this safe?"}])
+
+        assert response.content == "safe"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_dict_prompt_reaches_the_provider_unchanged(self, reset_llm_call_context):
+        """llm_call normalizes dicts to ChatMessage; the engine converts them back to
+        an equivalent wire payload rather than leaking ChatMessage internals."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await llm_call(engine, [{"role": "user", "content": "Is this safe?"}])
+
+        assert _posted_body(client)["messages"] == [{"role": "user", "content": "Is this safe?"}]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_task_manager_message_prompts_are_rekeyed_to_role(self, reset_llm_call_context):
+        """``LLMTaskManager.render_task_prompt`` renders a ``messages:``-style task
+        prompt with a ``type`` key, which the completions endpoint would reject.
+        Normalization rewrites it to ``role`` before the request goes out."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await llm_call(engine, [{"type": "system", "content": "be safe"}, {"type": "user", "content": "hi"}])
+
+        assert _posted_body(client)["messages"] == [
+            {"role": "system", "content": "be safe"},
+            {"role": "user", "content": "hi"},
+        ]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_string_task_prompt_becomes_a_user_message(self, reset_llm_call_context):
+        """Every shipped rail task prompt is configured with ``content:``, so
+        ``render_task_prompt`` hands rail actions a string. It must reach the
+        provider as a single user message."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await llm_call(engine, "Task: Check if there is unsafe content...")
+
+        assert _posted_body(client)["messages"] == [
+            {"role": "user", "content": "Task: Check if there is unsafe content..."}
+        ]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_llm_params_are_forwarded_to_the_provider(self, reset_llm_call_context):
+        """llm_params reach the request body, so rail actions can set sampling params."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await llm_call(engine, "Hi", llm_params={"temperature": 0.0, "max_tokens": 10})
+
+        body = _posted_body(client)
+        assert body["temperature"] == 0.0
+        assert body["max_tokens"] == 10
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_populates_llm_call_info_from_the_engine(self, reset_llm_call_context):
+        """The engine's model and provider names land on LLMCallInfo, which is what
+        IORails synthesizes its GenerationLog from."""
+        client = _mock_chat_client()
+        engine = _started_engine(client)
+
+        await llm_call(engine, "Hi")
+
+        call_info = llm_call_info_var.get()
+        assert call_info is not None
+        assert call_info.llm_model_name == "meta/llama-3.3-70b-instruct"
+        assert call_info.llm_provider_name == "nim"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_token_usage_reaches_llm_stats(self, reset_llm_call_context):
+        """Usage from the provider increments the shared LLMStats counters."""
+        client = _mock_chat_client(
+            {
+                "choices": [{"message": {"role": "assistant", "content": "safe"}}],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+            }
+        )
+        engine = _started_engine(client)
+
+        await llm_call(engine, "Hi")
+
+        llm_stats = llm_stats_var.get()
+        assert llm_stats is not None
+        stats = llm_stats.get_stats()
+        assert stats["total_calls"] == 1
+        assert stats["total_prompt_tokens"] == 7
+        assert stats["total_completion_tokens"] == 2
+        assert stats["total_tokens"] == 9
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_provider_failure_is_wrapped_in_llm_call_exception(self, reset_llm_call_context):
+        """A ModelEngineError is wrapped in LLMCallException with the engine's identity
+        in the detail, and the original error preserved as the cause."""
+        engine = _started_engine(_mock_chat_client(status=500))
+
+        with pytest.raises(LLMCallException) as exc_info:
+            await llm_call(engine, "Hi")
+
+        assert isinstance(exc_info.value.__cause__, ModelEngineError)
+        assert "model=meta/llama-3.3-70b-instruct" in str(exc_info.value)
+        assert "provider=nim" in str(exc_info.value)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_upstream_http_status_survives_the_wrapping(self, reset_llm_call_context):
+        """The provider's status must reach ``LLMCallException.status``.
+
+        The server maps that field to the response status and falls back to 500 for
+        an unknown one, so losing it turns a retryable upstream 429 into a
+        non-retryable server error for the caller.
+        """
+        engine = _started_engine(_mock_chat_client(status=429))
+
+        with pytest.raises(LLMCallException) as exc_info:
+            await llm_call(engine, "Hi")
+
+        assert exc_info.value.status == 429


### PR DESCRIPTION
## Description

This PR is the second in a series of stacked PRs to allow IORails to run the recently refactored actions in nemoguardrails/library/* directly and avoid duplicating actions for the two engines. The rough PR plan (this may change during implementation) is shown below:

* PR 1 #2241
* **PR 2 This PR #2246**
* PR 3 CompiledRail + shared rail_guard envelope; delete RailAction and its three subclasses, supported-flow set held constant
* PR 4 enable the 49 block-only input/output surfaces via catalog-derived gating
* PR 5 transform surfaces (18): RailResult.transforms, rewrite threading, MODIFIED status
* PR 6 model_caches response-cache parity with LLMRails

## Related Issue(s)

* [NGUARD-821](https://jirasw.nvidia.com/browse/NGUARD-821) Migrate all actions to IORails.

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
.......................................................................................................................s........s..... [  2%]
s........s.......s.........s.....s..........................s...s..s..s..................................................s............ [  4%]
...................................................................................................................................... [  6%]
...................................................................................................................................... [  8%]
.......................................................................................................s.............................. [ 10%]
...................................................................................................................................... [ 12%]
...................................................................................................................sss.sssss.......... [ 14%]
......sss.sss.....s.s..s.....................................s..ssss.ss.s............................................................. [ 16%]
...................................................................................................................................... [ 18%]
...................................................................................................................................... [ 20%]
...................................................................................................................................... [ 22%]
...................................................................................................................................... [ 24%]
...................................................................................................................................... [ 26%]
...................................................................................................................................... [ 28%]
...................................................................................................................................... [ 30%]
...................................................................................................................................... [ 32%]
...................................................................................................................................... [ 34%]
...................................................................................................................................... [ 36%]
ss.sss..........s.sssssssss.sssssss.s.............................................................s.........ss........................ [ 39%]
............................................................s.......................................s................................. [ 41%]
...................................................................................................................................... [ 43%]
............................................................................................................ssss.s.....ss.s.ss........ [ 45%]
...................................................................................................................................... [ 47%]
...................................................................................................................................... [ 49%]
..................s................................................................................................................... [ 51%]
...................................................................................................................................... [ 53%]
....................................................................................................................s................. [ 55%]
...................................................................................................................................... [ 57%]
...................................................................................................................................... [ 59%]
............................................................................s......................................................... [ 61%]
............................................................................sssss.s...................................s.ss............ [ 63%]
..........ss................s...........................s..........s.s...................s.......................................s.s.. [ 65%]
...............................s....s...........ss..........s.........ss..............sssssssssssss................................... [ 67%]
....................................................s................................................................................. [ 69%]
..............................................................................................................s....................... [ 71%]
....................................................................................................s................................. [ 73%]
...................................................................................................................................... [ 75%]
................................................................s..................................................................... [ 78%]
..................sssssss............ssssssss......................................................................................... [ 80%]
...................................................................................................................................... [ 82%]
....................................................................................................................ssssssss.......... [ 84%]
.......................................sssssssss.ssssssssss..............................................................ss........... [ 86%]
..................................................................................s................................................... [ 88%]
...................................................................................................................................... [ 90%]
.........................................................................................................s............................ [ 92%]
...................................................................................................................................... [ 94%]
......................................................................ss........................................s..................... [ 96%]
.........................................................s....sssssss................................................................. [ 98%]
.............................................................................................                                          [100%]

══════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will
only return x and inline-snapshot will not be able to fix snapshots or generate reports.


===================================================== 6347 passed, 178 skipped in 35.80s =====================================================
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config examples/configs/content_safety
Starting the chat (Press Ctrl + C twice to quit) ...
2026-08-03 14:49:57 INFO: Registered model engine: type=main, model=nvidia/nemotron-3-nano-30b-a3b, base_url=https://integrate.api.nvidia.com
2026-08-03 14:49:57 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-08-03 14:49:57 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-08-03 14:50:02 INFO: [6261e9b0fd4d742c] generate_async called
2026-08-03 14:50:02 INFO: [6261e9b0fd4d742c] Running tool result rails
2026-08-03 14:50:02 INFO: [6261e9b0fd4d742c] Running input rails
2026-08-03 14:50:02 INFO: [6261e9b0fd4d742c] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-03 14:50:03 INFO: [6261e9b0fd4d742c] Calling main LLM
2026-08-03 14:50:03 INFO: [6261e9b0fd4d742c] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3-nano-30b-a3b'
2026-08-03 14:50:03 INFO: [6261e9b0fd4d742c] Running output rails
2026-08-03 14:50:03 INFO: [6261e9b0fd4d742c] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-03 14:50:04 INFO: [6261e9b0fd4d742c] generate_async completed time=1353.0ms
<think>User says "Hello!" Likely just a greeting. Should respond politely.
</think>
Hello! How can I assist you today?

> How can I burn a house down
2026-08-03 14:50:10 INFO: [c4d753296741846c] generate_async called
2026-08-03 14:50:10 INFO: [c4d753296741846c] Running tool result rails
2026-08-03 14:50:10 INFO: [c4d753296741846c] Running input rails
2026-08-03 14:50:10 INFO: [c4d753296741846c] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-03 14:50:10 INFO: [c4d753296741846c] Input flow content safety check input $model=content_safety blocked
2026-08-03 14:50:10 INFO: [c4d753296741846c] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-08-03 14:50:10 INFO: [c4d753296741846c] generate_async completed time=462.3ms
I'm sorry, I can't respond to that.

```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent support for prompt-based and message-based model requests, including streaming responses.
  * Exposed configured language models and provider connection details for improved integration.
  * Added configurable telemetry, metrics, and optional content capture for model interactions.
  * Added shared HTTP connection management across model operations.

* **Bug Fixes**
  * Improved request parameter handling and OpenAI-compatible prompt normalization.
  * Preserved upstream HTTP status information in model errors.
  * Improved cleanup and error handling for interrupted streaming responses.

* **Tests**
  * Expanded coverage for model calls, streaming, telemetry, lifecycle handling, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->