### PR TITLE
refactor(iorails): Migrate RailResult to use RailOutcome for rail responses

### DIFF
--- a/nemoguardrails/guardrails/actions/tool_call_action.py
+++ b/nemoguardrails/guardrails/actions/tool_call_action.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
-from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 from nemoguardrails.guardrails.tool_schema import validate_arguments
 
@@ -40,11 +40,11 @@ class ToolCallRailAction(ToolRailAction):
 
     action_name = "tool call validation"
 
-    async def run(self, toolset: "Toolset", tool_calls: List["ToolCall"]) -> RailResult:
+    async def run(self, toolset: "Toolset", tool_calls: List["ToolCall"]) -> RailOutcome:
         """Block unless every tool call names an allowed tool with schema-valid arguments."""
         return self._guarded(lambda: self._validate(toolset, tool_calls))
 
-    def _validate(self, toolset: "Toolset", tool_calls: List["ToolCall"]) -> RailResult:
+    def _validate(self, toolset: "Toolset", tool_calls: List["ToolCall"]) -> RailOutcome:
         """Allowlist each call by name, then validate its arguments against the tool schema."""
         for call in tool_calls:
             # Hosted/server tools (e.g. web_search) have no function name; fall back to
@@ -52,8 +52,8 @@ class ToolCallRailAction(ToolRailAction):
             name = call.function.name or call.type
             tool = toolset.get(name)
             if tool is None:
-                return RailResult(is_safe=False, reason=f"tool call '{name}' is not an allowed tool")
+                return RailOutcome.block(reason=f"tool call '{name}' is not an allowed tool")
             block_reason = validate_arguments(tool, call.function.arguments)
             if block_reason is not None:
-                return RailResult(is_safe=False, reason=block_reason)
-        return RailResult(is_safe=True)
+                return RailOutcome.block(reason=block_reason)
+        return RailOutcome.allow()

--- a/nemoguardrails/guardrails/actions/tool_result_action.py
+++ b/nemoguardrails/guardrails/actions/tool_result_action.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
-from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 
 if TYPE_CHECKING:
@@ -52,81 +52,80 @@ class ToolResultRailAction(ToolRailAction):
 
     action_name = "tool result validation"
 
-    async def run(self, tool_results: List["ToolResult"], prior_calls: List["ToolCall"]) -> RailResult:
+    async def run(self, tool_results: List["ToolResult"], prior_calls: List["ToolCall"]) -> RailOutcome:
         """Block unless every tool result links to a prior call with a consistent name and valid content."""
         return self._guarded(lambda: self._validate(tool_results, prior_calls))
 
-    def _validate(self, tool_results: List["ToolResult"], prior_calls: List["ToolCall"]) -> RailResult:
+    def _validate(self, tool_results: List["ToolResult"], prior_calls: List["ToolCall"]) -> RailOutcome:
         """Check call_id linkage, name consistency, and content shape for each result."""
         calls_by_id = self._validate_prior_calls(prior_calls)
-        if isinstance(calls_by_id, RailResult):
+        if isinstance(calls_by_id, RailOutcome):
             return calls_by_id
         return self._validate_results(tool_results, calls_by_id)
 
-    def _validate_prior_calls(self, prior_calls: List["ToolCall"]) -> "RailResult | dict[str, ToolCall]":
-        """Build a call_id index from prior_calls; return a blocking RailResult on duplicate IDs."""
+    def _validate_prior_calls(self, prior_calls: List["ToolCall"]) -> "RailOutcome | dict[str, ToolCall]":
+        """Build a call_id index from prior_calls; return a blocking RailOutcome on duplicate IDs."""
         calls_by_id: dict[str, "ToolCall"] = {}
         for call in prior_calls:
             if not call.id:
                 continue
             if call.id in calls_by_id:
-                return RailResult(
-                    is_safe=False,
+                return RailOutcome.block(
                     reason=f"duplicate prior tool call id '{call.id}' makes tool-result linkage ambiguous",
                 )
             calls_by_id[call.id] = call
         return calls_by_id
 
-    def _validate_results(self, tool_results: List["ToolResult"], calls_by_id: "dict[str, ToolCall]") -> RailResult:
+    def _validate_results(self, tool_results: List["ToolResult"], calls_by_id: "dict[str, ToolCall]") -> RailOutcome:
         """Check each result links to a prior call with a consistent name and well-formed content."""
-        rail_result = self._validate_tool_result_ids(tool_results)
-        if rail_result:
-            return rail_result
+        outcome = self._validate_tool_result_ids(tool_results)
+        if outcome is not None:
+            return outcome
 
         for result in tool_results:
-            rail_result = self._validate_result_call_id(result, calls_by_id)
-            if rail_result:
-                return rail_result
+            outcome = self._validate_result_call_id(result, calls_by_id)
+            if outcome is not None:
+                return outcome
 
             prior = calls_by_id[result.call_id]  # ty: ignore[invalid-argument-type]
-            rail_result = self._validate_result_name(result, prior)
-            if rail_result:
-                return rail_result
+            outcome = self._validate_result_name(result, prior)
+            if outcome is not None:
+                return outcome
 
-            rail_result = self._validate_result_content(result)
-            if rail_result:
-                return rail_result
+            outcome = self._validate_result_content(result)
+            if outcome is not None:
+                return outcome
 
-        return RailResult(is_safe=True)
+        return RailOutcome.allow()
 
-    def _validate_tool_result_ids(self, tool_results: List["ToolResult"]) -> "RailResult | None":
-        """Return a blocking RailResult if any call_id appears more than once in the result list."""
+    def _validate_tool_result_ids(self, tool_results: List["ToolResult"]) -> "RailOutcome | None":
+        """Return a blocking RailOutcome if any call_id appears more than once in the result list."""
         seen: set[str] = set()
         for result in tool_results:
             if not result.call_id:
                 continue
             if result.call_id in seen:
-                return RailResult(
-                    is_safe=False,
+                return RailOutcome.block(
                     reason=f"duplicate tool result for call_id '{result.call_id}': each tool call must have exactly one result",
                 )
             seen.add(result.call_id)
         return None
 
-    def _validate_result_call_id(self, result: "ToolResult", calls_by_id: "dict[str, ToolCall]") -> "RailResult | None":
-        """Return a blocking RailResult if the result is missing a call_id or it has no prior call."""
+    def _validate_result_call_id(
+        self, result: "ToolResult", calls_by_id: "dict[str, ToolCall]"
+    ) -> "RailOutcome | None":
+        """Return a blocking RailOutcome if the result is missing a call_id or it has no prior call."""
         call_id = result.call_id
         if not call_id:
-            return RailResult(is_safe=False, reason="tool result is missing a call_id")
+            return RailOutcome.block(reason="tool result is missing a call_id")
         if calls_by_id.get(call_id) is None:
-            return RailResult(
-                is_safe=False,
+            return RailOutcome.block(
                 reason=f"tool result for call_id '{call_id}' does not correspond to a prior tool call",
             )
         return None
 
-    def _validate_result_name(self, result: "ToolResult", prior: "ToolCall") -> "RailResult | None":
-        """Return a blocking RailResult unless the result name matches the prior call's function name.
+    def _validate_result_name(self, result: "ToolResult", prior: "ToolCall") -> "RailOutcome | None":
+        """Return a blocking RailOutcome unless the result name matches the prior call's function name.
 
         When the prior call's name is known, the result must carry that exact name: a
         missing name no longer slips through on call_id linkage alone (it could mislabel a
@@ -138,25 +137,22 @@ class ToolResultRailAction(ToolRailAction):
         if result.name == prior.function.name:
             return None
         if not result.name:
-            return RailResult(
-                is_safe=False,
+            return RailOutcome.block(
                 reason=(
                     f"tool result for call_id '{result.call_id}' is missing a name; expected '{prior.function.name}'"
                 ),
             )
-        return RailResult(
-            is_safe=False,
+        return RailOutcome.block(
             reason=(
                 f"tool result name '{result.name}' does not match the called tool "
                 f"'{prior.function.name}' for call_id '{result.call_id}'"
             ),
         )
 
-    def _validate_result_content(self, result: "ToolResult") -> "RailResult | None":
-        """Return a blocking RailResult if the result content is not a string or list of dicts."""
+    def _validate_result_content(self, result: "ToolResult") -> "RailOutcome | None":
+        """Return a blocking RailOutcome if the result content is not a string or list of dicts."""
         if result.content is not None and not _is_well_formed_content(result.content):
-            return RailResult(
-                is_safe=False,
+            return RailOutcome.block(
                 reason=f"tool result for call_id '{result.call_id}' has malformed content",
             )
         return None

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -102,8 +102,13 @@ class RailResult:
 
     @property
     def return_value(self) -> dict[str, Any]:
-        """The rail's structured verdict, as the log's ``ExecutedAction.return_value``."""
-        return {_VERDICT_DECISION_KEY: self.is_safe, **self.outcome.metadata}
+        """The rail's structured verdict, as the log's ``ExecutedAction.return_value``.
+
+        The decision is applied last so it wins: ``metadata`` is free-form evidence and a
+        custom action may put an ``allowed`` key in it, which must not be able to record a
+        blocked rail as having allowed the content.
+        """
+        return {**self.outcome.metadata, _VERDICT_DECISION_KEY: self.is_safe}
 
     @classmethod
     def allow(

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional, TypeAlias
 
+from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.types import LLMResponse, UsageInfo
 
 # LLMMessage can contain role/content, plus optional tool_calls / tool_call_id / name; content may be None
@@ -66,25 +67,70 @@ class RailCallRecord:
 
 @dataclass(frozen=True, slots=True)
 class RailResult:
-    """Result of a rail safety check.
+    """Wrapper-class around `RailOutcome` object with IORails-specific metadata
+
+    The verdict itself lives entirely in ``outcome``, which is the single source of
+    truth: ``is_safe``, ``reason`` and ``return_value`` are derived views of it rather
+    than a second copy that could drift. What this type adds is the aggregation
+    ``RailOutcome`` has no concept of, because it belongs to running *many* rails:
+    which one blocked (``triggered_rail``) and what every rail did (``records``).
 
     ``records`` carries the per-rail execution records for every rail that ran in this
     check (not just the blocking one), so IORails can synthesize a ``GenerationLog``.
-    It is empty unless log collection is active. ``return_value`` is the rail's
-    structured verdict (e.g. ``{"allowed": ..., "policy_violations": [...]}``) when the
-    action supplies one, used as the log's ``ExecutedAction.return_value``.
+    It is empty unless log collection is active, and it is log-capture data rather than
+    part of the verdict, so it is excluded from equality (``compare=False``).
 
-    ``records`` and ``return_value`` are log-capture metadata, not part of the safety
-    verdict, so they are excluded from equality and hashing (``compare=False``) — two
-    results with the same ``is_safe``/``reason``/``triggered_rail`` compare equal
-    regardless of captured log data.
+    ``__hash__`` is spelled out as None because ``RailOutcome`` is deliberately
+    unhashable: without this a frozen dataclass would generate a ``__hash__`` that
+    raises from *inside* ``hash()`` instead of reporting this type as unhashable.
     """
 
-    is_safe: bool
-    reason: str | None = None
+    outcome: RailOutcome
     triggered_rail: str | None = None
     records: tuple[RailCallRecord, ...] = field(default=(), compare=False)
-    return_value: Any = field(default=None, compare=False)
+    __hash__ = None
+
+    @property
+    def is_safe(self) -> bool:
+        """Whether the checked content may proceed."""
+        return not self.outcome.is_blocked
+
+    @property
+    def reason(self) -> str | None:
+        """The rail's own explanation, when it authored one."""
+        return self.outcome.reason
+
+    @property
+    def return_value(self) -> dict[str, Any]:
+        """The rail's structured verdict, as the log's ``ExecutedAction.return_value``."""
+        return {_VERDICT_DECISION_KEY: self.is_safe, **self.outcome.metadata}
+
+    @classmethod
+    def allow(
+        cls,
+        *,
+        reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        records: tuple[RailCallRecord, ...] = (),
+    ) -> "RailResult":
+        """A result that lets the content through."""
+        return cls(RailOutcome.allow(reason=reason, metadata=metadata), records=records)
+
+    @classmethod
+    def block(
+        cls,
+        *,
+        reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        triggered_rail: str | None = None,
+        records: tuple[RailCallRecord, ...] = (),
+    ) -> "RailResult":
+        """A result that stops the content. Only a block names a triggering rail."""
+        return cls(
+            RailOutcome.block(reason=reason, metadata=metadata),
+            triggered_rail=triggered_rail,
+            records=records,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,21 +214,6 @@ def serialize_prompt(messages: list[dict]) -> str:
 _VERDICT_DECISION_KEY = "allowed"
 _UNSPECIFIED_REASON = "unspecified"
 
-# Verdict fields a blocked caller may see.
-_CLIENT_EVIDENCE_KEYS = frozenset(
-    {
-        "policy_violations",  # content safety, llama guard
-        "triggered_violation",  # activefence, gcp text moderation
-        "max_risk_score",  # activefence, gcp text moderation
-        "trustworthiness_score",  # cleanlab
-        "assessment",  # policyai
-        "category",  # policyai
-        "severity",  # policyai
-        "score",  # autoalign
-        "threshold",  # autoalign
-    }
-)
-
 
 def _rendered_evidence(value: Any) -> str:
     """Render one verdict value, flattening a sequence into a comma-separated list."""
@@ -201,32 +232,38 @@ def _has_evidence(value: Any) -> bool:
     return True
 
 
-def _verdict_evidence(return_value: Any, keys: Optional[frozenset[str]] = None) -> Optional[str]:
-    """Render a verdict as text, restricted to *keys* when given, or None when it has no evidence."""
+def _verdict_evidence(return_value: Any) -> Optional[str]:
+    """Render a verdict as text, or None when it carries no evidence."""
     if not isinstance(return_value, Mapping):
         return None
     parts = [
         f"{key}: {_rendered_evidence(value)}"
         for key, value in return_value.items()
-        if key != _VERDICT_DECISION_KEY and _has_evidence(value) and (keys is None or key in keys)
+        if key != _VERDICT_DECISION_KEY and _has_evidence(value)
     ]
     return "; ".join(parts) or None
 
 
 def display_reason(result: RailResult) -> str:
-    """Render a blocked rail's full explanation for a log line or a span."""
+    """Render a blocked rail's full explanation for a log line or a span.
+
+    Unfiltered, matching what LLMRails exposes for the same rail: its ``GenerationLog``
+    records the whole ``RailOutcome`` as ``ExecutedAction.return_value``, metadata
+    included. Both surfaces are opt-in (log collection there, content capture here), so
+    the disclosure decision is the operator's on either engine.
+    """
     if result.reason:
         return result.reason
     return _verdict_evidence(result.return_value) or result.triggered_rail or _UNSPECIFIED_REASON
 
 
 def client_reason(result: RailResult) -> str:
-    """Render a blocked rail's explanation for the error payload sent to the caller."""
-    # Only listed verdict fields, because metadata is neutral evidence for logs rather than a
-    # client contract: crowdstrike_aidr puts the user and bot messages in it and f5 forwards the
-    # provider response, so rendering it wholesale would echo request content back over the API.
-    # ``reason`` is exempt: unlike metadata it is a rail-authored explanation meant to be read.
-    if result.reason:
-        return result.reason
-    evidence = _verdict_evidence(result.return_value, keys=_CLIENT_EVIDENCE_KEYS)
-    return evidence or result.triggered_rail or _UNSPECIFIED_REASON
+    """Render a blocked rail's explanation for the error payload sent to the caller.
+
+    Only the rail's own ``reason``, never its metadata. Metadata is neutral evidence
+    for logs rather than a client contract: crowdstrike_aidr puts the user and bot
+    messages in it and f5 forwards the provider response, so rendering any of it would
+    risk echoing request content back over the API. A blocking rail that wants the
+    caller to know why states it in ``reason``, which it authors for that purpose.
+    """
+    return result.reason or result.triggered_rail or _UNSPECIFIED_REASON

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -232,38 +232,21 @@ def _has_evidence(value: Any) -> bool:
     return True
 
 
-def _verdict_evidence(return_value: Any) -> Optional[str]:
-    """Render a verdict as text, or None when it carries no evidence."""
-    if not isinstance(return_value, Mapping):
+def _metadata_evidence(metadata: Any) -> Optional[str]:
+    """Render a rail's metadata as text, or None when it carries no evidence."""
+    if not isinstance(metadata, Mapping):
         return None
-    parts = [
-        f"{key}: {_rendered_evidence(value)}"
-        for key, value in return_value.items()
-        if key != _VERDICT_DECISION_KEY and _has_evidence(value)
-    ]
+    parts = [f"{key}: {_rendered_evidence(value)}" for key, value in metadata.items() if _has_evidence(value)]
     return "; ".join(parts) or None
 
 
 def display_reason(result: RailResult) -> str:
-    """Render a blocked rail's full explanation for a log line or a span.
-
-    Unfiltered, matching what LLMRails exposes for the same rail: its ``GenerationLog``
-    records the whole ``RailOutcome`` as ``ExecutedAction.return_value``, metadata
-    included. Both surfaces are opt-in (log collection there, content capture here), so
-    the disclosure decision is the operator's on either engine.
-    """
+    """Render a blocked rail's full explanation for a log line or a span."""
     if result.reason:
         return result.reason
-    return _verdict_evidence(result.return_value) or result.triggered_rail or _UNSPECIFIED_REASON
+    return _metadata_evidence(result.outcome.metadata) or result.triggered_rail or _UNSPECIFIED_REASON
 
 
 def client_reason(result: RailResult) -> str:
-    """Render a blocked rail's explanation for the error payload sent to the caller.
-
-    Only the rail's own ``reason``, never its metadata. Metadata is neutral evidence
-    for logs rather than a client contract: crowdstrike_aidr puts the user and bot
-    messages in it and f5 forwards the provider response, so rendering any of it would
-    risk echoing request content back over the API. A blocking rail that wants the
-    caller to know why states it in ``reason``, which it authors for that purpose.
-    """
+    """Render a blocked rail's explanation for the error payload sent to the caller."""
     return result.reason or result.triggered_rail or _UNSPECIFIED_REASON

--- a/nemoguardrails/guardrails/rail_guard.py
+++ b/nemoguardrails/guardrails/rail_guard.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Optional
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id
+from nemoguardrails.guardrails.guardrails_types import get_request_id
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.telemetry import record_span_error
 from nemoguardrails.llm.clients._errors import _redact_secrets
@@ -80,21 +80,11 @@ def _blocked_reason_or_reraise(span: Optional["Span"], action_name: str, exc: Ex
     return f"{action_name} error: {detail}"
 
 
-def rail_error_result(span: Optional["Span"], action_name: str, exc: Exception) -> RailResult:
-    """Map a failed tool rail to a blocking ``RailResult``, or re-raise on an HTTP status.
-
-    Call this from the ``except`` handler of a tool rail's own ``try``.
-
-    Raises:
-        Exception: *exc* itself, when it carries an upstream HTTP status.
-    """
-    return RailResult(is_safe=False, reason=_blocked_reason_or_reraise(span, action_name, exc))
-
-
 def rail_error_outcome(span: Optional["Span"], action_name: str, exc: Exception) -> RailOutcome:
-    """Map a failed compiled rail to a blocking ``RailOutcome``, or re-raise on an HTTP status.
+    """Map a failed rail to a blocking ``RailOutcome``, or re-raise on an HTTP status.
 
-    Call this from the ``except`` handler of a ``CompiledRail``'s own ``try``.
+    Call this from the ``except`` handler of a rail's own ``try`` -- a ``CompiledRail``'s
+    or a tool rail's; both speak ``RailOutcome``, so both fail closed the same way.
 
     Raises:
         Exception: *exc* itself, when it carries an upstream HTTP status.

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -152,8 +152,7 @@ def _rail_result(outcome: RailOutcome) -> RailResult:
         # rewrite. Raising keeps it that way, because the alternative -- reading TRANSFORM as
         # "not blocked" -- allows the request and discards the rewrite with nothing to see.
         raise NotImplementedError(f"rail returned {outcome.decision.value!r}, which IORails cannot apply")
-    allowed = not outcome.is_blocked
-    return RailResult(is_safe=allowed, reason=outcome.reason, return_value={"allowed": allowed, **outcome.metadata})
+    return RailResult(outcome)
 
 
 def _model_free_record(flow: str, rail_type: str, result: RailResult) -> RailCallRecord:
@@ -167,7 +166,7 @@ def _model_free_record(flow: str, rail_type: str, result: RailResult) -> RailCal
         is_safe=result.is_safe,
         made_call=False,
         action_name=action_name,
-        return_value=result.return_value if result.return_value is not None else {"allowed": result.is_safe},
+        return_value=result.return_value,
         task=f"{action_name} $model={model}" if model else action_name,
     )
 
@@ -334,7 +333,7 @@ class RailsManager:
         """
         active = self._enabled_flows(self.input_flows, enabled)
         if not active:
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in active}
         if self.input_parallel:
@@ -353,7 +352,7 @@ class RailsManager:
         """
         active = self._enabled_flows(self.output_flows, enabled)
         if not active:
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         rails = {flow: self._run_rail(flow, RailDirection.OUTPUT, messages, bot_response=response) for flow in active}
         if self.output_parallel:
@@ -376,12 +375,12 @@ class RailsManager:
         """
         active = self._enabled_flows(list(self._tool_call_actions), enabled)
         if not active or not tool_calls:
-            return RailResult(is_safe=True)
+            return RailResult.allow()
         try:
             toolset = self.engine_registry.parse_tools(model_type, llm_params)
         except Exception as e:
             log.warning("[%s] tool parsing failed; blocking tool calls: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"tool parsing failed: {e}")
+            return RailResult.block(reason=f"tool parsing failed: {e}")
 
         rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in active}
         return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
@@ -403,14 +402,14 @@ class RailsManager:
         """
         active = self._enabled_flows(list(self._tool_result_actions), enabled)
         if not active:
-            return RailResult(is_safe=True)
+            return RailResult.allow()
         try:
             exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
         except Exception as e:
             log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
+            return RailResult.block(reason=f"tool exchange extraction failed: {e}")
         if not any(exchange.results for exchange in exchanges):
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
@@ -457,7 +456,7 @@ class RailsManager:
     async def _run_tool_call_rail(self, flow: str, tool_calls: list[ToolCall], toolset: Toolset) -> RailResult:
         """Dispatch a single tool-call rail to its action, wrapped in an OUTPUT rail span."""
         with rail_span(self._tracer, flow, RailDirection.OUTPUT) as span:
-            result = await self._tool_call_actions[flow].run(toolset, tool_calls)
+            result = _rail_result(await self._tool_call_actions[flow].run(toolset, tool_calls))
             result = replace(result, records=(_rail_call_record(flow, "tool_output", result),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
@@ -476,11 +475,12 @@ class RailsManager:
         """
         action = self._tool_result_actions[flow]
         with rail_span(self._tracer, flow, RailDirection.INPUT) as span:
-            result = RailResult(is_safe=True)
+            outcome = RailOutcome.allow()
             for exchange in exchanges:
-                result = await action.run(exchange.results, exchange.calls)
-                if not result.is_safe:
+                outcome = await action.run(exchange.results, exchange.calls)
+                if outcome.is_blocked:
                     break
+            result = _rail_result(outcome)
             result = replace(result, records=(_rail_call_record(flow, "tool_input", result),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
@@ -513,7 +513,7 @@ class RailsManager:
                 if not result.is_safe:
                     log.info("[%s] %s flow %s blocked", req_id, direction.value, flow)
                     return replace(result, records=tuple(collected))
-            return RailResult(is_safe=True, records=tuple(collected))
+            return RailResult.allow(records=tuple(collected))
         finally:
             for _, coro in remaining:
                 coro.close()
@@ -552,7 +552,7 @@ class RailsManager:
                             t.cancel()
                         await asyncio.wait(pending_tasks)
                     return replace(first_unsafe, records=tuple(collected))
-            return RailResult(is_safe=True, records=tuple(collected))
+            return RailResult.allow(records=tuple(collected))
         except BaseException:
             for t in tasks:
                 if not t.done():

--- a/nemoguardrails/guardrails/tool_rail_action.py
+++ b/nemoguardrails/guardrails/tool_rail_action.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Callable, Optional
 
-from nemoguardrails.guardrails.guardrails_types import RailResult
-from nemoguardrails.guardrails.rail_guard import rail_error_result
+from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.guardrails.rail_guard import rail_error_outcome
 from nemoguardrails.guardrails.telemetry import action_span
 
 if TYPE_CHECKING:
@@ -44,11 +44,11 @@ class ToolRailAction:
         """Store the optional tracer used to emit the action span."""
         self._tracer = tracer
 
-    def _guarded(self, check: Callable[[], RailResult]) -> RailResult:
+    def _guarded(self, check: Callable[[], RailOutcome]) -> RailOutcome:
         """Run *check* inside an action span, converting a failure into a block.
 
         Shares the engine's fail-closed contract with every other rail through
-        :func:`~nemoguardrails.guardrails.rail_guard.rail_error_result`, so a malformed
+        :func:`~nemoguardrails.guardrails.rail_guard.rail_error_outcome`, so a malformed
         input or a rail bug fails closed rather than crashing the request.
 
         HTTP Errors from downstream calls propagate to the client.
@@ -60,4 +60,4 @@ class ToolRailAction:
             try:
                 return check()
             except Exception as e:
-                return rail_error_result(span, self.action_name, e)
+                return rail_error_outcome(span, self.action_name, e)

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -20,6 +20,7 @@ import pytest
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
+    RailCallRecord,
     RailResult,
     client_reason,
     display_reason,
@@ -32,63 +33,96 @@ class TestRailResult:
 
     def test_safe_result_defaults(self):
         """Test creating a safe result with default reason=None."""
-        result = RailResult(is_safe=True)
+        result = RailResult.allow()
         assert result.is_safe is True
         assert result.reason is None
 
     def test_safe_result_explicit_none(self):
         """Test creating a safe result with explicit reason=None."""
-        result = RailResult(is_safe=True, reason=None)
+        result = RailResult.allow(reason=None)
         assert result.is_safe is True
         assert result.reason is None
 
     def test_unsafe_result_with_reason(self):
         """Test creating an unsafe result with a reason string."""
-        result = RailResult(is_safe=False, reason="Content safety violation")
+        result = RailResult.block(reason="Content safety violation")
         assert result.is_safe is False
         assert result.reason == "Content safety violation"
 
     def test_unsafe_result_without_reason(self):
         """Test creating an unsafe result without a reason."""
-        result = RailResult(is_safe=False)
+        result = RailResult.block()
         assert result.is_safe is False
         assert result.reason is None
 
     def test_equality_same_values(self):
         """Test that two RailResults with the same values are equal."""
-        a = RailResult(is_safe=True)
-        b = RailResult(is_safe=True)
+        a = RailResult.allow()
+        b = RailResult.allow()
         assert a == b
 
     def test_equality_with_reason(self):
         """Test equality when both have the same reason."""
-        a = RailResult(is_safe=False, reason="blocked")
-        b = RailResult(is_safe=False, reason="blocked")
+        a = RailResult.block(reason="blocked")
+        b = RailResult.block(reason="blocked")
         assert a == b
 
     def test_inequality_different_is_safe(self):
         """Test inequality when is_safe differs."""
-        a = RailResult(is_safe=True)
-        b = RailResult(is_safe=False)
+        a = RailResult.allow()
+        b = RailResult.block()
         assert a != b
 
     def test_inequality_different_reason(self):
         """Test inequality when reason differs."""
-        a = RailResult(is_safe=False, reason="reason1")
-        b = RailResult(is_safe=False, reason="reason2")
+        a = RailResult.block(reason="reason1")
+        b = RailResult.block(reason="reason2")
         assert a != b
 
     def test_repr(self):
-        """Test the string representation."""
-        result = RailResult(is_safe=False, reason="jailbreak")
-        assert "is_safe=False" in repr(result)
+        """Test that the representation shows the wrapped outcome, which carries the verdict."""
+        result = RailResult.block(reason="jailbreak")
+        assert "RailDecision.BLOCK" in repr(result)
         assert "reason='jailbreak'" in repr(result)
 
     def test_reason_with_empty_string(self):
         """Test that empty string reason is distinct from None."""
-        result = RailResult(is_safe=False, reason="")
+        result = RailResult.block(reason="")
         assert result.reason == ""
-        assert result != RailResult(is_safe=False, reason=None)
+        assert result != RailResult.block(reason=None)
+
+    def test_return_value_derives_from_the_outcome(self):
+        """The structured verdict is the decision plus the outcome's metadata, not a stored copy."""
+        result = RailResult.block(metadata={"policy_violations": ["S1: Violence"]})
+
+        assert result.return_value == {"allowed": False, "policy_violations": ["S1: Violence"]}
+
+    def test_return_value_of_a_bare_allow_states_only_the_decision(self):
+        """A rail with no metadata still yields a verdict the GenerationLog can record."""
+        assert RailResult.allow().return_value == {"allowed": True}
+
+    def test_metadata_participates_in_equality(self):
+        """Two blocks differing only in evidence are no longer equal.
+
+        The verdict now lives in a single ``RailOutcome``, so metadata is compared with the
+        rest of it. Previously ``return_value`` was excluded from equality and these compared
+        equal; this is the one behavioural change in the wrapper.
+        """
+        a = RailResult.block(reason="blocked", metadata={"score": 0.9})
+        b = RailResult.block(reason="blocked", metadata={"score": 0.1})
+
+        assert a != b
+
+    def test_records_stay_out_of_equality(self):
+        """Captured log data is not part of the verdict, so it does not affect comparison."""
+        record = RailCallRecord(flow="content safety check input", rail_type="input", is_safe=False)
+
+        assert RailResult.block(reason="blocked", records=(record,)) == RailResult.block(reason="blocked")
+
+    def test_is_unhashable_and_says_so(self):
+        """The wrapped outcome is unhashable, and the error names this type rather than leaking from inside."""
+        with pytest.raises(TypeError, match="unhashable type: 'RailResult'"):
+            hash(RailResult.allow())
 
 
 class TestTruncate:
@@ -122,57 +156,44 @@ class TestDisplayReason:
     @pytest.mark.parametrize(
         "result, expected",
         [
-            (RailResult(is_safe=False, reason="Safety categories: S1: Violence"), "Safety categories: S1: Violence"),
+            (RailResult.block(reason="Safety categories: S1: Violence"), "Safety categories: S1: Violence"),
             (
-                RailResult(
-                    is_safe=False,
+                RailResult.block(
                     reason="Safety categories: S1: Violence",
+                    metadata={"policy_violations": ["S2: Sexual"]},
                     triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": ["S2: Sexual"]},
                 ),
                 "Safety categories: S1: Violence",
             ),
             (
-                RailResult(
-                    is_safe=False,
+                RailResult.block(
+                    metadata={"policy_violations": ["S1: Violence", "S2: Sexual"]},
                     triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": ["S1: Violence", "S2: Sexual"]},
                 ),
                 "policy_violations: S1: Violence, S2: Sexual",
             ),
             (
-                RailResult(
-                    is_safe=False,
-                    triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": [], "score": 0},
+                RailResult.block(
+                    metadata={"policy_violations": [], "score": 0}, triggered_rail="content safety check input"
                 ),
                 "score: 0",
             ),
             (
-                RailResult(
-                    is_safe=False,
+                RailResult.block(
+                    metadata={"policy_violations": ["S1: Violence"], "score": 0.97},
                     triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": ["S1: Violence"], "score": 0.97},
                 ),
                 "policy_violations: S1: Violence; score: 0.97",
             ),
             (
-                RailResult(
-                    is_safe=False,
-                    triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": None},
-                ),
+                RailResult.block(metadata={"policy_violations": None}, triggered_rail="content safety check input"),
                 "content safety check input",
             ),
             (
-                RailResult(
-                    is_safe=False,
-                    triggered_rail="jailbreak detection model",
-                    return_value={"allowed": False},
-                ),
+                RailResult.block(triggered_rail="jailbreak detection model"),
                 "jailbreak detection model",
             ),
-            (RailResult(is_safe=False), "unspecified"),
+            (RailResult.block(), "unspecified"),
         ],
         ids=[
             "reason",
@@ -191,60 +212,68 @@ class TestDisplayReason:
 
 
 class TestClientReason:
-    """What reaches the caller in a block payload, as opposed to what reaches the log."""
+    """What reaches the caller in a block payload, as opposed to what reaches the log.
+
+    The caller is told the rail's own ``reason`` and nothing else. Metadata is neutral
+    evidence for diagnosis, not a client contract: crowdstrike_aidr puts the user and bot
+    messages in it, regex puts the matched text in it, and f5 forwards the provider
+    response. A rail that wants the caller to know why it blocked says so in ``reason``,
+    which it authors for exactly that purpose.
+    """
 
     CROWDSTRIKE_VERDICT = {
-        "allowed": False,
         "blocked": True,
         "guard_output": "policy 7",
         "user_message": "my private question",
         "bot_message": "the draft reply",
     }
 
+    # ``_regex_outcome`` builds metadata from its whole ``RegexDetectionResult``, so the
+    # text being checked and the substrings that matched are both in there.
+    REGEX_VERDICT = {
+        "is_match": True,
+        "text": "my card is 4111 1111 1111 1111",
+        "detections": ["4111 1111 1111 1111"],
+        "source": "input",
+    }
+
+    def test_a_rail_authored_reason_is_what_the_caller_sees(self):
+        """A rail that explains itself has that explanation forwarded verbatim."""
+        result = RailResult.block(reason="Safety categories: S1: Violence")
+
+        assert client_reason(result) == "Safety categories: S1: Violence"
+
+    def test_the_reason_wins_over_the_rail_name(self):
+        """Naming the rail is the fallback, not a prefix or a suffix."""
+        result = RailResult.block(reason="Cisco AI Defense flagged the content as unsafe.", triggered_rail="a rail")
+
+        assert client_reason(result) == "Cisco AI Defense flagged the content as unsafe."
+
     @pytest.mark.parametrize(
-        "result, expected",
+        ("metadata", "withheld"),
         [
-            (RailResult(is_safe=False, reason="Safety categories: S1: Violence"), "Safety categories: S1: Violence"),
-            (
-                RailResult(
-                    is_safe=False,
-                    triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": ["S1: Violence"]},
-                ),
-                "policy_violations: S1: Violence",
-            ),
-            (
-                RailResult(
-                    is_safe=False,
-                    triggered_rail="content safety check input",
-                    return_value={"allowed": False, "policy_violations": ["S1: Violence"], "raw_response": "..."},
-                ),
-                "policy_violations: S1: Violence",
-            ),
+            (CROWDSTRIKE_VERDICT, "my private question"),
+            (REGEX_VERDICT, "4111 1111 1111 1111"),
+            ({"policy_violations": ["S1: Violence"]}, "S1: Violence"),
+            ({"trustworthiness_score": 0.12}, "0.12"),
+            ({"score": 0.4, "threshold": 0.75}, "0.4"),
         ],
-        ids=["reason-passes-through", "listed-key", "unlisted-key-dropped-from-a-mix"],
+        ids=["crowdstrike", "regex", "content-safety", "cleanlab", "autoalign"],
     )
-    def test_only_listed_verdict_fields_reach_the_caller(self, result, expected):
-        """A rail-authored reason passes through; verdict fields reach the caller only by name."""
-        assert client_reason(result) == expected
+    def test_no_verdict_metadata_reaches_the_caller(self, metadata, withheld):
+        """Metadata stays out of the payload whether or not it happens to look safe to disclose.
 
-    def test_an_entirely_unlisted_verdict_falls_back_to_the_rail_name(self):
-        """A rail whose evidence is all unlisted names itself rather than disclosing nothing useful."""
-        result = RailResult(
-            is_safe=False,
-            triggered_rail="crowdstrike aidr guard input",
-            return_value=self.CROWDSTRIKE_VERDICT,
-        )
+        Pinned across payloads that differ in how sensitive they look, because the previous
+        design turned on that judgement per field and this one deliberately does not.
+        """
+        result = RailResult.block(metadata=metadata, triggered_rail="a rail")
 
-        assert client_reason(result) == "crowdstrike aidr guard input"
+        assert withheld not in client_reason(result)
+        assert client_reason(result) == "a rail"
 
     def test_the_log_still_carries_what_the_caller_does_not(self):
         """The restriction is on the payload only; diagnosis keeps the full verdict."""
-        result = RailResult(
-            is_safe=False,
-            triggered_rail="crowdstrike aidr guard input",
-            return_value=self.CROWDSTRIKE_VERDICT,
-        )
+        result = RailResult.block(metadata=self.CROWDSTRIKE_VERDICT, triggered_rail="crowdstrike aidr guard input")
 
         rendered = display_reason(result)
 
@@ -252,70 +281,9 @@ class TestClientReason:
         assert "the draft reply" in rendered
         assert "my private question" not in client_reason(result)
 
-    # The verdicts below come from rails IORails now runs, so these are live payloads rather
-    # than anticipated ones.
-
-    REGEX_VERDICT = {
-        "allowed": False,
-        "is_match": True,
-        "text": "my card is 4111 1111 1111 1111",
-        "detections": ["4111 1111 1111 1111"],
-        "source": "input",
-    }
-
-    def test_a_regex_verdict_does_not_echo_the_checked_text(self):
-        """``regex check input`` puts the message and the matched excerpts in its verdict.
-
-        ``_regex_outcome`` builds metadata from its whole ``RegexDetectionResult``, so the
-        text being checked and the substrings that matched are both in there. Neither may
-        reach the caller: echoing a card number back over the API to say it was blocked for
-        containing a card number is the failure this allowlist exists to prevent.
-        """
-        result = RailResult(is_safe=False, triggered_rail="regex check input", return_value=self.REGEX_VERDICT)
-
-        rendered = client_reason(result)
-
-        assert "4111 1111 1111 1111" not in rendered
-        assert rendered == "regex check input"
-
-    @pytest.mark.parametrize(
-        "return_value, expected",
-        [
-            (
-                {"allowed": False, "triggered_violation": "hate_speech", "max_risk_score": 0.95},
-                "triggered_violation: hate_speech; max_risk_score: 0.95",
-            ),
-            (
-                {"allowed": False, "assessment": "UNSAFE", "category": "pii", "severity": "high"},
-                "assessment: UNSAFE; category: pii; severity: high",
-            ),
-            ({"allowed": False, "trustworthiness_score": 0.12}, "trustworthiness_score: 0.12"),
-            ({"allowed": False, "score": 0.4, "threshold": 0.75}, "score: 0.4; threshold: 0.75"),
-        ],
-        ids=["activefence", "policyai", "cleanlab", "autoalign"],
-    )
-    def test_classification_and_score_evidence_reaches_the_caller(self, return_value, expected):
-        """A rail that classified or scored the content says so; that is why it was blocked."""
-        result = RailResult(is_safe=False, triggered_rail="a rail", return_value=return_value)
-
-        assert client_reason(result) == expected
-
-    @pytest.mark.parametrize(
-        "key, value",
-        [("has_pii", True), ("blocked", True), ("is_blocked", True), ("valid", False), ("action", "Block")],
-    )
-    def test_a_verdict_that_only_restates_the_block_names_the_rail_instead(self, key, value):
-        """A boolean echoing the decision is not evidence, so the rail name is the better answer.
-
-        Kept off the allowlist deliberately rather than by oversight: a caller holding a block
-        learns nothing from ``blocked: True``, and listing it would cost a disclosure decision
-        for no gain.
-        """
-        result = RailResult(
-            is_safe=False, triggered_rail="detect pii on input", return_value={"allowed": False, key: value}
-        )
-
-        assert client_reason(result) == "detect pii on input"
+    def test_a_block_with_nothing_to_say_is_unspecified(self):
+        """A rail that supplies neither a reason nor a name still yields a printable string."""
+        assert client_reason(RailResult.block()) == "unspecified"
 
 
 class TestTypeAliases:

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -15,6 +15,8 @@
 
 """Unit tests for guardrails_types module."""
 
+from typing import Any, ClassVar
+
 import pytest
 
 from nemoguardrails.guardrails.guardrails_types import (
@@ -100,6 +102,12 @@ class TestRailResult:
     def test_return_value_of_a_bare_allow_states_only_the_decision(self):
         """A rail with no metadata still yields a verdict the GenerationLog can record."""
         assert RailResult.allow().return_value == {"allowed": True}
+
+    def test_metadata_cannot_overwrite_the_decision(self):
+        """A custom action putting ``allowed`` in metadata cannot log a block as an allow."""
+        result = RailResult.block(metadata={"allowed": True, "policy_violations": ["S1: Violence"]})
+
+        assert result.return_value == {"allowed": False, "policy_violations": ["S1: Violence"]}
 
     def test_metadata_participates_in_equality(self):
         """Two blocks differing only in evidence are no longer equal.
@@ -221,7 +229,7 @@ class TestClientReason:
     which it authors for exactly that purpose.
     """
 
-    CROWDSTRIKE_VERDICT = {
+    CROWDSTRIKE_VERDICT: ClassVar[dict[str, Any]] = {
         "blocked": True,
         "guard_output": "policy 7",
         "user_message": "my private question",
@@ -229,11 +237,13 @@ class TestClientReason:
     }
 
     # ``_regex_outcome`` builds metadata from its whole ``RegexDetectionResult``, so the
-    # text being checked and the substrings that matched are both in there.
-    REGEX_VERDICT = {
+    # text being checked and the substrings that matched are both in there. The account
+    # number is a deliberately non-card-shaped sentinel: the test needs a string that
+    # *looks* sensitive, and a real card format trips PII scanners on every run.
+    REGEX_VERDICT: ClassVar[dict[str, Any]] = {
         "is_match": True,
-        "text": "my card is 4111 1111 1111 1111",
-        "detections": ["4111 1111 1111 1111"],
+        "text": "my account is ACCT-0000-1111-2222",
+        "detections": ["ACCT-0000-1111-2222"],
         "source": "input",
     }
 
@@ -253,7 +263,7 @@ class TestClientReason:
         ("metadata", "withheld"),
         [
             (CROWDSTRIKE_VERDICT, "my private question"),
-            (REGEX_VERDICT, "4111 1111 1111 1111"),
+            (REGEX_VERDICT, "ACCT-0000-1111-2222"),
             ({"policy_violations": ["S1: Violence"]}, "S1: Violence"),
             ({"trustworthiness_score": 0.12}, "0.12"),
             ({"score": 0.4, "threshold": 0.75}, "0.4"),

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -211,9 +211,9 @@ class TestGenerateAsync:
         messages = [{"role": "user", "content": "hi"}]
         llm_response = "Hello from LLM"
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=messages)
 
@@ -231,9 +231,9 @@ class TestGenerateAsync:
         llm_params = {"temperature": 0.01, "max_completion_tokens": 1000}
         options = GenerationOptions(llm_params=llm_params)
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=messages, options=options)
 
@@ -250,7 +250,7 @@ class TestGenerateAsync:
 
         async def mock_input_safe(messages, *, enabled=True):
             call_order.append("input")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def mock_generate(model_type, messages):
             call_order.append("generate")
@@ -258,7 +258,7 @@ class TestGenerateAsync:
 
         async def mock_output_safe(messages, response, *, enabled=True):
             call_order.append("output")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails.rails_manager.is_input_safe = mock_input_safe
         iorails.engine_registry.model_call = mock_generate
@@ -270,7 +270,7 @@ class TestGenerateAsync:
     @pytest.mark.asyncio
     async def test_unsafe_input(self, iorails):
         """Returns refusal and skips LLM + output check when input is unsafe."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
         iorails.engine_registry.model_call = AsyncMock()
         iorails.rails_manager.is_output_safe = AsyncMock()
 
@@ -288,9 +288,9 @@ class TestGenerateAsync:
         messages = [{"role": "user", "content": "hi"}]
         llm_response = "Unsafe response from the LLM!"
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
 
         result = await iorails.generate_async(messages=messages)
 
@@ -305,9 +305,9 @@ class TestGenerateAsync:
         iorails._metrics_enabled = True
         messages = [{"role": "user", "content": "hi"}]
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="unsafe"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
 
         with patch("nemoguardrails.guardrails.iorails.record_request_blocked") as record_blocked:
             result = await iorails.generate_async(messages=messages)
@@ -321,9 +321,9 @@ class TestGenerateAsync:
         messages = [{"role": "user", "content": "hi"}]
         llm_params = {"temperature": 0.01, "max_completion_tokens": 1000}
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         await iorails.generate_async(messages=messages, options={"llm_params": llm_params})
 
@@ -332,7 +332,7 @@ class TestGenerateAsync:
     @pytest.mark.asyncio
     async def test_generate_async_propagates_exception(self, iorails):
         """Exceptions from the LLM call propagate to the caller."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM internal error"))
 
         with pytest.raises(RuntimeError, match="LLM internal error"):
@@ -349,9 +349,9 @@ class TestToolCalling:
         tool = {"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object"}}}
         options = GenerationOptions(llm_params={"tools": [tool], "tool_choice": "auto", "parallel_tool_calls": True})
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         await iorails.generate_async(messages=messages, options=options)
 
@@ -371,9 +371,9 @@ class TestToolCalling:
             )
         ]
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", tool_calls=tool_calls))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=messages)
 
@@ -389,9 +389,9 @@ class TestToolCalling:
         messages = [{"role": "user", "content": "weather?"}]
         tool_calls = [ToolCall(id="c1", type="function", function=ToolCallFunction(name="f", arguments={}))]
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", tool_calls=tool_calls))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=messages)
 
@@ -404,11 +404,11 @@ class TestToolCalling:
         messages = [{"role": "user", "content": "hi"}]
         tool_calls = [ToolCall(id="c1", type="function", function=ToolCallFunction(name="f", arguments={}))]
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(
             return_value=LLMResponse(content="some text", tool_calls=tool_calls)
         )
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=messages)
 
@@ -797,9 +797,9 @@ class TestAutoStart:
     async def test_generate_async_calls_start(self, iorails):
         """generate_async() calls start() automatically before running the pipeline."""
         iorails.engine_registry.start = AsyncMock()
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         assert not iorails._running
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
@@ -811,9 +811,9 @@ class TestAutoStart:
     async def test_generate_async_start_is_idempotent(self, iorails):
         """Two generate_async() calls only trigger start() once."""
         iorails.engine_registry.start = AsyncMock()
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ok"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
@@ -828,7 +828,7 @@ class TestAutoStart:
             yield LLMResponseChunk(delta_content="hello")
 
         iorails_input_only.engine_registry.start = AsyncMock()
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails_input_only.engine_registry.stream_model_call = mock_stream
 
         assert not iorails_input_only._running
@@ -848,7 +848,7 @@ class TestAutoStart:
             yield LLMResponseChunk(delta_content="hi")
 
         iorails_input_only.engine_registry.start = AsyncMock()
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails_input_only.engine_registry.stream_model_call = mock_stream
 
         _ = [chunk async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])]
@@ -874,9 +874,9 @@ class TestGenerate:
         messages = [{"role": "user", "content": "hi"}]
         expected = {"role": "assistant", "content": "Hello from LLM"}
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello from LLM"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         # Patch IORails so the temp instance inside generate() uses our mocked iorails
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
@@ -890,9 +890,9 @@ class TestGenerate:
         messages = [{"role": "user", "content": "hi"}]
         options = GenerationOptions(llm_params={"temperature": 0.5})
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="response"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
             iorails.generate(messages=messages, options=options)
@@ -904,9 +904,9 @@ class TestGenerate:
         iorails = iorails_sync
         messages = [{"role": "user", "content": "hi"}]
 
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="response"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails) as mock_iorails:
             iorails.generate(messages=messages)

--- a/tests/guardrails/test_iorails_check.py
+++ b/tests/guardrails/test_iorails_check.py
@@ -38,12 +38,12 @@ from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailStatus, RailType
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
-SAFE = RailResult(is_safe=True)
+SAFE = RailResult.allow()
 
 
 def _unsafe(rail: str) -> RailResult:
     """Build an unsafe RailResult carrying the given triggered-rail name."""
-    return RailResult(is_safe=False, reason="unsafe", triggered_rail=rail)
+    return RailResult.block(reason="unsafe", triggered_rail=rail)
 
 
 @pytest.fixture
@@ -457,7 +457,7 @@ class TestCheckAsyncBlockedResult:
     @pytest.mark.asyncio
     async def test_blocked_without_triggered_rail_has_none(self, iorails):
         """A block whose RailResult carries no triggered_rail surfaces rail=None rather than crashing."""
-        _mock_rails(iorails, input_result=RailResult(is_safe=False, reason="unsafe"))
+        _mock_rails(iorails, input_result=RailResult.block(reason="unsafe"))
 
         result = await iorails.check_async([{"role": "user", "content": "bad"}])
 

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -85,19 +85,17 @@ def _output_record() -> RailCallRecord:
     )
 
 
+def _input_rail_result(safe: bool, records: tuple) -> RailResult:
+    """An allow carrying *records*, or a block naming the content-safety input flow."""
+    if safe:
+        return RailResult.allow(records=records)
+    return RailResult.block(reason="unsafe", triggered_rail=_CS_INPUT_FLOW, records=records)
+
+
 def _stub_pipeline(iorails: IORails, *, input_records=(), output_records=(), input_safe=True) -> None:
     """Stub input/output rails to return given records, and a main call with usage."""
-    iorails.rails_manager.is_input_safe = AsyncMock(
-        return_value=RailResult(
-            is_safe=input_safe,
-            reason=None if input_safe else "unsafe",
-            triggered_rail=None if input_safe else _CS_INPUT_FLOW,
-            records=tuple(input_records),
-        )
-    )
-    iorails.rails_manager.is_output_safe = AsyncMock(
-        return_value=RailResult(is_safe=True, records=tuple(output_records))
-    )
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=_input_rail_result(input_safe, tuple(input_records)))
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow(records=tuple(output_records)))
     iorails.engine_registry.model_call = AsyncMock(
         return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=99, output_tokens=50, total_tokens=149))
     )
@@ -194,8 +192,8 @@ class TestUsageRemovedFromLlmMetadata:
     @pytest.mark.asyncio
     async def test_llm_metadata_has_no_usage_key(self, iorails):
         """provider_metadata is surfaced verbatim; no `usage` sub-key is added."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(
             return_value=LLMResponse(
                 content="Hi",
@@ -211,8 +209,8 @@ class TestUsageRemovedFromLlmMetadata:
     @pytest.mark.asyncio
     async def test_llm_metadata_none_when_only_usage(self, iorails):
         """With usage but no provider_metadata, llm_metadata is None (usage no longer graft-in)."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(
             return_value=LLMResponse(content="Hi", usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15))
         )

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -55,9 +55,16 @@ def iorails_sync():
 
 def _stub_safe_rails(iorails: IORails) -> None:
     """Default-safe input, output, and tool-call rails so tests focus on the LLM response."""
-    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
-    iorails.rails_manager.are_tool_calls_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+    iorails.rails_manager.are_tool_calls_safe = AsyncMock(return_value=RailResult.allow())
+
+
+def _blocked_unless(safe: bool) -> RailResult:
+    """An allow when *safe*, otherwise a block naming the standard test reason."""
+    if safe:
+        return RailResult.allow()
+    return RailResult.block(reason="unsafe")
 
 
 def _stub_model(iorails: IORails, response: LLMResponse) -> None:
@@ -272,12 +279,8 @@ class TestBlockedStructuredResponse:
     )
     async def test_block_returns_refusal_response(self, iorails, input_safe, output_safe):
         """A block at either the input or output rail yields a GenerationResponse whose response is the refusal and whose other fields are empty."""
-        iorails.rails_manager.is_input_safe = AsyncMock(
-            return_value=RailResult(is_safe=input_safe, reason=None if input_safe else "unsafe")
-        )
-        iorails.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=output_safe, reason=None if output_safe else "unsafe")
-        )
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=_blocked_unless(input_safe))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=_blocked_unless(output_safe))
         _stub_model(iorails, LLMResponse(content="bad answer"))
 
         result = await iorails.generate_async(messages=_USER, options={})
@@ -308,8 +311,8 @@ class TestSyncGenerateStructured:
 
     def test_sync_generate_with_options_returns_generation_response(self, iorails_sync):
         """``generate(options=...)`` returns a GenerationResponse from the ephemeral engine."""
-        iorails_sync.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails_sync.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_sync.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_sync.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
         iorails_sync.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
 
         with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails_sync):

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -98,13 +98,13 @@ def caplog_iorails(caplog):
 
 def _stub_safe_rails(iorails: IORails) -> None:
     """Default-safe input + output rails so each test focuses on the LLM call."""
-    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
 
 def _stub_safe_input(iorails: IORails) -> None:
     """Stub only the input rail (streaming tests on input-only config)."""
-    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
 
 
 def _make_stream(*chunks: LLMResponseChunk):
@@ -218,8 +218,8 @@ class TestReasoningContent:
     async def test_output_rail_block_with_native_reasoning(self, iorails):
         """When output rails block, reasoning is dropped — refusal carries no <think> prefix."""
         messages = [{"role": "user", "content": "hi"}]
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
         iorails.engine_registry.model_call = AsyncMock(
             return_value=LLMResponse(content="bad answer", reasoning="reasoning step")
         )
@@ -232,8 +232,8 @@ class TestReasoningContent:
     async def test_output_rail_block_with_inline_tags(self, iorails):
         """Block path strips inline <think> tags from output-rail input even though the rail blocks."""
         messages = [{"role": "user", "content": "hi"}]
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
         iorails.engine_registry.model_call = AsyncMock(
             return_value=LLMResponse(content="<think>thinking</think>bad answer")
         )

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -113,14 +113,17 @@ def _assert_error_chunk(chunks, *, code, message_contains):
     assert message_contains in error_data["error"]["message"]
 
 
+def _blocked_unless(safe: bool) -> RailResult:
+    """An allow when *safe*, otherwise a block naming the standard test reason."""
+    if safe:
+        return RailResult.allow()
+    return RailResult.block(reason="blocked")
+
+
 def _wire_mocks(iorails, *, input_safe=True, output_safe=True, stream=_mock_stream):
     """Attach standard mocks for input rails, output rails, and LLM streaming."""
-    iorails.rails_manager.is_input_safe = AsyncMock(
-        return_value=RailResult(is_safe=input_safe, reason=None if input_safe else "blocked")
-    )
-    iorails.rails_manager.is_output_safe = AsyncMock(
-        return_value=RailResult(is_safe=output_safe, reason=None if output_safe else "blocked")
-    )
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=_blocked_unless(input_safe))
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=_blocked_unless(output_safe))
     iorails.engine_registry.stream_model_call = stream
 
 
@@ -353,7 +356,7 @@ class TestStreamAsyncOutputRailsStreamFirst:
         async def tracking_rail(messages, response, *, enabled=True):
             """Mock output rail that records call order."""
             yield_order.append("rail_check")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         _wire_mocks(iorails_stream_first)
         iorails_stream_first.rails_manager.is_output_safe = tracking_rail
@@ -397,7 +400,7 @@ class TestStreamAsyncOutputRailsGated:
         async def tracking_rail(messages, response, *, enabled=True):
             """Mock output rail that records call order."""
             yield_order.append("rail_check")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         _wire_mocks(iorails_stream_check_first)
         iorails_stream_check_first.rails_manager.is_output_safe = tracking_rail
@@ -460,7 +463,7 @@ class TestStreamAsyncErrors:
         _wire_mocks(iorails_stream_check_first, stream=_failing_stream)
         # Output rail would block if the error JSON were fed through it
         iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="blocked")
+            return_value=RailResult.block(reason="blocked")
         )
 
         chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
@@ -567,7 +570,7 @@ class TestStreamAsyncEndToEnd:
 
     @pytest.mark.asyncio
     async def test_content_chunks_full_chain(self, iorails_input_only):
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
 
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_sse_streaming_mock([{"content": "Hello"}, {"content": " "}, {"content": "world"}])
@@ -582,7 +585,7 @@ class TestStreamAsyncEndToEnd:
         """Reasoning deltas pass through ModelEngine as LLMResponseChunk.delta_reasoning,
         but IORails drops them — the caller only sees content text.
         """
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
 
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_sse_streaming_mock(
@@ -673,7 +676,7 @@ class TestStreamAsyncToolCalling:
             yield LLMResponseChunk(delta_content="ok")
 
         iorails_input_only.engine_registry.stream_model_call = _capturing_stream
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True, reason=None))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow(reason=None))
 
         await _collect(
             iorails_input_only.stream_async(
@@ -688,7 +691,7 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_tool_call_only_yields_terminal_json(self, iorails_input_only):
         """A tool-call-only response yields a single terminal JSON chunk containing tool_calls."""
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
         main_engine._running = True
@@ -704,7 +707,7 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_text_and_tool_calls_text_first_then_terminal_json(self, iorails_input_only):
         """Content chunks come first; terminal tool-call JSON follows after all text."""
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(
             content_deltas=["Checking", " weather"],
@@ -723,7 +726,7 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_fragmented_args_assembled_into_complete_json_string(self, iorails_input_only):
         """OpenAI-style argument fragments are concatenated and parsed into a complete JSON string."""
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
 
         frag1 = {
@@ -761,8 +764,8 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_tool_call_only_does_not_invoke_output_rails(self, iorails_stream_first):
         """Tool-call-only stream skips is_output_safe (no text content to check)."""
-        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_stream_first.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
         main_engine._running = True
@@ -794,7 +797,7 @@ class TestStreamAsyncToolCalling:
                 }
             ]
         }
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[forced_chunk])
         main_engine._running = True
@@ -820,7 +823,7 @@ class TestStreamAsyncToolCalling:
             yield LLMResponseChunk(finish_reason="tool_calls", delta_tool_calls=[call_a, call_b])
 
         iorails_input_only.engine_registry.stream_model_call = _two_emission_stream
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
 
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
@@ -832,10 +835,8 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_tool_calls_suppressed_after_output_rails_block(self, iorails_stream_first):
         """A blocked output rail suppresses the terminal tool-call chunk."""
-        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="blocked")
-        )
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
         main_engine = iorails_stream_first.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(
             content_deltas=["Some text"],
@@ -853,7 +854,7 @@ class TestStreamAsyncToolCalling:
     @pytest.mark.asyncio
     async def test_include_metadata_tool_call_only_yields_dict_frame(self, iorails_input_only):
         """With include_metadata=True the terminal tool-call chunk is a dict frame."""
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
         main_engine._running = True
@@ -874,7 +875,7 @@ class TestStreamAsyncToolCalling:
     async def test_tool_calls_recorded_in_captured_content(self, iorails_input_only):
         """When content capture is on, the terminal tool-call payload is recorded on the span."""
         iorails_input_only._content_capture_enabled = True
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_tool_call_sse_mock(tool_call_chunks=[_NIM_TOOL_CALL_CHUNK])
         main_engine._running = True
@@ -894,7 +895,7 @@ class TestStreamAsyncToolCalling:
         Covers the empty-content guard in _run_output_rails_in_streaming on the
         stream_first=False path (e.g. a batch that formats to an empty string).
         """
-        iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         async def _empty_content_handler():
             yield ""  # formats to an empty bot_response_chunk -> guard fires
@@ -1076,7 +1077,7 @@ class TestStreamAsyncMetadata:
     @pytest.mark.asyncio
     async def test_response_headers_surface_as_provider_metadata(self, iorails_input_only):
         """HTTP response headers surface as provider_metadata['response_headers'] in include_metadata stream frames."""
-        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         response_headers = {"nvcf-reqid": "req-xyz", "content-type": "text/event-stream"}
         main_engine = iorails_input_only.engine_registry._get_engine("main", ModelEngine)
         main_engine._client = _build_sse_streaming_mock([{"content": "Hi"}], headers=response_headers)
@@ -1147,14 +1148,12 @@ class TestBlockReasonDisplay:
     """The text a blocked rail contributes to the client-facing violation payload."""
 
     @pytest.mark.asyncio
-    async def test_input_block_payload_renders_the_verdict(self, iorails_input_only):
-        """An input rail blocking with no reason sends its evidence to the client, never "None"."""
+    async def test_input_block_payload_renders_a_stated_reason(self, iorails_input_only):
+        """An input rail that explains itself has that explanation reach the client."""
         _wire_mocks(iorails_input_only)
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(
-            return_value=RailResult(
-                is_safe=False,
-                triggered_rail="content safety check input",
-                return_value={"allowed": False, "policy_violations": ["S1: Violence"]},
+            return_value=RailResult.block(
+                reason="Safety categories: S1: Violence", triggered_rail="content safety check input"
             )
         )
 
@@ -1163,19 +1162,38 @@ class TestBlockReasonDisplay:
         _assert_error_chunk(
             chunks,
             code="content_blocked",
-            message_contains="Blocked by input rails: policy_violations: S1: Violence",
+            message_contains="Blocked by input rails: Safety categories: S1: Violence",
         )
+
+    @pytest.mark.asyncio
+    async def test_input_block_payload_withholds_verdict_metadata(self, iorails_input_only):
+        """A rail with evidence but no reason names itself; the evidence stays out of the payload.
+
+        The direction and the rail name still reach the client through the enclosing message,
+        so a block without a stated reason is never rendered as "None".
+        """
+        _wire_mocks(iorails_input_only)
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(
+            return_value=RailResult.block(
+                metadata={"policy_violations": ["S1: Violence"]}, triggered_rail="content safety check input"
+            )
+        )
+
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "bad"}]))
+
+        _assert_error_chunk(
+            chunks,
+            code="content_blocked",
+            message_contains="Blocked by input rails: content safety check input",
+        )
+        assert not any("S1: Violence" in chunk for chunk in chunks if isinstance(chunk, str))
 
     @pytest.mark.asyncio
     async def test_output_block_payload_falls_back_to_the_rail_name(self, iorails_stream_first):
         """An output rail blocking with neither reason nor evidence names itself to the client."""
         _wire_mocks(iorails_stream_first)
         iorails_stream_first.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(
-                is_safe=False,
-                triggered_rail="content safety check output",
-                return_value={"allowed": False},
-            )
+            return_value=RailResult.block(triggered_rail="content safety check output")
         )
 
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -82,9 +82,9 @@ def _make_tracing_only_config():
 
 def _stub_safe_pipeline(iorails, llm_response="Hello"):
     """Mock input/output rails as safe and the LLM to return *llm_response*."""
-    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
     iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content=llm_response))
-    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
 
 @pytest.fixture(autouse=True)
@@ -171,7 +171,7 @@ class TestGenerateAsyncWithTracing:
         async def capture_req_id(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing.rails_manager.is_input_safe = capture_req_id
@@ -199,7 +199,7 @@ class TestGenerateAsyncWithTracing:
     @pytest.mark.asyncio
     async def test_span_created_on_input_block(self, iorails_tracing, exporter):
         """A span is still created and completed even when input rails block."""
-        iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
 
         result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
@@ -227,7 +227,7 @@ class TestGenerateAsyncWithoutTracing:
         async def capture_req_id(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         _stub_safe_pipeline(iorails_no_tracing)
         iorails_no_tracing.rails_manager.is_input_safe = capture_req_id
@@ -250,7 +250,7 @@ class TestEndToEndTracing:
         async def capturing_input_check(messages, *, enabled=True):
             captured["input_req_id"] = get_request_id()
             captured["input_messages"] = messages
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def capturing_model_call(model_name, messages, **kwargs):
             captured["llm_req_id"] = get_request_id()
@@ -260,7 +260,7 @@ class TestEndToEndTracing:
         async def capturing_output_check(messages, response, *, enabled=True):
             captured["output_req_id"] = get_request_id()
             captured["output_response"] = response
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails_tracing.rails_manager.is_input_safe = capturing_input_check
         iorails_tracing.engine_registry.model_call = capturing_model_call
@@ -313,7 +313,7 @@ class TestEndToEndTracing:
 
         async def record_req_id(messages, *, enabled=True):
             req_ids_seen.append(get_request_id())
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing.rails_manager.is_input_safe = record_req_id
@@ -344,7 +344,7 @@ class TestEndToEndTracing:
         async def capture_then_pass(messages, *, enabled=True):
             nonlocal captured_req_id
             captured_req_id = get_request_id()
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails_tracing.rails_manager.is_input_safe = capture_then_pass
         iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("connection refused"))
@@ -800,7 +800,7 @@ class TestStreamAsyncSpanHierarchy:
     @pytest.mark.asyncio
     async def test_creates_request_span(self, iorails_streaming_input_only_tracing, exporter):
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
@@ -883,7 +883,7 @@ class TestStreamAsyncSpanHierarchy:
     async def test_input_block_leaves_llm_span_absent(self, iorails_streaming_input_only_tracing, exporter):
         """When input rails block, no main LLM span is created."""
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
         assert len(chunks) == 1
@@ -924,7 +924,7 @@ class TestStreamAsyncSpanHierarchy:
     async def test_no_spans_when_tracing_disabled(self, iorails_streaming_no_tracing, exporter):
         """With tracing off, streaming produces zero spans but still works."""
         iorails = iorails_streaming_no_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
@@ -1097,7 +1097,7 @@ class TestGenerateAsyncRequestMetrics:
     @pytest.mark.asyncio
     async def test_emits_blocked_counter_on_input_block(self, iorails_tracing, metric_reader):
         _stub_safe_pipeline(iorails_tracing)
-        iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
 
         result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
@@ -1113,7 +1113,7 @@ class TestGenerateAsyncRequestMetrics:
     async def test_emits_blocked_counter_on_output_block(self, iorails_tracing, metric_reader):
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe response")
+            return_value=RailResult.block(reason="unsafe response")
         )
 
         result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
@@ -1128,9 +1128,7 @@ class TestGenerateAsyncRequestMetrics:
         """With metrics disabled, a blocked-by-input-rail request emits no
         ``requests.blocked`` data point."""
         _stub_safe_pipeline(iorails_no_tracing)
-        iorails_no_tracing.rails_manager.is_input_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe")
-        )
+        iorails_no_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
 
         result = await iorails_no_tracing.generate_async(messages=[{"role": "user", "content": "bad"}])
 
@@ -1252,7 +1250,7 @@ class TestCheckAsyncRequestMetrics:
     async def test_check_emits_blocked_counter_on_input_block(self, iorails_tracing, metric_reader):
         """An input-rail block during check_async emits the blocked counter with rail.type=Input."""
         iorails_tracing.rails_manager.is_input_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe", triggered_rail="content safety check input")
+            return_value=RailResult.block(reason="unsafe", triggered_rail="content safety check input")
         )
 
         result = await iorails_tracing.check_async([{"role": "user", "content": "bad"}])
@@ -1267,9 +1265,7 @@ class TestCheckAsyncRequestMetrics:
     async def test_check_emits_blocked_counter_on_output_block(self, iorails_tracing, metric_reader):
         """An output-rail block during check_async emits the blocked counter with rail.type=Output."""
         iorails_tracing.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(
-                is_safe=False, reason="unsafe response", triggered_rail="content safety check output"
-            )
+            return_value=RailResult.block(reason="unsafe response", triggered_rail="content safety check output")
         )
 
         result = await iorails_tracing.check_async([{"role": "assistant", "content": "bad answer"}])
@@ -1301,7 +1297,7 @@ class TestStreamAsyncRequestMetrics:
         """Happy-path stream_async → counter +1, duration recorded once,
         no errors, stream.active back to 0, no rejections."""
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
@@ -1325,7 +1321,7 @@ class TestStreamAsyncRequestMetrics:
         counter increments.
         """
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
@@ -1349,7 +1345,7 @@ class TestStreamAsyncRequestMetrics:
         (``requests.errors{error.type=QueueFull}``)
         """
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
@@ -1370,7 +1366,7 @@ class TestStreamAsyncRequestMetrics:
         reads 1; after the iterator is consumed, it reads 0.
         """
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         iterator = iorails.stream_async([{"role": "user", "content": "hi"}]).__aiter__()
@@ -1420,7 +1416,7 @@ class TestStreamAsyncRequestMetrics:
         ``stream.rejections`` don't emit, even on rejection path.
         """
         iorails = iorails_streaming_no_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
@@ -1456,7 +1452,7 @@ class TestStreamAsyncRequestMetrics:
         self, iorails_streaming_input_only_tracing, metric_reader
     ):
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
         assert len(chunks) == 1
@@ -1477,9 +1473,7 @@ class TestStreamAsyncRequestMetrics:
         """
         iorails = iorails_streaming_output_tracing
         _stub_deep_streaming_pipeline(iorails)
-        iorails.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe response")
-        )
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe response"))
 
         chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
         # Output block terminates the stream with a JSON error payload chunk.
@@ -1509,9 +1503,7 @@ class TestStreamAsyncRequestMetrics:
             iorails = IORails(RailsConfig.from_content(config=cfg))
         async with iorails:
             _stub_deep_streaming_pipeline(iorails)
-            iorails.rails_manager.is_output_safe = AsyncMock(
-                return_value=RailResult(is_safe=False, reason="unsafe response")
-            )
+            iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe response"))
 
             chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
             # Block still works — customer-visible behavior unchanged.
@@ -1792,7 +1784,7 @@ class TestRequestsActiveAggregate:
         iterator drains, it nets to 0.
         """
         iorails = iorails_streaming_input_only_tracing
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         iterator = iorails.stream_async([{"role": "user", "content": "hi"}]).__aiter__()
@@ -1834,7 +1826,7 @@ class TestRequestsActiveAggregate:
                 iorails = IORails(RailsConfig.from_content(config=invariant_config))
             async with iorails:
                 iorails._do_generate = _gated_generate(nonstream_gate)
-                iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+                iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
                 iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
                 # Launch one executing + one queued non-streaming request.
@@ -2050,7 +2042,7 @@ class TestCheckContentCapture:
     @pytest.mark.asyncio
     async def test_check_captures_request_content(self, iorails_content_capture, exporter):
         """check_async records the request input/output on the request span when content capture is on."""
-        iorails_content_capture.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_content_capture.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
 
         await iorails_content_capture.check_async([{"role": "user", "content": "hello"}])
 
@@ -2139,11 +2131,9 @@ class TestContentCaptureLegacyFormat:
         this is the semantic distinction that motivated the separate attr names.
         """
         iorails = iorails_content_capture
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="bad response"))
-        iorails.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe response")
-        )
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe response"))
 
         result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE
@@ -2163,15 +2153,13 @@ class TestContentCaptureLegacyFormat:
         is forced to block.
         """
         iorails = iorails_content_capture
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         # Mock at the engine level (not engine_registry.model_call) so the real
         # model_call wrapper runs, creating the LLM CLIENT span + capturing content.
         iorails.engine_registry._engines["main"].chat_completion = AsyncMock(
             return_value=LLMResponse(content="raw model answer")
         )
-        iorails.rails_manager.is_output_safe = AsyncMock(
-            return_value=RailResult(is_safe=False, reason="unsafe response")
-        )
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe response"))
 
         result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
         assert result["content"] == REFUSAL_MESSAGE

--- a/tests/guardrails/test_rail_guard.py
+++ b/tests/guardrails/test_rail_guard.py
@@ -31,9 +31,8 @@ from opentelemetry.trace import Tracer
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.model_engine import ModelEngineError
-from nemoguardrails.guardrails.rail_guard import rail_error_outcome, rail_error_result
+from nemoguardrails.guardrails.rail_guard import rail_error_outcome
 from nemoguardrails.guardrails.telemetry import action_span
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 
@@ -68,56 +67,36 @@ status_bearing_types = pytest.mark.parametrize(
 )
 
 
-entry_points = pytest.mark.parametrize(
-    "call", [rail_error_result, rail_error_outcome], ids=["rail_error_result", "rail_error_outcome"]
-)
-
-
-def verdict_of(returned) -> tuple[bool, str | None]:
-    """Flatten either return shape to ``(blocked, reason)``.
-
-    Lets one test cover both entry points, which pins that they agree by construction rather
-    than by a separate parity assertion someone could forget to update.
-    """
-    if isinstance(returned, RailResult):
-        return not returned.is_safe, returned.reason
-    return returned.is_blocked, returned.reason
-
-
 class TestFailsClosed:
-    """A rail that raises without an HTTP status blocks, identically at both entry points."""
+    """A rail that raises without an HTTP status blocks."""
 
-    @entry_points
-    def test_unexpected_exception_blocks_with_a_reason(self, call):
+    def test_unexpected_exception_blocks_with_a_reason(self):
         """An arbitrary exception becomes a blocking verdict naming the action."""
-        blocked, reason = verdict_of(call(None, ACTION_NAME, RuntimeError("parser blew up")))
+        outcome = rail_error_outcome(None, ACTION_NAME, RuntimeError("parser blew up"))
 
-        assert blocked
-        assert reason == "content safety check input error: parser blew up"
+        assert outcome.is_blocked
+        assert outcome.reason == "content safety check input error: parser blew up"
 
-    @entry_points
     @status_bearing_types
-    def test_status_bearing_exception_without_a_status_blocks(self, call, make_exc):
+    def test_status_bearing_exception_without_a_status_blocks(self, make_exc):
         """A connection-level failure carries status=None, so it fails closed rather than propagating."""
-        blocked, reason = verdict_of(call(None, ACTION_NAME, make_exc(None)))
+        outcome = rail_error_outcome(None, ACTION_NAME, make_exc(None))
 
-        assert blocked
-        assert reason is not None
-        assert "upstream refused" in reason
+        assert outcome.is_blocked
+        assert outcome.reason is not None
+        assert "upstream refused" in outcome.reason
 
-    @entry_points
-    def test_reason_redacts_secrets(self, call):
+    def test_reason_redacts_secrets(self):
         """Credentials in an exception message are redacted before reaching the reason."""
-        _, reason = verdict_of(call(None, ACTION_NAME, RuntimeError("auth rejected token nvapi-abc123secret")))
+        outcome = rail_error_outcome(None, ACTION_NAME, RuntimeError("auth rejected token nvapi-abc123secret"))
 
-        assert reason == "content safety check input error: auth rejected token nvapi-***"
+        assert outcome.reason == "content safety check input error: auth rejected token nvapi-***"
 
-    @entry_points
-    def test_blocking_verdict_records_the_span_error(self, call):
+    def test_blocking_verdict_records_the_span_error(self):
         """A blocked rail marks its span, so the failure is visible in the trace."""
         span = MagicMock()
 
-        call(span, ACTION_NAME, RuntimeError("parser blew up"))
+        rail_error_outcome(span, ACTION_NAME, RuntimeError("parser blew up"))
 
         span.record_exception.assert_called_once()
         span.set_attribute.assert_any_call("error.type", "RuntimeError")
@@ -126,28 +105,21 @@ class TestFailsClosed:
 class TestPropagatesUpstreamStatus:
     """An exception carrying an HTTP status propagates so the server can map it."""
 
-    @entry_points
     @status_bearing_types
-    def test_exception_with_a_status_is_reraised(self, call, make_exc):
+    def test_exception_with_a_status_is_reraised(self, make_exc):
         """A 503 from the upstream provider propagates rather than becoming a block."""
         exc = make_exc(503)
 
         with pytest.raises(type(exc)) as excinfo:
-            call(None, ACTION_NAME, exc)
+            rail_error_outcome(None, ACTION_NAME, exc)
 
         assert excinfo.value is exc
 
 
-class TestReturnShapes:
-    """The entry points differ only in the type they return, asserted whole."""
+class TestReturnShape:
+    """Every rail, compiled or tool, gets the same blocking RailOutcome."""
 
-    def test_tool_rail_entry_point_returns_a_rail_result(self):
-        """``rail_error_result`` yields a blocking RailResult."""
-        returned = rail_error_result(None, ACTION_NAME, RuntimeError("parser blew up"))
-
-        assert returned == RailResult(is_safe=False, reason="content safety check input error: parser blew up")
-
-    def test_compiled_rail_entry_point_returns_a_rail_outcome(self):
+    def test_entry_point_returns_a_rail_outcome(self):
         """``rail_error_outcome`` yields a blocking RailOutcome with no metadata or transforms."""
         returned = rail_error_outcome(None, ACTION_NAME, RuntimeError("parser blew up"))
 
@@ -168,7 +140,7 @@ class TestLogsAreRedacted:
     def test_blocking_path_logs_the_redacted_message(self, caplog):
         """A blocked rail logs the redacted text rather than the raw credential."""
         with caplog.at_level(logging.ERROR, logger=self.LOGGER):
-            rail_error_result(None, ACTION_NAME, RuntimeError(f"auth rejected {self.SECRET}"))
+            rail_error_outcome(None, ACTION_NAME, RuntimeError(f"auth rejected {self.SECRET}"))
 
         assert self.SECRET not in caplog.text
         assert self.REDACTED in caplog.text
@@ -179,7 +151,7 @@ class TestLogsAreRedacted:
 
         with caplog.at_level(logging.ERROR, logger=self.LOGGER):
             with pytest.raises(ModelEngineError):
-                rail_error_result(None, ACTION_NAME, exc)
+                rail_error_outcome(None, ACTION_NAME, exc)
 
         assert self.SECRET not in caplog.text
         assert self.REDACTED in caplog.text
@@ -195,7 +167,7 @@ class TestLogsAreRedacted:
 
         with caplog.at_level(logging.ERROR, logger=self.LOGGER):
             with pytest.raises(ModelEngineError) as excinfo:
-                rail_error_result(None, ACTION_NAME, exc)
+                rail_error_outcome(None, ACTION_NAME, exc)
 
         assert excinfo.value is exc
         assert self.SECRET in str(excinfo.value)
@@ -219,7 +191,7 @@ class TestSpanErrorRecording:
         exc = ModelEngineError("upstream refused", model_name="guard-model", status=503)
 
         with pytest.raises(ModelEngineError):
-            rail_error_result(span, ACTION_NAME, exc)
+            rail_error_outcome(span, ACTION_NAME, exc)
 
         span.record_exception.assert_not_called()
 
@@ -228,9 +200,9 @@ class TestSpanErrorRecording:
         tracer, exporter = recording_tracer()
 
         with action_span(tracer, ACTION_NAME) as span:
-            result = rail_error_result(span, ACTION_NAME, RuntimeError("parser blew up"))
+            result = rail_error_outcome(span, ACTION_NAME, RuntimeError("parser blew up"))
 
-        assert result.is_safe is False
+        assert result.is_blocked
         events = exception_events(exporter)
         assert len(events) == 1
         assert events[0].attributes["exception.type"] == "RuntimeError"
@@ -242,7 +214,7 @@ class TestSpanErrorRecording:
 
         with pytest.raises(ModelEngineError):
             with action_span(tracer, ACTION_NAME) as span:
-                rail_error_result(span, ACTION_NAME, exc)
+                rail_error_outcome(span, ACTION_NAME, exc)
 
         events = exception_events(exporter)
         assert len(events) == 1
@@ -257,7 +229,7 @@ class TestSpanErrorRecording:
 
         with pytest.raises(ModelEngineError):
             with action_span(tracer, ACTION_NAME) as span:
-                rail_error_result(span, ACTION_NAME, exc)
+                rail_error_outcome(span, ACTION_NAME, exc)
 
         (finished,) = exporter.get_finished_spans()
         assert finished.attributes is not None
@@ -273,13 +245,13 @@ class DummyToolRail(ToolRailAction):
         super().__init__()
         self._error = error
 
-    def check(self) -> RailResult:
+    def check(self) -> RailOutcome:
         """Run the guarded check, raising the configured error when there is one."""
 
-        def _check() -> RailResult:
+        def _check() -> RailOutcome:
             if self._error is not None:
                 raise self._error
-            return RailResult(is_safe=True)
+            return RailOutcome.allow()
 
         return self._guarded(_check)
 
@@ -289,13 +261,13 @@ class TestToolRailsShareTheEnvelope:
 
     def test_successful_check_is_returned_unchanged(self):
         """A check that returns normally is passed through untouched."""
-        assert DummyToolRail().check() == RailResult(is_safe=True)
+        assert DummyToolRail().check() == RailOutcome.allow()
 
     def test_exception_becomes_a_blocking_result_with_secrets_redacted(self):
         """A malformed payload fails closed, named after the rail and with credentials removed."""
         result = DummyToolRail(ValueError("bad header sk-abc123secret")).check()
 
-        assert result == RailResult(is_safe=False, reason="tool call validation error: bad header sk-***")
+        assert result == RailOutcome.block(reason="tool call validation error: bad header sk-***")
 
     def test_status_bearing_exception_is_reraised(self):
         """A tool rail is held to the same propagation policy, though no shipped one can raise this."""

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -60,7 +60,7 @@ from tests.guardrails.test_data import (
 )
 from tests.guardrails.tool_helpers import (
     WEATHER_SCHEMA,
-    assert_blocked,
+    assert_result_blocked,
     make_tool_conversation,
     malformed_prior_tool_call_messages,
     multi_turn_reused_call_id_messages,
@@ -836,7 +836,7 @@ class TestRailsManagerToolCalls:
     async def test_blocks_undeclared_call(self):
         mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
         result = await mgr.are_tool_calls_safe([_call("rm_rf", {})], {"tools": [WEATHER_TOOL]})
-        assert_blocked(result, "rm_rf")
+        assert_result_blocked(result, "rm_rf")
 
     @pytest.mark.asyncio
     async def test_no_tool_calls_returns_safe(self):
@@ -852,7 +852,7 @@ class TestRailsManagerToolCalls:
         result = await mgr.are_tool_calls_safe(
             [_call("get_weather", {"city": "Paris"})], {"tools": [WEATHER_TOOL, WEATHER_TOOL]}
         )
-        assert_blocked(result, "tool parsing failed")
+        assert_result_blocked(result, "tool parsing failed")
 
     @pytest.mark.asyncio
     async def test_disabled_toggle_skips_validation(self):
@@ -866,7 +866,7 @@ class TestRailsManagerToolCalls:
         result = await mgr.are_tool_calls_safe(
             [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=["tool call validation"]
         )
-        assert_blocked(result, "rm_rf")
+        assert_result_blocked(result, "rm_rf")
 
 
 class TestRailsManagerToolResults:
@@ -894,7 +894,7 @@ class TestRailsManagerToolResults:
     async def test_blocks_unlinked_result(self):
         mgr = _tool_rails_manager_with_main(tool_result_flows=["tool result validation"])
         result = await mgr.are_tool_results_safe(make_tool_conversation(result_call_id="call_999"))
-        assert_blocked(result, "call_999")
+        assert_result_blocked(result, "call_999")
 
     @pytest.mark.asyncio
     async def test_recycled_call_ids_across_turns_are_safe(self):
@@ -933,7 +933,7 @@ class TestRailsManagerToolResults:
 
         mgr.engine_registry.extract_tool_exchanges = _boom
         result = await mgr.are_tool_results_safe(make_tool_conversation())
-        assert_blocked(result, "tool exchange extraction failed")
+        assert_result_blocked(result, "tool exchange extraction failed")
 
 
 class TestRailsManagerToolToggleNormalization:
@@ -966,7 +966,7 @@ class TestRailsManagerToolToggleNormalization:
         result = await mgr.are_tool_calls_safe(
             [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=["tool call validation"]
         )
-        assert_blocked(result, "rm_rf")
+        assert_result_blocked(result, "rm_rf")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("configured_flow", SUFFIXED_RESULT_FLOWS)
@@ -977,7 +977,7 @@ class TestRailsManagerToolToggleNormalization:
         result = await mgr.are_tool_results_safe(
             make_tool_conversation(result_call_id="call_999"), enabled=["tool result validation"]
         )
-        assert_blocked(result, "call_999")
+        assert_result_blocked(result, "call_999")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("configured_flow", SUFFIXED_CALL_FLOWS)
@@ -988,7 +988,7 @@ class TestRailsManagerToolToggleNormalization:
         result = await mgr.are_tool_calls_safe(
             [_call("rm_rf", {})], {"tools": [WEATHER_TOOL]}, enabled=[configured_flow]
         )
-        assert_blocked(result, "rm_rf")
+        assert_result_blocked(result, "rm_rf")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("configured_flow", SUFFIXED_RESULT_FLOWS)
@@ -997,7 +997,7 @@ class TestRailsManagerToolToggleNormalization:
         result = await mgr.are_tool_results_safe(
             make_tool_conversation(result_call_id="call_999"), enabled=[configured_flow]
         )
-        assert_blocked(result, "call_999")
+        assert_result_blocked(result, "call_999")
 
 
 def _capture_tool_rails_manager():
@@ -1087,18 +1087,18 @@ class TestRunRailsParallel:
         async def slow_safe():
             try:
                 await asyncio.sleep(5)
-                return RailResult(is_safe=True)
+                return RailResult.allow()
             except asyncio.CancelledError:
                 cancelled.set()
                 raise
 
         async def fast_unsafe():
-            return RailResult(is_safe=False, reason="blocked fast")
+            return RailResult.block(reason="blocked fast")
 
         rails = {"slow": slow_safe(), "fast": fast_unsafe()}
         result = await mgr._run_rails_parallel(rails, RailDirection.INPUT)
 
-        assert_blocked(result, "blocked fast")
+        assert_result_blocked(result, "blocked fast")
         assert cancelled.is_set(), "the still-pending rail should have been cancelled"
 
     @pytest.mark.asyncio
@@ -1109,7 +1109,7 @@ class TestRunRailsParallel:
         async def slow_safe():
             try:
                 await asyncio.sleep(5)
-                return RailResult(is_safe=True)
+                return RailResult.allow()
             except asyncio.CancelledError:
                 cancelled.set()
                 raise
@@ -1206,7 +1206,7 @@ class TestRailCallRecordNaming:
     )
     def test_underscore_task_and_action_name(self, flow, action_name, task):
         """action_name/task use the underscore prompt-template key; ``flow`` keeps its space form."""
-        record = _rail_call_record(flow=flow, rail_type="input", result=RailResult(is_safe=True))
+        record = _rail_call_record(flow=flow, rail_type="input", result=RailResult.allow())
 
         assert record.flow == flow
         assert record.action_name == action_name
@@ -1228,7 +1228,7 @@ class TestRailCallRecordMultipleCalls:
             record = _rail_call_record(
                 flow="content safety check input $model=content_safety",
                 rail_type="input",
-                result=RailResult(is_safe=True),
+                result=RailResult.allow(),
                 calls=calls,
             )
 
@@ -1243,7 +1243,7 @@ class TestRailCallRecordMultipleCalls:
             record = _rail_call_record(
                 flow="content safety check input $model=content_safety",
                 rail_type="input",
-                result=RailResult(is_safe=True),
+                result=RailResult.allow(),
                 calls=[self._call("only-model", 7)],
             )
 
@@ -1309,10 +1309,10 @@ class TestParallelBatchDrainsRecords:
         safe_record = RailCallRecord(flow="content safety check input", rail_type="input", is_safe=True)
 
         async def _unsafe():
-            return RailResult(is_safe=False, reason="blocked", records=(unsafe_record,))
+            return RailResult.block(reason="blocked", records=(unsafe_record,))
 
         async def _safe():
-            return RailResult(is_safe=True, records=(safe_record,))
+            return RailResult.allow(records=(safe_record,))
 
         # Insertion order sets task_order, so the unsafe rail sorts first in the done batch.
         rails = {"unsafe": _unsafe(), "safe": _safe()}

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -119,9 +119,9 @@ class TestSingleRequest:
         """The generated request ID is an 8-character hex string."""
         captured_ids = []
 
-        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult.allow())
         iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
-        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult.allow())
 
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
@@ -134,9 +134,9 @@ class TestSingleRequest:
         """Input rails, LLM call, and output rails all see the same request ID."""
         captured_ids = []
 
-        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult.allow())
         iorails.engine_registry.model_call = _make_capturing_mock(captured_ids, "llm", LLMResponse(content="Hello"))
-        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult.allow())
 
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
@@ -146,9 +146,9 @@ class TestSingleRequest:
     @pytest.mark.asyncio
     async def test_request_id_reset_after_completion(self, iorails):
         """After generate_async returns, the ContextVar is reset to default."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
@@ -157,7 +157,7 @@ class TestSingleRequest:
     @pytest.mark.asyncio
     async def test_request_id_reset_after_input_blocked(self, iorails):
         """ContextVar is reset even when the request is blocked at input."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
 
         await iorails.generate_async(messages=[{"role": "user", "content": "bad"}])
 
@@ -166,9 +166,9 @@ class TestSingleRequest:
     @pytest.mark.asyncio
     async def test_request_id_reset_after_output_blocked(self, iorails):
         """ContextVar is reset even when the request is blocked at output."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="bad response"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="blocked"))
 
         await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
 
@@ -195,11 +195,11 @@ class TestMultipleSequentialRequests:
 
         async def capture_input(*args, **kwargs):
             ids_per_request.append(get_request_id())
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails.rails_manager.is_input_safe = capture_input
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         for _ in range(5):
             await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
@@ -214,7 +214,7 @@ class TestMultipleSequentialRequests:
 
         async def capture_input(*args, **kwargs):
             request_snapshots.append(("input", get_request_id()))
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def capture_llm(*args, **kwargs):
             request_snapshots.append(("llm", get_request_id()))
@@ -222,7 +222,7 @@ class TestMultipleSequentialRequests:
 
         async def capture_output(*args, **kwargs):
             request_snapshots.append(("output", get_request_id()))
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails.rails_manager.is_input_safe = capture_input
         iorails.engine_registry.model_call = capture_llm
@@ -261,7 +261,7 @@ class TestMultipleConcurrentRequests:
             captured.append(("input", rid))
             # Synchronize so all requests overlap
             await barrier.wait()
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def capture_llm(*args, **kwargs):
             captured.append(("llm", get_request_id()))
@@ -269,7 +269,7 @@ class TestMultipleConcurrentRequests:
 
         async def capture_output(*args, **kwargs):
             captured.append(("output", get_request_id()))
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails.rails_manager.is_input_safe = capture_input
         iorails.engine_registry.model_call = capture_llm
@@ -305,7 +305,7 @@ class TestMultipleConcurrentRequests:
                 captured.append(get_request_id())
                 # Insert a barrier which waits for all three make_iorails_calls to complete
                 await barrier.wait()
-                return RailResult(is_safe=True)
+                return RailResult.allow()
 
             async def capture_llm(*args, **kwargs):
                 captured.append(get_request_id())
@@ -313,7 +313,7 @@ class TestMultipleConcurrentRequests:
 
             async def capture_output(*args, **kwargs):
                 captured.append(get_request_id())
-                return RailResult(is_safe=True)
+                return RailResult.allow()
 
             # Each concurrent call needs its own IORails with independent mocks
             config = iorails.config
@@ -345,9 +345,9 @@ class TestMultipleConcurrentRequests:
     @pytest.mark.asyncio
     async def test_contextvar_reset_after_concurrent_requests(self, iorails):
         """ContextVar is back to default after all concurrent requests complete."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="Hello"))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         messages = [{"role": "user", "content": "hi"}]
         await asyncio.gather(

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -48,12 +48,12 @@ def _hi_model() -> AsyncMock:
 async def _slow_reject(messages, *, enabled=True):
     """Input rails that reject after a short delay (so generation finishes first)."""
     await asyncio.sleep(0.05)
-    return RailResult(is_safe=False, reason="unsafe")
+    return RailResult.block(reason="unsafe")
 
 
 async def _immediate_reject(messages, *, enabled=True):
     """Input rails that reject immediately (so rails and generation finish in the same tick)."""
-    return RailResult(is_safe=False, reason="unsafe")
+    return RailResult.block(reason="unsafe")
 
 
 @pytest_asyncio.fixture
@@ -98,7 +98,7 @@ class TestSpeculativeGeneration:
         """Rails finish first and pass — generation is awaited, output rails run."""
 
         async def fast_rails(messages, *, enabled=True):
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def slow_llm(model_type, messages):
             await asyncio.sleep(0.05)
@@ -106,7 +106,7 @@ class TestSpeculativeGeneration:
 
         iorails.rails_manager.is_input_safe = fast_rails
         iorails.engine_registry.model_call = slow_llm
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=MESSAGES)
 
@@ -119,7 +119,7 @@ class TestSpeculativeGeneration:
         llm_completed = False
 
         async def fast_reject(messages, *, enabled=True):
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def slow_llm(model_type, messages):
             nonlocal llm_started, llm_completed
@@ -148,14 +148,14 @@ class TestSpeculativeGeneration:
 
         async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.05)
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def fast_llm(model_type, messages):
             return LLMResponse(content="Fast LLM response")
 
         iorails.rails_manager.is_input_safe = slow_rails
         iorails.engine_registry.model_call = fast_llm
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails.generate_async(messages=MESSAGES)
 
@@ -167,7 +167,7 @@ class TestSpeculativeGeneration:
 
         async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def fast_llm(model_type, messages):
             return LLMResponse(content="Should be discarded")
@@ -187,7 +187,7 @@ class TestSpeculativeGeneration:
 
         async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.5)
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails.rails_manager.is_input_safe = slow_rails
         iorails.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM crashed"))
@@ -214,7 +214,7 @@ class TestSpeculativeGeneration:
         """Rails reject + LLM raises in the same scheduling window — refusal returned, exception drained."""
 
         async def fast_reject(messages, *, enabled=True):
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def slow_raises(model_type, messages):
             # Yield once so rails wins the race, then raise — the cleanup path
@@ -261,7 +261,7 @@ class TestSpeculativeGeneration:
         cfg["metrics"] = {"enabled": True}
 
         async def fast_reject(messages, *, enabled=True):
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def slow_llm(model_type, messages):
             await asyncio.sleep(0.5)
@@ -287,7 +287,7 @@ class TestSpeculativeGeneration:
 
         async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def fast_llm(model_type, messages):
             return LLMResponse(content="Should be discarded")
@@ -311,7 +311,7 @@ class TestSpeculativeGeneration:
 
         async def mock_input(messages, *, enabled=True):
             call_order.append("input")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def mock_generate(model_type, messages):
             call_order.append("generate")
@@ -319,7 +319,7 @@ class TestSpeculativeGeneration:
 
         async def mock_output(messages, response, *, enabled=True):
             call_order.append("output")
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         iorails_sequential.rails_manager.is_input_safe = mock_input
         iorails_sequential.engine_registry.model_call = mock_generate
@@ -369,7 +369,7 @@ class TestSpeculativeGenerationTelemetry:
         """Rails finish first and pass — first_completed=input_rails, first_rejector=none."""
 
         async def fast_rails(messages, *, enabled=True):
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def slow_llm(model_type, messages):
             await asyncio.sleep(0.05)
@@ -377,7 +377,7 @@ class TestSpeculativeGenerationTelemetry:
 
         iorails_speculative_tracing.rails_manager.is_input_safe = fast_rails
         iorails_speculative_tracing.engine_registry.model_call = slow_llm
-        iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
@@ -395,7 +395,7 @@ class TestSpeculativeGenerationTelemetry:
         """Rails finish first and reject — first_completed=input_rails, first_rejector=input_rails."""
 
         async def fast_reject(messages, *, enabled=True):
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def slow_llm(model_type, messages):
             await asyncio.sleep(0.5)
@@ -422,14 +422,14 @@ class TestSpeculativeGenerationTelemetry:
 
         async def slow_rails(messages, *, enabled=True):
             await asyncio.sleep(0.05)
-            return RailResult(is_safe=True)
+            return RailResult.allow()
 
         async def fast_llm(model_type, messages):
             return LLMResponse(content="Fast LLM response")
 
         iorails_speculative_tracing.rails_manager.is_input_safe = slow_rails
         iorails_speculative_tracing.engine_registry.model_call = fast_llm
-        iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails_speculative_tracing.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
         result = await iorails_speculative_tracing.generate_async(messages=MESSAGES)
 
@@ -448,7 +448,7 @@ class TestSpeculativeGenerationTelemetry:
 
         async def slow_reject(messages, *, enabled=True):
             await asyncio.sleep(0.05)
-            return RailResult(is_safe=False, reason="unsafe")
+            return RailResult.block(reason="unsafe")
 
         async def fast_llm(model_type, messages):
             return LLMResponse(content="Should be discarded")
@@ -477,9 +477,9 @@ class TestSpeculativeGenerationTelemetry:
             with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
                 iorails = IORails(RailsConfig.from_content(config=cfg))
             async with iorails:
-                iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+                iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
                 iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="response"))
-                iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+                iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
 
                 await iorails.generate_async(messages=MESSAGES)
 
@@ -498,8 +498,8 @@ class TestSpeculativeGenerationTiming:
     @pytest.mark.asyncio
     async def test_main_call_record_carries_timing(self, iorails):
         """On the speculative path, the generation call in the log has real timestamps and a duration."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
         iorails.engine_registry.model_call = _hi_model()
 
         result = await iorails.generate_async(messages=MESSAGES, options={"log": {"llm_calls": True}})

--- a/tests/guardrails/test_tool_call_action.py
+++ b/tests/guardrails/test_tool_call_action.py
@@ -20,7 +20,7 @@ import pytest
 from nemoguardrails.guardrails.actions.tool_call_action import ToolCallRailAction
 from nemoguardrails.guardrails.tool_schema import Tool, Toolset
 from nemoguardrails.types import ToolCall, ToolCallFunction
-from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked
+from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_outcome_blocked
 
 
 def _toolset() -> Toolset:
@@ -35,51 +35,51 @@ class TestToolCallRailAction:
     @pytest.mark.asyncio
     async def test_allowed_call_with_valid_arguments_is_safe(self):
         result = await ToolCallRailAction().run(_toolset(), [_call("get_weather", {"city": "Paris"})])
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_no_parameter_function_tool_with_arguments_is_blocked(self):
         """A function tool that declares no parameters accepts no arguments, so a call supplying any is blocked."""
         result = await ToolCallRailAction().run(_toolset(), [_call("ping", {"anything": 1})])
-        assert_blocked(result, "ping", "no arguments")
+        assert_outcome_blocked(result, "ping", "no arguments")
 
     @pytest.mark.asyncio
     async def test_no_parameter_function_tool_without_arguments_is_safe(self):
         """A no-parameter function tool called with no arguments passes."""
         result = await ToolCallRailAction().run(_toolset(), [_call("ping", {})])
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_undeclared_tool_is_blocked(self):
         result = await ToolCallRailAction().run(_toolset(), [_call("rm_rf", {})])
-        assert_blocked(result, "rm_rf", "not an allowed tool")
+        assert_outcome_blocked(result, "rm_rf", "not an allowed tool")
 
     @pytest.mark.asyncio
     async def test_invalid_arguments_are_blocked(self):
         result = await ToolCallRailAction().run(_toolset(), [_call("get_weather", {})])
-        assert_blocked(result, "get_weather")
+        assert_outcome_blocked(result, "get_weather")
 
     @pytest.mark.asyncio
     async def test_empty_tool_calls_is_safe(self):
         result = await ToolCallRailAction().run(_toolset(), [])
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_one_bad_call_blocks_the_batch(self):
         calls = [_call("get_weather", {"city": "Paris"}), _call("rm_rf", {})]
         result = await ToolCallRailAction().run(_toolset(), calls)
-        assert_blocked(result, "rm_rf")
+        assert_outcome_blocked(result, "rm_rf")
 
     @pytest.mark.asyncio
     async def test_hosted_tool_matched_by_type_when_name_is_empty(self):
         toolset = Toolset(tools=[Tool(name=None, type="web_search")])
         call = ToolCall(id="c1", type="web_search", function=ToolCallFunction(name="", arguments={}))
         result = await ToolCallRailAction().run(toolset, [call])
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_undeclared_hosted_tool_type_is_blocked(self):
         toolset = Toolset(tools=[Tool(name=None, type="web_search")])
         call = ToolCall(id="c1", type="code_interpreter", function=ToolCallFunction(name="", arguments={}))
         result = await ToolCallRailAction().run(toolset, [call])
-        assert_blocked(result, "code_interpreter", "not an allowed tool")
+        assert_outcome_blocked(result, "code_interpreter", "not an allowed tool")

--- a/tests/guardrails/test_tool_rail_action.py
+++ b/tests/guardrails/test_tool_rail_action.py
@@ -15,7 +15,7 @@
 
 """Unit tests for the ToolRailAction base (span wrapper + fail-closed error handling)."""
 
-from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
 
 
@@ -28,19 +28,19 @@ class TestToolRailActionGuarded:
         assert _ProbeRail().requires_model is False
 
     def test_returns_safe_check_result(self):
-        assert _ProbeRail()._guarded(lambda: RailResult(is_safe=True)) == RailResult(is_safe=True)
+        assert _ProbeRail()._guarded(lambda: RailOutcome.allow()) == RailOutcome.allow()
 
     def test_returns_unsafe_check_result(self):
-        result = _ProbeRail()._guarded(lambda: RailResult(is_safe=False, reason="bad call"))
-        assert result.is_safe is False
+        result = _ProbeRail()._guarded(lambda: RailOutcome.block(reason="bad call"))
+        assert result.is_blocked
         assert result.reason == "bad call"
 
     def test_exception_fails_closed(self):
-        def boom() -> RailResult:
+        def boom() -> RailOutcome:
             raise ValueError("kaboom")
 
         result = _ProbeRail()._guarded(boom)
-        assert result.is_safe is False
+        assert result.is_blocked
         assert result.reason is not None
         assert "probe tool rail" in result.reason
         assert "kaboom" in result.reason

--- a/tests/guardrails/test_tool_rails_e2e.py
+++ b/tests/guardrails/test_tool_rails_e2e.py
@@ -36,7 +36,7 @@ from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
-from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_blocked, make_tool_conversation
+from tests.guardrails.tool_helpers import WEATHER_SCHEMA, assert_result_blocked, make_tool_conversation
 
 STACK_CONFIG = {"models": [{"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"}]}
 
@@ -224,7 +224,7 @@ class TestToolCallRailEndToEndNonStreaming:
         if blocked is None:
             assert result.is_safe is True
         else:
-            assert_blocked(result, blocked)
+            assert_result_blocked(result, blocked)
 
 
 class TestToolResultRailEndToEnd:
@@ -239,7 +239,7 @@ class TestToolResultRailEndToEnd:
         if blocked is None:
             assert result.is_safe is True
         else:
-            assert_blocked(result, blocked)
+            assert_result_blocked(result, blocked)
 
 
 class TestToolCallRailEndToEndStreaming:
@@ -257,4 +257,4 @@ class TestToolCallRailEndToEndStreaming:
         if blocked is None:
             assert result.is_safe is True
         else:
-            assert_blocked(result, blocked)
+            assert_result_blocked(result, blocked)

--- a/tests/guardrails/test_tool_result_action.py
+++ b/tests/guardrails/test_tool_result_action.py
@@ -20,7 +20,7 @@ import pytest
 from nemoguardrails.guardrails.actions.tool_result_action import ToolResultRailAction
 from nemoguardrails.guardrails.tool_schema import ToolResult
 from nemoguardrails.types import ToolCall, ToolCallFunction
-from tests.guardrails.tool_helpers import assert_blocked
+from tests.guardrails.tool_helpers import assert_outcome_blocked
 
 
 def _prior_calls() -> list:
@@ -38,40 +38,40 @@ class TestToolResultRailAction:
     @pytest.mark.asyncio
     async def test_linked_result_with_matching_name_is_safe(self):
         result = await ToolResultRailAction().run([_result("c1", name="get_weather")], _prior_calls())
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_result_without_name_blocked_when_prior_name_known(self):
         """When the prior call's name is known, a result without a name should be blocked"""
         result = await ToolResultRailAction().run([_result("c2")], _prior_calls())
-        assert_blocked(result, "missing a name", "search")
+        assert_outcome_blocked(result, "missing a name", "search")
 
     @pytest.mark.asyncio
     async def test_list_content_is_well_formed(self):
         result = await ToolResultRailAction().run(
             [_result("c1", name="get_weather", content=[{"type": "text", "text": "18C"}])], _prior_calls()
         )
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_empty_results_is_safe(self):
         result = await ToolResultRailAction().run([], _prior_calls())
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_missing_call_id_is_blocked(self):
         result = await ToolResultRailAction().run([_result("")], _prior_calls())
-        assert_blocked(result, "missing a call_id")
+        assert_outcome_blocked(result, "missing a call_id")
 
     @pytest.mark.asyncio
     async def test_unlinked_call_id_is_blocked(self):
         result = await ToolResultRailAction().run([_result("c9")], _prior_calls())
-        assert_blocked(result, "c9", "does not correspond to a prior tool call")
+        assert_outcome_blocked(result, "c9", "does not correspond to a prior tool call")
 
     @pytest.mark.asyncio
     async def test_name_mismatch_is_blocked(self):
         result = await ToolResultRailAction().run([_result("c1", name="search")], _prior_calls())
-        assert_blocked(result, "does not match the called tool", "get_weather")
+        assert_outcome_blocked(result, "does not match the called tool", "get_weather")
 
     @pytest.mark.asyncio
     async def test_malformed_content_is_blocked(self):
@@ -79,7 +79,7 @@ class TestToolResultRailAction:
             [_result("c1", name="get_weather", content={"unexpected": "shape"})],  # type: ignore[arg-type]
             _prior_calls(),
         )
-        assert_blocked(result, "malformed content")
+        assert_outcome_blocked(result, "malformed content")
 
     @pytest.mark.asyncio
     async def test_list_of_non_dicts_is_blocked(self):
@@ -87,18 +87,18 @@ class TestToolResultRailAction:
             [_result("c1", name="get_weather", content=[1, 2, 3])],  # type: ignore[arg-type]
             _prior_calls(),
         )
-        assert_blocked(result, "malformed content")
+        assert_outcome_blocked(result, "malformed content")
 
     @pytest.mark.asyncio
     async def test_empty_content_list_is_well_formed(self):
         result = await ToolResultRailAction().run([_result("c1", name="get_weather", content=[])], _prior_calls())
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_one_bad_result_blocks_the_batch(self):
         results = [_result("c1", name="get_weather"), _result("c9")]
         result = await ToolResultRailAction().run(results, _prior_calls())
-        assert_blocked(result, "c9")
+        assert_outcome_blocked(result, "c9")
 
     @pytest.mark.asyncio
     async def test_duplicate_prior_call_id_is_blocked(self):
@@ -107,19 +107,19 @@ class TestToolResultRailAction:
             ToolCall(id="c1", function=ToolCallFunction(name="search", arguments={})),
         ]
         result = await ToolResultRailAction().run([_result("c1")], prior)
-        assert_blocked(result, "duplicate prior tool call id", "c1")
+        assert_outcome_blocked(result, "duplicate prior tool call id", "c1")
 
     @pytest.mark.asyncio
     async def test_prior_call_with_empty_id_is_skipped(self):
         prior = [ToolCall(id="", function=ToolCallFunction(name="get_weather", arguments={}))]
         result = await ToolResultRailAction().run([], prior)
-        assert result.is_safe is True
+        assert result.is_blocked is False
 
     @pytest.mark.asyncio
     async def test_duplicate_result_ids_are_blocked(self):
         results = [_result("c1", name="get_weather"), _result("c1", name="get_weather")]
         result = await ToolResultRailAction().run(results, _prior_calls())
-        assert_blocked(result, "duplicate tool result", "c1")
+        assert_outcome_blocked(result, "duplicate tool result", "c1")
 
 
 class TestValidateToolResultIds:
@@ -140,7 +140,7 @@ class TestValidateToolResultIds:
             ToolResult(call_id="call_123", name="search", content="real result"),
             ToolResult(call_id="call_123", name="search", content="duplicate/injected result"),
         ]
-        assert_blocked(self.action._validate_tool_result_ids(results), "duplicate tool result", "call_123")
+        assert_outcome_blocked(self.action._validate_tool_result_ids(results), "duplicate tool result", "call_123")
 
 
 class TestValidateResultCallId:
@@ -154,13 +154,13 @@ class TestValidateResultCallId:
         assert self.action._validate_result_call_id(_result("c1"), self.calls_by_id) is None
 
     def test_missing_call_id_is_blocked(self):
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_call_id(_result(""), self.calls_by_id),
             "missing a call_id",
         )
 
     def test_orphaned_call_id_is_blocked(self):
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_call_id(_result("c9"), self.calls_by_id),
             "c9",
             "does not correspond to a prior tool call",
@@ -177,7 +177,7 @@ class TestValidateResultName:
 
     def test_result_without_name_is_blocked_when_prior_name_known(self):
         """When the prior call's name is known, a result without a name should be blocked"""
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_name(_result("c1"), self.prior),
             "missing a name",
             "get_weather",
@@ -194,7 +194,7 @@ class TestValidateResultName:
         assert self.action._validate_result_name(_result("c1"), prior) is None
 
     def test_name_mismatch_is_blocked(self):
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_name(_result("c1", name="search"), self.prior),
             "search",
             "get_weather",
@@ -219,13 +219,13 @@ class TestValidateResultContent:
         assert self.action._validate_result_content(_result("c1", content=[])) is None
 
     def test_dict_content_is_blocked(self):
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_content(_result("c1", content={"key": "val"})),  # type: ignore[arg-type]
             "malformed content",
         )
 
     def test_list_of_non_dicts_is_blocked(self):
-        assert_blocked(
+        assert_outcome_blocked(
             self.action._validate_result_content(_result("c1", content=[1, 2, 3])),  # type: ignore[arg-type]
             "malformed content",
         )

--- a/tests/guardrails/tool_helpers.py
+++ b/tests/guardrails/tool_helpers.py
@@ -28,12 +28,28 @@ WEATHER_SCHEMA = {
 }
 
 
-def assert_blocked(result, *substrings: str) -> None:
-    """Assert *result* blocked the request and its reason contains each substring."""
-    assert result.is_safe is False, f"expected blocked, got {result!r}"
-    assert result.reason is not None, f"expected a block reason, got {result!r}"
+def _assert_reason_contains(reason, substrings, subject) -> None:
+    """Assert *subject* stated a reason and that it contains every substring."""
+    assert reason is not None, f"expected a block reason, got {subject!r}"
     for substring in substrings:
-        assert substring in result.reason, f"{substring!r} not in reason {result.reason!r}"
+        assert substring in reason, f"{substring!r} not in reason {reason!r}"
+
+
+def assert_outcome_blocked(outcome, *substrings: str) -> None:
+    """Assert a rail action's ``RailOutcome`` blocked, with a reason containing each substring."""
+    assert outcome.is_blocked, f"expected blocked, got {outcome!r}"
+    _assert_reason_contains(outcome.reason, substrings, outcome)
+
+
+def assert_result_blocked(result, *substrings: str) -> None:
+    """Assert a manager-level ``RailResult`` blocked, with a reason containing each substring.
+
+    Separate from :func:`assert_outcome_blocked` because the two layers speak different
+    types: a rail action returns a ``RailOutcome``, and ``RailsManager`` wraps it in a
+    ``RailResult`` that adds the triggering rail and the captured records.
+    """
+    assert result.is_safe is False, f"expected blocked, got {result!r}"
+    _assert_reason_contains(result.reason, substrings, result)
 
 
 def make_tool_conversation(result_call_id: str = "call_1") -> list:


### PR DESCRIPTION
## Description

This PR migrates the IORails specific `RailResult` to wrap the `RailOutcome` objects intended for use across both LLMRails and IORails.

This PR is part of a stack shown below, but isn't implemented using Github's stacks feature since all preceeding PRs are already merged to develop.

PR 1 https://github.com/NVIDIA-NeMo/Guardrails/pull/2241
PR 2 https://github.com/NVIDIA-NeMo/Guardrails/pull/2246
PR 3a https://github.com/NVIDIA-NeMo/Guardrails/pull/2253
PR 3b https://github.com/NVIDIA-NeMo/Guardrails/pull/2261 . Builds on the https://github.com/NVIDIA-NeMo/Guardrails/pull/2253 and migrates from RailAction subclasses to CompiledRail implementations for all currently-supported actions.
PR 4 https://github.com/NVIDIA-NeMo/Guardrails/pull/2264 enable the 49 block-only input/output surfaces via catalog-derived gating
PR 4.5 **THIS PR** #2286 Use RailOutcome instead of RailResult
PR 5 transform surfaces (18): RailResult.transforms, rewrite threading, MODIFIED status
PR 6 model_caches response-cache parity with LLMRails

## Related Issue(s)

* #2281 
* [NGUARD-821](https://jirasw.nvidia.com/browse/NGUARD-821)

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test

========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/refactor/iorails-rail-outcome
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
10 workers [6882 items]
..........................................sss................................sssss....................s.....s.................................................... [  2%]
.............................................................................................s...ss.s............................................................ [  4%]
................................................................................................................................................................. [  7%]
................................................s................................................................................................................ [  9%]
......................s...............................................................................................s.........................................s [ 11%]
....s.................................................................................................s..s.....s.........s.s.......s...s......................... [ 14%]
.....................................................................s........................................................................................... [ 16%]
.........................................................................s....................................................................................... [ 18%]
................................................................................................................................................................. [ 21%]
................................................................................................................................................................. [ 23%]
................................................................................................................................................................. [ 25%]
................................................................................................................................................................. [ 28%]
............................s.................................................................................................................................... [ 30%]
................................................................................................................................................................. [ 32%]
....................................................ssssssss........ssssss.....ss..s.................ssssssss.................................................... [ 35%]
........................................................................................ss.s.s.s.............ss.s...ss.s.s.s.s.ss..s.sss.sss..................... [ 37%]
................................................................................................................................................................. [ 39%]
...............................................................................................................................s...sssss......................... [ 42%]
................................................................................................................................................................. [ 44%]
................................................................................................................................................................. [ 46%]
..................................s.ssss......................................................................................................................... [ 49%]
...............ssssssssssssss.................................................................................................................................... [ 51%]
..........................................................................................ss.sssss............................................................... [ 53%]
.......................s......................................................................................................................................... [ 56%]
..............s.......................................................................................................................................sssss.s.... [ 58%]
...............................................sss......................ss.....................ss................................................................ [ 60%]
......................................................................sssssssssssss..s.......................s................................................... [ 63%]
............ss.......................................s......................................................................................s.................... [ 65%]
.....................ss......................................................................................s.s................................................. [ 67%]
..............s.......................................................................................................s.......................................... [ 70%]
................................................................................s................................................................................ [ 72%]
..........................................................................................................s...........................sssssssss.ssssss.ssss...... [ 74%]
................................................................................................................................................................. [ 77%]
..........................................................................................................................................................s...... [ 79%]
......................................................................................................................................s......................s... [ 81%]
..............................................................................................................s.................................................. [ 84%]
................................................................................................................................................................. [ 86%]
........................................................................................s.s.ssss.ss.............................................................. [ 88%]
.................................................ss..........................................................................................................s... [ 91%]
.....................................................................................................................................................sssssss..... [ 93%]
.........ss.ssss.s..........................................................................................................................ssss................. [ 95%]
..........................sss.s.................................................................................................................................. [ 98%]
........................................................................................................................                                          [100%]

════════════════════════════════════════════════════════════════════════════ inline-snapshot ════════════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and
inline-snapshot will not be able to fix snapshots or generate reports.


================================================================== 6675 passed, 207 skipped in 39.10s ===================================================================
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-08-12 17:07:58 INFO: Registered model engine: type=main, model=nvidia/nemotron-3.5-lightning-30b-a3b, base_url=https://integrate.api.nvidia.com
2026-08-12 17:07:58 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-08-12 17:07:58 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-08-12 17:07:58 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-08-12 17:08:01 INFO: [5e1792057d2c40aa] generate_async called
2026-08-12 17:08:01 INFO: [5e1792057d2c40aa] Running tool result rails
2026-08-12 17:08:01 INFO: [5e1792057d2c40aa] Running input rails
2026-08-12 17:08:01 INFO: [5e1792057d2c40aa] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-12 17:08:01 INFO: [5e1792057d2c40aa] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-08-12 17:08:02 INFO: [5e1792057d2c40aa] Calling main LLM
2026-08-12 17:08:02 INFO: [5e1792057d2c40aa] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-lightning-30b-a3b'
2026-08-12 17:08:03 INFO: [5e1792057d2c40aa] Running output rails
2026-08-12 17:08:03 INFO: [5e1792057d2c40aa] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-12 17:08:03 INFO: [5e1792057d2c40aa] generate_async completed time=2439.4ms
<think>Here's a thinking process:

1.  **Analyze User Input:** User said "Hello!"
2.  **Identify Intent:** Greeting
3.  **Determine Response:** Friendly greeting, offer help
4.  **Formulate Response:** "Hello! How can I help you today?" or similar.
5.  **Check constraints:** None specific. Just respond naturally.
6.  **Output:** Generate response.✅</think>
Hello! How can I help you today? 😊

> How can I burn a house down?
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] generate_async called
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] Running tool result rails
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] Running input rails
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] Input flow content safety check input $model=content_safety blocked
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] Input blocked: policy_violations: Violence, Criminal Planning/Confessions
2026-08-12 17:08:14 INFO: [02b48b77c6ef9cb1] generate_async completed time=444.6ms
I'm sorry, I can't respond to that.
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized guardrail decisions across input, output, tool-call, and tool-result processing.
  - Preserved outcome details and diagnostic metadata for more consistent logging and monitoring.
  - Improved client-facing block messages by exposing authored reasons or rail names while keeping policy evidence private.
  - Maintained fail-closed behavior for invalid tool requests, malformed results, and execution errors.
- **Tests**
  - Expanded coverage for blocked outcomes, metadata handling, streaming responses, telemetry, and tool validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->