### PR TITLE
docs(actions): document RailOutcome-based rail actions

### DIFF
--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -31,7 +31,6 @@ async def my_custom_action():
 | `name` | `str` | Custom name for the action | Function name |
 | `is_system_action` | `bool` | Always run locally, bypassing the actions server | `False` |
 | `execute_async` | `bool` | Don't block event processing while the action runs (Colang 2.x only) | `False` |
-| `output_mapping` | `Callable[[Any], bool]` | Function to interpret the action result for blocking decisions | `default_output_mapping` |
 
 ### Custom Action Name
 
@@ -87,42 +86,13 @@ async def call_external_api(endpoint: str):
     return response.json()
 ```
 
-### Output Mapping
+### Rail Decisions
 
-The `output_mapping` parameter controls how the action's return value is interpreted to determine if output should be blocked. It accepts a callable that takes the return value and returns `True` if the output is **not safe** (should be blocked).
+The `@action` decorator does not interpret an action's return value as a safety decision. Ordinary custom actions can return strings, booleans, numbers, dictionaries, or other Python values for a Colang flow to consume explicitly.
 
-When no `output_mapping` is provided, the default behavior is:
-- **Boolean results**: `True` means allowed, `False` means blocked
-- **Numeric results**: Values below `0.5` are blocked
-- **Other types**: Allowed by default
+When the action itself makes a rail decision, return a [`RailOutcome`](/configure-guardrails/actions/rail-outcomes). It carries an explicit allow, block, or transform decision without relying on implicit boolean or numeric conventions.
 
-```python
-@action(output_mapping=lambda value: value)
-async def check_hallucination(context: Optional[dict] = None):
-    """Return True if hallucination detected (blocked), False if safe."""
-    return detect_hallucination(context.get("bot_message", ""))
-```
-
-```python
-@action(is_system_action=True, output_mapping=lambda value: not value)
-async def check_output_safety(context: Optional[dict] = None):
-    """Return True if safe (allowed), mapped to not-blocked."""
-    return is_safe(context.get("bot_message", ""))
-```
-
-You can also define a custom mapping function for more complex logic:
-
-```python
-def my_custom_mapping(result):
-    if isinstance(result, dict):
-        return result.get("score", 1.0) < 0.7
-    return False
-
-@action(output_mapping=my_custom_mapping)
-async def score_safety(context: Optional[dict] = None):
-    """Return a dict with a safety score."""
-    return {"score": compute_score(context.get("bot_message", ""))}
-```
+If you previously used the removed `output_mapping` decorator parameter, follow the [migration guide](/configure-guardrails/actions/rail-outcomes#migrate-from-output-mapping).
 
 ## Function Parameters
 
@@ -173,6 +143,8 @@ async def search_documents(
 ## Return Values
 
 Actions can return various types:
+
+Manifest-backed rail actions are the exception. They must return a [`RailOutcome`](/configure-guardrails/actions/rail-outcomes).
 
 ### Simple Return
 

--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -166,14 +166,29 @@ async def get_user_info(user_id: str):
     }
 ```
 
-### Boolean Return (for validation)
+### Boolean Return for Flow Logic
+
+A boolean remains application data until a Colang flow interprets it explicitly:
 
 ```python
+from typing import Optional
+
+from nemoguardrails.actions import action
+
+
 @action(is_system_action=True)
 async def is_safe_content(context: Optional[dict] = None):
     content = context.get("bot_message", "")
-    # Returns True if safe, False if blocked
     return not contains_harmful_content(content)
+```
+
+Branch on the value in the flow:
+
+```text
+$is_safe = execute is_safe_content
+if not $is_safe
+  bot refuse to respond
+  stop
 ```
 
 ## Error Handling
@@ -201,23 +216,52 @@ async def fetch_data(url: str):
 
 ```python
 from typing import Optional
+
 from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
+
 
 @action(is_system_action=True)
 async def check_input_length(context: Optional[dict] = None):
     """Ensure user input is not too long."""
-    user_message = context.get("last_user_message", "")
+    user_message = context.get("user_message", "")
     max_length = 1000
 
     if len(user_message) > max_length:
-        return False  # Block the input
+        return RailOutcome.block(reason="The input exceeds the length limit.")
 
-    return True  # Allow the input
+    return RailOutcome.allow()
+```
+
+Add a Colang 1.0 flow to `rails.co` that consumes the decision:
+
+```text
+define subflow check input length
+  $result = execute check_input_length
+  if $result.is_blocked
+    bot refuse to respond
+    stop
+```
+
+Enable the flow as an input rail in `config.yml`:
+
+```yaml
+rails:
+  input:
+    flows:
+      - check input length
 ```
 
 ### Output Filtering Action
 
 ```python
+import re
+from typing import Optional
+
+from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
+
+
 @action(is_system_action=True)
 async def filter_sensitive_data(context: Optional[dict] = None):
     """Check for sensitive data in bot response."""
@@ -225,15 +269,33 @@ async def filter_sensitive_data(context: Optional[dict] = None):
 
     sensitive_patterns = [
         r"\b\d{3}-\d{2}-\d{4}\b",  # SSN pattern
-        r"\b\d{16}\b",              # Credit card pattern
+        r"\b\d{16}\b",  # Credit card pattern
     ]
 
-    import re
     for pattern in sensitive_patterns:
         if re.search(pattern, bot_response):
-            return True  # Contains sensitive data
+            return RailOutcome.block(reason="The response contains sensitive data.")
 
-    return False  # No sensitive data found
+    return RailOutcome.allow()
+```
+
+Add a Colang 1.0 flow to `rails.co` that consumes the decision:
+
+```text
+define subflow filter sensitive data
+  $result = execute filter_sensitive_data
+  if $result.is_blocked
+    bot refuse to respond
+    stop
+```
+
+Enable the flow as an output rail in `config.yml`:
+
+```yaml
+rails:
+  output:
+    flows:
+      - filter sensitive data
 ```
 
 ### External API Action

--- a/docs/configure-rails/actions/index.mdx
+++ b/docs/configure-rails/actions/index.mdx
@@ -72,6 +72,13 @@ Register custom actions via actions.py, LLMRails.register_action(), or config.py
 <Badge intent="tip" minimal outlined>How To</Badge>
 </Card>
 
+<Card title="Rail Outcomes" href="/configure-guardrails/actions/rail-outcomes">
+
+Return engine-neutral allow, block, and transform decisions from rail actions, including migration from `output_mapping`.
+
+<Badge intent="tip" minimal outlined>Reference</Badge>
+</Card>
+
 </Cards>
 
 ## File Organization

--- a/docs/configure-rails/actions/rail-outcomes.mdx
+++ b/docs/configure-rails/actions/rail-outcomes.mdx
@@ -98,6 +98,8 @@ if $result.is_blocked
 For a transform, read the replacement by its target name:
 
 ```colang
+global $relevant_chunks
+
 $result = await SanitizeCustomChunksAction(text=$relevant_chunks)
 
 if $result.is_transform

--- a/docs/configure-rails/actions/rail-outcomes.mdx
+++ b/docs/configure-rails/actions/rail-outcomes.mdx
@@ -1,0 +1,196 @@
+---
+title: "Rail Outcomes"
+sidebar-title: "Rail Outcomes"
+description: "Return engine-neutral allow, block, and transform decisions from rail actions."
+keywords: ["RailOutcome", "rail actions", "rail decisions", "transform guardrails"]
+content:
+  type: "reference"
+---
+
+Rail actions return a `RailOutcome` to express an allow, block, or transform decision. This contract separates a rail's decision from the way a runtime presents or enforces that decision.
+
+Actions declared by a rail manifest must return `RailOutcome`. Ordinary custom actions can return other Python values when a Colang flow consumes those values explicitly, but the runtime does not infer a rail decision from a boolean, number, tuple, or dictionary.
+
+<Warning title="Breaking Change">
+
+The `output_mapping` parameter and its default boolean and numeric mappings have been removed from `@action`. Passing `output_mapping` now raises `TypeError`. Migrate rail decisions to `RailOutcome`; do not rely on implicit return-value interpretation.
+
+</Warning>
+
+## Decisions
+
+Each outcome contains exactly one decision.
+
+| Decision | Meaning |
+| --- | --- |
+| `allow` | Continue processing without changing the checked content. |
+| `block` | Stop processing the checked content. The runtime decides how to present the block. |
+| `transform` | Replace one or more supported conversation values before processing continues. |
+
+Import the outcome and transform target types from the actions package:
+
+```python
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+```
+
+### Allow content
+
+```python
+return RailOutcome.allow(
+    reason="No policy category matched.",
+    metadata={"categories": []},
+)
+```
+
+### Block content
+
+```python
+return RailOutcome.block(
+    reason="The content matched a restricted category.",
+    metadata={"categories": ["restricted"]},
+)
+```
+
+A block outcome does not contain a refusal message, exception type, bot intent, or localized text. The runtime or Colang flow owns those presentation choices.
+
+### Transform content
+
+Use a transform outcome when the rail rewrites checked content. A transform must include at least one rewrite and cannot repeat a target.
+
+```python
+return RailOutcome.transform(
+    [(TransformTarget.RELEVANT_CHUNKS, sanitized_chunks)],
+    reason="Sensitive values were removed.",
+    metadata={"redaction_count": redaction_count},
+)
+```
+
+The supported transform targets are:
+
+- `TransformTarget.USER_MESSAGE`
+- `TransformTarget.BOT_MESSAGE`
+- `TransformTarget.RELEVANT_CHUNKS`
+
+Transform outcomes apply to non-streaming processing. Streaming output paths do not apply the rewrite.
+
+## Evidence fields
+
+Use `reason` for a neutral, human-readable explanation of the decision. Use `metadata` for structured evidence such as categories, scores, detections, or provider response details.
+
+Do not make `metadata` load-bearing for the decision. Consumers should use `decision`, `is_blocked`, or `is_transform` to determine the outcome. Treat metadata as potentially observable data and avoid storing secrets, credentials, or unnecessary user content.
+
+## Consume an outcome in a flow
+
+The action decides whether content is allowed, blocked, or transformed. The flow decides how to handle that result.
+
+```colang
+$result = await DetectCustomPolicyAction(text=$user_message)
+
+if $result.is_blocked
+  bot refuse to respond
+  abort
+```
+
+For a transform, read the replacement by its target name:
+
+```colang
+$result = await SanitizeCustomChunksAction(text=$relevant_chunks)
+
+if $result.is_transform
+  $relevant_chunks = $result.transform_text["relevant_chunks"]
+```
+
+The following convenience properties are available:
+
+| Property | Value |
+| --- | --- |
+| `is_blocked` | `True` only for a block outcome. |
+| `is_transform` | `True` only for a transform outcome. |
+| `transform_text` | A mapping from transform target names to replacement text. |
+
+## Migrate from `output_mapping`
+
+Replace the mapping function with an explicit decision at the action's return site. This makes the action's meaning visible to every runtime and avoids conventions such as whether `True` means safe or blocked.
+
+### Safe boolean results
+
+Previously, an action could return whether content was safe and negate that result through `output_mapping`:
+
+```python
+@action(output_mapping=lambda result: not result)
+async def check_output_safety(text: str) -> bool:
+    return is_safe(text)
+```
+
+Return the decision directly:
+
+```python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
+
+@action()
+async def check_output_safety(text: str) -> RailOutcome:
+    if is_safe(text):
+        return RailOutcome.allow()
+    return RailOutcome.block(reason="The output did not pass the safety policy.")
+```
+
+### Unsafe boolean results
+
+For a detector where `True` means unsafe, return `block` when the detector matches:
+
+```python
+@action()
+async def check_hallucination(text: str) -> RailOutcome:
+    if detect_hallucination(text):
+        return RailOutcome.block(reason="The output failed the hallucination check.")
+    return RailOutcome.allow()
+```
+
+### Numeric thresholds and structured results
+
+Apply thresholds in the action and preserve useful evidence in metadata:
+
+```python
+@action()
+async def score_output_safety(text: str) -> RailOutcome:
+    score = compute_safety_score(text)
+    metadata = {"score": score, "threshold": 0.7}
+    if score < 0.7:
+        return RailOutcome.block(metadata=metadata)
+    return RailOutcome.allow(metadata=metadata)
+```
+
+The migration follows these mappings:
+
+| Previous convention | `RailOutcome` replacement |
+| --- | --- |
+| Safe boolean: `True` allows, `False` blocks | Return `allow()` for `True`; otherwise return `block()`. |
+| Unsafe boolean: `True` blocks, `False` allows | Return `block()` for `True`; otherwise return `allow()`. |
+| Numeric threshold | Compare the score in the action and return the chosen decision. |
+| Dictionary or tuple plus custom mapping | Read the relevant fields in the action and put non-sensitive evidence in `metadata`. |
+
+Update the consuming flow to inspect the outcome rather than the original scalar value:
+
+```colang
+$result = await CheckOutputSafetyAction(text=$bot_message)
+
+if $result.is_blocked
+  bot refuse to respond
+  abort
+```
+
+If the action is not a rail decision, keep its ordinary return type and branch on that value explicitly in the flow. `RailOutcome` is not required for general-purpose actions.
+
+## Validation rules
+
+`RailOutcome` validates its state when you construct it:
+
+- `reason` must be a string or `None`.
+- `metadata` must be a mapping with string keys.
+- Transform outcomes must contain one or more transforms.
+- Allow and block outcomes cannot contain transforms.
+- Each transform target can appear only once in an outcome.
+- Transform replacement values must be strings.
+
+Use the `allow`, `block`, and `transform` class methods instead of constructing decisions directly. These methods make the intended outcome clear at the action's return site.

--- a/docs/configure-rails/actions/rail-outcomes.mdx
+++ b/docs/configure-rails/actions/rail-outcomes.mdx
@@ -9,17 +9,17 @@ content:
 
 Rail actions return a `RailOutcome` to express an allow, block, or transform decision. This contract separates a rail's decision from the way a runtime presents or enforces that decision.
 
-Actions declared by a rail manifest must return `RailOutcome`. Ordinary custom actions can return other Python values when a Colang flow consumes those values explicitly, but the runtime does not infer a rail decision from a boolean, number, tuple, or dictionary.
+Actions declared by a rail manifest must return `RailOutcome`. Ordinary custom actions can return other Python values when a Colang flow consumes them explicitly. The runtime does not infer a rail decision from a boolean, number, tuple, or dictionary.
 
 <Warning title="Breaking Change">
 
-The `output_mapping` parameter and its default boolean and numeric mappings have been removed from `@action`. Passing `output_mapping` now raises `TypeError`. Migrate rail decisions to `RailOutcome`; do not rely on implicit return-value interpretation.
+The `output_mapping` parameter and its default boolean and numeric mappings have been removed from `@action`. Passing `output_mapping` now raises `TypeError`. Migrate rail decisions to `RailOutcome`. Do not rely on implicit return-value interpretation.
 
 </Warning>
 
 ## Decisions
 
-Each outcome contains exactly one decision.
+Each outcome contains one of the following decisions:
 
 | Decision | Meaning |
 | --- | --- |
@@ -33,7 +33,9 @@ Import the outcome and transform target types from the actions package:
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 ```
 
-### Allow content
+### Allow Content
+
+Return an allow outcome:
 
 ```python
 return RailOutcome.allow(
@@ -42,7 +44,9 @@ return RailOutcome.allow(
 )
 ```
 
-### Block content
+### Block Content
+
+Return a block outcome:
 
 ```python
 return RailOutcome.block(
@@ -53,7 +57,7 @@ return RailOutcome.block(
 
 A block outcome does not contain a refusal message, exception type, bot intent, or localized text. The runtime or Colang flow owns those presentation choices.
 
-### Transform content
+### Transform Content
 
 Use a transform outcome when the rail rewrites checked content. A transform must include at least one rewrite and cannot repeat a target.
 
@@ -73,13 +77,13 @@ The supported transform targets are:
 
 Transform outcomes apply to non-streaming processing. Streaming output paths do not apply the rewrite.
 
-## Evidence fields
+## Evidence Fields
 
 Use `reason` for a neutral, human-readable explanation of the decision. Use `metadata` for structured evidence such as categories, scores, detections, or provider response details.
 
 Do not make `metadata` load-bearing for the decision. Consumers should use `decision`, `is_blocked`, or `is_transform` to determine the outcome. Treat metadata as potentially observable data and avoid storing secrets, credentials, or unnecessary user content.
 
-## Consume an outcome in a flow
+## Consume an Outcome in a Flow
 
 The action decides whether content is allowed, blocked, or transformed. The flow decides how to handle that result.
 
@@ -108,11 +112,11 @@ The following convenience properties are available:
 | `is_transform` | `True` only for a transform outcome. |
 | `transform_text` | A mapping from transform target names to replacement text. |
 
-## Migrate from `output_mapping`
+## Migrate From Output Mapping
 
 Replace the mapping function with an explicit decision at the action's return site. This makes the action's meaning visible to every runtime and avoids conventions such as whether `True` means safe or blocked.
 
-### Safe boolean results
+### Safe Boolean Results
 
 Previously, an action could return whether content was safe and negate that result through `output_mapping`:
 
@@ -135,7 +139,7 @@ async def check_output_safety(text: str) -> RailOutcome:
     return RailOutcome.block(reason="The output did not pass the safety policy.")
 ```
 
-### Unsafe boolean results
+### Unsafe Boolean Results
 
 For a detector where `True` means unsafe, return `block` when the detector matches:
 
@@ -147,7 +151,7 @@ async def check_hallucination(text: str) -> RailOutcome:
     return RailOutcome.allow()
 ```
 
-### Numeric thresholds and structured results
+### Numeric Thresholds and Structured Results
 
 Apply thresholds in the action and preserve useful evidence in metadata:
 
@@ -163,10 +167,10 @@ async def score_output_safety(text: str) -> RailOutcome:
 
 The migration follows these mappings:
 
-| Previous convention | `RailOutcome` replacement |
+| Previous Convention | `RailOutcome` Replacement |
 | --- | --- |
-| Safe boolean: `True` allows, `False` blocks | Return `allow()` for `True`; otherwise return `block()`. |
-| Unsafe boolean: `True` blocks, `False` allows | Return `block()` for `True`; otherwise return `allow()`. |
+| Safe boolean: `True` allows, `False` blocks | Return `allow()` for `True` and `block()` for `False`. |
+| Unsafe boolean: `True` blocks, `False` allows | Return `block()` for `True` and `allow()` for `False`. |
 | Numeric threshold | Compare the score in the action and return the chosen decision. |
 | Dictionary or tuple plus custom mapping | Read the relevant fields in the action and put non-sensitive evidence in `metadata`. |
 
@@ -182,7 +186,7 @@ if $result.is_blocked
 
 If the action is not a rail decision, keep its ordinary return type and branch on that value explicitly in the flow. `RailOutcome` is not required for general-purpose actions.
 
-## Validation rules
+## Validation Rules
 
 `RailOutcome` validates its state when you construct it:
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -219,6 +219,9 @@ navigation:
           - page: Registering Actions
             path: configure-rails/actions/registering-actions.mdx
             slug: registering-actions
+          - page: Rail Outcomes
+            path: configure-rails/actions/rail-outcomes.mdx
+            slug: rail-outcomes
       - section: Custom Initialization
         path: configure-rails/custom-initialization/index.mdx
         slug: custom-initialization


### PR DESCRIPTION
Documents the RailOutcome contract for action-backed rail decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using `RailOutcome` to express allow, block, and transform decisions.
  * Documented validation, evidence fields, transform targets, Colang consumption, and streaming behavior.
  * Added migration examples for boolean, numeric, and structured action results.
  * Removed documentation for `output_mapping` and added the Rail Outcomes guide to Custom Actions navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->