### PR TITLE
fix(server): handle stop and malformed messages

### DIFF
--- a/nemoguardrails/llm/call.py
+++ b/nemoguardrails/llm/call.py
@@ -87,12 +87,14 @@ async def llm_call(
     _setup_llm_call_info(model, model_name, model_provider)
     _log_prompt(prompt)
     chat_prompt = _ensure_chat_messages(prompt)
+    call_params = dict(llm_params or {})
+    stop = call_params.pop("stop", stop)
 
     if streaming_handler:
-        return await _stream_llm_call(model, chat_prompt, streaming_handler, stop, llm_params)
+        return await _stream_llm_call(model, chat_prompt, streaming_handler, stop, call_params)
 
     try:
-        response: LLMResponse = await model.generate_async(chat_prompt, stop=stop, **(llm_params or {}))
+        response: LLMResponse = await model.generate_async(chat_prompt, stop=stop, **call_params)
     except Exception as e:
         _raise_llm_call_exception(e, model)
 

--- a/nemoguardrails/llm/call.py
+++ b/nemoguardrails/llm/call.py
@@ -114,7 +114,7 @@ async def _stream_llm_call(
     stop: Optional[List[str]],
     llm_params: Optional[dict] = None,
 ) -> LLMResponse:
-    handler.stop = stop or []
+    handler.stop = [stop] if isinstance(stop, str) else stop or []
     streaming_handler_metadata: Dict[str, Any] = {}
     accumulated_provider_metadata: Dict[str, Any] = {}
     accumulated_reasoning: List[str] = []

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -16,10 +16,10 @@
 """OpenAI API schema definitions for the NeMo Guardrails server."""
 
 import os
-from typing import Any, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional, Union
 
 from openai.types.chat.chat_completion import ChatCompletion
-from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from nemoguardrails.rails.llm.options import GenerationOptions
 
@@ -43,10 +43,30 @@ class GuardrailsChatCompletion(ChatCompletion):
     guardrails: Optional[GuardrailsDataOutput] = Field(default=None, description="Guardrails specific output data.")
 
 
+class _OpenAIChatMessageSchema(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+
+
+def _validate_openai_chat_message(message: Any) -> Any:
+    _OpenAIChatMessageSchema.model_validate(message)
+    return message
+
+
+OpenAIChatMessage = Annotated[
+    dict[str, Any],
+    BeforeValidator(
+        _validate_openai_chat_message,
+        json_schema_input_type=_OpenAIChatMessageSchema,
+    ),
+]
+
+
 class OpenAIChatCompletionRequest(BaseModel):
     """Standard OpenAI chat completion request parameters."""
 
-    messages: Optional[List[dict]] = Field(
+    messages: Optional[List[OpenAIChatMessage]] = Field(
         default=None,
         description="The list of messages in the current conversation.",
     )

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -512,3 +512,40 @@ class TestWarnIfTruncated:
             result = warn_if_truncated(response, "self_check_input")
         assert result is False
         assert not caplog.records
+
+
+class RecordingModel:
+    model_name = "test-model"
+    provider_name = "test-provider"
+    provider_url = "https://example.test/v1"
+
+    def __init__(self):
+        self.calls = []
+
+    async def generate_async(self, prompt, *, stop=None, **kwargs):
+        self.calls.append((stop, kwargs))
+        return LLMResponse(content="ok")
+
+    async def stream_async(self, prompt, *, stop=None, **kwargs):
+        self.calls.append((stop, kwargs))
+        yield LLMResponseChunk(delta_content="ok", finish_reason="stop")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("request_stop", ["END", ["END"], None])
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_llm_params_stop_overrides_explicit_stop_without_mutation(request_stop, streaming):
+    model = RecordingModel()
+    llm_params = {"stop": request_stop, "temperature": 0.2}
+    handler = StreamingHandler() if streaming else None
+
+    await llm_call(
+        model,
+        "prompt",
+        stop=["PROMPT_END"],
+        llm_params=llm_params,
+        streaming_handler=handler,
+    )
+
+    assert model.calls == [(request_stop, {"temperature": 0.2})]
+    assert llm_params == {"stop": request_stop, "temperature": 0.2}

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -549,3 +549,6 @@ async def test_llm_params_stop_overrides_explicit_stop_without_mutation(request_
 
     assert model.calls == [(request_stop, {"temperature": 0.2})]
     assert llm_params == {"stop": request_stop, "temperature": 0.2}
+    if streaming:
+        assert handler is not None
+        assert handler.stop == ([request_stop] if isinstance(request_stop, str) else request_stop or [])

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -293,9 +293,25 @@ def test_request_body_messages():
         "messages": [{"content": "Hello"}],
         "guardrails": {"config_id": "test_config"},
     }
-    request_body = GuardrailsChatCompletionRequest.model_validate(data)
-    assert request_body.messages is not None
-    assert len(request_body.messages) == 1
+    with pytest.raises(ValueError, match="role"):
+        GuardrailsChatCompletionRequest.model_validate(data)
+
+
+def test_chat_completion_rejects_message_without_role():
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"content": "Hello"}],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["param"] == "messages.0.role"
+    get_rails.assert_not_awaited()
 
 
 def test_request_body_tools_and_tool_choice():
@@ -396,6 +412,39 @@ def test_chat_completion_passes_tools_to_llm_params():
     assert captured_options["options"].llm_params["tools"] == tools
     assert captured_options["options"].llm_params["tool_choice"] == "auto"
     assert captured_options["options"].llm_params["parallel_tool_calls"] is False
+
+
+@pytest.mark.parametrize("stop", ["END", ["END"], None])
+def test_chat_completion_accepts_stop_parameter(stop):
+    from nemoguardrails.rails.llm.options import GenerationResponse
+
+    captured_options = {}
+
+    async def mock_generate_async(*, messages, options, state):
+        captured_options["options"] = options
+        return GenerationResponse(response=[{"role": "assistant", "content": "ok"}])
+
+    mock_rails = AsyncMock()
+    mock_rails.generate_async = mock_generate_async
+    mock_rails.config.colang_version = "1.0"
+    mock_rails.config.passthrough = False
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock(return_value=mock_rails)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stop": stop,
+                "guardrails": {"config_id": "with_custom_llm"},
+            },
+        )
+
+    assert response.status_code == 200
+    if stop is None:
+        assert "stop" not in captured_options["options"].llm_params
+    else:
+        assert captured_options["options"].llm_params["stop"] == stop
 
 
 def test_chat_completion_rejects_tools_for_non_passthrough_config():


### PR DESCRIPTION
## Summary

Fixes NGUARD-880 stop handling, streaming normalization, and malformed-message validation.



## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Stack Position

Part 2 of 2.

- Previous: #2265
- Next: none, final stack PR

## Stack Context

Moves llm_call tests first so the NGUARD-880 fix is reviewed as a small behavioral diff.

Please review each PR against its parent branch, not directly against the root base branch, except for part 1.

| Order | PR | Branch | Base |
|---:|---|---|---|
| 1 | #2265 | `pouyanpi/refactor-llm-call-tests` | `develop` |
| 2 | #2266 | `pouyanpi/fix-nguard-880-stop-and-messages` | `pouyanpi/refactor-llm-call-tests` |

## Validation

```text
89 passed, 3 skipped
pre-commit passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stop sequences for standard and streaming requests, including consistent normalization.
  * Prevented request parameters from being modified during LLM calls.
  * Enhanced validation of chat messages to require a string `role`.
  * Invalid messages now return a clear HTTP 422 response.
  * Improved error reporting for unsupported or unidentified providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->