### PR TITLE
test(llm): move call tests to module mirrors

### DIFF
--- a/tests/integrations/langchain/test_langchain_llm_adapter.py
+++ b/tests/integrations/langchain/test_langchain_llm_adapter.py
@@ -18,9 +18,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage, ToolMessage
 
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.integrations.langchain.llm_adapter import (
     LangChainFramework,
     LangChainLLMAdapter,
+    _infer_provider_from_module,
     _langchain_chunk_to_llm_response_chunk,
     _langchain_response_to_llm_response,
 )
@@ -28,7 +30,164 @@ from nemoguardrails.integrations.langchain.message_utils import (
     chatmessage_to_langchain_message,
     chatmessages_to_langchain_messages,
 )
+from nemoguardrails.llm.call import llm_call
 from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, Role, ToolCall, ToolCallFunction
+
+
+class MockOpenAILLM:
+    __module__ = "langchain_openai.chat_models"
+
+
+class MockAnthropicLLM:
+    __module__ = "langchain_anthropic.chat_models"
+
+
+class MockNVIDIALLM:
+    __module__ = "langchain_nvidia_ai_endpoints.chat_models"
+
+
+class MockCommunityOllama:
+    __module__ = "langchain_community.chat_models.ollama"
+
+
+class MockUnknownLLM:
+    __module__ = "some_custom_package.models"
+
+
+def test_infer_provider_openai():
+    llm = MockOpenAILLM()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "openai"
+
+
+def test_infer_provider_anthropic():
+    llm = MockAnthropicLLM()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "anthropic"
+
+
+def test_infer_provider_nvidia_ai_endpoints():
+    llm = MockNVIDIALLM()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "nvidia_ai_endpoints"
+
+
+def test_infer_provider_community_ollama():
+    llm = MockCommunityOllama()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "ollama"
+
+
+def test_infer_provider_unknown():
+    llm = MockUnknownLLM()
+    provider = _infer_provider_from_module(llm)
+    assert provider is None
+
+
+def test_infer_provider_checks_base_classes():
+    class BaseOpenAI:
+        __module__ = "langchain_openai.chat_models"
+
+    class CustomWrapper(BaseOpenAI):
+        __module__ = "my_custom_wrapper.llms"
+
+    llm = CustomWrapper()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "openai"
+
+
+def test_infer_provider_multiple_inheritance():
+    class BaseNVIDIA:
+        __module__ = "langchain_nvidia_ai_endpoints.chat_models"
+
+    class Mixin:
+        __module__ = "some_mixin.utils"
+
+    class MultipleInheritance(Mixin, BaseNVIDIA):
+        __module__ = "custom_package.models"
+
+    llm = MultipleInheritance()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "nvidia_ai_endpoints"
+
+
+def test_infer_provider_deeply_nested_inheritance():
+    class Original:
+        __module__ = "langchain_anthropic.chat_models"
+
+    class Wrapper1(Original):
+        __module__ = "wrapper1.models"
+
+    class Wrapper2(Wrapper1):
+        __module__ = "wrapper2.models"
+
+    class Wrapper3(Wrapper2):
+        __module__ = "wrapper3.models"
+
+    llm = Wrapper3()
+    provider = _infer_provider_from_module(llm)
+    assert provider == "anthropic"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm_params", [None, {}])
+async def test_llm_call_stop_tokens_passed_without_llm_params(llm_params):
+    mock_llm = MagicMock()
+    mock_llm.model_name = "gpt-4"
+    bound_llm = AsyncMock()
+    bound_llm.ainvoke.return_value = MagicMock(content="response")
+    mock_llm.bind.return_value = bound_llm
+
+    wrapped = LangChainLLMAdapter(mock_llm)
+    await llm_call(wrapped, "prompt", stop=["User:"], llm_params=llm_params)
+
+    mock_llm.bind.assert_called_once_with(stop=["User:"])
+
+
+@pytest.mark.asyncio
+async def test_llm_call_exception_enrichment_with_model_and_provider():
+    mock_llm = MockOpenAILLM()
+    mock_llm.model_name = "gpt-4"
+    mock_llm.ainvoke = AsyncMock(side_effect=ConnectionError("Connection refused"))
+
+    wrapped = LangChainLLMAdapter(mock_llm)
+    with pytest.raises(LLMCallException) as exc_info:
+        await llm_call(wrapped, "test prompt")
+
+    exc_str = str(exc_info.value)
+    assert "gpt-4" in exc_str
+    assert "provider=openai" in exc_str
+    assert "Connection refused" in exc_str
+    assert isinstance(exc_info.value.inner_exception, ConnectionError)
+
+
+@pytest.mark.asyncio
+async def test_llm_call_exception_without_provider():
+    mock_llm = MockUnknownLLM()
+    mock_llm.model_name = "custom-model"
+    mock_llm.ainvoke = AsyncMock(side_effect=ValueError("Invalid request"))
+
+    wrapped = LangChainLLMAdapter(mock_llm)
+    with pytest.raises(LLMCallException) as exc_info:
+        await llm_call(wrapped, "test prompt")
+
+    exc_str = str(exc_info.value)
+    assert "custom-model" in exc_str
+    assert "Invalid request" in exc_str
+
+
+@pytest.mark.asyncio
+async def test_llm_call_kwargs_flow_through_to_generate():
+    mock_llm = MagicMock()
+    mock_llm.model_name = "gpt-4"
+    bound_llm = AsyncMock()
+    bound_llm.ainvoke.return_value = MagicMock(content="response")
+    mock_llm.bind.return_value = bound_llm
+
+    wrapped = LangChainLLMAdapter(mock_llm)
+    await llm_call(wrapped, "prompt", llm_params={"temperature": 0.5, "max_tokens": 100})
+
+    mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
 
 
 class TestLangChainLLMAdapter:

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from nemoguardrails.context import (
@@ -23,11 +21,6 @@ from nemoguardrails.context import (
     llm_stats_var,
     reasoning_trace_var,
     tool_calls_var,
-)
-from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.integrations.langchain.llm_adapter import (
-    LangChainLLMAdapter,
-    _infer_provider_from_module,
 )
 from nemoguardrails.llm.call import (
     _log_completion,
@@ -53,101 +46,6 @@ def reset_context_vars():
 
     reasoning_trace_var.reset(reasoning_token)
     tool_calls_var.reset(tool_calls_token)
-
-
-class MockOpenAILLM:
-    __module__ = "langchain_openai.chat_models"
-
-
-class MockAnthropicLLM:
-    __module__ = "langchain_anthropic.chat_models"
-
-
-class MockNVIDIALLM:
-    __module__ = "langchain_nvidia_ai_endpoints.chat_models"
-
-
-class MockCommunityOllama:
-    __module__ = "langchain_community.chat_models.ollama"
-
-
-class MockUnknownLLM:
-    __module__ = "some_custom_package.models"
-
-
-def test_infer_provider_openai():
-    llm = MockOpenAILLM()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "openai"
-
-
-def test_infer_provider_anthropic():
-    llm = MockAnthropicLLM()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "anthropic"
-
-
-def test_infer_provider_nvidia_ai_endpoints():
-    llm = MockNVIDIALLM()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "nvidia_ai_endpoints"
-
-
-def test_infer_provider_community_ollama():
-    llm = MockCommunityOllama()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "ollama"
-
-
-def test_infer_provider_unknown():
-    llm = MockUnknownLLM()
-    provider = _infer_provider_from_module(llm)
-    assert provider is None
-
-
-def test_infer_provider_checks_base_classes():
-    class BaseOpenAI:
-        __module__ = "langchain_openai.chat_models"
-
-    class CustomWrapper(BaseOpenAI):
-        __module__ = "my_custom_wrapper.llms"
-
-    llm = CustomWrapper()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "openai"
-
-
-def test_infer_provider_multiple_inheritance():
-    class BaseNVIDIA:
-        __module__ = "langchain_nvidia_ai_endpoints.chat_models"
-
-    class Mixin:
-        __module__ = "some_mixin.utils"
-
-    class MultipleInheritance(Mixin, BaseNVIDIA):
-        __module__ = "custom_package.models"
-
-    llm = MultipleInheritance()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "nvidia_ai_endpoints"
-
-
-def test_infer_provider_deeply_nested_inheritance():
-    class Original:
-        __module__ = "langchain_anthropic.chat_models"
-
-    class Wrapper1(Original):
-        __module__ = "wrapper1.models"
-
-    class Wrapper2(Wrapper1):
-        __module__ = "wrapper2.models"
-
-    class Wrapper3(Wrapper2):
-        __module__ = "wrapper3.models"
-
-    llm = Wrapper3()
-    provider = _infer_provider_from_module(llm)
-    assert provider == "anthropic"
 
 
 def test_store_reasoning_traces_from_reasoning_field():
@@ -265,71 +163,6 @@ def test_store_tool_calls_with_multiple_tool_call_objects():
     assert len(tool_calls) == 2
     assert tool_calls[0]["function"]["name"] == "foo"
     assert tool_calls[1]["function"]["name"] == "bar"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("llm_params", [None, {}])
-async def test_llm_call_stop_tokens_passed_without_llm_params(llm_params):
-    from unittest.mock import AsyncMock, MagicMock
-
-    from nemoguardrails.actions.llm.utils import llm_call
-
-    mock_llm = MagicMock()
-    mock_llm.model_name = "gpt-4"
-    bound_llm = AsyncMock()
-    bound_llm.ainvoke.return_value = MagicMock(content="response")
-    mock_llm.bind.return_value = bound_llm
-
-    wrapped = LangChainLLMAdapter(mock_llm)
-    await llm_call(wrapped, "prompt", stop=["User:"], llm_params=llm_params)
-
-    mock_llm.bind.assert_called_once_with(stop=["User:"])
-
-
-@pytest.mark.asyncio
-async def test_llm_call_exception_enrichment_with_model_and_provider():
-    mock_llm = MockOpenAILLM()
-    mock_llm.model_name = "gpt-4"
-    mock_llm.ainvoke = AsyncMock(side_effect=ConnectionError("Connection refused"))
-
-    wrapped = LangChainLLMAdapter(mock_llm)
-    with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(wrapped, "test prompt")
-
-    exc_str = str(exc_info.value)
-    assert "gpt-4" in exc_str
-    assert "provider=openai" in exc_str
-    assert "Connection refused" in exc_str
-    assert isinstance(exc_info.value.inner_exception, ConnectionError)
-
-
-@pytest.mark.asyncio
-async def test_llm_call_exception_without_provider():
-    mock_llm = MockUnknownLLM()
-    mock_llm.model_name = "custom-model"
-    mock_llm.ainvoke = AsyncMock(side_effect=ValueError("Invalid request"))
-
-    wrapped = LangChainLLMAdapter(mock_llm)
-    with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(wrapped, "test prompt")
-
-    exc_str = str(exc_info.value)
-    assert "custom-model" in exc_str
-    assert "Invalid request" in exc_str
-
-
-@pytest.mark.asyncio
-async def test_llm_call_kwargs_flow_through_to_generate():
-    mock_llm = MagicMock()
-    mock_llm.model_name = "gpt-4"
-    bound_llm = AsyncMock()
-    bound_llm.ainvoke.return_value = MagicMock(content="response")
-    mock_llm.bind.return_value = bound_llm
-
-    wrapped = LangChainLLMAdapter(mock_llm)
-    await llm_call(wrapped, "prompt", llm_params={"temperature": 0.5, "max_tokens": 100})
-
-    mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
 
 
 class TestLogCompletion:

--- a/tests/llm/test_call_reasoning.py
+++ b/tests/llm/test_call_reasoning.py
@@ -16,7 +16,7 @@
 import pytest
 
 from nemoguardrails.context import reasoning_trace_var
-from nemoguardrails.llm.call import _store_reasoning_traces
+from nemoguardrails.llm.call import _store_reasoning_traces, llm_call
 from nemoguardrails.types import LLMResponse
 from tests.utils import FakeLLMModel
 
@@ -132,8 +132,6 @@ class TestReasoningTraceIntegration:
 
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content="The answer is 42", reasoning=test_reasoning)])
 
-        from nemoguardrails.actions.llm.utils import llm_call
-
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "What is the answer?")
 
@@ -146,8 +144,6 @@ class TestReasoningTraceIntegration:
     @pytest.mark.asyncio
     async def test_llm_call_handles_missing_reasoning_content(self):
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content="Regular response")])
-
-        from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "Hello")
@@ -163,8 +159,6 @@ class TestReasoningTraceIntegration:
         test_reasoning = "Analyzing the conversation context..."
 
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content="Here's my response", reasoning=test_reasoning)])
-
-        from nemoguardrails.actions.llm.utils import llm_call
 
         messages = [
             {"role": "user", "content": "Hello"},
@@ -192,8 +186,6 @@ class TestReasoningTraceIntegration:
             ]
         )
 
-        from nemoguardrails.actions.llm.utils import llm_call
-
         reasoning_trace_var.set(None)
         result1 = await llm_call(fake_llm, "First query")
         trace1 = reasoning_trace_var.get()
@@ -213,8 +205,6 @@ class TestReasoningTraceIntegration:
 
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content="Response", reasoning=test_reasoning)])
 
-        from nemoguardrails.actions.llm.utils import llm_call
-
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "Query")
 
@@ -229,8 +219,6 @@ class TestReasoningTraceIntegration:
         test_reasoning = "Let me analyze this step by step"
 
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content=f"<think>{test_reasoning}</think>The answer is 42")])
-
-        from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "What is the answer?")
@@ -256,8 +244,6 @@ class TestReasoningTraceIntegration:
             ]
         )
 
-        from nemoguardrails.actions.llm.utils import llm_call
-
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "Query")
 
@@ -277,8 +263,6 @@ Step 3: Formulate the answer"""
             llm_responses=[LLMResponse(content=f"<think>{multiline_reasoning}</think>Final answer")]
         )
 
-        from nemoguardrails.actions.llm.utils import llm_call
-
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "Question")
 
@@ -292,8 +276,6 @@ Step 3: Formulate the answer"""
     @pytest.mark.asyncio
     async def test_llm_call_handles_incomplete_think_tags(self):
         fake_llm = FakeLLMModel(llm_responses=[LLMResponse(content="<think>This is incomplete")])
-
-        from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
         result = await llm_call(fake_llm, "Query")


### PR DESCRIPTION
## Summary

Moves llm.call tests into module-aligned files; no runtime changes.

Related: follow-up to #2241.

## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Stack Position

Part 1 of 2.

- Previous: none, based on `develop`
- Next: #2266

## Stack Context

Moves llm_call tests first so the NGUARD-880 fix is reviewed as a small behavioral diff.

Please review each PR against its parent branch, not directly against the root base branch, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #2265 | `pouyanpi/refactor-llm-call-tests` | `develop` |
| 2 | #2266 | `pouyanpi/fix-nguard-880-stop-and-messages` | `pouyanpi/refactor-llm-call-tests` |

## Validation

```text
593 passed, 25 skipped
pre-commit passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for LangChain provider detection, including wrapped, nested, unknown, and multiple-inheritance models.
  * Added tests for forwarding stop tokens and parameters, excluding empty values.
  * Added exception-handling tests that verify model and provider details are included.
  * Simplified existing reasoning tests without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->