### PR TITLE
docs(http): document canonical outbound HTTP clients

### DIFF
--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -30,7 +30,7 @@ async def my_custom_action():
 |-----------|------|-------------|---------|
 | `name` | `str` | Custom name for the action | Function name |
 | `is_system_action` | `bool` | Always run locally, bypassing the actions server | `False` |
-| `execute_async` | `bool` | Don't block event processing while the action runs (Colang 2.x only) | `False` |
+| `execute_async` | `bool` | Continue event processing while the action runs (Colang 2.x only) | `False` |
 
 ### Custom Action Name
 
@@ -70,7 +70,7 @@ async def check_policy_compliance(context: Optional[dict] = None):
 
 ### Async Execution
 
-When `execute_async=True`, the event processing loop does not wait for the action to complete before continuing. The action runs in the background and the result is picked up later via polling. This is useful for long-running operations where you don't need the result immediately.
+When `execute_async=True`, the event processing loop does not wait for the action to complete before continuing. The action runs in the background, and the event processing loop retrieves the result later by polling. Use this setting for long-running operations when you do not need the result immediately.
 
 <Note>
 
@@ -79,7 +79,9 @@ This flag is only supported in the Colang 2.x runtime. In the Colang 1.0 runtime
 </Note>
 
 ```python
+from nemoguardrails.actions import action
 from nemoguardrails.http import HTTPClient, http_call
+
 
 @action(execute_async=True)
 async def call_external_api(
@@ -201,7 +203,9 @@ if not $is_safe
 Handle errors gracefully within actions:
 
 ```python
+from nemoguardrails.actions import action
 from nemoguardrails.http import HTTPClient, HTTPTimeoutError, http_call
+
 
 @action()
 async def fetch_data(
@@ -307,7 +311,9 @@ rails:
 ### External API Action
 
 ```python
+from nemoguardrails.actions import action
 from nemoguardrails.http import HTTPClient, http_call
+
 
 @action(execute_async=True)
 async def query_knowledge_base(

--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -31,7 +31,6 @@ async def my_custom_action():
 | `name` | `str` | Custom name for the action | Function name |
 | `is_system_action` | `bool` | Always run locally, bypassing the actions server | `False` |
 | `execute_async` | `bool` | Don't block event processing while the action runs (Colang 2.x only) | `False` |
-| `output_mapping` | `Callable[[Any], bool]` | Function to interpret the action result for blocking decisions | `default_output_mapping` |
 
 ### Custom Action Name
 
@@ -87,42 +86,13 @@ async def call_external_api(endpoint: str):
     return response.json()
 ```
 
-### Output Mapping
+### Rail Decisions
 
-The `output_mapping` parameter controls how the action's return value is interpreted to determine if output should be blocked. It accepts a callable that takes the return value and returns `True` if the output is **not safe** (should be blocked).
+The `@action` decorator does not interpret an action's return value as a safety decision. Ordinary custom actions can return strings, booleans, numbers, dictionaries, or other Python values for a Colang flow to consume explicitly.
 
-When no `output_mapping` is provided, the default behavior is:
-- **Boolean results**: `True` means allowed, `False` means blocked
-- **Numeric results**: Values below `0.5` are blocked
-- **Other types**: Allowed by default
+When the action itself makes a rail decision, return a [`RailOutcome`](/configure-guardrails/actions/rail-outcomes). It carries an explicit allow, block, or transform decision without relying on implicit boolean or numeric conventions.
 
-```python
-@action(output_mapping=lambda value: value)
-async def check_hallucination(context: Optional[dict] = None):
-    """Return True if hallucination detected (blocked), False if safe."""
-    return detect_hallucination(context.get("bot_message", ""))
-```
-
-```python
-@action(is_system_action=True, output_mapping=lambda value: not value)
-async def check_output_safety(context: Optional[dict] = None):
-    """Return True if safe (allowed), mapped to not-blocked."""
-    return is_safe(context.get("bot_message", ""))
-```
-
-You can also define a custom mapping function for more complex logic:
-
-```python
-def my_custom_mapping(result):
-    if isinstance(result, dict):
-        return result.get("score", 1.0) < 0.7
-    return False
-
-@action(output_mapping=my_custom_mapping)
-async def score_safety(context: Optional[dict] = None):
-    """Return a dict with a safety score."""
-    return {"score": compute_score(context.get("bot_message", ""))}
-```
+If you previously used the removed `output_mapping` decorator parameter, follow the [migration guide](/configure-guardrails/actions/rail-outcomes#migrate-from-output-mapping).
 
 ## Function Parameters
 
@@ -173,6 +143,8 @@ async def search_documents(
 ## Return Values
 
 Actions can return various types:
+
+Manifest-backed rail actions are the exception. They must return a [`RailOutcome`](/configure-guardrails/actions/rail-outcomes).
 
 ### Simple Return
 

--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -79,10 +79,15 @@ This flag is only supported in the Colang 2.x runtime. In the Colang 1.0 runtime
 </Note>
 
 ```python
+from nemoguardrails.http import HTTPClient, http_call
+
 @action(execute_async=True)
-async def call_external_api(endpoint: str):
+async def call_external_api(
+    endpoint: str,
+    http_client: HTTPClient | None = None,
+):
     """Call an external API without blocking event processing."""
-    response = await http_client.get(endpoint)
+    response = await http_call(http_client, "GET", endpoint)
     return response.json()
 ```
 
@@ -196,18 +201,19 @@ if not $is_safe
 Handle errors gracefully within actions:
 
 ```python
+from nemoguardrails.http import HTTPClient, HTTPTimeoutError, http_call
+
 @action()
-async def fetch_data(url: str):
+async def fetch_data(
+    url: str,
+    http_client: HTTPClient | None = None,
+):
     """Fetch data with error handling."""
     try:
-        response = await http_client.get(url)
-        response.raise_for_status()
+        response = await http_call(http_client, "GET", url)
         return response.json()
-    except Exception as e:
-        # Log the error
-        print(f"Error fetching data: {e}")
-        # Return a safe default or raise
-        return None
+    except HTTPTimeoutError as error:
+        raise RuntimeError("External data service timed out") from error
 ```
 
 ## Example Actions
@@ -301,18 +307,22 @@ rails:
 ### External API Action
 
 ```python
-import aiohttp
+from nemoguardrails.http import HTTPClient, http_call
 
 @action(execute_async=True)
-async def query_knowledge_base(query: str, top_k: int = 5):
+async def query_knowledge_base(
+    query: str,
+    top_k: int = 5,
+    http_client: HTTPClient | None = None,
+):
     """Query an external knowledge base API."""
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
-            "https://api.example.com/search",
-            json={"query": query, "limit": top_k}
-        ) as response:
-            data = await response.json()
-            return data.get("results", [])
+    response = await http_call(
+        http_client,
+        "POST",
+        "https://api.example.com/search",
+        json={"query": query, "limit": top_k},
+    )
+    return response.json().get("results", [])
 ```
 
 ## Related Topics
@@ -320,3 +330,4 @@ async def query_knowledge_base(query: str, top_k: int = 5):
 - [Built-in Actions](built-in-actions) - Default actions in the library
 - [Action Parameters](action-parameters) - Special parameters provided automatically
 - [Registering Actions](registering-actions) - Different ways to register actions
+- [Outbound HTTP](outbound-http) - Send external requests through the canonical client boundary

--- a/docs/configure-rails/actions/index.mdx
+++ b/docs/configure-rails/actions/index.mdx
@@ -81,7 +81,7 @@ Return engine-neutral allow, block, and transform decisions from rail actions, i
 
 <Card title="Outbound HTTP" href="/configure-guardrails/actions/outbound-http">
 
-Use the canonical client boundary for lifecycle, retries, observability, and deterministic tests.
+Use the canonical HTTP client for lifecycle management, retries, observability, and deterministic tests.
 
 <Badge intent="tip" minimal outlined>How To</Badge>
 </Card>

--- a/docs/configure-rails/actions/index.mdx
+++ b/docs/configure-rails/actions/index.mdx
@@ -72,6 +72,13 @@ Register custom actions via actions.py, LLMRails.register_action(), or config.py
 <Badge intent="tip" minimal outlined>How To</Badge>
 </Card>
 
+<Card title="Rail Outcomes" href="/configure-guardrails/actions/rail-outcomes">
+
+Return engine-neutral allow, block, and transform decisions from rail actions, including migration from `output_mapping`.
+
+<Badge intent="tip" minimal outlined>Reference</Badge>
+</Card>
+
 </Cards>
 
 ## File Organization

--- a/docs/configure-rails/actions/index.mdx
+++ b/docs/configure-rails/actions/index.mdx
@@ -79,6 +79,13 @@ Return engine-neutral allow, block, and transform decisions from rail actions, i
 <Badge intent="tip" minimal outlined>Reference</Badge>
 </Card>
 
+<Card title="Outbound HTTP" href="/configure-guardrails/actions/outbound-http">
+
+Use the canonical client boundary for lifecycle, retries, observability, and deterministic tests.
+
+<Badge intent="tip" minimal outlined>How To</Badge>
+</Card>
+
 </Cards>
 
 ## File Organization

--- a/docs/configure-rails/actions/outbound-http.mdx
+++ b/docs/configure-rails/actions/outbound-http.mdx
@@ -11,7 +11,7 @@ Use the `nemoguardrails.http` boundary for outbound HTTP requests from actions a
 
 Do not construct `aiohttp`, `httpx`, `requests`, or `urllib3` clients inside an action. Direct transports bypass shared ownership, retry, testing, and observability policy.
 
-## Send a request from an action
+## Send a Request From an Action
 
 Accept an optional `HTTPClient` and call `http_call`:
 
@@ -36,7 +36,7 @@ async def query_policy_service(
 
 `http_call` raises `HTTPStatusError` for responses with status code 400 or greater by default. Pass `raise_for_status=False` only when the integration must inspect an error response and apply provider-specific behavior.
 
-## Client ownership
+## Client Ownership
 
 The client argument determines ownership for each call:
 
@@ -49,7 +49,7 @@ The `None` fallback is safe and deterministic. Inject a shared client for applic
 
 A runtime can own one shared pooled client, pass it to every action that declares `http_client`, and close it when the runtime stops. The action signature is the injection contract; rail manifests do not declare whether the runtime should allocate a transport.
 
-Create and close a shared client at the same application-lifecycle boundary:
+Create and close a shared client at the same application lifecycle boundary:
 
 ```python
 from nemoguardrails import LLMRails, RailsConfig
@@ -71,13 +71,13 @@ async def run():
 
 The synchronous `config.py` initialization hook has no asynchronous teardown hook. Do not create a long-lived HTTP client there unless another application component owns and closes it.
 
-## Request and response contract
+## Request and Response Contract
 
 `HTTPClient.request` and `http_call` support:
 
 - HTTP method and absolute URL.
 - Headers and query parameters.
-- A JSON body or raw string or byte content.
+- A JSON body, raw string content, or raw byte content.
 - A per-request total timeout.
 
 They return a materialized `HTTPResponse`. Its body bytes remain available after a call-scoped client closes.
@@ -103,7 +103,7 @@ The canonical error hierarchy is:
 
 Catch the narrowest error that the integration can handle without changing its intended fail-open or fail-closed behavior. Do not log response bodies, request bodies, credentials, or unsanitized exception details.
 
-## Configure the pooled transport
+## Configure the Pooled Transport
 
 `create_http_client` creates a closable HTTPX-backed client behind the neutral protocol. The default client:
 
@@ -129,7 +129,7 @@ client = create_http_client(
 
 `HTTPTLSConfig` also supports a client certificate and key for mutual TLS. Configure both together. Keep certificate verification enabled in production.
 
-## Add bounded retries
+## Add Bounded Retries
 
 Requests are not retried unless the client has a `RetryPolicy`. `max_attempts` includes the initial request.
 
@@ -144,20 +144,23 @@ policy = RetryPolicy(
 client = create_http_client(retry_policy=policy)
 ```
 
-The default policy retries eligible connection and timeout failures and the status codes `408`, `409`, `429`, `500`, `502`, `503`, and `504`. It uses bounded exponential backoff with jitter and accepts an in-policy `Retry-After` value.
+The default policy retries eligible connection and timeout failures and the status codes `408`, `409`, `429`, `500`, `502`, `503`, and `504`. It uses bounded exponential backoff with jitter and accepts `Retry-After` values within the configured limit.
 
 The safe default method set excludes `POST`. Add `POST` only when the provider documents the operation as retry-safe or the request uses a supported idempotency mechanism:
 
 ```python
+default_methods = RetryPolicy().retryable_methods
 policy = RetryPolicy(
     max_attempts=3,
-    retryable_methods=frozenset({"POST"}),
+    retryable_methods=default_methods | {"POST"},
 )
 ```
 
+The `retryable_methods` argument replaces the default set. This example preserves the default methods and adds `POST`.
+
 Keep retry policy close to the integration that owns the provider semantics. Do not add a broad global POST retry policy.
 
-## Add privacy-safe instrumentation
+## Add Privacy-Safe Instrumentation
 
 Wrap a shared client with `instrument_http_client` to enable tracing, metrics, or both:
 
@@ -192,9 +195,9 @@ Instrumentation does not record header values, query values, JSON bodies, raw bo
 
 Instrumentation is explicit at this boundary. Creating an HTTP client without `instrument_http_client` does not enable HTTP spans or metrics automatically. The component that creates the instrumented client must also close it.
 
-See [Span Reference](/observability/tracing/span-reference#outbound-http-client-spans) and [Metric Reference](/observability/metrics/reference#http-client-metrics) for the emitted names and attributes.
+For the emitted names and attributes, refer to [Span Reference](/observability/tracing/span-reference#outbound-http-client-spans) and [Metric Reference](/observability/metrics/reference#http-client-metrics).
 
-## Test without network access
+## Test Without Network Access
 
 Use `RecordingHTTPClient` to queue responses and inspect the exact provider request:
 
@@ -222,4 +225,4 @@ async def test_policy_request_contract():
 
 Queue transport errors and non-success responses to verify retry, timeout, decoding, and fail-open or fail-closed behavior. Unit tests must not call a live provider.
 
-For configuration-level testing patterns, see [Testing Your Guardrails Configuration](/configure-guardrails/custom-initialization/testing-your-config).
+For configuration-level testing patterns, refer to [Testing Your Guardrails Configuration](/configure-guardrails/custom-initialization/testing-your-config).

--- a/docs/configure-rails/actions/outbound-http.mdx
+++ b/docs/configure-rails/actions/outbound-http.mdx
@@ -1,0 +1,223 @@
+---
+title: "Outbound HTTP in Actions"
+sidebar-title: "Outbound HTTP"
+description: "Use the canonical asynchronous HTTP boundary for action requests, retries, telemetry, lifecycle management, and deterministic tests."
+keywords: ["HTTPClient", "http_call", "action HTTP", "HTTP retries", "HTTP telemetry"]
+content:
+  type: "how_to"
+---
+
+Use the `nemoguardrails.http` boundary for outbound HTTP requests from actions and library rails. It provides transport-neutral request, response, error, retry, and instrumentation contracts while keeping client ownership explicit.
+
+Do not construct `aiohttp`, `httpx`, `requests`, or `urllib3` clients inside an action. Direct transports bypass shared ownership, retry, testing, and observability policy.
+
+## Send a request from an action
+
+Accept an optional `HTTPClient` and call `http_call`:
+
+```python
+from nemoguardrails.actions import action
+from nemoguardrails.http import HTTPClient, http_call
+
+@action()
+async def query_policy_service(
+    text: str,
+    http_client: HTTPClient | None = None,
+):
+    response = await http_call(
+        http_client,
+        "POST",
+        "https://policy.example.com/v1/check",
+        json={"text": text},
+        timeout=10.0,
+    )
+    return response.json()
+```
+
+`http_call` raises `HTTPStatusError` for responses with status code 400 or greater by default. Pass `raise_for_status=False` only when the integration must inspect an error response and apply provider-specific behavior.
+
+## Client ownership
+
+The client argument determines ownership for each call:
+
+| Client value | Owner | Behavior |
+| --- | --- | --- |
+| Injected `HTTPClient` | Caller | `http_call` borrows the client and leaves it open. |
+| `None` | `http_call` | The helper creates a client for the call and closes it after the response body is materialized. |
+
+The `None` fallback is safe and deterministic. Inject a shared client for applications that make repeated requests and benefit from connection-pool reuse.
+
+Create and close a shared client at the same application-lifecycle boundary:
+
+```python
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.http import create_http_client
+
+async def run():
+    http_client = create_http_client(timeout=10.0)
+    config = RailsConfig.from_path("config")
+    app = LLMRails(config)
+    app.register_action_param("http_client", http_client)
+
+    try:
+        return await app.generate_async(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+    finally:
+        await http_client.close()
+```
+
+The synchronous `config.py` initialization hook has no asynchronous teardown hook. Do not create a long-lived HTTP client there unless another application component owns and closes it.
+
+## Request and response contract
+
+`HTTPClient.request` and `http_call` support:
+
+- HTTP method and absolute URL.
+- Headers and query parameters.
+- A JSON body or raw string or byte content.
+- A per-request total timeout.
+
+They return a materialized `HTTPResponse`. Its body bytes remain available after a call-scoped client closes.
+
+```python
+response.status_code
+response.headers
+response.content
+response.text
+response.json()
+response.is_success
+```
+
+`HTTPResponse.json()` raises `HTTPResponseDecodeError` for invalid JSON. `HTTPResponse.raise_for_status()` and `http_call` raise `HTTPStatusError` for status codes of 400 or greater.
+
+The canonical error hierarchy is:
+
+- `HTTPClientError`
+- `HTTPConnectionError`
+- `HTTPTimeoutError`
+- `HTTPStatusError`
+- `HTTPResponseDecodeError`
+
+Catch the narrowest error that the integration can handle without changing its intended fail-open or fail-closed behavior. Do not log response bodies, request bodies, credentials, or unsanitized exception details.
+
+## Configure the pooled transport
+
+`create_http_client` creates a closable HTTPX-backed client behind the neutral protocol. The default client:
+
+- Uses a 30-second total timeout.
+- Verifies TLS certificates.
+- Does not follow redirects.
+- Pools up to 100 connections, including up to 20 keep-alive connections.
+
+Override these policies explicitly when an integration requires different behavior:
+
+```python
+import httpx
+
+from nemoguardrails.http import HTTPTLSConfig, create_http_client
+
+client = create_http_client(
+    timeout=10.0,
+    limits=httpx.Limits(max_connections=40, max_keepalive_connections=10),
+    follow_redirects=False,
+    tls=HTTPTLSConfig(ca_bundle="/path/to/ca-bundle.pem"),
+)
+```
+
+`HTTPTLSConfig` also supports a client certificate and key for mutual TLS. Configure both together. Keep certificate verification enabled in production.
+
+## Add bounded retries
+
+Requests are not retried unless the client has a `RetryPolicy`. `max_attempts` includes the initial request.
+
+```python
+from nemoguardrails.http import RetryPolicy, create_http_client
+
+policy = RetryPolicy(
+    max_attempts=3,
+    initial_delay=0.25,
+    max_delay=2.0,
+)
+client = create_http_client(retry_policy=policy)
+```
+
+The default policy retries eligible connection and timeout failures and the status codes `408`, `409`, `429`, `500`, `502`, `503`, and `504`. It uses bounded exponential backoff with jitter and accepts an in-policy `Retry-After` value.
+
+The safe default method set excludes `POST`. Add `POST` only when the provider documents the operation as retry-safe or the request uses a supported idempotency mechanism:
+
+```python
+policy = RetryPolicy(
+    max_attempts=3,
+    retryable_methods=frozenset({"POST"}),
+)
+```
+
+Keep retry policy close to the integration that owns the provider semantics. Do not add a broad global POST retry policy.
+
+## Add privacy-safe instrumentation
+
+Wrap a shared client with `instrument_http_client` to enable tracing, metrics, or both:
+
+```python
+from opentelemetry import trace
+
+from nemoguardrails.http import (
+    RetryPolicy,
+    create_http_client,
+    instrument_http_client,
+)
+
+base_client = create_http_client(retry_policy=RetryPolicy())
+http_client = instrument_http_client(
+    base_client,
+    tracer=trace.get_tracer("guardrails-app"),
+    metrics_enabled=True,
+)
+```
+
+Wrap the retrying client, as shown above, to record one span and one duration observation for the logical request rather than one per retry attempt.
+
+Tracing emits a `CLIENT` span named `HTTP {METHOD}`. Metrics emit the `http.client.request.duration` histogram. Telemetry can include:
+
+- Method, URL scheme, server address, and port.
+- A sanitized URL without credentials, query parameters, or fragments.
+- Raw request-body size when `content` is used.
+- Response status and body size.
+- Retry count and error type.
+
+Instrumentation does not record header values, query values, JSON bodies, raw body content, credentials, response content, or exception messages. Telemetry failures do not change the request result.
+
+Instrumentation is explicit at this boundary. Creating an HTTP client without `instrument_http_client` does not enable HTTP spans or metrics automatically. The component that creates the instrumented client must also close it.
+
+See [Span Reference](/observability/tracing/span-reference#outbound-http-client-spans) and [Metric Reference](/observability/metrics/reference#http-client-metrics) for the emitted names and attributes.
+
+## Test without network access
+
+Use `RecordingHTTPClient` to queue responses and inspect the exact provider request:
+
+```python
+import pytest
+
+from nemoguardrails.http import HTTPResponse
+from nemoguardrails.testing import RecordingHTTPClient
+
+@pytest.mark.asyncio
+async def test_policy_request_contract():
+    client = RecordingHTTPClient(
+        [HTTPResponse(status_code=200, content=b'{"allowed": true}')]
+    )
+
+    result = await query_policy_service("hello", http_client=client)
+
+    assert result == {"allowed": True}
+    assert len(client.requests) == 1
+    request = client.requests[0]
+    assert request.method == "POST"
+    assert request.url == "https://policy.example.com/v1/check"
+    assert request.json == {"text": "hello"}
+```
+
+Queue transport errors and non-success responses to verify retry, timeout, decoding, and fail-open or fail-closed behavior. Unit tests must not call a live provider.
+
+For configuration-level testing patterns, see [Testing Your Guardrails Configuration](/configure-guardrails/custom-initialization/testing-your-config).

--- a/docs/configure-rails/actions/outbound-http.mdx
+++ b/docs/configure-rails/actions/outbound-http.mdx
@@ -47,6 +47,8 @@ The client argument determines ownership for each call:
 
 The `None` fallback is safe and deterministic. Inject a shared client for applications that make repeated requests and benefit from connection-pool reuse.
 
+A runtime can own one shared pooled client, pass it to every action that declares `http_client`, and close it when the runtime stops. The action signature is the injection contract; rail manifests do not declare whether the runtime should allocate a transport.
+
 Create and close a shared client at the same application-lifecycle boundary:
 
 ```python

--- a/docs/configure-rails/actions/outbound-http.mdx
+++ b/docs/configure-rails/actions/outbound-http.mdx
@@ -47,7 +47,7 @@ The client argument determines ownership for each call:
 
 The `None` fallback is safe and deterministic. Inject a shared client for applications that make repeated requests and benefit from connection-pool reuse.
 
-A runtime can own one shared pooled client, pass it to every action that declares `http_client`, and close it when the runtime stops. The action signature is the injection contract; rail manifests do not declare whether the runtime should allocate a transport.
+Manifest-driven IORails owns one shared pooled client, passes it to every rail action that declares `http_client`, and closes it when the runtime stops. Other applications can use the same lifecycle pattern. The action signature is the injection contract; rail manifests do not declare whether the runtime should allocate a transport.
 
 Create and close a shared client at the same application lifecycle boundary:
 

--- a/docs/configure-rails/actions/rail-outcomes.mdx
+++ b/docs/configure-rails/actions/rail-outcomes.mdx
@@ -1,0 +1,196 @@
+---
+title: "Rail Outcomes"
+sidebar-title: "Rail Outcomes"
+description: "Return engine-neutral allow, block, and transform decisions from rail actions."
+keywords: ["RailOutcome", "rail actions", "rail decisions", "transform guardrails"]
+content:
+  type: "reference"
+---
+
+Rail actions return a `RailOutcome` to express an allow, block, or transform decision. This contract separates a rail's decision from the way a runtime presents or enforces that decision.
+
+Actions declared by a rail manifest must return `RailOutcome`. Ordinary custom actions can return other Python values when a Colang flow consumes those values explicitly, but the runtime does not infer a rail decision from a boolean, number, tuple, or dictionary.
+
+<Warning title="Breaking Change">
+
+The `output_mapping` parameter and its default boolean and numeric mappings have been removed from `@action`. Passing `output_mapping` now raises `TypeError`. Migrate rail decisions to `RailOutcome`; do not rely on implicit return-value interpretation.
+
+</Warning>
+
+## Decisions
+
+Each outcome contains exactly one decision.
+
+| Decision | Meaning |
+| --- | --- |
+| `allow` | Continue processing without changing the checked content. |
+| `block` | Stop processing the checked content. The runtime decides how to present the block. |
+| `transform` | Replace one or more supported conversation values before processing continues. |
+
+Import the outcome and transform target types from the actions package:
+
+```python
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+```
+
+### Allow content
+
+```python
+return RailOutcome.allow(
+    reason="No policy category matched.",
+    metadata={"categories": []},
+)
+```
+
+### Block content
+
+```python
+return RailOutcome.block(
+    reason="The content matched a restricted category.",
+    metadata={"categories": ["restricted"]},
+)
+```
+
+A block outcome does not contain a refusal message, exception type, bot intent, or localized text. The runtime or Colang flow owns those presentation choices.
+
+### Transform content
+
+Use a transform outcome when the rail rewrites checked content. A transform must include at least one rewrite and cannot repeat a target.
+
+```python
+return RailOutcome.transform(
+    [(TransformTarget.RELEVANT_CHUNKS, sanitized_chunks)],
+    reason="Sensitive values were removed.",
+    metadata={"redaction_count": redaction_count},
+)
+```
+
+The supported transform targets are:
+
+- `TransformTarget.USER_MESSAGE`
+- `TransformTarget.BOT_MESSAGE`
+- `TransformTarget.RELEVANT_CHUNKS`
+
+Transform outcomes apply to non-streaming processing. Streaming output paths do not apply the rewrite.
+
+## Evidence fields
+
+Use `reason` for a neutral, human-readable explanation of the decision. Use `metadata` for structured evidence such as categories, scores, detections, or provider response details.
+
+Do not make `metadata` load-bearing for the decision. Consumers should use `decision`, `is_blocked`, or `is_transform` to determine the outcome. Treat metadata as potentially observable data and avoid storing secrets, credentials, or unnecessary user content.
+
+## Consume an outcome in a flow
+
+The action decides whether content is allowed, blocked, or transformed. The flow decides how to handle that result.
+
+```colang
+$result = await DetectCustomPolicyAction(text=$user_message)
+
+if $result.is_blocked
+  bot refuse to respond
+  abort
+```
+
+For a transform, read the replacement by its target name:
+
+```colang
+$result = await SanitizeCustomChunksAction(text=$relevant_chunks)
+
+if $result.is_transform
+  $relevant_chunks = $result.transform_text["relevant_chunks"]
+```
+
+The following convenience properties are available:
+
+| Property | Value |
+| --- | --- |
+| `is_blocked` | `True` only for a block outcome. |
+| `is_transform` | `True` only for a transform outcome. |
+| `transform_text` | A mapping from transform target names to replacement text. |
+
+## Migrate from `output_mapping`
+
+Replace the mapping function with an explicit decision at the action's return site. This makes the action's meaning visible to every runtime and avoids conventions such as whether `True` means safe or blocked.
+
+### Safe boolean results
+
+Previously, an action could return whether content was safe and negate that result through `output_mapping`:
+
+```python
+@action(output_mapping=lambda result: not result)
+async def check_output_safety(text: str) -> bool:
+    return is_safe(text)
+```
+
+Return the decision directly:
+
+```python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
+
+@action()
+async def check_output_safety(text: str) -> RailOutcome:
+    if is_safe(text):
+        return RailOutcome.allow()
+    return RailOutcome.block(reason="The output did not pass the safety policy.")
+```
+
+### Unsafe boolean results
+
+For a detector where `True` means unsafe, return `block` when the detector matches:
+
+```python
+@action()
+async def check_hallucination(text: str) -> RailOutcome:
+    if detect_hallucination(text):
+        return RailOutcome.block(reason="The output failed the hallucination check.")
+    return RailOutcome.allow()
+```
+
+### Numeric thresholds and structured results
+
+Apply thresholds in the action and preserve useful evidence in metadata:
+
+```python
+@action()
+async def score_output_safety(text: str) -> RailOutcome:
+    score = compute_safety_score(text)
+    metadata = {"score": score, "threshold": 0.7}
+    if score < 0.7:
+        return RailOutcome.block(metadata=metadata)
+    return RailOutcome.allow(metadata=metadata)
+```
+
+The migration follows these mappings:
+
+| Previous convention | `RailOutcome` replacement |
+| --- | --- |
+| Safe boolean: `True` allows, `False` blocks | Return `allow()` for `True`; otherwise return `block()`. |
+| Unsafe boolean: `True` blocks, `False` allows | Return `block()` for `True`; otherwise return `allow()`. |
+| Numeric threshold | Compare the score in the action and return the chosen decision. |
+| Dictionary or tuple plus custom mapping | Read the relevant fields in the action and put non-sensitive evidence in `metadata`. |
+
+Update the consuming flow to inspect the outcome rather than the original scalar value:
+
+```colang
+$result = await CheckOutputSafetyAction(text=$bot_message)
+
+if $result.is_blocked
+  bot refuse to respond
+  abort
+```
+
+If the action is not a rail decision, keep its ordinary return type and branch on that value explicitly in the flow. `RailOutcome` is not required for general-purpose actions.
+
+## Validation rules
+
+`RailOutcome` validates its state when you construct it:
+
+- `reason` must be a string or `None`.
+- `metadata` must be a mapping with string keys.
+- Transform outcomes must contain one or more transforms.
+- Allow and block outcomes cannot contain transforms.
+- Each transform target can appear only once in an outcome.
+- Transform replacement values must be strings.
+
+Use the `allow`, `block`, and `transform` class methods instead of constructing decisions directly. These methods make the intended outcome clear at the action's return site.

--- a/docs/configure-rails/actions/rail-outcomes.mdx
+++ b/docs/configure-rails/actions/rail-outcomes.mdx
@@ -79,9 +79,9 @@ Transform outcomes apply to non-streaming processing. Streaming output paths do 
 
 ## Evidence Fields
 
-Use `reason` for a neutral, human-readable explanation of the decision. Use `metadata` for structured evidence such as categories, scores, detections, or provider response details.
+Use `reason` for a neutral, human-readable explanation of the decision. Use `metadata` for structured evidence such as categories, scores, detections, or redacted provider status and error codes.
 
-Do not make `metadata` load-bearing for the decision. Consumers should use `decision`, `is_blocked`, or `is_transform` to determine the outcome. Treat metadata as potentially observable data and avoid storing secrets, credentials, or unnecessary user content.
+Do not make `metadata` load-bearing for the decision. Consumers should use `decision`, `is_blocked`, or `is_transform` to determine the outcome. Treat metadata as potentially observable data. Do not store secrets, credentials, raw provider payloads, or unnecessary user content.
 
 ## Consume an Outcome in a Flow
 

--- a/docs/configure-rails/actions/registering-actions.mdx
+++ b/docs/configure-rails/actions/registering-actions.mdx
@@ -256,23 +256,22 @@ Provide shared resources to actions:
 # config/config.py
 def init(app: LLMRails):
     # Create shared resources
-    http_client = aiohttp.ClientSession()
     cache = RedisCache()
 
     # Register as action parameters
-    app.register_action_param("http_client", http_client)
     app.register_action_param("cache", cache)
 ```
 
 ```python
 # config/actions.py
 from nemoguardrails.actions import action
+from nemoguardrails.http import HTTPClient, http_call
 
 @action()
 async def fetch_with_cache(
     url: str,
-    http_client=None,  # Injected automatically
-    cache=None         # Injected automatically
+    cache=None,
+    http_client: HTTPClient | None = None,
 ):
     # Check cache first
     cached = await cache.get(url)
@@ -280,12 +279,14 @@ async def fetch_with_cache(
         return cached
 
     # Fetch and cache
-    response = await http_client.get(url)
-    data = await response.json()
+    response = await http_call(http_client, "GET", url)
+    data = response.json()
     await cache.set(url, data)
 
     return data
 ```
+
+An injected HTTP client remains caller-owned and must be closed by the application that created it. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#client-ownership) for the shared-client lifecycle pattern.
 
 ## Best Practices
 
@@ -345,3 +346,4 @@ async def search_knowledge_base(
 - [Creating Custom Actions](creating-actions) - Create your own actions
 - [Built-in Actions](built-in-actions) - Default actions in the library
 - [Action Parameters](action-parameters) - Special parameters for actions
+- [Outbound HTTP](outbound-http) - Inject and manage the canonical HTTP client

--- a/docs/configure-rails/actions/registering-actions.mdx
+++ b/docs/configure-rails/actions/registering-actions.mdx
@@ -267,6 +267,7 @@ def init(app: LLMRails):
 from nemoguardrails.actions import action
 from nemoguardrails.http import HTTPClient, http_call
 
+
 @action()
 async def fetch_with_cache(
     url: str,
@@ -286,7 +287,7 @@ async def fetch_with_cache(
     return data
 ```
 
-An injected HTTP client remains caller-owned and must be closed by the application that created it. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#client-ownership) for the shared-client lifecycle pattern.
+An injected HTTP client remains caller-owned and must be closed by the application that created it. For the shared-client lifecycle pattern, refer to [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#client-ownership).
 
 ## Best Practices
 

--- a/docs/configure-rails/custom-initialization/init-function.mdx
+++ b/docs/configure-rails/custom-initialization/init-function.mdx
@@ -121,11 +121,12 @@ def init(app: LLMRails):
 
 The synchronous `init` function has no asynchronous teardown hook. Do not create a long-lived HTTP client in `init` unless another application component owns and closes it.
 
-Create a shared canonical client at the surrounding application-lifecycle boundary, register it as an action parameter, and close it at shutdown:
+Create a shared canonical client at the surrounding application lifecycle boundary, register it as an action parameter, and close it at shutdown:
 
 ```python
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.http import create_http_client
+
 
 async def run():
     http_client = create_http_client(timeout=10.0)
@@ -141,4 +142,4 @@ async def run():
         await http_client.close()
 ```
 
-Actions that accept `http_client: HTTPClient | None = None` can use a shared injected client or let `http_call` create and close a call-scoped fallback. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http).
+Actions that accept `http_client: HTTPClient | None = None` can use a shared injected client or let `http_call` create and close a call-scoped fallback. For details, refer to [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http).

--- a/docs/configure-rails/custom-initialization/init-function.mdx
+++ b/docs/configure-rails/custom-initialization/init-function.mdx
@@ -117,22 +117,28 @@ def init(app: LLMRails):
     app.register_action_param("db_conn", conn)
 ```
 
-## Example: API Client Initialization
+## HTTP Client Lifecycle
+
+The synchronous `init` function has no asynchronous teardown hook. Do not create a long-lived HTTP client in `init` unless another application component owns and closes it.
+
+Create a shared canonical client at the surrounding application-lifecycle boundary, register it as an action parameter, and close it at shutdown:
 
 ```python
-import os
-import httpx
-from nemoguardrails import LLMRails
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.http import create_http_client
 
-def init(app: LLMRails):
-    # Get API key from custom_data in config.yml
-    api_key = os.environ.get("API_KEY") or app.config.custom_data.get("api_key")
+async def run():
+    http_client = create_http_client(timeout=10.0)
+    config = RailsConfig.from_path("config")
+    app = LLMRails(config)
+    app.register_action_param("http_client", http_client)
 
-    # Create HTTP client with authentication
-    client = httpx.AsyncClient(
-        base_url="https://api.example.com",
-        headers={"Authorization": f"Bearer {api_key}"}
-    )
-
-    app.register_action_param("http_client", client)
+    try:
+        return await app.generate_async(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+    finally:
+        await http_client.close()
 ```
+
+Actions that accept `http_client: HTTPClient | None = None` can use a shared injected client or let `http_call` create and close a call-scoped fallback. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http).

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -219,6 +219,9 @@ navigation:
           - page: Registering Actions
             path: configure-rails/actions/registering-actions.mdx
             slug: registering-actions
+          - page: Rail Outcomes
+            path: configure-rails/actions/rail-outcomes.mdx
+            slug: rail-outcomes
       - section: Custom Initialization
         path: configure-rails/custom-initialization/index.mdx
         slug: custom-initialization

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -222,6 +222,9 @@ navigation:
           - page: Rail Outcomes
             path: configure-rails/actions/rail-outcomes.mdx
             slug: rail-outcomes
+          - page: Outbound HTTP
+            path: configure-rails/actions/outbound-http.mdx
+            slug: outbound-http
       - section: Custom Initialization
         path: configure-rails/custom-initialization/index.mdx
         slug: custom-initialization

--- a/docs/observability/metrics/reference.mdx
+++ b/docs/observability/metrics/reference.mdx
@@ -3,18 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Metric Reference"
 sidebar-title: "Metric Reference"
-description: "Reference every metric IORails emits, with instrument types, units, labels, and emission semantics."
+description: "Reference IORails and canonical outbound HTTP metrics, including instrument types, units, labels, and emission semantics."
 content:
   type: "reference"
 ---
 
-This page lists every metric the IORails engine emits when `metrics.enabled: true` and a `MeterProvider` is configured.
+This page lists the metrics emitted by the IORails engine and the instrumented canonical outbound HTTP client.
 
-Metrics fall into two families:
+Metrics fall into three families:
 
 - **Request-level metrics** (`guardrails.*`) describe IORails request flow: volume, errors, blocks, latency, and saturation of the streaming and non-streaming admission paths.
 - **LLM client-side metrics** (`gen_ai.client.*`) describe downstream LLM calls IORails issues.
   These follow the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) and use the bucket boundaries recommended by that spec.
+- **HTTP client-side metrics** (`http.client.*`) describe outbound requests sent through an explicitly instrumented canonical HTTP client.
+
+IORails request and LLM metrics require `metrics.enabled: true` and a configured `MeterProvider`. HTTP client metrics require a configured `MeterProvider` and `instrument_http_client(..., metrics_enabled=True)`.
 
 ## Request-Level Metrics
 
@@ -77,6 +80,28 @@ A `QueueFull` rejection on the non-streaming path increments **both**:
 
 This is intentional: dashboards built around either signal alone still reflect the rejection.
 
+## HTTP Client Metrics
+
+The canonical outbound HTTP instrumentation records one observation for each logical request, including all retry attempts performed by a wrapped retrying client.
+
+| Metric | Instrument | Unit | Labels | Description |
+| --- | --- | --- | --- | --- |
+| `http.client.request.duration` | Histogram | `s` | `http.request.method`, `server.address`, `server.port`, optionally `http.response.status_code` and `error.type` | Wall-clock duration of an outbound HTTP request. |
+
+The method is normalized to uppercase. The server port is the explicit URL port or the default port for `http` and `https`. A response contributes `http.response.status_code`; status codes of 400 or greater also contribute `error.type` as the status string. A raised exception contributes its class name as `error.type` and has no response-status label.
+
+The metric does not include URL paths, query parameters, headers, bodies, credentials, or exception messages. URLs without a host or a recognized port do not produce an observation.
+
+### Bucket Boundaries: `http.client.request.duration`
+
+The histogram uses the OpenTelemetry HTTP client recommendation in seconds:
+
+```text
+[0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+```
+
+Use [`instrument_http_client`](/configure-guardrails/actions/outbound-http#add-privacy-safe-instrumentation) with `metrics_enabled=True` to enable this metric. `create_http_client` does not enable it automatically.
+
 ## LLM Client-Side Metrics
 
 These metrics are recorded once per downstream LLM call, not once per IORails request, and follow the OpenTelemetry GenAI semantic conventions.
@@ -127,21 +152,27 @@ When usage is absent, no observation is recorded; "no observation" is deliberate
 
 | Label | Used On | Values | Notes |
 | --- | --- | --- | --- |
-| `error.type` | `guardrails.requests.errors`, `gen_ai.client.operation.duration` (on error) | Exception class name | For example `QueueFull`, `TimeoutError`, `ValueError`. |
+| `error.type` | Request, LLM, and HTTP error metrics | Exception class name or HTTP error status | For example `QueueFull`, `TimeoutError`, `HTTPConnectionError`, or `503`. |
 | `rail.type` | `guardrails.requests.blocked` | `input`, `output` | Identifies whether an input or output rail blocked the request. |
 | `gen_ai.operation.name` | All `gen_ai.client.*` | For example `chat`, `completion`, `embedding` | OpenTelemetry GenAI operation name. |
 | `gen_ai.provider.name` | All `gen_ai.client.*` | For example `openai`, `anthropic` | OpenTelemetry GenAI provider name. |
 | `gen_ai.request.model` | All `gen_ai.client.*` | For example `gpt-4o-mini` | The model name passed in the request. |
 | `gen_ai.token.type` | `gen_ai.client.token.usage` | `input`, `output` | Required label per spec. |
+| `http.request.method` | `http.client.request.duration` | Uppercase HTTP method | For example `GET` or `POST`. |
+| `server.address` | `http.client.request.duration` | Destination host | Excludes credentials and port. |
+| `server.port` | `http.client.request.duration` | Destination port | Uses `80` or `443` when omitted from an HTTP or HTTPS URL. |
+| `http.response.status_code` | `http.client.request.duration` | HTTP status code | Present only when a response is received. |
 
 ## Public API Stability
 
 The metric names listed on this page are part of the library's public API, so dashboards and alerts can reference them.
 The library tests assert on the raw strings for this reason.
-Bucket boundaries follow the OpenTelemetry GenAI spec and can change if the spec changes.
+Bucket boundaries follow the relevant OpenTelemetry HTTP or GenAI specification and can change if those specifications change.
 
 ## Related Resources
 
 - [Enable Guardrails Metrics](/observability/metrics/enable-metrics) — Minimal SDK setup with console output.
 - [OpenTelemetry Metrics Integration](/observability/metrics/opentelemetry-integration) — Production exporters: OTLP, Prometheus.
+- [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http): Canonical client ownership, retries, instrumentation, and testing.
+- [OpenTelemetry HTTP metrics specification](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/): Upstream HTTP client metric conventions.
 - [OpenTelemetry GenAI metrics specification](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) — Upstream semantic conventions.

--- a/docs/observability/metrics/reference.mdx
+++ b/docs/observability/metrics/reference.mdx
@@ -88,7 +88,7 @@ The canonical outbound HTTP instrumentation records one observation for each log
 | --- | --- | --- | --- | --- |
 | `http.client.request.duration` | Histogram | `s` | `http.request.method`, `server.address`, `server.port`, optionally `http.response.status_code` and `error.type` | Wall-clock duration of an outbound HTTP request. |
 
-The method is normalized to uppercase. The server port is the explicit URL port or the default port for `http` and `https`. A response contributes `http.response.status_code`; status codes of 400 or greater also contribute `error.type` as the status string. A raised exception contributes its class name as `error.type` and has no response-status label.
+The instrumentation normalizes the method to uppercase. The server port is the explicit URL port or the default port for `http` and `https`. A response contributes `http.response.status_code`. Status codes of 400 or greater also contribute `error.type` as the status string. A raised exception contributes its class name as `error.type` and has no response-status label.
 
 The metric does not include URL paths, query parameters, headers, bodies, credentials, or exception messages. URLs without a host or a recognized port do not produce an observation.
 

--- a/docs/observability/tracing/span-reference.mdx
+++ b/docs/observability/tracing/span-reference.mdx
@@ -8,16 +8,16 @@ content:
     type: "reference"
 ---
 
-The NeMo Guardrails library emits OpenTelemetry spans, allowing you to trace individual requests.
-This reference documents shared outbound HTTP client spans and the spans each engine produces.
+The NVIDIA NeMo Guardrails library emits OpenTelemetry spans, allowing you to trace individual requests.
+This reference documents shared outbound HTTP client spans and engine-specific spans.
 
 ## Outbound HTTP Client Spans
 
-The canonical outbound HTTP boundary can emit a `CLIENT` span for each logical request. This instrumentation is engine-neutral and is enabled by wrapping a client with `instrument_http_client` and supplying a tracer. It is not enabled by `create_http_client` alone.
+An instrumented canonical outbound HTTP client can emit a `CLIENT` span for each logical request. To enable this engine-neutral instrumentation, wrap a client with `instrument_http_client` and supply a tracer. Calling `create_http_client` alone does not enable it.
 
-The span is named `HTTP {METHOD}`, such as `HTTP GET` or `HTTP POST`. When a request runs under an active OpenTelemetry span, the HTTP span uses that span as its parent.
+The instrumentation names the span `HTTP {METHOD}`, such as `HTTP GET` or `HTTP POST`. When a request runs under an active OpenTelemetry span, the HTTP span uses that span as its parent.
 
-| Attribute | Type | When set | Description |
+| Attribute | Type | When Set | Description |
 | --- | --- | --- | --- |
 | `http.request.method` | string | Always | Uppercase HTTP method. |
 | `url.full` | string | Always | URL with credentials, query parameters, and fragments removed. |
@@ -32,7 +32,7 @@ The span is named `HTTP {METHOD}`, such as `HTTP GET` or `HTTP POST`. When a req
 
 Raised errors add an `exception` event containing only `exception.type`. The instrumentation does not record header values, query values, JSON bodies, raw body content, credentials, response content, or exception messages.
 
-Wrap the retrying client rather than its underlying transport to produce one span for the logical request and include its retry count. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#add-privacy-safe-instrumentation) for configuration and lifecycle examples.
+Wrap the retrying client rather than its underlying transport to produce one span for the logical request and include its retry count. For configuration and lifecycle examples, refer to [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#add-privacy-safe-instrumentation).
 
 ## LLMRails
 

--- a/docs/observability/tracing/span-reference.mdx
+++ b/docs/observability/tracing/span-reference.mdx
@@ -3,13 +3,36 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Span Reference"
 sidebar-title: "Span Reference"
-description: "Every span and attribute the LLMRails and IORails engines emit when tracing is enabled, including the token-level GenAI attributes on the LLM span."
+description: "Reference the LLMRails, IORails, and canonical outbound HTTP spans and attributes emitted when tracing is enabled."
 content:
     type: "reference"
 ---
 
 The NeMo Guardrails library emits OpenTelemetry spans, allowing you to trace individual requests.
-This reference documents the spans and attributes each engine produces. It covers the default LLMRails engine first, then the opt-in IORails engine.
+This reference documents shared outbound HTTP client spans and the spans each engine produces.
+
+## Outbound HTTP Client Spans
+
+The canonical outbound HTTP boundary can emit a `CLIENT` span for each logical request. This instrumentation is engine-neutral and is enabled by wrapping a client with `instrument_http_client` and supplying a tracer. It is not enabled by `create_http_client` alone.
+
+The span is named `HTTP {METHOD}`, such as `HTTP GET` or `HTTP POST`. When a request runs under an active OpenTelemetry span, the HTTP span uses that span as its parent.
+
+| Attribute | Type | When set | Description |
+| --- | --- | --- | --- |
+| `http.request.method` | string | Always | Uppercase HTTP method. |
+| `url.full` | string | Always | URL with credentials, query parameters, and fragments removed. |
+| `url.scheme` | string | URL has a scheme | URL scheme, such as `https`. |
+| `server.address` | string | URL has a host | Destination host. |
+| `server.port` | int | URL contains an explicit port | Destination port. |
+| `http.request.body.size` | int | Raw `content` is supplied | Encoded raw request-body size. JSON bodies are not measured. |
+| `http.response.status_code` | int | Response received | HTTP response status code. |
+| `http.response.body.size` | int | Response received | Materialized response-body size. |
+| `http.request.resend_count` | int | Request retried | Number of completed retries. |
+| `error.type` | string | Error response or exception | Status code for an error response or exception class name for a raised error. |
+
+Raised errors add an `exception` event containing only `exception.type`. The instrumentation does not record header values, query values, JSON bodies, raw body content, credentials, response content, or exception messages.
+
+Wrap the retrying client rather than its underlying transport to produce one span for the logical request and include its retry count. See [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http#add-privacy-safe-instrumentation) for configuration and lifecycle examples.
 
 ## LLMRails
 
@@ -285,7 +308,7 @@ When content capture is enabled, the LLM span also records the prompt and comple
 | ---------- | ------ | -------- | --------------------------------- |
 | `api.name` | string | Always   | The name of the API being called. |
 
-These endpoints are plain HTTP services rather than GenAI operations, so the span uses `api.name` instead of the `gen_ai.*` attributes. HTTP transport attributes can be added later without conflict.
+These endpoints are plain HTTP services rather than GenAI operations, so the span uses `api.name` instead of the `gen_ai.*` attributes. When the action uses an instrumented canonical HTTP client, the nested `HTTP {METHOD}` span carries the transport attributes described in [Outbound HTTP Client Spans](#outbound-http-client-spans).
 
 ## Token-Level Attributes
 
@@ -369,5 +392,7 @@ Pin your `opentelemetry-sdk` version and review release notes before upgrading.
 
 - [Quick Start](/observability/tracing/quick-start): Minimal tracing setup with the OpenTelemetry SDK.
 - [OpenTelemetry](/observability/tracing/opentelemetry-integration): Production exporters and ecosystem compatibility.
-- [Metric Reference](/observability/metrics/reference): The metrics IORails emits, including the `gen_ai.client.token.usage` histogram.
+- [Metric Reference](/observability/metrics/reference): IORails and canonical outbound HTTP metrics.
+- [Outbound HTTP in Actions](/configure-guardrails/actions/outbound-http): Canonical request, ownership, retry, and instrumentation patterns.
+- [OpenTelemetry HTTP spans specification](https://opentelemetry.io/docs/specs/semconv/http/http-spans/): Upstream HTTP client span conventions.
 - [OpenTelemetry GenAI spans specification](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/): Upstream semantic conventions for span names and attributes.


### PR DESCRIPTION
Documents the canonical outbound HTTP client contract, lifecycle, and observability behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for Rail Outcomes, including allow, block, transform, validation, and migration examples.
  * Added Outbound HTTP documentation covering client usage, lifecycle, retries, errors, security, instrumentation, and testing.
  * Added Rail Manifest reference documentation, including structure, configuration, requirements, privacy, and validation.
  * Updated custom action and initialization guides with current HTTP client and lifecycle practices.
  * Expanded observability references for HTTP metrics and tracing.
  * Improved documentation navigation and added related-topic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->