### PR TITLE
feat: Add streaming tool call types

### DIFF
--- a/benchmark/tests/test_mock_api.py
+++ b/benchmark/tests/test_mock_api.py
@@ -642,6 +642,18 @@ class TestChatCompletionsStreaming:
         # ID should have correct prefix
         assert list(ids)[0].startswith("chatcmpl-")
 
+    def test_chat_completions_streaming_tool_call_delta(self, client):
+        """Test that streaming tool call delta is returned."""
+        payload = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+            "tools": [{"type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        content = response.text
+        assert "tool_calls" in content
+
 
 class TestCompletionsStreaming:
     """Test the /v1/completions endpoint with streaming."""

--- a/nemoguardrails/llm/call.py
+++ b/nemoguardrails/llm/call.py
@@ -29,6 +29,7 @@ Neighbouring modules: text helpers for interpreting a completion live in
 helpers in :mod:`nemoguardrails.actions.llm.utils`.
 """
 
+import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union, cast
@@ -43,6 +44,7 @@ from nemoguardrails.context import (
 from nemoguardrails.exceptions import LLMCallException, LLMClientError
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.llm_tracker import track_llm_call
+from nemoguardrails.tool_call_types import ChunkToolCallDelta, FunctionCallDelta, ToolCallDelta
 from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
 
 if TYPE_CHECKING:
@@ -129,6 +131,20 @@ async def _stream_llm_call(
                 accumulated_reasoning.append(chunk.delta_reasoning)
             if chunk.delta_tool_calls:
                 tool_calls = chunk.delta_tool_calls
+                frame = ChunkToolCallDelta(
+                    tool_calls=[
+                        ToolCallDelta(
+                            index=index,
+                            id=tc.id,
+                            function=FunctionCallDelta(
+                                name=tc.function.name,
+                                arguments=json.dumps(tc.function.arguments),
+                            ),
+                        )
+                        for index, tc in enumerate(chunk.delta_tool_calls)
+                    ],
+                )
+                await handler.push_chunk(frame.model_dump_json())
             if chunk.model:
                 model_name = chunk.model
             if chunk.finish_reason:

--- a/nemoguardrails/rails/llm/buffer.py
+++ b/nemoguardrails/rails/llm/buffer.py
@@ -16,9 +16,24 @@
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, NamedTuple
 
+from pydantic import ValidationError
+
 from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.tool_call_types import ChunkToolCallDelta
 
 __all__ = ["ChunkBatch", "BufferStrategy", "RollingBuffer", "get_buffer_strategy"]
+
+
+def _is_tool_call_delta_chunk(text: str) -> bool:
+    """True when a streamed chunk is a ``ChunkToolCallDelta`` frame.
+    """
+    if '"tool_call_delta"' not in text:
+        return False
+    try:
+        ChunkToolCallDelta.model_validate_json(text)
+        return True
+    except (ValidationError, ValueError):
+        return False
 
 
 class ChunkBatch(NamedTuple):
@@ -292,7 +307,13 @@ class RollingBuffer(BufferStrategy):
         total_chunks = 0
 
         async for chunk in streaming_handler:
-            buffer.append(chunk["text"] if isinstance(chunk, dict) else chunk)
+            text = chunk["text"] if isinstance(chunk, dict) else chunk
+
+            if isinstance(text, str) and _is_tool_call_delta_chunk(text):
+                yield ChunkBatch(processing_context=[], user_output_chunks=[chunk])
+                continue
+
+            buffer.append(text)
             total_chunks += 1
 
             if len(buffer) >= self.buffer_chunk_size:

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -69,6 +69,7 @@ from nemoguardrails.server.schemas.utils import (
     resolve_tool_calls,
     warn_if_thread_history_invalid_for_tool_use,
 )
+from nemoguardrails.tool_call_types import ChunkToolCallDelta
 
 try:
     from chainlit.utils import mount_chainlit as _mount_chainlit
@@ -528,7 +529,7 @@ async def _format_streaming_response(
         yield "data: [DONE]\n\n"
 
 
-def process_chunk(chunk: Any) -> Union[Any, ChunkError]:
+def process_chunk(chunk: Any) -> Union[Any, ChunkError, ChunkToolCallDelta]:
     """
     Processes a single chunk from the stream.
 
@@ -537,7 +538,9 @@ def process_chunk(chunk: Any) -> Union[Any, ChunkError]:
         model: The model name (not used in processing but kept for signature consistency).
 
     Returns:
-        Union[Any, StreamingError]: StreamingError instance for errors or the original chunk.
+        Union[Any, ChunkError, ChunkToolCallDelta]: A ChunkError instance for terminal error
+        frames, a ChunkToolCallDelta instance for streaming tool-call frames, or the original
+        chunk for ordinary content tokens.
     """
     # Convert chunk to string for JSON parsing if needed
     chunk_str = chunk if isinstance(chunk, str) else json.dumps(chunk) if isinstance(chunk, dict) else str(chunk)
@@ -547,6 +550,20 @@ def process_chunk(chunk: Any) -> Union[Any, ChunkError]:
         return validated_data  # Return the StreamingError instance directly
     except ValidationError:
         # Not an error, just a normal token
+        pass
+    except json.JSONDecodeError:
+        # Invalid JSON format, treat as normal token
+        pass
+    except Exception as e:
+        log.warning(
+            f"Unexpected error processing stream chunk: {type(e).__name__}: {str(e)}",
+            extra={"chunk": chunk_str},
+        )
+
+    try:
+        return ChunkToolCallDelta.model_validate_json(chunk_str)
+    except ValidationError:
+        # Not a tool-call delta, just a normal token
         pass
     except json.JSONDecodeError:
         # Invalid JSON format, treat as normal token

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -37,6 +37,7 @@ from nemoguardrails.server.schemas.openai import (
     GuardrailsDataOutput,
     OpenAIModel,
 )
+from nemoguardrails.tool_call_types import ChunkToolCallDelta
 
 log = logging.getLogger(__name__)
 
@@ -457,7 +458,34 @@ def format_streaming_chunk(
         chunk_id = f"chatcmpl-{uuid.uuid4()}"
 
     # Determine the payload format based on chunk type
-    if isinstance(chunk, dict):
+    if isinstance(chunk, ChunkToolCallDelta):
+        return {
+            "id": chunk_id,
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": tool_call.index,
+                                "id": tool_call.id,
+                                "type": tool_call.type,
+                                "function": {
+                                    "name": tool_call.function.name,
+                                    "arguments": tool_call.function.arguments,
+                                },
+                            }
+                            for tool_call in chunk.tool_calls
+                        ]
+                    },
+                    "index": 0,
+                    "finish_reason": None,
+                }
+            ],
+        }
+    elif isinstance(chunk, dict):
         return {
             "id": chunk_id,
             "object": "chat.completion.chunk",

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -245,7 +245,7 @@ class StreamingHandler(AsyncIterator):
                 # not ones directly pushed by the user
                 if chunk is not None:
                     if self.include_metadata:
-                        chunk_dict: Dict[str, Any] = {"text": chunk if chunk is not END_OF_STREAM else END_OF_STREAM}
+                        chunk_dict: Dict[str, Any] = {"text": (chunk if chunk is not END_OF_STREAM else END_OF_STREAM)}
                         if chunk is END_OF_STREAM:
                             metadata = self.current_metadata.copy() if self.current_metadata else {}
                             metadata.setdefault("response_metadata", None)

--- a/nemoguardrails/tool_call_types.py
+++ b/nemoguardrails/tool_call_types.py
@@ -1,0 +1,20 @@
+from typing import List, Literal
+
+from pydantic import BaseModel
+
+
+class FunctionCallDelta(BaseModel):
+    name: str
+    arguments: str
+
+
+class ToolCallDelta(BaseModel):
+    index: int
+    id: str
+    function: FunctionCallDelta
+    type: Literal["function"] = "function"
+
+
+class ChunkToolCallDelta(BaseModel):
+    tool_calls: List[ToolCallDelta]
+    type: Literal["tool_call_delta"] = "tool_call_delta"

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -45,6 +45,7 @@ from nemoguardrails.server.schemas.utils import (
     resolve_tool_calls,
     warn_if_thread_history_invalid_for_tool_use,
 )
+from nemoguardrails.tool_call_types import ChunkToolCallDelta, FunctionCallDelta, ToolCallDelta
 
 # ===== Tests for extract_bot_message_from_response =====
 
@@ -284,6 +285,23 @@ def test_create_error_chat_completion_without_config_id():
 # ===== Tests for format_streaming_chunk =====
 
 
+def test_format_streaming_chunk_with_tool_call_delta():
+    """Test formatting a tool call delta chunk."""
+    chunk = ChunkToolCallDelta(
+        tool_calls=[ToolCallDelta(index=0, id="call_1", function=FunctionCallDelta(name="get_weather", arguments="{}"))]
+    )
+    result = format_streaming_chunk(chunk, model="test_model")
+    assert result["object"] == "chat.completion.chunk"
+    assert result["model"] == "test_model"
+    assert result["choices"][0]["delta"] == {
+        "tool_calls": [
+            {"index": 0, "id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+        ]
+    }
+    assert result["choices"][0]["index"] == 0
+    assert result["choices"][0]["finish_reason"] is None
+
+
 def test_format_streaming_chunk_with_dict():
     """Test formatting a dict chunk."""
     chunk = {"content": "Hello"}
@@ -372,6 +390,23 @@ def test_format_streaming_chunk_as_sse_with_empty_string():
     payload = json.loads(json_str)
     assert payload["choices"][0]["delta"] == {
         "content": "",
+    }
+
+
+def test_format_streaming_chunk_as_sse_with_tool_call_delta():
+    """Test formatting a tool call delta chunk as SSE."""
+    chunk = ChunkToolCallDelta(
+        tool_calls=[ToolCallDelta(index=0, id="call_1", function=FunctionCallDelta(name="get_weather", arguments="{}"))]
+    )
+    result = format_streaming_chunk_as_sse(chunk, model="test_model")
+    assert result.startswith("data: ")
+    assert result.endswith("\n\n")
+    json_str = result[6:-2]
+    payload = json.loads(json_str)
+    assert payload["choices"][0]["delta"] == {
+        "tool_calls": [
+            {"index": 0, "id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+        ]
     }
 
 

--- a/tests/test_buffer_strategy.py
+++ b/tests/test_buffer_strategy.py
@@ -21,6 +21,11 @@ from nemoguardrails.rails.llm.buffer import (
     get_buffer_strategy,
 )
 from nemoguardrails.rails.llm.config import OutputRailsStreamingConfig
+from nemoguardrails.tool_call_types import (
+    ChunkToolCallDelta,
+    FunctionCallDelta,
+    ToolCallDelta,
+)
 
 
 async def fake_streaming_handler():
@@ -272,7 +277,10 @@ async def test_process_stream_with_metadata_dicts():
 
     async def metadata_streaming_handler():
         for token in ["Hello", " ", "world", "!"]:
-            yield {"text": token, "metadata": {"response_metadata": {"model_provider": "openai"}}}
+            yield {
+                "text": token,
+                "metadata": {"response_metadata": {"model_provider": "openai"}},
+            }
 
     buffer_strategy = RollingBuffer(buffer_context_size=1, buffer_chunk_size=2)
 
@@ -294,8 +302,14 @@ async def test_process_stream_with_mixed_chunk_types():
 
     async def mixed_streaming_handler():
         yield "Hello"
-        yield {"text": " ", "metadata": {"response_metadata": {"model_provider": "openai"}}}
-        yield {"text": "world", "metadata": {"response_metadata": {"model_provider": "openai"}}}
+        yield {
+            "text": " ",
+            "metadata": {"response_metadata": {"model_provider": "openai"}},
+        }
+        yield {
+            "text": "world",
+            "metadata": {"response_metadata": {"model_provider": "openai"}},
+        }
         yield "!"
 
     buffer_strategy = RollingBuffer(buffer_context_size=1, buffer_chunk_size=2)
@@ -534,3 +548,58 @@ async def test_complete_implementation_works():
     assert results[0].user_output_chunks == ["a", "b"]
     assert results[1].processing_context == ["c"]
     assert results[1].user_output_chunks == ["c"]
+
+
+def _tool_call_delta_json() -> str:
+    frame = ChunkToolCallDelta(
+        tool_calls=[
+            ToolCallDelta(
+                index=0,
+                id="call_1",
+                function=FunctionCallDelta(name="get_weather", arguments='{"city": "Boston"}'),
+            )
+        ]
+    )
+    return frame.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_rolling_buffer_bypasses_tool_call_delta_chunk():
+    """A ChunkToolCallDelta frame is yielded straight through, not buffered as prose."""
+    tool_call_chunk = _tool_call_delta_json()
+
+    async def handler():
+        for token in ["Hello", " ", "world"]:
+            yield token
+        yield tool_call_chunk
+
+    buffer = RollingBuffer(buffer_context_size=1, buffer_chunk_size=10)
+    results = [batch async for batch in buffer.process_stream(handler())]
+
+    tool_call_batches = [b for b in results if b.user_output_chunks == [tool_call_chunk]]
+    assert len(tool_call_batches) == 1
+    assert tool_call_batches[0].processing_context == []
+
+    all_processing_text = "".join(chunk for b in results for chunk in b.processing_context)
+    assert "tool_call_delta" not in all_processing_text
+
+    all_user_output = [chunk for b in results for chunk in b.user_output_chunks]
+    assert tool_call_chunk in all_user_output
+    assert "".join(c for c in all_user_output if isinstance(c, str) and c != tool_call_chunk) == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_rolling_buffer_bypasses_tool_call_delta_chunk_with_metadata_wrapping():
+    """The {"text": ...} framing used under include_metadata=True is unwrapped before detection."""
+    tool_call_chunk = {"text": _tool_call_delta_json()}
+
+    async def handler():
+        yield {"text": "Hi"}
+        yield tool_call_chunk
+
+    buffer = RollingBuffer(buffer_context_size=0, buffer_chunk_size=10)
+    results = [batch async for batch in buffer.process_stream(handler())]
+
+    tool_call_batches = [b for b in results if b.user_output_chunks == [tool_call_chunk]]
+    assert len(tool_call_batches) == 1
+    assert tool_call_batches[0].processing_context == []


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->
This PR adds initial support for streaming tool calls; when a model makes a tool call while streaming a response, NeMo Guardrails now forward it to the OpenAI-compat `tool_calls` delta instead of dropping it. 

* Adds new Pydantic types `FunctionCallDelta`, `ToolCallDelta`, and `ChunkToolCallDelta` to represent streaming tool-call delta as JSON-encoded strings
* Updates `format_streaming_chunk()`/`format_streaming_chunk_as_sse()` to parse these types and normalise them as OpenAI choices[0].delta.tool_calls SSE chunks
* Updates `RollingBuffer.process_stream()` to pass these types through 

## Related Issue(s)

<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->
#1615

## Limitations 
This is meant to be part of a larger series of PRs to complete streaming tool calls. There will be a follow-up PR to address the following limitations. Streaming tool calls are pushed to the client as soon as the model outputs them, skipping output rails. The tools + stream: true combination is still blocked with a 422 to not break existing code. 

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
