### PR TITLE
fix(checks): reject unsatisfiable rail_types with 422 instead of silent pass

### DIFF
--- a/docs/run-rails/using-python-apis/check-messages.mdx
+++ b/docs/run-rails/using-python-apis/check-messages.mdx
@@ -85,6 +85,15 @@ result = await rails.check_async(
 | `RailType.INPUT` | Run input rails |
 | `RailType.OUTPUT` | Run output rails |
 
+<Note>
+
+Requesting a rail type that has no configured flows raises
+`RailTypeNotConfiguredError` (HTTP 422 on the `/v1/checks` endpoint). For
+example, passing `rail_types=[RailType.OUTPUT]` on a config that only defines
+input flows will raise an error instead of silently returning a passed result.
+
+</Note>
+
 ## RailsResult
 
 The `RailsResult` object contains the outcome of the rails check.

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -31,7 +31,7 @@ __all__ = [
     "LLMConnectionError",
     "LLMResponseValidationError",
     "StreamingNotSupportedError",
-    "UnsatisfiableRailTypeError",
+    "RailTypeNotConfiguredError",
 ]
 
 
@@ -68,7 +68,7 @@ class StreamingNotSupportedError(InvalidRailsConfigurationError):
     pass
 
 
-class UnsatisfiableRailTypeError(InvalidRailsConfigurationError):
+class RailTypeNotConfiguredError(InvalidRailsConfigurationError):
     """Raised when an explicitly requested rail type has no configured flows."""
 
     pass

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "LLMConnectionError",
     "LLMResponseValidationError",
     "StreamingNotSupportedError",
+    "UnsatisfiableRailTypeError",
 ]
 
 
@@ -63,6 +64,12 @@ class InvalidRailsConfigurationError(ConfigurationError):
 
 class StreamingNotSupportedError(InvalidRailsConfigurationError):
     """Raised when streaming is requested but not supported by the configuration."""
+
+    pass
+
+
+class UnsatisfiableRailTypeError(InvalidRailsConfigurationError):
+    """Raised when an explicitly requested rail type has no configured flows."""
 
     pass
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
-from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.exceptions import StreamingNotSupportedError, UnsatisfiableRailTypeError
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.compiled_rail import (
     RailCompilationError,
@@ -1310,6 +1310,10 @@ class IORails(BaseGuardrails):
         Submitted through the same admission queue as ``generate_async`` so the
         check path shares non-streaming concurrency limits, request metrics, and
         the per-request trace span.
+
+        Raises:
+            UnsatisfiableRailTypeError: If a requested rail type has no
+                configured flows.
         """
         await self.start()
         metrics_ctx = request_metrics() if self._metrics_enabled else nullcontext()
@@ -1354,6 +1358,9 @@ class IORails(BaseGuardrails):
         log.debug("[%s] check messages=%s", req_id, truncate(messages))
 
         if rail_types is not None:
+            for rt in rail_types:
+                if not getattr(self.config.rails, rt.value).flows:
+                    raise UnsatisfiableRailTypeError(f"Requested rail type '{rt.value}' has no configured rails.")
             rails_to_run = [rail_type.value for rail_type in rail_types]
         else:
             determined = _determine_rails_from_messages(messages)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1280,6 +1280,10 @@ class IORails(BaseGuardrails):
         Mirrors ``generate``: spins up a short-lived IORails engine with tracing
         and metrics disabled and runs the check on it. For production use, prefer
         the asynchronous ``check_async``.
+
+        Raises:
+            UnsatisfiableRailTypeError: If a requested rail type has no
+                configured flows.
         """
         if check_sync_call_from_async_loop():
             raise RuntimeError(

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
-from nemoguardrails.exceptions import StreamingNotSupportedError, UnsatisfiableRailTypeError
+from nemoguardrails.exceptions import RailTypeNotConfiguredError, StreamingNotSupportedError
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.compiled_rail import (
     RailCompilationError,
@@ -1282,7 +1282,7 @@ class IORails(BaseGuardrails):
         the asynchronous ``check_async``.
 
         Raises:
-            UnsatisfiableRailTypeError: If a requested rail type has no
+            RailTypeNotConfiguredError: If a requested rail type has no
                 configured flows.
         """
         if check_sync_call_from_async_loop():
@@ -1316,7 +1316,7 @@ class IORails(BaseGuardrails):
         the per-request trace span.
 
         Raises:
-            UnsatisfiableRailTypeError: If a requested rail type has no
+            RailTypeNotConfiguredError: If a requested rail type has no
                 configured flows.
         """
         await self.start()
@@ -1364,7 +1364,7 @@ class IORails(BaseGuardrails):
         if rail_types is not None:
             for rt in rail_types:
                 if not getattr(self.config.rails, rt.value).flows:
-                    raise UnsatisfiableRailTypeError(f"Requested rail type '{rt.value}' has no configured rails.")
+                    raise RailTypeNotConfiguredError(f"Requested rail type '{rt.value}' has no configured rails.")
             rails_to_run = [rail_type.value for rail_type in rail_types]
         else:
             determined = _determine_rails_from_messages(messages)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -72,6 +72,7 @@ from nemoguardrails.exceptions import (
     InvalidRailsConfigurationError,
     InvalidStateError,
     StreamingNotSupportedError,
+    UnsatisfiableRailTypeError,
 )
 from nemoguardrails.kb.kb import KnowledgeBase
 from nemoguardrails.llm.cache import CacheInterface, LFUCache
@@ -1662,8 +1663,15 @@ class LLMRails(BaseGuardrails):
             Run only input rails explicitly::
 
                 result = await rails.check_async(messages, rail_types=[RailType.INPUT])
+
+        Raises:
+            UnsatisfiableRailTypeError: If a requested rail type has no
+                configured flows.
         """
         if rail_types is not None:
+            for rt in rail_types:
+                if not getattr(self.config.rails, rt.value).flows:
+                    raise UnsatisfiableRailTypeError(f"Requested rail type '{rt.value}' has no configured rails.")
             options: Optional[dict] = {"rails": [r.value for r in rail_types]}
         else:
             options = _determine_rails_from_messages(messages)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -71,8 +71,8 @@ from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidRailsConfigurationError,
     InvalidStateError,
+    RailTypeNotConfiguredError,
     StreamingNotSupportedError,
-    UnsatisfiableRailTypeError,
 )
 from nemoguardrails.kb.kb import KnowledgeBase
 from nemoguardrails.llm.cache import CacheInterface, LFUCache
@@ -1665,13 +1665,13 @@ class LLMRails(BaseGuardrails):
                 result = await rails.check_async(messages, rail_types=[RailType.INPUT])
 
         Raises:
-            UnsatisfiableRailTypeError: If a requested rail type has no
+            RailTypeNotConfiguredError: If a requested rail type has no
                 configured flows.
         """
         if rail_types is not None:
             for rt in rail_types:
                 if not getattr(self.config.rails, rt.value).flows:
-                    raise UnsatisfiableRailTypeError(f"Requested rail type '{rt.value}' has no configured rails.")
+                    raise RailTypeNotConfiguredError(f"Requested rail type '{rt.value}' has no configured rails.")
             options: Optional[dict] = {"rails": [r.value for r in rail_types]}
         else:
             options = _determine_rails_from_messages(messages)
@@ -1721,7 +1721,7 @@ class LLMRails(BaseGuardrails):
             RailsResult containing status, content, and optional blocking rail name.
 
         Raises:
-            UnsatisfiableRailTypeError: If a requested rail type has no
+            RailTypeNotConfiguredError: If a requested rail type has no
                 configured flows.
         """
         if check_sync_call_from_async_loop():

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1719,6 +1719,10 @@ class LLMRails(BaseGuardrails):
 
         Returns:
             RailsResult containing status, content, and optional blocking rail name.
+
+        Raises:
+            UnsatisfiableRailTypeError: If a requested rail type has no
+                configured flows.
         """
         if check_sync_call_from_async_loop():
             raise RuntimeError(

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -35,7 +35,12 @@ from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.responses import JSONResponse, RedirectResponse, StreamingResponse
 
 from nemoguardrails import LLMRails, RailsConfig, utils
-from nemoguardrails.exceptions import InvalidStateError, LLMCallException, StreamingNotSupportedError
+from nemoguardrails.exceptions import (
+    InvalidStateError,
+    LLMCallException,
+    StreamingNotSupportedError,
+    UnsatisfiableRailTypeError,
+)
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError
 from nemoguardrails.llm.clients._errors import build_error_payload, normalize_error_status
@@ -50,6 +55,7 @@ from nemoguardrails.server.exception_handlers import (
     invalid_state_error_handler,
     llm_call_exception_handler,
     model_initialization_error_handler,
+    unsatisfiable_rail_type_error_handler,
     validation_error_handler,
 )
 from nemoguardrails.server.schemas.openai import (
@@ -217,6 +223,7 @@ _EXCEPTION_HANDLERS = (
     (HTTPClientError, llm_call_exception_handler),
     (ModelInitializationError, model_initialization_error_handler),
     (StreamingNotSupportedError, bad_request_error_handler),
+    (UnsatisfiableRailTypeError, unsatisfiable_rail_type_error_handler),
     (InvalidStateError, invalid_state_error_handler),
     (RequestValidationError, validation_error_handler),
     (StarletteHTTPException, http_exception_handler),

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -38,8 +38,8 @@ from nemoguardrails import LLMRails, RailsConfig, utils
 from nemoguardrails.exceptions import (
     InvalidStateError,
     LLMCallException,
+    RailTypeNotConfiguredError,
     StreamingNotSupportedError,
-    UnsatisfiableRailTypeError,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError
@@ -55,7 +55,7 @@ from nemoguardrails.server.exception_handlers import (
     invalid_state_error_handler,
     llm_call_exception_handler,
     model_initialization_error_handler,
-    unsatisfiable_rail_type_error_handler,
+    rail_type_not_configured_error_handler,
     validation_error_handler,
 )
 from nemoguardrails.server.schemas.openai import (
@@ -223,7 +223,7 @@ _EXCEPTION_HANDLERS = (
     (HTTPClientError, llm_call_exception_handler),
     (ModelInitializationError, model_initialization_error_handler),
     (StreamingNotSupportedError, bad_request_error_handler),
-    (UnsatisfiableRailTypeError, unsatisfiable_rail_type_error_handler),
+    (RailTypeNotConfiguredError, rail_type_not_configured_error_handler),
     (InvalidStateError, invalid_state_error_handler),
     (RequestValidationError, validation_error_handler),
     (StarletteHTTPException, http_exception_handler),

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -775,7 +775,10 @@ def _map_rail_status(status: RailStatus) -> str:
     response_model_exclude_none=True,
 )
 async def guardrail_check(body: GuardrailCheckRequest, request: Request):
-    """Guardrail check request."""
+    """Guardrail check request.
+
+    Returns 422 when ``rail_types`` includes a type with no configured flows.
+    """
     api_request_headers.set(request.headers)
 
     if not body.messages:

--- a/nemoguardrails/server/exception_handlers.py
+++ b/nemoguardrails/server/exception_handlers.py
@@ -26,8 +26,8 @@ from nemoguardrails.exceptions import (
     InvalidStateError,
     LLMCallException,
     LLMRateLimitError,
+    RailTypeNotConfiguredError,
     StreamingNotSupportedError,
-    UnsatisfiableRailTypeError,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError, HTTPStatusError
@@ -114,8 +114,8 @@ async def bad_request_error_handler(request: Request, exc: StreamingNotSupported
     return _error_response(400, str(exc))
 
 
-async def unsatisfiable_rail_type_error_handler(request: Request, exc: UnsatisfiableRailTypeError) -> Response:
-    log.warning("Unsatisfiable rail type: %s", exc)
+async def rail_type_not_configured_error_handler(request: Request, exc: RailTypeNotConfiguredError) -> Response:
+    log.warning("Rail type not configured: %s", exc)
     return _error_response(422, str(exc))
 
 

--- a/nemoguardrails/server/exception_handlers.py
+++ b/nemoguardrails/server/exception_handlers.py
@@ -27,6 +27,7 @@ from nemoguardrails.exceptions import (
     LLMCallException,
     LLMRateLimitError,
     StreamingNotSupportedError,
+    UnsatisfiableRailTypeError,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError, HTTPStatusError
@@ -111,6 +112,11 @@ async def bad_request_error_handler(request: Request, exc: StreamingNotSupported
     """
     log.warning("Bad request: %s", exc)
     return _error_response(400, str(exc))
+
+
+async def unsatisfiable_rail_type_error_handler(request: Request, exc: UnsatisfiableRailTypeError) -> Response:
+    log.warning("Unsatisfiable rail type: %s", exc)
+    return _error_response(422, str(exc))
 
 
 async def invalid_state_error_handler(request: Request, exc: InvalidStateError) -> Response:

--- a/tests/guardrails/test_iorails_check.py
+++ b/tests/guardrails/test_iorails_check.py
@@ -27,7 +27,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 
-from nemoguardrails.exceptions import UnsatisfiableRailTypeError
+from nemoguardrails.exceptions import RailTypeNotConfiguredError
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import (
     REFUSAL_MESSAGE,
@@ -675,7 +675,7 @@ class TestCheckWithRewritingRails:
 
 
 class TestUnsatisfiableRailTypes:
-    """Requesting a rail type with no configured flows raises UnsatisfiableRailTypeError."""
+    """Requesting a rail type with no configured flows raises RailTypeNotConfiguredError."""
 
     @pytest.fixture
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
@@ -692,7 +692,7 @@ class TestUnsatisfiableRailTypes:
 
     @pytest.mark.asyncio
     async def test_unsatisfiable_output_raises(self, input_only_engine):
-        with pytest.raises(UnsatisfiableRailTypeError, match="output"):
+        with pytest.raises(RailTypeNotConfiguredError, match="output"):
             await input_only_engine.check_async([{"role": "user", "content": "hi"}], rail_types=[RailType.OUTPUT])
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_check.py
+++ b/tests/guardrails/test_iorails_check.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 
+from nemoguardrails.exceptions import UnsatisfiableRailTypeError
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import (
     REFUSAL_MESSAGE,
@@ -37,7 +38,7 @@ from nemoguardrails.guardrails.iorails import (
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailStatus, RailType
 from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
-from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG, TOPIC_SAFETY_CONFIG
 
 SAFE = RailResult.allow()
 
@@ -671,3 +672,39 @@ class TestCheckWithRewritingRails:
         assert result.status == RailStatus.BLOCKED
         assert result.content == REFUSAL_MESSAGE
         assert result.rail == "content safety check output"
+
+
+class TestUnsatisfiableRailTypes:
+    """Requesting a rail type with no configured flows raises UnsatisfiableRailTypeError."""
+
+    @pytest.fixture
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def input_only_config(self):
+        return RailsConfig.from_content(config=TOPIC_SAFETY_CONFIG)
+
+    @pytest_asyncio.fixture
+    async def input_only_engine(self, input_only_config):
+        engine = IORails(input_only_config)
+        try:
+            yield engine
+        finally:
+            await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_output_raises(self, input_only_engine):
+        with pytest.raises(UnsatisfiableRailTypeError, match="output"):
+            await input_only_engine.check_async([{"role": "user", "content": "hi"}], rail_types=[RailType.OUTPUT])
+
+    @pytest.mark.asyncio
+    async def test_satisfiable_input_succeeds(self, input_only_engine):
+        _mock_rails(input_only_engine)
+        result = await input_only_engine.check_async([{"role": "user", "content": "hi"}], rail_types=[RailType.INPUT])
+        assert result.status == RailStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_skips_validation(self, input_only_engine):
+        _mock_rails(input_only_engine)
+        result = await input_only_engine.check_async(
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        )
+        assert result.status == RailStatus.PASSED

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -20,7 +20,7 @@ import pytest
 pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
-from nemoguardrails.exceptions import UnsatisfiableRailTypeError
+from nemoguardrails.exceptions import RailTypeNotConfiguredError
 from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
 from nemoguardrails.server import api
 
@@ -299,7 +299,7 @@ def test_unsatisfiable_rail_types_returns_422():
     result = RailsResult(status=RailStatus.PASSED, content="hi")
     mock = _mock_rails(result)
     mock.check_async = AsyncMock(
-        side_effect=UnsatisfiableRailTypeError("Requested rail type 'output' has no configured rails.")
+        side_effect=RailTypeNotConfiguredError("Requested rail type 'output' has no configured rails.")
     )
 
     with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -20,6 +20,7 @@ import pytest
 pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
+from nemoguardrails.exceptions import UnsatisfiableRailTypeError
 from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
 from nemoguardrails.server import api
 
@@ -289,3 +290,26 @@ def test_rail_types_invalid_value_returns_422():
         }
     )
     assert resp.status_code == 422
+
+
+# --- Unsatisfiable rail_types ---
+
+
+def test_unsatisfiable_rail_types_returns_422():
+    result = RailsResult(status=RailStatus.PASSED, content="hi")
+    mock = _mock_rails(result)
+    mock.check_async = AsyncMock(
+        side_effect=UnsatisfiableRailTypeError("Requested rail type 'output' has no configured rails.")
+    )
+
+    with patch.object(api, "_get_rails", new_callable=AsyncMock, return_value=mock):
+        resp = _post(
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {"config_id": "test", "rail_types": ["output"]},
+            }
+        )
+
+    assert resp.status_code == 422
+    assert "output" in resp.json()["error"]["message"]

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -18,6 +18,7 @@ import logging
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.exceptions import UnsatisfiableRailTypeError
 from nemoguardrails.rails.llm.llmrails import (
     _determine_rails_from_messages,
     _get_blocking_rail,
@@ -535,6 +536,47 @@ class TestCheckAsyncExplicitRails:
         ]
         result = mock_rails.check(messages, rail_types=None)
         assert result.status == RailStatus.BLOCKED
+
+
+class TestUnsatisfiableRailTypes:
+    @pytest.fixture
+    def input_only_rails(self):
+        config = RailsConfig.from_content(
+            """
+            define flow input rail
+              if $user_message == "block"
+                bot refuse to respond
+                stop
+            """,
+            """
+            rails:
+                input:
+                    flows:
+                        - input rail
+            """,
+        )
+        return LLMRails(config)
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_output_raises(self, input_only_rails):
+        messages = [{"role": "user", "content": "hello"}]
+        with pytest.raises(UnsatisfiableRailTypeError, match="output"):
+            await input_only_rails.check_async(messages, rail_types=[RailType.OUTPUT])
+
+    @pytest.mark.asyncio
+    async def test_satisfiable_input_succeeds(self, input_only_rails):
+        messages = [{"role": "user", "content": "hello"}]
+        result = await input_only_rails.check_async(messages, rail_types=[RailType.INPUT])
+        assert result.status == RailStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_auto_detect_skips_validation(self, input_only_rails):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        result = await input_only_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
 
 
 @pytest.fixture

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -18,7 +18,7 @@ import logging
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
-from nemoguardrails.exceptions import UnsatisfiableRailTypeError
+from nemoguardrails.exceptions import RailTypeNotConfiguredError
 from nemoguardrails.rails.llm.llmrails import (
     _determine_rails_from_messages,
     _get_blocking_rail,
@@ -560,7 +560,7 @@ class TestUnsatisfiableRailTypes:
     @pytest.mark.asyncio
     async def test_unsatisfiable_output_raises(self, input_only_rails):
         messages = [{"role": "user", "content": "hello"}]
-        with pytest.raises(UnsatisfiableRailTypeError, match="output"):
+        with pytest.raises(RailTypeNotConfiguredError, match="output"):
             await input_only_rails.check_async(messages, rail_types=[RailType.OUTPUT])
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description



## Related Issue(s)

This PR deals with the following [GH issue](https://github.com/NVIDIA-NeMo/Guardrails/issues/2275)

## Verification

1. All local tests pass, e.g.

```bash
make test TEST=tests/server/test_guardrail_checks.py

.....................                                                                                          [100%]

══════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, 
but snapshot(x) will only return x and inline-snapshot will not be able to fix snapshots or generate reports.


================================================= 21 passed in 6.18s =================================================
```

2. Tests against the live local server yields the following results: 

Case 1: define only input rail 

```yaml
rails:
  config:
    hf_classifier:
      hap:
        engine: local
        model: ibm-granite/granite-guardian-hap-125m
        threshold: 0.5
        blocked_labels:
          - LABEL_1

  input:
    flows:
      - hf classifier check input $classifier=hap
```

successful request (200)

```bash
curl -s localhost:8000/v1/checks \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "checks_input_only",
    "messages": [{"role": "user", "content": "hello"}],
    "guardrails": {"config_id": "checks_input_only", "rail_types": ["input"]}
  }'
{"status":"passed","content":"hello"}%
```

unsuccessful request (422 error)

```bash
curl -s localhost:8000/v1/checks \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "checks_input_only",
    "messages": [{"role": "user", "content": "hello"}],
    "guardrails": {"config_id": "checks_input_only", "rail_types": ["output"]}
  }'
{"error":{"message":"Requested rail type 'output' has no configured rails.","type":"invalid_request_error","param":null,"code":null}}
```

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear validation when explicitly requested rail types are not configured.
  * Exposed a dedicated error for unsatisfiable rail requests.
  * API responses now return HTTP 422 with a descriptive error message.

* **Bug Fixes**
  * Prevented generation or checks from running when requested rails cannot be satisfied.
  * Automatic rail detection continues to work without unnecessary validation errors.

* **Tests**
  * Added coverage for configured, unconfigured, and automatically detected rail types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->