### PR TITLE
fix(library): correct fail-open, payload-leak, and manifest defects in built-in rails

### DIFF
--- a/nemoguardrails/http/retry.py
+++ b/nemoguardrails/http/retry.py
@@ -127,7 +127,7 @@ class RetryingHTTPClient:
         policy: RetryPolicy | None = None,
         *,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
-        random_value: Callable[[], float] = random.random,
+        random_value: Callable[[], float] | None = None,
         now: Callable[[], datetime] | None = None,
     ):
         """Initialize a retrying client.
@@ -143,7 +143,7 @@ class RetryingHTTPClient:
         self._client = client
         self._policy = policy or RetryPolicy()
         self._sleep = sleep
-        self._random_value = random_value
+        self._random_value = random_value if random_value is not None else random.random
         self._now = now or (lambda: datetime.now(timezone.utc))
         self._closed = False
 

--- a/nemoguardrails/library/clavata/actions.py
+++ b/nemoguardrails/library/clavata/actions.py
@@ -251,6 +251,10 @@ async def clavata_check(
     try:
         labels = get_labels(clavata_config, labels=labels, rail=rail)
     except ClavataPluginValueError:
+        log.debug(
+            "No labels resolved for rail %r; falling back to whole-policy matching.",
+            rail,
+        )
         labels = None
 
     result = await evaluate_with_policy(text, str(policy_id), clavata_config, http_client=http_client)

--- a/nemoguardrails/library/clavata/flows.co
+++ b/nemoguardrails/library/clavata/flows.co
@@ -9,7 +9,7 @@ flow clavata check for $text $policy $labels=""
   if $is_match.is_blocked
     if $system.config.enable_rails_exceptions
       global $msg
-      $msg = "Interaction blocked by clavata check with policy={$policy} and text={$text}"
+      $msg = "Interaction blocked by clavata check with policy={$policy}"
       send ClavataPolicyMatchException(message=$msg)
     else
       bot refuse to respond

--- a/nemoguardrails/library/clavata/flows.v1.co
+++ b/nemoguardrails/library/clavata/flows.v1.co
@@ -7,8 +7,7 @@ define flow clavata check input
 
   if $is_match.is_blocked
     if $config.enable_rails_exceptions
-      $msg = "Interaction blocked by clavata check with policy={$policy} and text={$text}"
-      create event ClavataPolicyMatchException(message=$msg)
+      create event ClavataPolicyMatchException(message="Interaction blocked by clavata check on input.")
     else
       bot refuse to respond
     stop
@@ -21,8 +20,7 @@ define flow clavata check output
 
   if $is_match.is_blocked
     if $config.enable_rails_exceptions
-      $msg = "Interaction blocked by clavata check with policy={$policy} and text={$text}"
-      create event ClavataPolicyMatchException(message=$msg)
+      create event ClavataPolicyMatchException(message="Interaction blocked by clavata check on output.")
     else
       bot refuse to respond
     stop

--- a/nemoguardrails/library/clavata/request.py
+++ b/nemoguardrails/library/clavata/request.py
@@ -43,7 +43,6 @@ from .errs import (
 log = logging.getLogger(__name__)
 
 
-_CLAVATA_API_KEY = os.environ.get("CLAVATA_API_KEY")
 _CLAVATA_RETRY_POLICY = RetryPolicy(
     max_attempts=3,
     retryable_methods=frozenset({"POST"}),
@@ -64,7 +63,7 @@ class AuthHeader:
         """
         Converts the auth token into request headers.
         """
-        api_key = self.api_key or _CLAVATA_API_KEY
+        api_key = self.api_key or os.environ.get("CLAVATA_API_KEY")
         if api_key is None:
             raise ClavataPluginConfigurationError(
                 "CLAVATA_API_KEY environment variable is not set. "

--- a/nemoguardrails/library/clavata/request.py
+++ b/nemoguardrails/library/clavata/request.py
@@ -203,27 +203,26 @@ class ClavataClient:
                 )
 
             if response.status_code != 200:
-                raise ClavataPluginAPIError(
-                    f"Clavata call failed with status code {response.status_code}.\nDetails: {response.text}"
-                )
+                raise ClavataPluginAPIError(f"Clavata call failed with status code {response.status_code}.")
 
             try:
                 parsed_response = response.json()
             except HTTPResponseDecodeError as e:
                 raise ClavataPluginValueError(
-                    f"Failed to parse Clavata response as JSON. Status: {response.status_code}, "
-                    f"Content: {response.text}"
+                    f"Failed to parse Clavata response as JSON. Status: {response.status_code}"
                 ) from e
 
             try:
                 return response_model.model_validate(parsed_response)
             except ValidationError as e:
-                raise ClavataPluginValueError(f"Invalid response format from Clavata API. Details: {e}") from e
+                raise ClavataPluginValueError(
+                    f"Invalid response format from Clavata API. Validation errors: {e.error_count()}"
+                ) from e
 
         except ClavataPluginError:
             raise
         except Exception as e:
-            raise ClavataPluginAPIError(f"Failed to make Clavata API request. Error: {e}") from e
+            raise ClavataPluginAPIError(f"Failed to make Clavata API request. Error: {type(e).__name__}") from e
 
     async def create_job(self, text: str, policy_id: str) -> Job:
         """

--- a/nemoguardrails/library/content_safety/flows.co
+++ b/nemoguardrails/library/content_safety/flows.co
@@ -27,7 +27,7 @@ flow content safety check output $model
 
   if not $allowed
     if $system.config.enable_rails_exceptions
-      send ContentSafetyCheckOuputException(message="Output not allowed. The output was blocked by the 'content safety check output $model='{$model}'' flow.")
+      send ContentSafetyCheckOutputException(message="Output not allowed. The output was blocked by the 'content safety check output $model='{$model}'' flow.")
     else
       if $system.config.rails.config.content_safety.multilingual.enabled
         $lang_result = await DetectLanguageAction()

--- a/nemoguardrails/library/content_safety/flows.v1.co
+++ b/nemoguardrails/library/content_safety/flows.v1.co
@@ -9,7 +9,7 @@ define flow content safety check input
 
   if not $allowed
     if $config.enable_rails_exceptions
-      create event ContentSafetyCheckInputException(message="Input not allowed. The input was blocked by the 'content safety check input $model='{$model}'' flow.")
+      create event ContentSafetyCheckInputException(message="Input not allowed. The input was blocked by the 'content safety check input' flow.")
     else
       if $config.rails.config.content_safety.multilingual.enabled
         $lang_result = execute detect_language
@@ -26,7 +26,7 @@ define flow content safety check output
 
   if not $allowed
     if $config.enable_rails_exceptions
-      create event ContentSafetyCheckOutputException(message="Output not allowed. The output was blocked by the 'content safety check output $model='{$model}'' flow.")
+      create event ContentSafetyCheckOutputException(message="Output not allowed. The output was blocked by the 'content safety check output' flow.")
     else
       if $config.rails.config.content_safety.multilingual.enabled
         $lang_result = execute detect_language

--- a/nemoguardrails/library/content_safety/flows.v1.co
+++ b/nemoguardrails/library/content_safety/flows.v1.co
@@ -26,7 +26,7 @@ define flow content safety check output
 
   if not $allowed
     if $config.enable_rails_exceptions
-      create event ContentSafetyCheckOuputException(message="Output not allowed. The output was blocked by the 'content safety check output $model='{$model}'' flow.")
+      create event ContentSafetyCheckOutputException(message="Output not allowed. The output was blocked by the 'content safety check output $model='{$model}'' flow.")
     else
       if $config.rails.config.content_safety.multilingual.enabled
         $lang_result = execute detect_language

--- a/nemoguardrails/library/content_safety/rail.py
+++ b/nemoguardrails/library/content_safety/rail.py
@@ -17,6 +17,7 @@ from nemoguardrails.manifests import (
     ActionRef,
     Binding,
     ConfigSpecRef,
+    ModelRequirement,
     RailActions,
     RailConfigSchema,
     RailDirection,
@@ -24,6 +25,7 @@ from nemoguardrails.manifests import (
     RailManifest,
     RailMetadata,
     RailPrivacy,
+    RailRequirements,
     RailSpec,
     RailSurface,
 )
@@ -78,6 +80,10 @@ RAIL = RailManifest(
                 action=CONTENT_SAFETY_CHECK_OUTPUT,
                 bindings=(Binding.surface_param("model_name", "model"),),
             ),
+        ),
+        requirements=RailRequirements(
+            models=(ModelRequirement(type="content_safety", required=True),),
+            extras=("multilingual",),
         ),
         privacy=RailPrivacy(sends_user_text=True, sends_bot_text=True),
     ),

--- a/nemoguardrails/library/f5/actions.py
+++ b/nemoguardrails/library/f5/actions.py
@@ -81,7 +81,6 @@ def _retrying_http_client(client: HTTPClient, f5_config: F5GuardrailsRailConfig)
         client,
         _retry_policy(f5_config),
         sleep=asyncio.sleep,
-        random_value=lambda: 1.0,
     )
 
 

--- a/nemoguardrails/library/injection_detection/actions.py
+++ b/nemoguardrails/library/injection_detection/actions.py
@@ -59,8 +59,13 @@ def _injection_detection_outcome(
     action_option: str,
     original_text: str,
 ) -> RailOutcome:
-    metadata = dict(result)
-    metadata["action"] = action_option
+    # the checked text is deliberately excluded: outcome metadata reaches
+    # processing logs and tracing exporters
+    metadata = {
+        "is_injection": result["is_injection"],
+        "detections": result["detections"],
+        "action": action_option,
+    }
     if action_option == "reject" and result["is_injection"]:
         return RailOutcome.block(metadata=metadata)
     if result["text"] != original_text:

--- a/nemoguardrails/library/injection_detection/actions.py
+++ b/nemoguardrails/library/injection_detection/actions.py
@@ -193,7 +193,7 @@ def _load_rules(
     except yara.SyntaxError as e:
         msg = f"Failed to initialize injection detection due to configuration or YARA rule error: YARA compilation failed: {e}"
         log.error(msg)
-        return None
+        raise ValueError(msg) from e
     return rules
 
 

--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -30,8 +30,9 @@ class RegexDetectionResult(TypedDict):
 
 
 def _regex_outcome(source: str, result: RegexDetectionResult) -> RailOutcome:
-    metadata = dict(result)
-    metadata["source"] = source
+    # the checked text is deliberately excluded: outcome metadata reaches
+    # processing logs and tracing exporters
+    metadata = {"is_match": result["is_match"], "detections": result["detections"], "source": source}
     if result["is_match"] and source == "retrieval":
         return RailOutcome.transform([(TransformTarget.RELEVANT_CHUNKS, "")], metadata=metadata)
     if result["is_match"]:

--- a/tests/test_f5_guardrails.py
+++ b/tests/test_f5_guardrails.py
@@ -678,8 +678,11 @@ async def test_f5_guardrails_429_exhausted_fail_closed(config_no_backoff, monkey
 
 @pytest.mark.asyncio
 async def test_f5_guardrails_429_no_retry_after_uses_backoff(monkeypatch):
-    """When Retry-After is missing, retry_backoff_seconds * 2**attempt is used."""
+    """When Retry-After is missing, retry_backoff_seconds * 2**attempt is the jitter cap."""
     monkeypatch.setenv("F5_GUARDRAILS_API_KEY", "test-key")
+    # backoff is full jitter, a uniform draw in [0, cap]; pin the draw to the
+    # cap so the delays below are deterministic
+    monkeypatch.setattr("nemoguardrails.http.retry.random.random", lambda: 1.0)
 
     cfg = RailsConfig.from_content(
         yaml_content="""

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -90,15 +90,13 @@ def create_mock_rules(matches=None):
             {"is_injection": False, "text": "normal", "detections": []},
             "reject",
             "normal",
-            RailOutcome.allow(metadata={"is_injection": False, "text": "normal", "detections": [], "action": "reject"}),
+            RailOutcome.allow(metadata={"is_injection": False, "detections": [], "action": "reject"}),
         ),
         (
             {"is_injection": True, "text": "normal", "detections": ["sqli"]},
             "reject",
             "normal",
-            RailOutcome.block(
-                metadata={"is_injection": True, "text": "normal", "detections": ["sqli"], "action": "reject"}
-            ),
+            RailOutcome.block(metadata={"is_injection": True, "detections": ["sqli"], "action": "reject"}),
         ),
         (
             {"is_injection": True, "text": "omitted", "detections": ["sqli"]},
@@ -106,7 +104,7 @@ def create_mock_rules(matches=None):
             "normal",
             RailOutcome.transform(
                 [(TransformTarget.BOT_MESSAGE, "omitted")],
-                metadata={"is_injection": True, "text": "omitted", "detections": ["sqli"], "action": "omit"},
+                metadata={"is_injection": True, "detections": ["sqli"], "action": "omit"},
             ),
         ),
     ],

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -711,8 +711,8 @@ async def test_omit_action_with_exceptions_enabled():
 
 
 @pytest.mark.asyncio
-async def test_malformed_inline_yara_rule_fails_gracefully(caplog):
-    """Test that a malformed inline YARA rule leads to graceful failure (detection becomes no-op)."""
+async def test_malformed_inline_yara_rule_fails_closed(caplog):
+    """Test that a malformed inline YARA rule fails closed rather than disabling detection."""
 
     inline_rule_name = "malformed_rule"
     # this rule is malformed: missing { after rule name
@@ -750,8 +750,10 @@ async def test_malformed_inline_yara_rule_fails_gracefully(caplog):
 
     result = await rails.generate_async(messages=[{"role": "user", "content": "trigger detection"}])
 
-    # check that no exception was raised
-    assert result.get("role") != "exception", f"Expected no exception, but got {result}"
+    # a rule that cannot compile must not silently disable detection: the
+    # unchecked model output must never reach the caller
+    assert some_text_that_would_be_injection not in result["content"]
+    assert "internal error" in result["content"]
 
     # verify the error log was created with the expected content
     assert any(

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -687,10 +687,8 @@ async def test_regex_action_accepts_extra_kwargs():
 def test_regex_output_verdict_blocks_on_match():
     from nemoguardrails.actions.rail_outcome import RailOutcome
 
-    matched = RailOutcome.block(
-        metadata={"is_match": True, "text": "fight club", "detections": ["\\bfight\\s+club\\b"]}
-    )
-    no_match = RailOutcome.allow(metadata={"is_match": False, "text": "hello", "detections": []})
+    matched = RailOutcome.block(metadata={"is_match": True, "detections": ["\\bfight\\s+club\\b"]})
+    no_match = RailOutcome.allow(metadata={"is_match": False, "detections": []})
 
     assert matched.is_blocked is True
     assert no_match.is_blocked is False


### PR DESCRIPTION
## Description

Ten fixes to built-in rails, found by auditing the rails that the rail
contribution guide holds up as exemplars. Each is independent; the two that
matter most:

- **`injection_detection` failed open on a malformed YARA rule.** `_load_rules`
  returned `None` on `yara.SyntaxError`, and the caller treats `None` as "no
  rules configured" and allows. A single bad rule silently disabled injection
  detection for every bot message. It now raises, matching the four existing
  config-error sites in the same module.
- **`clavata` put vendor response bodies into exception messages.** Clavata
  echoes the evaluated text back in its responses, so checked content reached
  logs and tracebacks. Status codes are kept, bodies dropped.

The rest: `f5` had retry jitter disabled in production (`random_value=lambda:
1.0`); `content_safety` declared no requirements at all despite being a model
judge that imports `fast_langdetect`; `clavata` cached the API key in a module
global at import time; both dialects of `content_safety` sent a misspelled
exception event; Colang 1 flows in `clavata` and `content_safety` interpolated
variables that are never bound; `regex` and `injection_detection` copied the
full checked text into outcome metadata, which reaches the processing log and
tracing exporters.

### Behavior changes worth flagging

- **`ContentSafetyCheckOuputException` is renamed to
  `ContentSafetyCheckOutputException`.** This is a public event name. The
  shipped spelling never matched `docs/configure-rails/exceptions.mdx`, which
  documents the corrected name, so anything filtering on the documented name
  has never fired.
- **`injection_detection` now raises on a malformed rule** instead of allowing.
  `test_malformed_inline_yara_rule_fails_gracefully` asserted the old fail-open
  behavior; it is renamed and inverted.
- **`RetryingHTTPClient.random_value` is now late-bound** (`None` resolves to
  `random.random` at construction) so tests can pin the jitter draw instead of
  production disabling it.



Nothing skipped.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the CONTRIBUTING guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry behavior with automatic jittered backoff when no custom setting is provided.
  - Corrected content-safety error names and clarified blocked-interaction messages.
  - Improved handling of policy-label resolution failures by falling back to broader policy matching.
  - Malformed injection-detection rules now fail closed with safer error handling.

- **Security & Privacy**
  - Reduced sensitive interaction text and model-specific details in diagnostic metadata and error messages.
  - Content-safety requirements are now clearly enforced when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->