### PR TITLE
fix(regex): bound regex matching to prevent ReDoS

### DIFF
--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -22,6 +22,12 @@ from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 
 log = logging.getLogger(__name__)
 
+# Per-pattern matching budget. Python's backtracking engine can spend unbounded
+# time on a pathological configured pattern; the third-party ``regex`` module
+# supports a matching timeout, so a crafted input can stall a worker for at most
+# this long per pattern (ReDoS hardening, #2203).
+REGEX_MATCH_TIMEOUT_SECONDS = 0.5
+
 
 class RegexDetectionResult(TypedDict):
     is_match: bool
@@ -85,7 +91,15 @@ async def detect_regex_pattern(
     # Match against pre-compiled patterns and collect all matches.
     matched: List[str] = []
     for compiled, raw_pattern in zip(compiled_patterns, options.patterns):
-        if compiled.search(text):
+        try:
+            is_match = compiled.search(text, timeout=REGEX_MATCH_TIMEOUT_SECONDS) is not None
+        except TimeoutError:
+            # Fail closed: if a configured pattern cannot be evaluated within
+            # the budget, treat the text as matching so forbidden content is
+            # not let through because the matcher was too slow.
+            log.warning("regex pattern %r timed out on %s text; blocking (fail-closed)", raw_pattern, source)
+            is_match = True
+        if is_match:
             log.info("Regex pattern matched: %s", raw_pattern)
             matched.append(raw_pattern)
 

--- a/nemoguardrails/library/regex/rail_config.py
+++ b/nemoguardrails/library/regex/rail_config.py
@@ -16,6 +16,8 @@
 import re
 from typing import List, Optional
 
+import regex
+
 from nemoguardrails.manifests.config_schema import (
     Field,
     PrivateAttr,
@@ -38,23 +40,23 @@ class RegexDetectionOptions(RailConfigBaseModel):
         description="Whether to perform case-insensitive matching.",
     )
 
-    _compiled_patterns: List["re.Pattern[str]"] = PrivateAttr(default_factory=list)
+    _compiled_patterns: List["regex.Pattern[str]"] = PrivateAttr(default_factory=list)
 
     @model_validator(mode="after")
     def compile_patterns(self) -> "RegexDetectionOptions":
         """Pre-compile regex patterns at config load time."""
-        flags = re.IGNORECASE if self.case_insensitive else 0
+        flags = regex.IGNORECASE if self.case_insensitive else 0
         compiled = []
         for i, pattern in enumerate(self.patterns):
             try:
-                compiled.append(re.compile(pattern, flags))
-            except re.error as e:
+                compiled.append(regex.compile(pattern, flags))
+            except (re.error, regex.error) as e:
                 raise ValueError(f"Invalid regex pattern at index {i} ({pattern!r}): {e}") from e
         object.__setattr__(self, "_compiled_patterns", compiled)
         return self
 
     @property
-    def compiled_patterns(self) -> List["re.Pattern[str]"]:
+    def compiled_patterns(self) -> List["regex.Pattern[str]"]:
         """Return the pre-compiled regex patterns."""
         return self._compiled_patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "protobuf (>=5.29.5)",
   "pydantic (>=2.5,<3.0)",
   "pyyaml (>=6.0)",
+  "regex (>=2026.6.28)",
   "rich (>=13.5.2)",
   "simpleeval (>=0.9.13)",
   "typer (>=0.8)",

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import pytest
 from pydantic import ValidationError
 
@@ -681,6 +683,68 @@ async def test_regex_action_accepts_extra_kwargs():
     assert result.is_blocked is True
     assert result.metadata["is_match"] is True
     assert "\\bconfidential\\b" in result.metadata["detections"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_regex_action_bounds_catastrophic_backtracking():
+    """A pathological configured pattern must not pin the worker (ReDoS, #2203)."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "(a|aa)+$"
+        """,
+        colang_content="",
+    )
+
+    start = time.monotonic()
+    result = await detect_regex_pattern(
+        source="input",
+        text="a" * 40 + "b",
+        config=config,
+    )
+    elapsed = time.monotonic() - start
+
+    # The pattern would take effectively forever on this input under the plain
+    # `re` engine; with the timeout it must return promptly and fail closed.
+    assert elapsed < 2.0, f"regex matching took {elapsed:.2f}s"
+    assert result.is_blocked is True
+    assert result.metadata["is_match"] is True
+    assert "(a|aa)+$" in result.metadata["detections"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_regex_action_valid_pattern_still_matches_with_timeout():
+    """Ordinary valid patterns keep matching within the timeout budget."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpassword\\\\b"
+                    case_insensitive: true
+        """,
+        colang_content="",
+    )
+
+    result = await detect_regex_pattern(
+        source="input",
+        text="My PASSWORD is secret",
+        config=config,
+    )
+
+    assert result.is_blocked is True
+    assert result.metadata["is_match"] is True
+    assert "\\bpassword\\b" in result.metadata["detections"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Root Cause

`RegexDetectionOptions.compile_patterns` pre-compiles configured patterns with the stdlib backtracking `re` engine, and `detect_regex_pattern` evaluates them with `compiled.search(text)` — no time limit, no input bound. A pathological configured pattern (e.g. nested quantifiers) combined with crafted input, model output, or retrieval text can cause catastrophic backtracking and pin a worker indefinitely (ReDoS).

## Fix

- Compile patterns with the **timeout-capable `regex` module** (already an existing transitive dependency; now declared directly in `pyproject.toml`).
- Bound each match with `REGEX_MATCH_TIMEOUT_SECONDS = 0.5` (`nemoguardrails/library/regex/actions.py`).
- **Fail closed on timeout**: if a configured pattern cannot be evaluated within the budget, the text is treated as matching (blocked) and a warning is logged — forbidden content cannot slip through because the matcher was too slow.
- Preserve `case_insensitive` behavior and invalid-pattern error reporting at config load (`regex.error` and `re.error` are both caught and surfaced as the existing `ValueError`).

## Test

- `test_regex_action_bounds_catastrophic_backtracking`: the pathological pattern `(a|aa)+$` against `"a"*40 + "b"` returns a blocked outcome within 2s instead of hanging (previously effectively unbounded under `re`).
- `test_regex_action_valid_pattern_still_matches_with_timeout`: ordinary case-insensitive patterns still match within the budget.
- Existing suite `tests/test_regex_detection.py`: **18 passed** (including invalid-pattern-at-config-load, case-insensitive, multiple-pattern, input/output/retrieval flows).
- `ruff==0.14.6` check + format clean on changed files.

## Diff scope

4 files, +87/-6: `nemoguardrails/library/regex/rail_config.py`, `nemoguardrails/library/regex/actions.py`, `tests/test_regex_detection.py`, `pyproject.toml`.

## AI Disclosure

AI-assisted implementation and tests; human review of the fail-closed semantics, the `regex`-module compatibility (superset of `re`, error-type handling), timeout budget, and final diff before submission.

Closes #2203
