### PR TITLE
feat(iorails): Support transform rails

### DIFF
--- a/examples/configs/nemoguards/config.yml
+++ b/examples/configs/nemoguards/config.yml
@@ -1,7 +1,7 @@
 models:
   - type: main
     engine: nim
-    model: meta/llama-3.3-70b-instruct
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
 
   - type: content_safety
     engine: nim

--- a/examples/configs/nemoguards/config.yml
+++ b/examples/configs/nemoguards/config.yml
@@ -1,7 +1,7 @@
 models:
   - type: main
     engine: nim
-    model: nvidia/nemotron-3.5-lightning-30b-a3b
+    model: meta/llama-3.3-70b-instruct
 
   - type: content_safety
     engine: nim

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -367,11 +367,28 @@ def _context_parameters(surface: RailSurface, flow: str) -> tuple[_ContextParame
     return tuple(bound)
 
 
-def _transform_target_reason(surface: RailSurface) -> Optional[str]:
-    """Report a surface that rewrites content, which IORails cannot apply yet."""
+# The conversation variable a rail may rewrite in each direction. A retrieval rewrite has no
+# home in an input/output request, and IORails runs no retrieval stage to give it one.
+_REWRITABLE_TARGET: dict[RailDirection, TransformTarget] = {
+    RailDirection.INPUT: TransformTarget.USER_MESSAGE,
+    RailDirection.OUTPUT: TransformTarget.BOT_MESSAGE,
+}
+
+
+def _unapplicable_transform_reason(surface: RailSurface) -> Optional[str]:
+    """Report a surface declaring a rewrite IORails has nowhere to put.
+
+    Every shipped surface rewrites its own direction's variable, so this refuses nothing today.
+    It is kept because nothing in the manifest schema requires that agreement -- ``RailSurface``
+    validates only that no parameter is bound twice -- so a manifest could declare an input rail
+    that rewrites the bot message, and applying that to the user message would be worse than
+    refusing to run it.
+    """
     if surface.transform_target is None:
         return None
-    return f"transforms {surface.transform_target.value!r}"
+    if surface.transform_target is _REWRITABLE_TARGET.get(surface.direction):
+        return None
+    return f"rewrites {surface.transform_target.value!r}, which a {surface.direction.value} rail cannot apply here"
 
 
 # Surfaces whose actions read retrieval evidence out of the request context: ``relevant_chunks``,
@@ -412,9 +429,10 @@ def _unsupported_rail_reason(surface: RailSurface) -> Optional[str]:
 
 # Ordered so the cheapest, most structural check reports first. Each entry is removed by the
 # work that lifts its limitation: the context-binding refusal went when resolution was built,
-# and the transform refusal goes when IORails can apply a rewrite.
+# and the blanket transform refusal went when IORails learned to apply a rewrite -- what is left
+# of it refuses only a rewrite this engine has no variable for.
 _SURFACE_SUPPORT_CHECKS: tuple[Callable[[RailSurface], Optional[str]], ...] = (
-    _transform_target_reason,
+    _unapplicable_transform_reason,
     _retrieval_context_reason,
     _unsupported_rail_reason,
 )

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -196,11 +196,7 @@ class CompiledRail:
 
     @property
     def transform_target(self) -> Optional[TransformTarget]:
-        """The conversation variable this rail may rewrite, or None when it only allows or blocks.
-
-        What the manifest *declares*, not what a request produced: a rail free to rewrite mostly
-        does not, so this answers how to schedule the rail rather than what it decided.
-        """
+        """The variable the manifest says this rail may rewrite, which is how it is scheduled."""
         return self.surface.transform_target
 
     async def run(self, messages: LLMMessages, bot_response: Optional[str] = None) -> RailOutcome:
@@ -367,8 +363,7 @@ def _context_parameters(surface: RailSurface, flow: str) -> tuple[_ContextParame
     return tuple(bound)
 
 
-# The conversation variable a rail may rewrite in each direction. A retrieval rewrite has no
-# home in an input/output request, and IORails runs no retrieval stage to give it one.
+# The conversation variable a rail may rewrite in each direction; retrieval has no home here.
 _REWRITABLE_TARGET: dict[RailDirection, TransformTarget] = {
     RailDirection.INPUT: TransformTarget.USER_MESSAGE,
     RailDirection.OUTPUT: TransformTarget.BOT_MESSAGE,
@@ -378,11 +373,8 @@ _REWRITABLE_TARGET: dict[RailDirection, TransformTarget] = {
 def _unapplicable_transform_reason(surface: RailSurface) -> Optional[str]:
     """Report a surface declaring a rewrite IORails has nowhere to put.
 
-    Every shipped surface rewrites its own direction's variable, so this refuses nothing today.
-    It is kept because nothing in the manifest schema requires that agreement -- ``RailSurface``
-    validates only that no parameter is bound twice -- so a manifest could declare an input rail
-    that rewrites the bot message, and applying that to the user message would be worse than
-    refusing to run it.
+    Refuses nothing today: every shipped surface agrees with its direction, and no schema rule
+    makes it.
     """
     if surface.transform_target is None:
         return None
@@ -427,10 +419,8 @@ def _unsupported_rail_reason(surface: RailSurface) -> Optional[str]:
     return blocked.get((surface.direction, surface.name))
 
 
-# Ordered so the cheapest, most structural check reports first. Each entry is removed by the
-# work that lifts its limitation: the context-binding refusal went when resolution was built,
-# and the blanket transform refusal went when IORails learned to apply a rewrite -- what is left
-# of it refuses only a rewrite this engine has no variable for.
+# Ordered so the cheapest, most structural check reports first. Each entry goes when the work
+# lifting its limitation lands, as the blanket transform refusal did.
 _SURFACE_SUPPORT_CHECKS: tuple[Callable[[RailSurface], Optional[str]], ...] = (
     _unapplicable_transform_reason,
     _retrieval_context_reason,

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -30,8 +30,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Sequence
 
-from nemoguardrails.actions.rail_outcome import RailOutcome, require_rail_outcome
-from nemoguardrails.guardrails.guardrails_types import LLMMessages
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget, require_rail_outcome
+from nemoguardrails.guardrails.guardrails_types import LLMMessages, current_user_turn_index, last_user_content
 from nemoguardrails.guardrails.rail_guard import rail_error_outcome
 from nemoguardrails.guardrails.telemetry import action_span
 from nemoguardrails.logging.processing_log import processing_log_var
@@ -93,15 +93,6 @@ _BOT_UTTERANCE_EVENT = "StartUtteranceBotAction"
 _SYSTEM_MESSAGE_EVENT = "SystemMessage"
 
 
-def _current_turn_index(messages: LLMMessages) -> Optional[int]:
-    """Position of the turn being checked: the last user message that carries content."""
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if message.get("role") == "user" and message.get("content"):
-            return index
-    return None
-
-
 def _history_before_current_turn(messages: LLMMessages) -> LLMMessages:
     """The turns preceding the one being checked.
 
@@ -111,7 +102,7 @@ def _history_before_current_turn(messages: LLMMessages) -> LLMMessages:
     transcript, say — would place a later turn ahead of it and reorder the conversation.
     With no user turn to check, every message is history.
     """
-    index = _current_turn_index(messages)
+    index = current_user_turn_index(messages)
     return messages if index is None else messages[:index]
 
 
@@ -132,16 +123,6 @@ def messages_to_events(messages: LLMMessages) -> list[dict[str, Any]]:
         elif role == "system":
             events.append({"type": _SYSTEM_MESSAGE_EVENT, "content": content})
     return events
-
-
-def _last_user_content(messages: LLMMessages) -> str:
-    """Return the most recent user message's content, or "" when there is none.
-
-    Empty rather than raising: the library actions read ``context.get(...)`` with a default
-    and call the model with empty text, and IORails now matches that.
-    """
-    index = _current_turn_index(messages)
-    return "" if index is None else messages[index]["content"]
 
 
 def _llm_calls_from(sink: list[dict[str, Any]]) -> tuple["LLMCallInfo", ...]:
@@ -176,7 +157,7 @@ _CONTEXT_KEYS = ("user_message", "bot_message")
 
 def _request_context(messages: LLMMessages, bot_response: Optional[str]) -> dict[str, str]:
     """Build the conversation variables for one request."""
-    return {"user_message": _last_user_content(messages), "bot_message": bot_response or ""}
+    return {"user_message": last_user_content(messages), "bot_message": bot_response or ""}
 
 
 class CompiledRail:
@@ -212,6 +193,15 @@ class CompiledRail:
     def surface_name(self) -> str:
         """The manifest surface name, without any ``$param=`` suffix."""
         return self.surface.name
+
+    @property
+    def transform_target(self) -> Optional[TransformTarget]:
+        """The conversation variable this rail may rewrite, or None when it only allows or blocks.
+
+        What the manifest *declares*, not what a request produced: a rail free to rewrite mostly
+        does not, so this answers how to schedule the rail rather than what it decided.
+        """
+        return self.surface.transform_target
 
     async def run(self, messages: LLMMessages, bot_response: Optional[str] = None) -> RailOutcome:
         """Execute the rail and return its engine-neutral verdict."""

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -29,6 +29,39 @@ LLMMessage: TypeAlias = dict[str, Any]
 LLMMessages: TypeAlias = list[LLMMessage]
 
 
+def current_user_turn_index(messages: LLMMessages) -> Optional[int]:
+    """Position of the turn being checked: the last user message that carries content."""
+    for index, message in reversed(list(enumerate(messages))):
+        if message.get("role") == "user" and message.get("content"):
+            return index
+    return None
+
+
+def last_user_content(messages: LLMMessages) -> str:
+    """Return the content of the turn being checked, or "" when there is none.
+
+    Empty rather than raising: the library actions read ``context.get(...)`` with a default
+    and call the model with empty text, and IORails matches that.
+    """
+    index = current_user_turn_index(messages)
+    return "" if index is None else messages[index]["content"]
+
+
+def rewrite_user_message(messages: LLMMessages, text: str) -> LLMMessages:
+    """Return *messages* with the turn under check rewritten to *text*.
+
+    The same turn ``last_user_content`` reads, so a rail's rewrite lands on the text that
+    rail was given. Copied at both levels rather than mutated, because the caller's own list
+    reaches the engine by identity: ``IORails._convert_to_messages`` hands it straight back.
+    """
+    index = current_user_turn_index(messages)
+    if index is None:
+        raise ValueError("no user turn carries content, so there is nothing to rewrite")
+    rewritten = list(messages)
+    rewritten[index] = {**messages[index], "content": text}
+    return rewritten
+
+
 class RailDirection(Enum):
     """Direction of a rail check, used for logging."""
 

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -38,21 +38,15 @@ def current_user_turn_index(messages: LLMMessages) -> Optional[int]:
 
 
 def last_user_content(messages: LLMMessages) -> str:
-    """Return the content of the turn being checked, or "" when there is none.
-
-    Empty rather than raising: the library actions read ``context.get(...)`` with a default
-    and call the model with empty text, and IORails matches that.
-    """
+    """Return the content of the turn being checked, or "" as the library actions expect."""
     index = current_user_turn_index(messages)
     return "" if index is None else messages[index]["content"]
 
 
 def rewrite_user_message(messages: LLMMessages, text: str) -> LLMMessages:
-    """Return *messages* with the turn under check rewritten to *text*.
+    """Return *messages* with the turn ``last_user_content`` reads rewritten to *text*.
 
-    The same turn ``last_user_content`` reads, so a rail's rewrite lands on the text that
-    rail was given. Copied at both levels rather than mutated, because the caller's own list
-    reaches the engine by identity: ``IORails._convert_to_messages`` hands it straight back.
+    Copied at both levels, because the caller's own list reaches the engine by identity.
     """
     index = current_user_turn_index(messages)
     if index is None:
@@ -270,11 +264,8 @@ def _has_evidence(value: Any) -> bool:
     return True
 
 
-# Verdict fields that repeat the request rather than describe it. A rail is free to echo the
-# text it judged -- ``injection_detection`` returns the whole bot message under ``text``, and the
-# rails that guard both sides of a turn return both variables -- but rendering that here would
-# put the conversation into an operator's log on every block, with no opt-in. Content reaches a
-# span only through content capture, which is configured, and reaches the caller not at all.
+# Verdict fields that repeat the request rather than describe it: a block writes a log line
+# unconditionally, and content belongs in a span only through configured content capture.
 _CONTENT_EVIDENCE_KEYS = frozenset({"text", "user_message", "bot_message"})
 
 

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -270,11 +270,23 @@ def _has_evidence(value: Any) -> bool:
     return True
 
 
+# Verdict fields that repeat the request rather than describe it. A rail is free to echo the
+# text it judged -- ``injection_detection`` returns the whole bot message under ``text``, and the
+# rails that guard both sides of a turn return both variables -- but rendering that here would
+# put the conversation into an operator's log on every block, with no opt-in. Content reaches a
+# span only through content capture, which is configured, and reaches the caller not at all.
+_CONTENT_EVIDENCE_KEYS = frozenset({"text", "user_message", "bot_message"})
+
+
 def _metadata_evidence(metadata: Any) -> Optional[str]:
     """Render a rail's metadata as text, or None when it carries no evidence."""
     if not isinstance(metadata, Mapping):
         return None
-    parts = [f"{key}: {_rendered_evidence(value)}" for key, value in metadata.items() if _has_evidence(value)]
+    parts = [
+        f"{key}: {_rendered_evidence(value)}"
+        for key, value in metadata.items()
+        if key not in _CONTENT_EVIDENCE_KEYS and _has_evidence(value)
+    ]
     return "; ".join(parts) or None
 
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -546,12 +546,9 @@ def _rewritten_bot_message(result: RailResult) -> Optional[str]:
 
 @dataclass(slots=True)
 class _TurnConversation:
-    """The messages a turn is running against, shared by the parts that read them after the rails.
+    """The messages a turn is running against, mutable so a rewrite reaches what was built first.
 
-    Mutable, and deliberately so. Streaming needs it because the output-rail wrapper is built
-    before the generation task starts, so a rewrite the input rails produce later has no other
-    way to reach it. Both paths need it for content capture, which happens at the request-span
-    boundary and must record the text the model actually read rather than what arrived.
+    The output-rail wrapper and the request span are both built before the input rails run.
     """
 
     messages: LLMMessages
@@ -559,12 +556,7 @@ class _TurnConversation:
 
 @dataclass(frozen=True, slots=True)
 class _GeneratedTurn:
-    """The main model's response, and the messages it was generated from.
-
-    The messages travel back with the response because input rails may have rewritten them, and
-    what the model actually read is what the output rails and the generation log must see.
-    ``response`` is None when the input rails blocked, so no generation happened.
-    """
+    """The main model's response and the messages it read, or no response when the rails blocked."""
 
     response: Optional[LLMResponse]
     messages: LLMMessages
@@ -753,11 +745,9 @@ class IORails(BaseGuardrails):
             report_usage(config, deployment_type="library", rails_engine=RailsEngineEnum.IORAILS.value)
 
     def _speculative_generation_allowed(self, config: RailsConfig) -> bool:
-        """Whether input rails may race the main call, which an input rail that rewrites rules out.
+        """Whether input rails may race the main call, which a rewriting input rail rules out.
 
-        Speculative generation starts the model before the input rails finish, so a rewrite lands
-        after the model has already read the original text. Applying it would describe a call that
-        never happened, and ignoring it would send unmasked text to the model, so the race goes.
+        The model reads the text before the rails finish with it, so a rewrite arrives too late.
         """
         if not config.rails.input.speculative_generation:
             return False
@@ -958,10 +948,9 @@ class IORails(BaseGuardrails):
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
                 raise
-            # Capture content once here at the traced_request boundary so any
-            # future early-return added to _do_generate is covered automatically. The messages
-            # recorded are the ones the model read: an input rail may have masked them, and a
-            # span carrying the text a mask removed would defeat the mask.
+            # Captured at the traced_request boundary, so a future early-return in _do_generate
+            # is covered. The messages are the ones the model read: a span carrying the text a
+            # mask removed would defeat the mask.
             if self._content_capture_enabled:
                 set_request_content(request_span, conversation.messages, _response_content_for_capture(result))
             elapsed_ms = (time.monotonic() - t0) * 1000
@@ -1049,8 +1038,7 @@ class IORails(BaseGuardrails):
         if turn.response is None:
             return _blocked_return()
 
-        # What the model read, which is what the output rails must check: an input rail may have
-        # rewritten the user message, and checking the text it replaced would judge the wrong turn.
+        # What the model read: judging the text an input rail replaced would judge the wrong turn.
         response = turn.response
         messages = turn.messages
         if conversation is not None:
@@ -1170,11 +1158,7 @@ class IORails(BaseGuardrails):
         input_enabled: Union[bool, list[str]] = True,
         records_out: Optional[list[RailCallRecord]] = None,
     ) -> _GeneratedTurn:
-        """Speculative path: input rails and LLM generation race concurrently.
-
-        The messages come back unchanged: the race is refused for a config whose input rails may
-        rewrite, because the model reads the text before the rails have finished with it.
-        """
+        """Speculative path: input rails and LLM generation race, so no rewrite can arrive."""
         log.info("[%s] Speculative generation: launching input rails + LLM concurrently", req_id)
 
         rails_task = asyncio.create_task(self.rails_manager.is_input_safe(messages, enabled=input_enabled))
@@ -1561,11 +1545,8 @@ class IORails(BaseGuardrails):
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
 
-                # Input rails finish before the first token is requested, so a rewrite reaches the
-                # model here exactly as it does when not streaming. It reaches the output rails
-                # too: they are handed ``conversation``, which is rebound here rather than passed
-                # by value when the stream was set up, so they judge the turn the model answered
-                # rather than the text an input rail replaced.
+                # Input rails finish before the first token, so the rewrite reaches the model
+                # here, and the output rails through ``conversation`` rather than a stale capture.
                 rewritten = _rewritten_user_message(input_result)
                 if rewritten is not None:
                     log.info("[%s] Input rails rewrote the user message", req_id)
@@ -1794,11 +1775,9 @@ class IORails(BaseGuardrails):
         - ``stream_first=False``: run output rails first, only yield chunks
           if safe.
 
-        A rail that rewrites the batch is applied rather than declined: the rewritten text is
-        what ships, and the rails that only judge have already read it, because a direction runs
-        its rewriting rails first. That holds only where the rewrite can be mapped onto what is
-        still to be sent, which is why ``RailsConfig`` refuses ``stream_first`` and a non-zero
-        ``context_size`` alongside a rewriting output rail.
+        A rewrite is applied rather than declined, which holds only where it maps onto what is
+        still to be sent -- hence the ``RailsConfig`` refusal of ``stream_first`` and a context
+        window alongside a rewriting rail.
         """
 
         # Unpack streaming config and get the buffer strategy
@@ -1846,10 +1825,10 @@ class IORails(BaseGuardrails):
 
             rewritten = _rewritten_bot_message(output_result)
             if rewritten is not None and stream_first:
-                # Unreachable through a loaded config: ``RailsConfig`` refuses this combination,
-                # because the batch has already been sent and there is nothing left to redact.
-                # Reachable only from a rail the catalog does not describe, and delivering more
-                # text after failing to mask is the one outcome worth refusing outright.
+                # No config reaches here: ``RailsConfig`` refuses ``stream_first`` alongside a
+                # rail that declares a rewrite, and one the catalog cannot describe never runs on
+                # this engine. What is left is a manifest declaring no target whose action rewrites
+                # anyway -- and the batch has gone, so stopping is all that remains.
                 log.error("[%s] Output rewrite arrived after the batch was streamed", req_id)
                 violation = self._guardrails_violation_payload(
                     "Blocked by output rails: a rewrite could not be applied to the stream", "output_rails"
@@ -1862,8 +1841,6 @@ class IORails(BaseGuardrails):
                     for chunk in user_output_chunks:
                         yield chunk
                 else:
-                    # The batch is replaced by what the rails made of it, in one frame: with
-                    # ``context_size`` at zero the judged window is exactly this batch, so the
-                    # rewritten text stands in for it whole rather than chunk by chunk.
+                    # One frame: with ``context_size`` at zero the judged window is this batch.
                     log.info("[%s] Output rails rewrote the streamed batch", req_id)
                     yield _frame_for_stream(rewritten, include_metadata)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -545,11 +545,13 @@ def _rewritten_bot_message(result: RailResult) -> Optional[str]:
 
 
 @dataclass(slots=True)
-class _StreamedConversation:
-    """The messages a streamed turn is running against, shared by the parts that read them.
+class _TurnConversation:
+    """The messages a turn is running against, shared by the parts that read them after the rails.
 
-    Mutable, and deliberately so: the output-rail wrapper is constructed before the generation
-    task starts, so a rewrite the input rails produce later has no other way to reach it.
+    Mutable, and deliberately so. Streaming needs it because the output-rail wrapper is built
+    before the generation task starts, so a rewrite the input rails produce later has no other
+    way to reach it. Both paths need it for content capture, which happens at the request-span
+    boundary and must record the text the model actually read rather than what arrived.
     """
 
     messages: LLMMessages
@@ -945,18 +947,23 @@ class IORails(BaseGuardrails):
         lifecycle scope by ``generate_async``, not here.
         """
         tracer = self._tracer if self._tracing_enabled else None
+        conversation = _TurnConversation(messages=messages)
         with traced_request(tracer) as (request_span, req_id):
             t0 = time.monotonic()
             try:
-                result = await self._do_generate(messages, req_id, request_span, options=options, **kwargs)
+                result = await self._do_generate(
+                    messages, req_id, request_span, conversation=conversation, options=options, **kwargs
+                )
             except Exception:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
                 raise
             # Capture content once here at the traced_request boundary so any
-            # future early-return added to _do_generate is covered automatically.
+            # future early-return added to _do_generate is covered automatically. The messages
+            # recorded are the ones the model read: an input rail may have masked them, and a
+            # span carrying the text a mask removed would defeat the mask.
             if self._content_capture_enabled:
-                set_request_content(request_span, messages, _response_content_for_capture(result))
+                set_request_content(request_span, conversation.messages, _response_content_for_capture(result))
             elapsed_ms = (time.monotonic() - t0) * 1000
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             return result
@@ -987,6 +994,7 @@ class IORails(BaseGuardrails):
         req_id: str,
         request_span: Optional["Span"] = None,
         *,
+        conversation: Optional["_TurnConversation"] = None,
         options: Optional[Union[dict, GenerationOptions]] = None,
         **kwargs,
     ) -> Union[LLMMessage, GenerationResponse]:
@@ -1045,6 +1053,8 @@ class IORails(BaseGuardrails):
         # rewritten the user message, and checking the text it replaced would judge the wrong turn.
         response = turn.response
         messages = turn.messages
+        if conversation is not None:
+            conversation.messages = messages
 
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
@@ -1497,7 +1507,7 @@ class IORails(BaseGuardrails):
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
         # The output-rail wrapper is built before the generation task runs, so it cannot be handed
         # the messages by value: an input rail may rewrite them after that point.
-        conversation = _StreamedConversation(messages=messages)
+        conversation = _TurnConversation(messages=messages)
         # Tool calls assembled by the stream: _generation_task rebinds this (via
         # nonlocal) to the engine's finalized list and _wrapped_iterator reads it
         # after the content stream drains. The engine emits the complete list once
@@ -1770,7 +1780,7 @@ class IORails(BaseGuardrails):
     async def _run_output_rails_in_streaming(
         self,
         streaming_handler: AsyncIterator[Union[str, dict]],
-        conversation: "_StreamedConversation",
+        conversation: "_TurnConversation",
         *,
         enabled: Union[bool, list[str]] = True,
         include_metadata: Optional[bool] = False,

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -687,7 +687,7 @@ class IORails(BaseGuardrails):
             tracer=self._tracer,
             content_capture_enabled=self._content_capture_enabled,
         )
-        self._speculative_generation = config.rails.input.speculative_generation or False
+        self._speculative_generation = self._speculative_generation_allowed(config)
 
         # Non-streaming admission queue + worker pool (owned by IORails so
         # all request-path concurrency controls sit under one roof).  The
@@ -711,6 +711,26 @@ class IORails(BaseGuardrails):
             from nemoguardrails.telemetry import RailsEngineEnum, report_usage
 
             report_usage(config, deployment_type="library", rails_engine=RailsEngineEnum.IORAILS.value)
+
+    def _speculative_generation_allowed(self, config: RailsConfig) -> bool:
+        """Whether input rails may race the main call, which an input rail that rewrites rules out.
+
+        Speculative generation starts the model before the input rails finish, so a rewrite lands
+        after the model has already read the original text. Applying it would describe a call that
+        never happened, and ignoring it would send unmasked text to the model, so the race goes.
+        """
+        if not config.rails.input.speculative_generation:
+            return False
+        rewriting = self.rails_manager.transform_flows[RailDirection.INPUT]
+        if not rewriting:
+            return True
+        warnings.warn(
+            f"rails.input.speculative_generation is not honored alongside an input rail that rewrites the "
+            f"user message ({', '.join(rewriting)}); generation waits for the input rails so the model reads "
+            f"the rewritten text.",
+            stacklevel=3,
+        )
+        return False
 
     @property
     def _has_streaming_output_rails(self) -> bool:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -27,8 +27,10 @@ import time
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import nullcontext, suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
+from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
@@ -44,10 +46,12 @@ from nemoguardrails.guardrails.guardrails_types import (
     LLMMessages,
     RailCallRecord,
     RailDirection,
+    RailResult,
     TimedLLMResponse,
     client_reason,
     display_reason,
     get_request_id,
+    rewrite_user_message,
     serialize_prompt,
     truncate,
 )
@@ -530,6 +534,29 @@ def _get_last_content_by_role(messages: list[dict], role: str) -> str:
     return ""
 
 
+def _rewritten_user_message(result: RailResult) -> Optional[str]:
+    """What the input rails rewrote the user message to, or None when they left it as it came."""
+    return result.outcome.transform_text.get(TransformTarget.USER_MESSAGE.value)
+
+
+def _rewritten_bot_message(result: RailResult) -> Optional[str]:
+    """What the output rails rewrote the response to, or None when they left it as generated."""
+    return result.outcome.transform_text.get(TransformTarget.BOT_MESSAGE.value)
+
+
+@dataclass(frozen=True, slots=True)
+class _GeneratedTurn:
+    """The main model's response, and the messages it was generated from.
+
+    The messages travel back with the response because input rails may have rewritten them, and
+    what the model actually read is what the output rails and the generation log must see.
+    ``response`` is None when the input rails blocked, so no generation happened.
+    """
+
+    response: Optional[LLMResponse]
+    messages: LLMMessages
+
+
 def _compile_only_deps(config: RailsConfig) -> RailDependencies:
     """Dependencies for the gate's trial compile: declared types and config, no live collaborators.
 
@@ -992,16 +1019,21 @@ class IORails(BaseGuardrails):
             return _blocked_return()
 
         if self._speculative_generation:
-            response = await self._do_generate_speculative(
+            turn = await self._do_generate_speculative(
                 messages, req_id, llm_kwargs, request_span, input_enabled=input_enabled, records_out=records
             )
         else:
-            response = await self._do_generate_sequential(
+            turn = await self._do_generate_sequential(
                 messages, req_id, llm_kwargs, input_enabled=input_enabled, records_out=records
             )
 
-        if response is None:
+        if turn.response is None:
             return _blocked_return()
+
+        # What the model read, which is what the output rails must check: an input rail may have
+        # rewritten the user message, and checking the text it replaced would judge the wrong turn.
+        response = turn.response
+        messages = turn.messages
 
         # Log raw content before reasoning extraction and think-token removal
         log.debug("[%s] Raw LLM response: %s", req_id, truncate(response.content))
@@ -1041,6 +1073,11 @@ class IORails(BaseGuardrails):
                     record_request_blocked(RailDirection.OUTPUT)
                 return _blocked_return()
 
+            rewritten = _rewritten_bot_message(output_result)
+            if rewritten is not None:
+                log.info("[%s] Output rails rewrote the response", req_id)
+                response_text = rewritten
+
         if has_generation_options:
             log_obj = _build_generation_log(records, options, time.monotonic() - t_start)
             return _build_generation_response(response_text, reasoning_content, response, log_obj)
@@ -1077,8 +1114,8 @@ class IORails(BaseGuardrails):
         *,
         input_enabled: Union[bool, list[str]] = True,
         records_out: Optional[list[RailCallRecord]] = None,
-    ) -> Optional[LLMResponse]:
-        """Sequential path: input rails block before LLM generation starts."""
+    ) -> _GeneratedTurn:
+        """Sequential path: input rails block, or rewrite, before LLM generation starts."""
         log.info("[%s] Running input rails", req_id)
         input_result = await self.rails_manager.is_input_safe(messages, enabled=input_enabled)
         if records_out is not None:
@@ -1087,7 +1124,12 @@ class IORails(BaseGuardrails):
             log.info("[%s] Input blocked: %s", req_id, display_reason(input_result))
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return None
+            return _GeneratedTurn(response=None, messages=messages)
+
+        rewritten = _rewritten_user_message(input_result)
+        if rewritten is not None:
+            log.info("[%s] Input rails rewrote the user message", req_id)
+            messages = rewrite_user_message(messages, rewritten)
 
         log.info("[%s] Calling main LLM", req_id)
         timed_llm_response = await self._timed_main_call(messages, llm_kwargs)
@@ -1095,7 +1137,7 @@ class IORails(BaseGuardrails):
             provider = self.engine_registry.provider_name("main")
             prompt = serialize_prompt(messages)
             records_out.append(_make_generation_record(timed_llm_response, provider, prompt))
-        return timed_llm_response.response
+        return _GeneratedTurn(response=timed_llm_response.response, messages=messages)
 
     async def _do_generate_speculative(
         self,
@@ -1106,8 +1148,12 @@ class IORails(BaseGuardrails):
         *,
         input_enabled: Union[bool, list[str]] = True,
         records_out: Optional[list[RailCallRecord]] = None,
-    ) -> Optional[LLMResponse]:
-        """Speculative path: input rails and LLM generation race concurrently."""
+    ) -> _GeneratedTurn:
+        """Speculative path: input rails and LLM generation race concurrently.
+
+        The messages come back unchanged: the race is refused for a config whose input rails may
+        rewrite, because the model reads the text before the rails have finished with it.
+        """
         log.info("[%s] Speculative generation: launching input rails + LLM concurrently", req_id)
 
         rails_task = asyncio.create_task(self.rails_manager.is_input_safe(messages, enabled=input_enabled))
@@ -1145,7 +1191,7 @@ class IORails(BaseGuardrails):
                     )
             raise
 
-        return response
+        return _GeneratedTurn(response=response, messages=messages)
 
     async def _parallel_input_rail_and_response_generation(
         self,
@@ -1311,10 +1357,15 @@ class IORails(BaseGuardrails):
                 return RailsResult(status=RailStatus.PASSED, content=last if isinstance(last, str) else "")
             rails_to_run = determined["rails"]
 
-        if "output" in rails_to_run:
+        # Which direction's text the caller gets back, and so which rewrites it can observe: with
+        # output rails in play the answer is the response, and an input rewrite is internal to the
+        # check. Matches how LLMRails decides what ``check`` reports.
+        reports_output = "output" in rails_to_run
+        if reports_output:
             pass_content = _get_last_content_by_role(messages, "assistant")
         else:
             pass_content = _get_last_content_by_role(messages, "user")
+        original_content = pass_content
 
         if "input" in rails_to_run:
             user_content = _get_last_content_by_role(messages, "user")
@@ -1330,10 +1381,16 @@ class IORails(BaseGuardrails):
                     return RailsResult(
                         status=RailStatus.BLOCKED, content=REFUSAL_MESSAGE, rail=input_result.triggered_rail
                     )
+                rewritten = _rewritten_user_message(input_result)
+                if rewritten is not None:
+                    log.info("[%s] Input rails rewrote the user message", req_id)
+                    messages = rewrite_user_message(messages, rewritten)
+                    if not reports_output:
+                        pass_content = rewritten
             else:
                 log.info("[%s] Input rails requested but no user content to check; skipping", req_id)
 
-        if "output" in rails_to_run:
+        if reports_output:
             bot_response = _get_last_content_by_role(messages, "assistant")
             # Skip when there is no assistant content: the content-safety action requires
             # bot_response and would otherwise raise, surfacing a false BLOCK.
@@ -1347,9 +1404,17 @@ class IORails(BaseGuardrails):
                     return RailsResult(
                         status=RailStatus.BLOCKED, content=REFUSAL_MESSAGE, rail=output_result.triggered_rail
                     )
+                rewritten = _rewritten_bot_message(output_result)
+                if rewritten is not None:
+                    log.info("[%s] Output rails rewrote the response", req_id)
+                    pass_content = rewritten
             else:
                 log.info("[%s] Output rails requested but no assistant content to check; skipping", req_id)
 
+        # MODIFIED is decided by comparing content, as LLMRails does, and names no rail: a rewrite
+        # is not a rail "triggering", and several rails may have contributed to the final text.
+        if pass_content != original_content:
+            return RailsResult(status=RailStatus.MODIFIED, content=pass_content)
         return RailsResult(status=RailStatus.PASSED, content=pass_content)
 
     def _validate_streaming_with_output_rails(self) -> None:
@@ -1436,7 +1501,7 @@ class IORails(BaseGuardrails):
 
             Inherits the request ID from the caller context via create_task().
             """
-            nonlocal accumulated_tool_calls
+            nonlocal accumulated_tool_calls, messages
             req_id = get_request_id()
             t0 = time.monotonic()
             try:
@@ -1471,6 +1536,15 @@ class IORails(BaseGuardrails):
                     )
                     await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
                     return
+
+                # Input rails finish before the first token is requested, so a rewrite reaches the
+                # model here exactly as it does when not streaming. The output-rail wrapper was
+                # handed the original messages when the stream was set up, and keeps them: LLMRails
+                # builds its streaming output-rail context from the raw messages too.
+                rewritten = _rewritten_user_message(input_result)
+                if rewritten is not None:
+                    log.info("[%s] Input rails rewrote the user message", req_id)
+                    messages = rewrite_user_message(messages, rewritten)
 
                 # Step 2: Stream main LLM content from structured response.
                 # delta_content is forwarded as text chunks; delta_tool_calls are
@@ -1699,6 +1773,9 @@ class IORails(BaseGuardrails):
         output_streaming_config = self.config.rails.output.streaming
         stream_first = output_streaming_config.stream_first
         buffer_strategy = get_buffer_strategy(output_streaming_config)
+        # A rewrite arrives per buffered batch; saying so once is enough to explain a stream whose
+        # masking rail appears to have done nothing.
+        rewrite_reported = False
 
         async for chunk_batch in buffer_strategy(streaming_handler):
             user_output_chunks = chunk_batch.user_output_chunks
@@ -1735,6 +1812,17 @@ class IORails(BaseGuardrails):
                 )
                 yield _frame_for_stream(violation, include_metadata)
                 return
+
+            # A rewrite cannot be applied to a stream: with stream_first the chunk has already
+            # reached the caller, and without it the rewrite covers one buffered batch rather than
+            # the response. So the check counts only as non-blocking, which is what LLMRails does.
+            if output_result.outcome.is_transform and not rewrite_reported:
+                rewrite_reported = True
+                log.info(
+                    "[%s] Output rails rewrote the response, which streaming cannot apply; rails %s",
+                    req_id,
+                    list(self.rails_manager.transform_flows[RailDirection.OUTPUT]),
+                )
 
             if not stream_first:
                 for chunk in user_output_chunks:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -544,6 +544,17 @@ def _rewritten_bot_message(result: RailResult) -> Optional[str]:
     return result.outcome.transform_text.get(TransformTarget.BOT_MESSAGE.value)
 
 
+@dataclass(slots=True)
+class _StreamedConversation:
+    """The messages a streamed turn is running against, shared by the parts that read them.
+
+    Mutable, and deliberately so: the output-rail wrapper is constructed before the generation
+    task starts, so a rewrite the input rails produce later has no other way to reach it.
+    """
+
+    messages: LLMMessages
+
+
 @dataclass(frozen=True, slots=True)
 class _GeneratedTurn:
     """The main model's response, and the messages it was generated from.
@@ -1484,6 +1495,9 @@ class IORails(BaseGuardrails):
         tool_output_enabled = options.rails.tool_output if options else True
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
+        # The output-rail wrapper is built before the generation task runs, so it cannot be handed
+        # the messages by value: an input rail may rewrite them after that point.
+        conversation = _StreamedConversation(messages=messages)
         # Tool calls assembled by the stream: _generation_task rebinds this (via
         # nonlocal) to the engine's finalized list and _wrapped_iterator reads it
         # after the content stream drains. The engine emits the complete list once
@@ -1538,13 +1552,15 @@ class IORails(BaseGuardrails):
                     return
 
                 # Input rails finish before the first token is requested, so a rewrite reaches the
-                # model here exactly as it does when not streaming. The output-rail wrapper was
-                # handed the original messages when the stream was set up, and keeps them: LLMRails
-                # builds its streaming output-rail context from the raw messages too.
+                # model here exactly as it does when not streaming. It reaches the output rails
+                # too: they are handed ``conversation``, which is rebound here rather than passed
+                # by value when the stream was set up, so they judge the turn the model answered
+                # rather than the text an input rail replaced.
                 rewritten = _rewritten_user_message(input_result)
                 if rewritten is not None:
                     log.info("[%s] Input rails rewrote the user message", req_id)
                     messages = rewrite_user_message(messages, rewritten)
+                conversation.messages = messages
 
                 # Step 2: Stream main LLM content from structured response.
                 # delta_content is forwarded as text chunks; delta_tool_calls are
@@ -1670,7 +1686,7 @@ class IORails(BaseGuardrails):
                                     if self._has_streaming_output_rails:
                                         base_iterator = self._run_output_rails_in_streaming(
                                             streaming_handler=streaming_handler,
-                                            messages=messages,
+                                            conversation=conversation,
                                             enabled=output_enabled,
                                             include_metadata=include_metadata,
                                         )
@@ -1754,7 +1770,7 @@ class IORails(BaseGuardrails):
     async def _run_output_rails_in_streaming(
         self,
         streaming_handler: AsyncIterator[Union[str, dict]],
-        messages: LLMMessages,
+        conversation: "_StreamedConversation",
         *,
         enabled: Union[bool, list[str]] = True,
         include_metadata: Optional[bool] = False,
@@ -1767,15 +1783,18 @@ class IORails(BaseGuardrails):
           rails.  If unsafe, inject an error and stop.
         - ``stream_first=False``: run output rails first, only yield chunks
           if safe.
+
+        A rail that rewrites the batch is applied rather than declined: the rewritten text is
+        what ships, and the rails that only judge have already read it, because a direction runs
+        its rewriting rails first. That holds only where the rewrite can be mapped onto what is
+        still to be sent, which is why ``RailsConfig`` refuses ``stream_first`` and a non-zero
+        ``context_size`` alongside a rewriting output rail.
         """
 
         # Unpack streaming config and get the buffer strategy
         output_streaming_config = self.config.rails.output.streaming
         stream_first = output_streaming_config.stream_first
         buffer_strategy = get_buffer_strategy(output_streaming_config)
-        # A rewrite arrives per buffered batch; saying so once is enough to explain a stream whose
-        # masking rail appears to have done nothing.
-        rewrite_reported = False
 
         async for chunk_batch in buffer_strategy(streaming_handler):
             user_output_chunks = chunk_batch.user_output_chunks
@@ -1802,7 +1821,9 @@ class IORails(BaseGuardrails):
                 continue
 
             log.info("[%s] Running output rails", req_id)
-            output_result = await self.rails_manager.is_output_safe(messages, bot_response_chunk, enabled=enabled)
+            output_result = await self.rails_manager.is_output_safe(
+                conversation.messages, bot_response_chunk, enabled=enabled
+            )
             if not output_result.is_safe:
                 log.info("[%s] Output blocked: %s", req_id, display_reason(output_result))
                 if self._metrics_enabled:
@@ -1813,17 +1834,26 @@ class IORails(BaseGuardrails):
                 yield _frame_for_stream(violation, include_metadata)
                 return
 
-            # A rewrite cannot be applied to a stream: with stream_first the chunk has already
-            # reached the caller, and without it the rewrite covers one buffered batch rather than
-            # the response. So the check counts only as non-blocking, which is what LLMRails does.
-            if output_result.outcome.is_transform and not rewrite_reported:
-                rewrite_reported = True
-                log.info(
-                    "[%s] Output rails rewrote the response, which streaming cannot apply; rails %s",
-                    req_id,
-                    list(self.rails_manager.transform_flows[RailDirection.OUTPUT]),
+            rewritten = _rewritten_bot_message(output_result)
+            if rewritten is not None and stream_first:
+                # Unreachable through a loaded config: ``RailsConfig`` refuses this combination,
+                # because the batch has already been sent and there is nothing left to redact.
+                # Reachable only from a rail the catalog does not describe, and delivering more
+                # text after failing to mask is the one outcome worth refusing outright.
+                log.error("[%s] Output rewrite arrived after the batch was streamed", req_id)
+                violation = self._guardrails_violation_payload(
+                    "Blocked by output rails: a rewrite could not be applied to the stream", "output_rails"
                 )
+                yield _frame_for_stream(violation, include_metadata)
+                return
 
             if not stream_first:
-                for chunk in user_output_chunks:
-                    yield chunk
+                if rewritten is None:
+                    for chunk in user_output_chunks:
+                        yield chunk
+                else:
+                    # The batch is replaced by what the rails made of it, in one frame: with
+                    # ``context_size`` at zero the judged window is exactly this batch, so the
+                    # rewritten text stands in for it whole rather than chunk by chunk.
+                    log.info("[%s] Output rails rewrote the streamed batch", req_id)
+                    yield _frame_for_stream(rewritten, include_metadata)

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -17,11 +17,12 @@
 
 import asyncio
 import logging
+import warnings
 from collections.abc import Coroutine, Mapping, Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
-from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.guardrails.actions.tool_call_action import ToolCallRailAction
 from nemoguardrails.guardrails.actions.tool_result_action import ToolResultRailAction
 from nemoguardrails.guardrails.compiled_rail import CompiledRail, RailDependencies, compile_rail
@@ -32,6 +33,8 @@ from nemoguardrails.guardrails.guardrails_types import (
     RailResult,
     display_reason,
     get_request_id,
+    last_user_content,
+    rewrite_user_message,
 )
 from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
@@ -145,14 +148,98 @@ _HTTP_CLIENT_SURFACE_NAMES: frozenset[str] = frozenset(
 )
 
 
+# The conversation variable each direction's rails may rewrite. A rewrite naming anything else
+# has nowhere to land here, so it is refused rather than dropped.
+_REWRITABLE_TARGET = {
+    RailDirection.INPUT: TransformTarget.USER_MESSAGE,
+    RailDirection.OUTPUT: TransformTarget.BOT_MESSAGE,
+}
+
+
+def _rewriting_flows(
+    rails: Mapping[tuple[RailDirection, str], CompiledRail],
+    direction: RailDirection,
+    flows: Sequence[str],
+) -> tuple[str, ...]:
+    """The configured flows whose surface declares they may rewrite the text they check."""
+    return tuple(flow for flow in flows if rails[(direction, flow)].transform_target is not None)
+
+
+def _transforms_first(rewriting: Sequence[str], flows: Sequence[str]) -> list[str]:
+    """Order a direction's flows so rails that may rewrite run ahead of rails that only judge.
+
+    A rewrite is only of use to the rails behind it: masking ahead of a safety check means the
+    check reads masked text. Configured order is kept within each group, so a direction with no
+    rewriting rail runs exactly as it was written.
+    """
+    ordered = list(rewriting)
+    already_ordered = set(rewriting)
+    ordered.extend(flow for flow in flows if flow not in already_ordered)
+    return ordered
+
+
 def _rail_result(outcome: RailOutcome) -> RailResult:
     """Map an engine-neutral rail verdict onto IORails' rail result."""
-    if outcome.is_transform:
-        # Unreachable: transform surfaces are refused at compile time until IORails can apply a
-        # rewrite. Raising keeps it that way, because the alternative -- reading TRANSFORM as
-        # "not blocked" -- allows the request and discards the rewrite with nothing to see.
-        raise NotImplementedError(f"rail returned {outcome.decision.value!r}, which IORails cannot apply")
     return RailResult(outcome)
+
+
+def _tool_rail_result(outcome: RailOutcome, flow: str) -> RailResult:
+    """Map a tool rail's verdict, refusing a rewrite it has nowhere to apply."""
+    if outcome.is_transform:
+        # Tool rails validate structure and declare no transform target, so there is no
+        # conversation variable to write. Unreachable, and loud so it stays that way: reading
+        # a rewrite as "not blocked" would allow the request and discard it with nothing to see.
+        raise NotImplementedError(f"tool rail {flow!r} returned a rewrite, which IORails cannot apply")
+    return RailResult(outcome)
+
+
+def _rewritten_text(outcome: RailOutcome, direction: RailDirection, flow: str) -> str:
+    """Return what a transform rail rewrote its direction's conversation variable to."""
+    target = _REWRITABLE_TARGET[direction]
+    rewrites = outcome.transform_text
+    if set(rewrites) != {target.value}:
+        # A surface declares which variable it rewrites, and compilation checks that declaration
+        # against the direction; an action returning something else contradicts its own manifest.
+        raise NotImplementedError(
+            f"{flow!r} rewrote {sorted(rewrites)}, which a {direction.value.lower()} rail cannot apply; "
+            f"it may rewrite {target.value!r}"
+        )
+    return rewrites[target.value]
+
+
+def _refuse_concurrent_rewrite(result: RailResult, flow: str) -> None:
+    """Refuse a rewrite produced by a rail running concurrently with its peers.
+
+    Rails in parallel mode all read the text as it arrived, so two rewrites cannot compose and
+    applying either would report a verdict computed over text the other never saw. A configured
+    transform rail therefore forces sequential execution, and this keeps that the only way in.
+    """
+    if result.outcome.is_transform:
+        raise NotImplementedError(f"{flow!r} returned a rewrite while running in parallel, which cannot be applied")
+
+
+def _checked_text(direction: RailDirection, messages: list[dict], bot_response: Optional[str]) -> str:
+    """Return the text this direction's rails check, which is the text a rewrite replaces."""
+    if direction is RailDirection.INPUT:
+        return last_user_content(messages)
+    return bot_response or ""
+
+
+def _result_after_rewrites(
+    direction: RailDirection,
+    original_text: str,
+    final_text: str,
+    records: tuple[RailCallRecord, ...],
+) -> RailResult:
+    """Return the verdict for a direction no rail blocked: its rewrite, or a plain allow.
+
+    Only the text that survived every rail is reported, rather than each rail's rewrite in turn,
+    so rails that rewrite and then restore the original say nothing happened -- which is what
+    lets ``check`` tell PASSED from MODIFIED the way LLMRails does, by comparing content.
+    """
+    if final_text == original_text:
+        return RailResult.allow(records=records)
+    return RailResult(RailOutcome.transform([(_REWRITABLE_TARGET[direction], final_text)]), records=records)
 
 
 def _model_free_record(flow: str, rail_type: str, result: RailResult) -> RailCallRecord:
@@ -244,7 +331,8 @@ class RailsManager:
         # the catalog offers in both directions and a config lists in both would otherwise
         # collide on one key and run whichever compiled last.
         self._rails: dict[tuple[RailDirection, str], CompiledRail] = {}
-        for direction, flows in ((RailDirection.INPUT, self.input_flows), (RailDirection.OUTPUT, self.output_flows)):
+        configured = ((RailDirection.INPUT, self.input_flows), (RailDirection.OUTPUT, self.output_flows))
+        for direction, flows in configured:
             for flow in flows:
                 try:
                     surface_name, _ = parse_configured_surface(flow)
@@ -254,6 +342,15 @@ class RailsManager:
                 self._rails[(direction, flow)] = compile_rail(
                     flow, _SURFACE_DIRECTIONS[direction], deps, http_client=http_client
                 )
+
+        # Which rails may rewrite decides whether this config can run its rails concurrently at
+        # all, which is settled once, here. The order they run in is not: it follows from the
+        # configured flows, which stay the single source of truth for what runs.
+        self.transform_flows: dict[RailDirection, tuple[str, ...]] = {
+            direction: _rewriting_flows(self._rails, direction, flows) for direction, flows in configured
+        }
+        if any(self.transform_flows.values()):
+            self._run_rails_sequentially()
 
         # Tool Call Actions run on tool invocations from the main LLM response
         # Tool Result Actions run on the results of executing Tool Calls in the harness
@@ -270,6 +367,26 @@ class RailsManager:
             self.input_parallel,
             self.output_parallel,
         )
+
+    def _run_rails_sequentially(self) -> None:
+        """Turn off parallel rails, which cannot carry a rewrite from one rail to the next.
+
+        Concurrent rails all read the text as it arrived, so two rewrites cannot compose and
+        applying either would report a verdict computed over text the other never saw. Both
+        directions are turned off together: a config should not run its rails one way in one
+        section and another way in the other.
+        """
+        if not (self.input_parallel or self.output_parallel):
+            return
+        rewriting = sorted(flow for flows in self.transform_flows.values() for flow in flows)
+        warnings.warn(
+            f"rails.input.parallel / rails.output.parallel are not honored alongside a rail that rewrites "
+            f"content ({', '.join(rewriting)}); input and output rails run sequentially so each rewrite "
+            f"reaches the rails behind it.",
+            stacklevel=3,
+        )
+        self.input_parallel = False
+        self.output_parallel = False
 
     def _rail_dependencies(self) -> RailDependencies:
         """Bundle the collaborators a compiled rail's action may declare as parameters."""
@@ -331,14 +448,14 @@ class RailsManager:
         named flows (matched on the normalized flow name). When parallel mode is enabled,
         all selected rails run concurrently and the first unsafe result cancels the rest.
         """
-        active = self._enabled_flows(self.input_flows, enabled)
+        active = self._flows_to_run(RailDirection.INPUT, self.input_flows, enabled)
         if not active:
             return RailResult.allow()
 
-        rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in active}
         if self.input_parallel:
+            rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in active}
             return await self._run_rails_parallel(rails, RailDirection.INPUT)
-        return await self._run_rails_sequential(rails, RailDirection.INPUT)
+        return await self._run_rails_sequential(active, RailDirection.INPUT, messages)
 
     async def is_output_safe(
         self, messages: list[dict], response: str, *, enabled: Union[bool, list[str]] = True
@@ -350,14 +467,14 @@ class RailsManager:
         named flows (matched on the normalized flow name). When parallel mode is enabled,
         all selected rails run concurrently and the first unsafe result cancels the rest.
         """
-        active = self._enabled_flows(self.output_flows, enabled)
+        active = self._flows_to_run(RailDirection.OUTPUT, self.output_flows, enabled)
         if not active:
             return RailResult.allow()
 
-        rails = {flow: self._run_rail(flow, RailDirection.OUTPUT, messages, bot_response=response) for flow in active}
         if self.output_parallel:
+            rails = {flow: self._run_rail(flow, RailDirection.OUTPUT, messages, response) for flow in active}
             return await self._run_rails_parallel(rails, RailDirection.OUTPUT)
-        return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
+        return await self._run_rails_sequential(active, RailDirection.OUTPUT, messages, response)
 
     async def are_tool_calls_safe(
         self,
@@ -383,7 +500,7 @@ class RailsManager:
             return RailResult.block(reason=f"tool parsing failed: {e}")
 
         rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in active}
-        return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
+        return await self._run_tool_rails_sequential(rails, RailDirection.OUTPUT)
 
     async def are_tool_results_safe(
         self,
@@ -412,7 +529,14 @@ class RailsManager:
             return RailResult.allow()
 
         rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
-        return await self._run_rails_sequential(rails, RailDirection.INPUT)
+        return await self._run_tool_rails_sequential(rails, RailDirection.INPUT)
+
+    def _flows_to_run(
+        self, direction: RailDirection, configured: list[str], enabled: Union[bool, list[str]]
+    ) -> list[str]:
+        """The flows this request runs, in the order it runs them: rewriting rails first."""
+        active = self._enabled_flows(configured, enabled)
+        return _transforms_first(_rewriting_flows(self._rails, direction, active), active)
 
     @staticmethod
     def _enabled_flows(configured: list[str], enabled: Union[bool, list[str]]) -> list[str]:
@@ -456,7 +580,7 @@ class RailsManager:
     async def _run_tool_call_rail(self, flow: str, tool_calls: list[ToolCall], toolset: Toolset) -> RailResult:
         """Dispatch a single tool-call rail to its action, wrapped in an OUTPUT rail span."""
         with rail_span(self._tracer, flow, RailDirection.OUTPUT) as span:
-            result = _rail_result(await self._tool_call_actions[flow].run(toolset, tool_calls))
+            result = _tool_rail_result(await self._tool_call_actions[flow].run(toolset, tool_calls), flow)
             result = replace(result, records=(_rail_call_record(flow, "tool_output", result),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
@@ -480,7 +604,7 @@ class RailsManager:
                 outcome = await action.run(exchange.results, exchange.calls)
                 if outcome.is_blocked:
                     break
-            result = _rail_result(outcome)
+            result = _tool_rail_result(outcome, flow)
             result = replace(result, records=(_rail_call_record(flow, "tool_input", result),))
             mark_rail_stop(span, result.is_safe)
             if self._content_capture_enabled:
@@ -498,10 +622,48 @@ class RailsManager:
 
     async def _run_rails_sequential(
         self,
+        flows: Sequence[str],
+        direction: RailDirection,
+        messages: list[dict],
+        bot_response: Optional[str] = None,
+    ) -> RailResult:
+        """Run one direction's input/output rails in turn, short-circuiting on the first unsafe result.
+
+        Each rail is dispatched only when its turn comes, so a rail that rewrites the text hands
+        the rewrite to the rails behind it: a masking rail ahead of a safety check means the check
+        reads masked text, which is what the rewrite is for.
+        """
+        req_id = get_request_id()
+        collected: list[RailCallRecord] = []
+        original_text = _checked_text(direction, messages, bot_response)
+        final_text = original_text
+        for flow in flows:
+            result = await self._run_rail(flow, direction, messages, bot_response)
+            collected.extend(result.records)
+            log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
+            if not result.is_safe:
+                log.info("[%s] %s flow %s blocked", req_id, direction.value, flow)
+                return replace(result, records=tuple(collected))
+            if result.outcome.is_transform:
+                final_text = _rewritten_text(result.outcome, direction, flow)
+                log.info("[%s] %s flow %s rewrote the text it checked", req_id, direction.value, flow)
+                if direction is RailDirection.INPUT:
+                    messages = rewrite_user_message(messages, final_text)
+                else:
+                    bot_response = final_text
+        return _result_after_rewrites(direction, original_text, final_text, tuple(collected))
+
+    async def _run_tool_rails_sequential(
+        self,
         rails: Mapping[str, Coroutine[Any, Any, RailResult]],
         direction: RailDirection,
     ) -> RailResult:
-        """Run rail coroutines sequentially, short-circuiting on first unsafe result."""
+        """Run tool rail coroutines sequentially, short-circuiting on first unsafe result.
+
+        Separate from the input/output loop because tool rails carry no text between them:
+        they validate structure, so there is nothing one could hand the next and their
+        coroutines are built up front. Unreached ones are closed rather than left pending.
+        """
         req_id = get_request_id()
         remaining = iter(rails.items())
         collected: list[RailCallRecord] = []
@@ -539,8 +701,9 @@ class RailsManager:
                 first_unsafe: Optional[RailResult] = None
                 for task in sorted(done, key=lambda t: task_order[t]):
                     result = task.result()
-                    collected.extend(result.records)
                     flow = task_to_flow[task]
+                    _refuse_concurrent_rewrite(result, flow)
+                    collected.extend(result.records)
                     log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
                     if not result.is_safe and first_unsafe is None:
                         first_unsafe = result

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -356,7 +356,7 @@ class RailsManager:
             direction: _rewriting_flows(self._rails, direction, flows) for direction, flows in configured
         }
         if any(self.transform_flows.values()):
-            self._run_rails_sequentially()
+            self._disable_parallel_execution()
 
         # Tool Call Actions run on tool invocations from the main LLM response
         # Tool Result Actions run on the results of executing Tool Calls in the harness
@@ -374,7 +374,7 @@ class RailsManager:
             self.output_parallel,
         )
 
-    def _run_rails_sequentially(self) -> None:
+    def _disable_parallel_execution(self) -> None:
         """Turn off parallel rails, which cannot carry a rewrite from one rail to the next.
 
         Concurrent rails all read the text as it arrived, so two rewrites cannot compose and
@@ -654,7 +654,20 @@ class RailsManager:
                 final_text = _rewritten_text(result.outcome, direction, flow)
                 log.info("[%s] %s flow %s rewrote the text it checked", req_id, direction.value, flow)
                 if direction is RailDirection.INPUT:
-                    messages = rewrite_user_message(messages, final_text)
+                    try:
+                        messages = rewrite_user_message(messages, final_text)
+                    except ValueError:
+                        # The rail was handed no text and answered with some: there is no turn to
+                        # write it to. Blocking keeps a misbehaving rail inside the fail-closed
+                        # envelope built for it, rather than failing the request as a server error.
+                        log.error(
+                            "[%s] %s flow %s rewrote a turn this request does not have", req_id, direction.value, flow
+                        )
+                        return RailResult.block(
+                            reason="a rail rewrote a message this request does not have",
+                            triggered_rail=_get_flow_name(flow) or flow,
+                            records=tuple(collected),
+                        )
                 else:
                     bot_response = final_text
         return _result_after_rewrites(direction, original_text, final_text, tuple(collected))

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -148,8 +148,7 @@ _HTTP_CLIENT_SURFACE_NAMES: frozenset[str] = frozenset(
 )
 
 
-# The conversation variable each direction's rails may rewrite. A rewrite naming anything else
-# has nowhere to land here, so it is refused rather than dropped.
+# The conversation variable each direction's rails may rewrite; anything else is refused.
 _REWRITABLE_TARGET = {
     RailDirection.INPUT: TransformTarget.USER_MESSAGE,
     RailDirection.OUTPUT: TransformTarget.BOT_MESSAGE,
@@ -166,12 +165,7 @@ def _rewriting_flows(
 
 
 def _transforms_first(rewriting: Sequence[str], flows: Sequence[str]) -> list[str]:
-    """Order a direction's flows so rails that may rewrite run ahead of rails that only judge.
-
-    A rewrite is only of use to the rails behind it: masking ahead of a safety check means the
-    check reads masked text. Configured order is kept within each group, so a direction with no
-    rewriting rail runs exactly as it was written.
-    """
+    """Order rails that may rewrite ahead of rails that only judge, so a mask reaches the check."""
     ordered = list(rewriting)
     already_ordered = set(rewriting)
     ordered.extend(flow for flow in flows if flow not in already_ordered)
@@ -186,26 +180,21 @@ def _rail_result(outcome: RailOutcome) -> RailResult:
 def _tool_rail_result(outcome: RailOutcome, flow: str) -> RailResult:
     """Map a tool rail's verdict, refusing a rewrite it has nowhere to apply."""
     if outcome.is_transform:
-        # Tool rails validate structure and declare no transform target, so there is no
-        # conversation variable to write. Unreachable, and loud so it stays that way: reading
-        # a rewrite as "not blocked" would allow the request and discard it with nothing to see.
+        # Reading it as "not blocked" would allow the request and drop the rewrite unseen.
         raise NotImplementedError(f"tool rail {flow!r} returned a rewrite, which IORails cannot apply")
     return RailResult(outcome)
 
 
 def _rewritten_text(outcome: RailOutcome, direction: RailDirection, flow: str) -> str:
-    """Return what a transform rail rewrote this direction's conversation variable to.
+    """Return what a rail rewrote this direction's variable to, ignoring any it also named.
 
-    A rail that guards both sides of a turn may name both variables in one verdict, and each
-    direction takes its own -- which is what the Colang flows do with the same outcome, each
-    indexing the one key it owns. Writing the other direction's text here would put a response
-    where the request goes.
+    A rail guarding both sides of a turn names both, and each direction takes its own, as the
+    Colang flows do with the same verdict.
     """
     target = _REWRITABLE_TARGET[direction]
     rewrites = outcome.transform_text
     if target.value not in rewrites:
-        # A surface declares which variable it rewrites, and compilation checks that declaration
-        # against the direction; an action naming none of it contradicts its own manifest.
+        # An action naming none of its direction's variable contradicts its own manifest.
         raise NotImplementedError(
             f"{flow!r} rewrote {sorted(rewrites)}, which a {direction.value.lower()} rail cannot apply; "
             f"it may rewrite {target.value!r}"
@@ -214,12 +203,7 @@ def _rewritten_text(outcome: RailOutcome, direction: RailDirection, flow: str) -
 
 
 def _refuse_concurrent_rewrite(result: RailResult, flow: str) -> None:
-    """Refuse a rewrite produced by a rail running concurrently with its peers.
-
-    Rails in parallel mode all read the text as it arrived, so two rewrites cannot compose and
-    applying either would report a verdict computed over text the other never saw. A configured
-    transform rail therefore forces sequential execution, and this keeps that the only way in.
-    """
+    """Refuse a rewrite from a concurrent rail: peers read the arriving text, so it cannot compose."""
     if result.outcome.is_transform:
         raise NotImplementedError(f"{flow!r} returned a rewrite while running in parallel, which cannot be applied")
 
@@ -237,12 +221,7 @@ def _result_after_rewrites(
     final_text: str,
     records: tuple[RailCallRecord, ...],
 ) -> RailResult:
-    """Return the verdict for a direction no rail blocked: its rewrite, or a plain allow.
-
-    Only the text that survived every rail is reported, rather than each rail's rewrite in turn,
-    so rails that rewrite and then restore the original say nothing happened -- which is what
-    lets ``check`` tell PASSED from MODIFIED the way LLMRails does, by comparing content.
-    """
+    """Report the text that survived every rail, so a rewrite undone by a later rail is no rewrite."""
     if final_text == original_text:
         return RailResult.allow(records=records)
     return RailResult(RailOutcome.transform([(_REWRITABLE_TARGET[direction], final_text)]), records=records)
@@ -375,13 +354,7 @@ class RailsManager:
         )
 
     def _disable_parallel_execution(self) -> None:
-        """Turn off parallel rails, which cannot carry a rewrite from one rail to the next.
-
-        Concurrent rails all read the text as it arrived, so two rewrites cannot compose and
-        applying either would report a verdict computed over text the other never saw. Both
-        directions are turned off together: a config should not run its rails one way in one
-        section and another way in the other.
-        """
+        """Turn both directions sequential, because concurrent rails cannot carry a rewrite."""
         if not (self.input_parallel or self.output_parallel):
             return
         rewriting = sorted(flow for flows in self.transform_flows.values() for flow in flows)
@@ -633,12 +606,7 @@ class RailsManager:
         messages: list[dict],
         bot_response: Optional[str] = None,
     ) -> RailResult:
-        """Run one direction's input/output rails in turn, short-circuiting on the first unsafe result.
-
-        Each rail is dispatched only when its turn comes, so a rail that rewrites the text hands
-        the rewrite to the rails behind it: a masking rail ahead of a safety check means the check
-        reads masked text, which is what the rewrite is for.
-        """
+        """Run a direction's rails in turn, threading each rewrite into the rails behind it."""
         req_id = get_request_id()
         collected: list[RailCallRecord] = []
         original_text = _checked_text(direction, messages, bot_response)
@@ -657,9 +625,8 @@ class RailsManager:
                     try:
                         messages = rewrite_user_message(messages, final_text)
                     except ValueError:
-                        # The rail was handed no text and answered with some: there is no turn to
-                        # write it to. Blocking keeps a misbehaving rail inside the fail-closed
-                        # envelope built for it, rather than failing the request as a server error.
+                        # Blocking keeps a misbehaving rail inside the fail-closed envelope,
+                        # rather than failing the request as a server error.
                         log.error(
                             "[%s] %s flow %s rewrote a turn this request does not have", req_id, direction.value, flow
                         )
@@ -677,11 +644,10 @@ class RailsManager:
         rails: Mapping[str, Coroutine[Any, Any, RailResult]],
         direction: RailDirection,
     ) -> RailResult:
-        """Run tool rail coroutines sequentially, short-circuiting on first unsafe result.
+        """Run tool rail coroutines in turn, short-circuiting on the first unsafe result.
 
-        Separate from the input/output loop because tool rails carry no text between them:
-        they validate structure, so there is nothing one could hand the next and their
-        coroutines are built up front. Unreached ones are closed rather than left pending.
+        Separate from the input/output loop because tool rails carry no text between them, so
+        their coroutines are built up front and the unreached ones need closing.
         """
         req_id = get_request_id()
         remaining = iter(rails.items())

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -194,12 +194,18 @@ def _tool_rail_result(outcome: RailOutcome, flow: str) -> RailResult:
 
 
 def _rewritten_text(outcome: RailOutcome, direction: RailDirection, flow: str) -> str:
-    """Return what a transform rail rewrote its direction's conversation variable to."""
+    """Return what a transform rail rewrote this direction's conversation variable to.
+
+    A rail that guards both sides of a turn may name both variables in one verdict, and each
+    direction takes its own -- which is what the Colang flows do with the same outcome, each
+    indexing the one key it owns. Writing the other direction's text here would put a response
+    where the request goes.
+    """
     target = _REWRITABLE_TARGET[direction]
     rewrites = outcome.transform_text
-    if set(rewrites) != {target.value}:
+    if target.value not in rewrites:
         # A surface declares which variable it rewrites, and compilation checks that declaration
-        # against the direction; an action returning something else contradicts its own manifest.
+        # against the direction; an action naming none of it contradicts its own manifest.
         raise NotImplementedError(
             f"{flow!r} rewrote {sorted(rewrites)}, which a {direction.value.lower()} rail cannot apply; "
             f"it may rewrite {target.value!r}"

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1119,6 +1119,52 @@ class RailsConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def check_streaming_can_apply_output_rewrites(cls, values):
+        """Reject configs whose output rails transform response with `stream_first` == True"""
+        from nemoguardrails.manifests import RailDirection, default_rail_catalog, parse_configured_surface
+
+        rails = values.get("rails") or {}
+        output = rails.get("output") or {}
+        streaming = output.get("streaming") or {}
+        if not streaming.get("enabled", False):
+            return values
+
+        surfaces = default_rail_catalog().surfaces()
+        rewriting = []
+        for flow in output.get("flows") or []:
+            try:
+                name, _ = parse_configured_surface(flow)
+            except ValueError:
+                continue
+            surface = surfaces.get((RailDirection.OUTPUT, name))
+            # An unknown flow is a custom or Colang-defined rail, which declares no target here.
+            if surface is not None and surface.transform_target is not None:
+                rewriting.append(flow)
+        if not rewriting:
+            return values
+
+        defaults = OutputRailsStreamingConfig()
+        stream_first = streaming.get("stream_first", defaults.stream_first)
+        context_size = streaming.get("context_size", defaults.context_size)
+        offending = [
+            setting
+            for setting, unusable in (
+                ("stream_first: True", stream_first),
+                (f"context_size: {context_size}", context_size),
+            )
+            if unusable
+        ]
+        if not offending:
+            return values
+
+        raise InvalidRailsConfigurationError(
+            f"Output rails {rewriting} rewrite the response, which streaming cannot apply with "
+            f"{' and '.join(offending)}: set rails.output.streaming.stream_first to False and "
+            f"context_size to 0, or remove the rewriting rails from a streaming configuration."
+        )
+
+    @model_validator(mode="before")
+    @classmethod
     def check_jailbreak_detection_config(cls, values):
         """Validate jailbreak detection configuration against enabled flows."""
         rails = values.get("rails") or {}

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stand-ins for compiled rails, for tests that need a rail to behave a certain way.
+
+A rail that rewrites cannot be configured yet -- transform surfaces are refused at compile time
+until IORails can apply a rewrite -- so a test needing one stands in for compilation rather than
+naming a real rewriting rail in a config. Once those surfaces compile, these stubs stay useful
+for the rails whose backend is a paid vendor call.
+"""
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+from unittest.mock import patch
+
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
+from nemoguardrails.guardrails.compiled_rail import RailExecution
+from nemoguardrails.manifests import RailDirection as SurfaceDirection
+
+
+class StubRail:
+    """Answers with one outcome, makes no model call, and keeps what it was handed.
+
+    ``transform_target`` mirrors what a surface declares rather than what the outcome does, so a
+    rail can be scheduled as a rewriting one while still answering with an allow.
+    """
+
+    def __init__(self, outcome: Optional[RailOutcome] = None, transform_target: Optional[TransformTarget] = None):
+        self.outcome = RailOutcome.allow() if outcome is None else outcome
+        self.transform_target = transform_target
+        self.seen_messages: list[dict] = []
+        self.seen_bot_response: Optional[str] = None
+        self.call_count = 0
+
+    async def execute(self, messages: list[dict], bot_response: Optional[str] = None) -> RailExecution:
+        self.seen_messages = [dict(message) for message in messages]
+        self.seen_bot_response = bot_response
+        self.call_count += 1
+        return RailExecution(outcome=self.outcome)
+
+    async def close(self) -> None:
+        """A compiled rail may own an HTTP client; a stub has nothing to release."""
+
+
+def rewriting_stub(text: str, direction: SurfaceDirection) -> StubRail:
+    """A rail that both declares it may rewrite and does, to its direction's variable."""
+    target = TransformTarget.USER_MESSAGE if direction is SurfaceDirection.INPUT else TransformTarget.BOT_MESSAGE
+    return StubRail(RailOutcome.transform([(target, text)]), transform_target=target)
+
+
+def declared_rewriter(direction: SurfaceDirection) -> StubRail:
+    """A rail free to rewrite that does not, which is what most requests to one look like."""
+    target = TransformTarget.USER_MESSAGE if direction is SurfaceDirection.INPUT else TransformTarget.BOT_MESSAGE
+    return StubRail(transform_target=target)
+
+
+@contextmanager
+def rails_compiled_as(rails: Mapping[str, StubRail]) -> Iterator[None]:
+    """Compile the named flows to their stubs, and every other configured flow to a plain allow.
+
+    Patches compilation rather than the compiled rails, so ``RailsManager`` reads the stubs while
+    deciding how to schedule its rails -- which is the part under test.
+    """
+
+    def _compile(flow: str, direction: SurfaceDirection, deps: Any, **kwargs: Any) -> StubRail:
+        return rails.get(flow, StubRail())
+
+    with patch("nemoguardrails.guardrails.rails_manager.compile_rail", side_effect=_compile):
+        yield

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -15,10 +15,11 @@
 
 """Stand-ins for compiled rails, for tests that need a rail to behave a certain way.
 
-A rail that rewrites cannot be configured yet -- transform surfaces are refused at compile time
-until IORails can apply a rewrite -- so a test needing one stands in for compilation rather than
-naming a real rewriting rail in a config. Once those surfaces compile, these stubs stay useful
-for the rails whose backend is a paid vendor call.
+Rewriting surfaces compile now, so a stub is no longer the only way to hold one. What it still
+buys is a rail with no backend: the shipped rewriting rails reach a paid vendor or a NIM, and a
+test about *scheduling* -- which rail runs first, what the one behind it reads -- should not
+depend on either. ``rails_compiled_as`` patches compilation rather than the compiled rails, so
+``RailsManager`` reads these while deciding how to order and downgrade.
 """
 
 from collections.abc import Mapping

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -13,13 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Stand-ins for compiled rails, for tests that need a rail to behave a certain way.
+"""Stand-ins for compiled rails, so a test about scheduling needs no paid vendor or NIM behind it.
 
-Rewriting surfaces compile now, so a stub is no longer the only way to hold one. What it still
-buys is a rail with no backend: the shipped rewriting rails reach a paid vendor or a NIM, and a
-test about *scheduling* -- which rail runs first, what the one behind it reads -- should not
-depend on either. ``rails_compiled_as`` patches compilation rather than the compiled rails, so
-``RailsManager`` reads these while deciding how to order and downgrade.
+``rails_compiled_as`` patches compilation rather than the compiled rails, so ``RailsManager``
+reads these while deciding how to order and downgrade.
 """
 
 from collections.abc import Mapping
@@ -36,8 +33,7 @@ from nemoguardrails.manifests import RailDirection as SurfaceDirection
 class StubRail:
     """Answers with one outcome, makes no model call, and keeps what it was handed.
 
-    ``transform_target`` mirrors what a surface declares rather than what the outcome does, so a
-    rail can be scheduled as a rewriting one while still answering with an allow.
+    ``transform_target`` mirrors what a surface declares, not what the outcome does.
     """
 
     def __init__(self, outcome: Optional[RailOutcome] = None, transform_target: Optional[TransformTarget] = None):
@@ -81,11 +77,7 @@ def bot_message_rewrite(text: str) -> RailResult:
 
 @contextmanager
 def rails_compiled_as(rails: Mapping[str, StubRail]) -> Iterator[None]:
-    """Compile the named flows to their stubs, and every other configured flow to a plain allow.
-
-    Patches compilation rather than the compiled rails, so ``RailsManager`` reads the stubs while
-    deciding how to schedule its rails -- which is the part under test.
-    """
+    """Compile the named flows to their stubs, and every other configured flow to a plain allow."""
 
     def _compile(flow: str, direction: SurfaceDirection, deps: Any, **kwargs: Any) -> StubRail:
         return rails.get(flow, StubRail())

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.guardrails.compiled_rail import RailExecution
+from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.manifests import RailDirection as SurfaceDirection
 
 
@@ -65,6 +66,16 @@ def declared_rewriter(direction: SurfaceDirection) -> StubRail:
     """A rail free to rewrite that does not, which is what most requests to one look like."""
     target = TransformTarget.USER_MESSAGE if direction is SurfaceDirection.INPUT else TransformTarget.BOT_MESSAGE
     return StubRail(transform_target=target)
+
+
+def user_message_rewrite(text: str) -> RailResult:
+    """The verdict input rails return when they rewrote the user message to *text*."""
+    return RailResult(RailOutcome.transform([(TransformTarget.USER_MESSAGE, text)]))
+
+
+def bot_message_rewrite(text: str) -> RailResult:
+    """The verdict output rails return when they rewrote the response to *text*."""
+    return RailResult(RailOutcome.transform([(TransformTarget.BOT_MESSAGE, text)]))
 
 
 @contextmanager

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -428,10 +428,30 @@ class TestUnrunnableSurfaces:
 
         assert unsupported_surface_reason(surface) is None
 
-    def test_transform_surfaces_do_not_compile(self, deps):
-        """A surface that rewrites content is refused until IORails can apply the rewrite."""
-        with pytest.raises(RailCompilationError, match="transform"):
-            compile_rail("autoalign check input", RailDirection.INPUT, deps)
+    def test_a_rewriting_surface_compiles(self, deps):
+        """A rail that rewrites its own direction's variable is runnable, which is the point of it."""
+        assert compile_rail("autoalign check input", RailDirection.INPUT, deps) is not None
+
+    @pytest.mark.parametrize(
+        "direction, target",
+        [
+            (RailDirection.INPUT, TransformTarget.BOT_MESSAGE),
+            (RailDirection.OUTPUT, TransformTarget.USER_MESSAGE),
+            (RailDirection.INPUT, TransformTarget.RELEVANT_CHUNKS),
+        ],
+        ids=["input-rewrites-bot", "output-rewrites-user", "input-rewrites-chunks"],
+    )
+    def test_a_surface_rewriting_the_wrong_variable_does_not_compile(self, deps, direction, target):
+        """A rewrite this engine has no variable for is refused rather than applied to the wrong one.
+
+        Nothing in the manifest schema forbids the mismatch, so the refusal is what keeps it out.
+        """
+        surface = synthetic_surface(
+            ActionRef(name="takes_text", target=TAKES_TEXT_TARGET), direction=direction, transform_target=target
+        )
+
+        with pytest.raises(RailCompilationError, match="cannot apply"):
+            compile_rail(SYNTHETIC_FLOW, direction, deps, catalog=StubCatalog(surface, direction))
 
 
 class TestDeclaredTransformTarget:
@@ -480,23 +500,41 @@ class TestDeclaredTransformTarget:
 
         assert not missing, f"deny-list names surfaces the catalog does not have: {missing}"
 
-    def test_the_block_only_tier_splits_into_servable_and_refused(self):
-        """Every block-only input/output surface is servable but for the eight refused ones.
+    def test_the_input_output_tier_splits_into_servable_and_refused(self):
+        """Every input/output surface is servable but for the eight refused ones.
 
-        Measured: 41 servable, 8 refused -- the seven retrieval-evidence surfaces plus
-        jailbreak heuristics, whose backend cannot be told apart from its manifest sibling's.
-        Pinning the split rather than a predicate means a newly added manifest surface, or an
-        action that grows a binding IORails cannot fill, fails here rather than in a config.
+        Measured: 59 servable -- 41 that only judge and the 18 that may rewrite -- against 8
+        refused: the seven retrieval-evidence surfaces plus jailbreak heuristics, whose backend
+        cannot be told apart from its manifest sibling's. Pinning the split rather than a
+        predicate means a newly added manifest surface, or an action that grows a binding
+        IORails cannot fill, fails here rather than in a config.
         """
         servable, refused = [], []
         for (direction, name), surface in default_rail_catalog().surfaces().items():
-            if direction is RailDirection.RETRIEVAL or surface.transform_target is not None:
+            if direction is RailDirection.RETRIEVAL:
                 continue
             bucket = refused if unsupported_surface_reason(surface) is not None else servable
             bucket.append((direction, name))
 
         assert sorted(refused) == sorted(RETRIEVAL_DEPENDENT_SURFACES | UNSUPPORTED_RAIL_SURFACES)
-        assert len(servable) == 41
+        assert len(servable) == 59
+
+    def test_the_rewriting_surfaces_are_all_servable(self):
+        """The eighteen this work exists for: nine each way, every one of them runnable.
+
+        Counted rather than named, because the names are the manifests' business; what this
+        pins is that no direction is left half-enabled.
+        """
+        rewriting = [
+            (direction, name)
+            for (direction, name), surface in default_rail_catalog().surfaces().items()
+            if direction is not RailDirection.RETRIEVAL and surface.transform_target is not None
+        ]
+
+        assert len(rewriting) == 18
+        assert [key for key in rewriting if key[0] is RailDirection.INPUT] != []
+        assert [key for key in rewriting if key[0] is RailDirection.OUTPUT] != []
+        assert all(unsupported_surface_reason(default_rail_catalog().surfaces()[key]) is None for key in rewriting)
 
     def test_refusal_precedes_the_action_import(self, deps, monkeypatch):
         """An unrunnable surface is refused before its action module is imported."""

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -27,7 +27,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.guardrails.compiled_rail import (
     _RETRIEVAL_CONTEXT_SURFACES,
     CompiledRail,
@@ -70,6 +70,7 @@ JAILBREAK_INPUT = "jailbreak detection model"
 USER_MESSAGES = [{"role": "user", "content": "hello there"}]
 
 SYNTHETIC_FLOW = "synthetic rail"
+TAKES_TEXT_TARGET = "tests.guardrails.test_compiled_rail:takes_text"
 CONTENT_SAFETY_ACTION_REF = ActionRef(
     name="content_safety_check_input",
     target="nemoguardrails.library.content_safety.actions:content_safety_check_input",
@@ -134,6 +135,7 @@ def synthetic_surface(
     *,
     bypass_validation: bool = False,
     direction: RailDirection = RailDirection.INPUT,
+    transform_target: Optional[TransformTarget] = None,
 ) -> RailSurface:
     """Build a one-off surface for a compilation path the real catalog cannot reach.
 
@@ -145,14 +147,31 @@ def synthetic_surface(
             direction=direction,
             action=action,
             bindings=bindings,
-            transform_target=None,
+            transform_target=transform_target,
         )
     return RailSurface(
         name=SYNTHETIC_FLOW,
         direction=direction,
         action=action,
         bindings=bindings,
-        transform_target=None,
+        transform_target=transform_target,
+    )
+
+
+def uncompiled_rail(surface: RailSurface, deps: RailDependencies) -> CompiledRail:
+    """Build a ``CompiledRail`` around *surface* without going through compilation.
+
+    The only way to hold a rail for a surface compilation still refuses, which is what a
+    rewriting surface is until IORails can apply the rewrite.
+    """
+    return CompiledRail(
+        flow=surface.name,
+        surface=surface,
+        action=takes_text,
+        bound=(),
+        context_bound=(),
+        deps=deps,
+        accepted=frozenset(),
     )
 
 
@@ -413,6 +432,32 @@ class TestUnrunnableSurfaces:
         """A surface that rewrites content is refused until IORails can apply the rewrite."""
         with pytest.raises(RailCompilationError, match="transform"):
             compile_rail("autoalign check input", RailDirection.INPUT, deps)
+
+
+class TestDeclaredTransformTarget:
+    """A rail reports the variable its surface says it may rewrite, which is how it is scheduled."""
+
+    def test_a_block_only_rail_declares_no_rewrite(self, deps):
+        """The shipped rails all judge without rewriting, so nothing about their scheduling changes."""
+        assert compile_rail(CONTENT_SAFETY_INPUT, RailDirection.INPUT, deps).transform_target is None
+
+    def test_a_rewriting_rail_reports_the_variable_it_may_rewrite(self, deps):
+        """Scheduling reads the manifest's declaration, not a verdict some request happened to produce."""
+        surface = synthetic_surface(
+            ActionRef(name="takes_text", target=TAKES_TEXT_TARGET), transform_target=TransformTarget.USER_MESSAGE
+        )
+
+        assert uncompiled_rail(surface, deps).transform_target is TransformTarget.USER_MESSAGE
+
+    def test_the_declaration_is_independent_of_what_a_rail_answers(self, deps):
+        """Most requests to a rewriting rail come back as a plain allow; it is still scheduled first."""
+        surface = synthetic_surface(
+            ActionRef(name="takes_text", target=TAKES_TEXT_TARGET), transform_target=TransformTarget.USER_MESSAGE
+        )
+        rail = uncompiled_rail(surface, deps)
+
+        assert rail.transform_target is TransformTarget.USER_MESSAGE
+        assert rail.surface.transform_target is TransformTarget.USER_MESSAGE
 
     @pytest.mark.parametrize(
         "direction, flow",

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -162,8 +162,9 @@ def synthetic_surface(
 def uncompiled_rail(surface: RailSurface, deps: RailDependencies) -> CompiledRail:
     """Build a ``CompiledRail`` around *surface* without going through compilation.
 
-    The only way to hold a rail for a surface compilation still refuses, which is what a
-    rewriting surface is until IORails can apply the rewrite.
+    Synthetic surfaces name an action the catalog cannot resolve, so ``compile_rail`` has no way
+    to reach one. Constructing the rail directly is what lets a test hold a surface the manifests
+    do not ship -- a rewrite crossed over to the wrong direction, say.
     """
     return CompiledRail(
         flow=surface.name,

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -160,12 +160,7 @@ def synthetic_surface(
 
 
 def uncompiled_rail(surface: RailSurface, deps: RailDependencies) -> CompiledRail:
-    """Build a ``CompiledRail`` around *surface* without going through compilation.
-
-    Synthetic surfaces name an action the catalog cannot resolve, so ``compile_rail`` has no way
-    to reach one. Constructing the rail directly is what lets a test hold a surface the manifests
-    do not ship -- a rewrite crossed over to the wrong direction, say.
-    """
+    """Build a ``CompiledRail`` around a synthetic *surface*, whose action the catalog cannot resolve."""
     return CompiledRail(
         flow=surface.name,
         surface=surface,
@@ -550,13 +545,9 @@ class TestSurfacesOutsideTheTier:
         assert not missing, f"deny-list names surfaces the catalog does not have: {missing}"
 
     def test_the_input_output_tier_splits_into_servable_and_refused(self):
-        """Every input/output surface is servable but for the eight refused ones.
+        """59 servable -- 41 judging and 18 rewriting -- against the 8 refused, pinned by name.
 
-        Measured: 59 servable -- 41 that only judge and the 18 that may rewrite -- against 8
-        refused: the seven retrieval-evidence surfaces plus jailbreak heuristics, whose backend
-        cannot be told apart from its manifest sibling's. Pinning the split rather than a
-        predicate means a newly added manifest surface, or an action that grows a binding
-        IORails cannot fill, fails here rather than in a config.
+        A predicate would follow the code it is checking; a new manifest surface fails here.
         """
         servable, refused = [], []
         for (direction, name), surface in default_rail_catalog().surfaces().items():
@@ -569,11 +560,7 @@ class TestSurfacesOutsideTheTier:
         assert len(servable) == 59
 
     def test_the_rewriting_surfaces_are_all_servable(self):
-        """The eighteen this work exists for: nine each way, every one of them runnable.
-
-        Counted rather than named, because the names are the manifests' business; what this
-        pins is that no direction is left half-enabled.
-        """
+        """The eighteen this work exists for, nine each way, with no direction half-enabled."""
         rewriting = [
             (direction, name)
             for (direction, name), surface in default_rail_catalog().surfaces().items()

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -36,6 +36,7 @@ from nemoguardrails.guardrails.compiled_rail import (
     _hf_classifier_runs_locally,
     _is_installed,
     _jailbreak_detection_runs_locally,
+    _unapplicable_transform_reason,
     compile_rail,
     messages_to_events,
     unservable_reason,
@@ -454,6 +455,49 @@ class TestUnrunnableSurfaces:
             compile_rail(SYNTHETIC_FLOW, direction, deps, catalog=StubCatalog(surface, direction))
 
 
+class TestUnapplicableTransformReason:
+    """`_unapplicable_transform_reason` refuses a declared rewrite this engine cannot place."""
+
+    def _surface(self, direction: RailDirection, target) -> RailSurface:
+        return synthetic_surface(
+            ActionRef(name="takes_text", target=TAKES_TEXT_TARGET), direction=direction, transform_target=target
+        )
+
+    def test_a_rail_that_only_judges_has_nothing_to_refuse(self):
+        """The common surface, which declares no rewrite at all."""
+        assert _unapplicable_transform_reason(self._surface(RailDirection.INPUT, None)) is None
+
+    @pytest.mark.parametrize(
+        "direction, target",
+        [
+            (RailDirection.INPUT, TransformTarget.USER_MESSAGE),
+            (RailDirection.OUTPUT, TransformTarget.BOT_MESSAGE),
+        ],
+        ids=["input-user", "output-bot"],
+    )
+    def test_a_direction_rewriting_its_own_variable_is_servable(self, direction, target):
+        """The agreement every shipped surface has, and the reason this check refuses nothing today."""
+        assert _unapplicable_transform_reason(self._surface(direction, target)) is None
+
+    @pytest.mark.parametrize(
+        "direction, target",
+        [
+            (RailDirection.INPUT, TransformTarget.BOT_MESSAGE),
+            (RailDirection.OUTPUT, TransformTarget.USER_MESSAGE),
+            (RailDirection.INPUT, TransformTarget.RELEVANT_CHUNKS),
+            (RailDirection.RETRIEVAL, TransformTarget.RELEVANT_CHUNKS),
+        ],
+        ids=["input-bot", "output-user", "input-chunks", "retrieval"],
+    )
+    def test_a_rewrite_with_nowhere_to_land_reports_why(self, direction, target):
+        """Nothing in the manifest schema forbids the mismatch, so the refusal is what keeps it out."""
+        reason = _unapplicable_transform_reason(self._surface(direction, target))
+
+        assert reason is not None
+        assert target.value in reason
+        assert "cannot apply" in reason
+
+
 class TestDeclaredTransformTarget:
     """A rail reports the variable its surface says it may rewrite, which is how it is scheduled."""
 
@@ -478,6 +522,10 @@ class TestDeclaredTransformTarget:
 
         assert rail.transform_target is TransformTarget.USER_MESSAGE
         assert rail.surface.transform_target is TransformTarget.USER_MESSAGE
+
+
+class TestSurfacesOutsideTheTier:
+    """Which catalog surfaces this engine refuses, and that the refusal is cheap."""
 
     @pytest.mark.parametrize(
         "direction, flow",

--- a/tests/guardrails/test_cross_engine_local_rails.py
+++ b/tests/guardrails/test_cross_engine_local_rails.py
@@ -295,7 +295,7 @@ class TestRewritingRailsAgreeAcrossEngines:
     @pytest.mark.asyncio
     async def test_an_output_rewrite_reaches_the_caller_on_both_engines(self):
         """Through ``generate``, the sanitized response is what the caller reads on either engine."""
-        rail = REWRITING_RAILS[0]
+        rail = next(candidate for candidate in REWRITING_RAILS if candidate.direction == "output")
         config_dict = _rewriting_config(rail)
 
         llmrails_content = await _llmrails_reply(config_dict, BENIGN_INPUT, rail.original)

--- a/tests/guardrails/test_cross_engine_local_rails.py
+++ b/tests/guardrails/test_cross_engine_local_rails.py
@@ -37,6 +37,7 @@ from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.manifests import RailDirection as SurfaceDirection
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.options import RailStatus, RailType
 from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 from tests.utils import TestChat
@@ -189,3 +190,123 @@ class TestARailWhoseDependencyIsMissing:
                 SurfaceDirection.INPUT,
                 RailDependencies(llms={"main": None}, llm_task_manager=None, config=None),
             )
+
+
+SQL_OUTPUT = "This is a SELECT * FROM users; -- malicious comment in text"
+SANITIZED_OUTPUT = "This is a  * FROM usersmalicious comment in text"
+INJECTION_OMIT_CONFIG = {"injection_detection": {"injections": ["sqli"], "action": "omit"}}
+
+BLOAT_LIMIT = 40
+BLOATED_INPUT = "tell me about guardrails and every option they support, at length, in detail"
+TRUNCATED_INPUT = BLOATED_INPUT[:BLOAT_LIMIT]
+CONTEXT_BLOAT_CONFIG = {"context_bloat_detection": {"max_chars": BLOAT_LIMIT, "action": "truncate"}}
+
+
+@dataclass(frozen=True)
+class RewritingRail:
+    """One in-process rail that rewrites, with the text that trips it and what it makes of it."""
+
+    rail_id: str
+    flow: str
+    direction: str
+    rails_config: dict
+    original: str
+    rewritten: str
+
+
+REWRITING_RAILS = [
+    RewritingRail(
+        rail_id="injection_detection_omit",
+        flow="injection detection",
+        direction="output",
+        rails_config=INJECTION_OMIT_CONFIG,
+        original=SQL_OUTPUT,
+        rewritten=SANITIZED_OUTPUT,
+    ),
+    RewritingRail(
+        rail_id="context_bloat_truncate",
+        flow="context bloat detection on input",
+        direction="input",
+        rails_config=CONTEXT_BLOAT_CONFIG,
+        original=BLOATED_INPUT,
+        rewritten=TRUNCATED_INPUT,
+    ),
+]
+
+
+def _rewriting_config(rail: RewritingRail) -> dict:
+    """Build the single-rail config both engines are given."""
+    return {
+        "models": [copy.deepcopy(NEMOGUARDS_CONFIG["models"][0])],
+        "rails": {rail.direction: {"flows": [rail.flow]}, "config": copy.deepcopy(rail.rails_config)},
+    }
+
+
+def _checked_messages(rail: RewritingRail) -> list[dict]:
+    """The conversation each direction's rails are asked about, carrying the offending text."""
+    if rail.direction == "input":
+        return [{"role": "user", "content": rail.original}]
+    return [{"role": "user", "content": BENIGN_INPUT}, {"role": "assistant", "content": rail.original}]
+
+
+async def _llmrails_check(config_dict: dict, rail: RewritingRail):
+    """Run ``check_async`` through LLMRails, which needs no main model for a rails-only check."""
+    config = RailsConfig.from_content(config=config_dict)
+    chat = TestChat(config, llm_completions=[BENIGN_OUTPUT])
+
+    return await chat.app.check_async(_checked_messages(rail), rail_types=[RailType(rail.direction)])
+
+
+async def _iorails_check(config_dict: dict, rail: RewritingRail):
+    """Run ``check_async`` through IORails on the same config and conversation."""
+    with patch.dict(os.environ, {"NVIDIA_API_KEY": "test-key"}):
+        iorails = IORails(RailsConfig.from_content(config=config_dict))
+
+    async with iorails:
+        return await iorails.check_async(_checked_messages(rail), rail_types=[RailType(rail.direction)])
+
+
+class TestRewritingRailsAgreeAcrossEngines:
+    """Each rewriting rail produces the same text on both engines, for the same message."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rail", REWRITING_RAILS, ids=[rail.rail_id for rail in REWRITING_RAILS])
+    async def test_both_engines_report_the_same_rewrite(self, rail: RewritingRail):
+        """``check`` is where the two engines can be compared directly: same status, same text."""
+        config_dict = _rewriting_config(rail)
+
+        llmrails_result = await _llmrails_check(config_dict, rail)
+        iorails_result = await _iorails_check(config_dict, rail)
+
+        assert llmrails_result.status == RailStatus.MODIFIED
+        assert iorails_result.status == RailStatus.MODIFIED
+        assert llmrails_result.content == rail.rewritten
+        assert iorails_result.content == rail.rewritten
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rail", REWRITING_RAILS, ids=[rail.rail_id for rail in REWRITING_RAILS])
+    async def test_a_rewrite_names_no_rail_on_either_engine(self, rail: RewritingRail):
+        """Neither engine treats a rewrite as a rail triggering, so neither names one."""
+        config_dict = _rewriting_config(rail)
+
+        assert (await _llmrails_check(config_dict, rail)).rail is None
+        assert (await _iorails_check(config_dict, rail)).rail is None
+
+    @pytest.mark.asyncio
+    async def test_an_output_rewrite_reaches_the_caller_on_both_engines(self):
+        """Through ``generate``, the sanitized response is what the caller reads on either engine."""
+        rail = REWRITING_RAILS[0]
+        config_dict = _rewriting_config(rail)
+
+        llmrails_content = await _llmrails_reply(config_dict, BENIGN_INPUT, rail.original)
+        iorails_content = await _iorails_reply(config_dict, BENIGN_INPUT, rail.original)
+
+        assert llmrails_content == rail.rewritten
+        assert iorails_content == rail.rewritten
+
+    @pytest.mark.parametrize("rail", REWRITING_RAILS, ids=[rail.rail_id for rail in REWRITING_RAILS])
+    def test_iorails_accepts_a_config_using_the_rail(self, rail: RewritingRail):
+        """``can_handle`` admits the rail, so a real config routes here rather than to LLMRails."""
+        config = RailsConfig.from_content(config=_rewriting_config(rail))
+
+        assert IORails.unsupported_reason(config, llm=None) is None

--- a/tests/guardrails/test_cross_engine_vendor_rails.py
+++ b/tests/guardrails/test_cross_engine_vendor_rails.py
@@ -652,7 +652,7 @@ class TestRewritingVendorRailsAgreeAcrossEngines:
     @pytest.mark.asyncio
     async def test_an_output_rewrite_reaches_the_caller_on_both_engines(self, monkeypatch):
         """Through ``generate``, the masked response is what the caller reads on either engine."""
-        rail = REWRITING_VENDOR_RAILS[1]
+        rail = next(candidate for candidate in REWRITING_VENDOR_RAILS if candidate.direction == "output")
         for name, value in rail.env.items():
             monkeypatch.setenv(name, value)
         config_dict = _rewriting_vendor_config(rail)

--- a/tests/guardrails/test_cross_engine_vendor_rails.py
+++ b/tests/guardrails/test_cross_engine_vendor_rails.py
@@ -40,6 +40,7 @@ from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.http import HTTPResponse
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.options import RailStatus, RailType
 from nemoguardrails.testing import RecordingHTTPClient
 from nemoguardrails.types import LLMResponse
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
@@ -547,5 +548,126 @@ class TestVendorRailsAreReachable:
         for name, value in rail.env.items():
             monkeypatch.setenv(name, value)
         config = RailsConfig.from_content(config=_vendor_config(rail))
+
+        assert IORails.unsupported_reason(config, llm=None) is None
+
+
+MASKED_INPUT = "hello [NAME_1]"
+MASKED_OUTPUT = "Hello [NAME_1]! How can I help?"
+
+
+@dataclass(frozen=True)
+class RewritingVendorRail:
+    """One HTTP-backed rail that rewrites, with the vendor reply that makes it do so."""
+
+    rail_id: str
+    flow: str
+    direction: str
+    payload: Any
+    rewritten: str
+    rails_config: dict
+    env: dict
+
+
+REWRITING_VENDOR_RAILS = [
+    RewritingVendorRail(
+        rail_id="privateai_mask_input",
+        flow="mask pii on input",
+        direction="input",
+        payload=[{"processed_text": MASKED_INPUT, "entities_present": ["NAME"]}],
+        rewritten=MASKED_INPUT,
+        rails_config=PRIVATEAI_CONFIG,
+        env={"PAI_API_KEY": "test-key"},
+    ),
+    RewritingVendorRail(
+        rail_id="privateai_mask_output",
+        flow="mask pii on output",
+        direction="output",
+        payload=[{"processed_text": MASKED_OUTPUT, "entities_present": ["NAME"]}],
+        rewritten=MASKED_OUTPUT,
+        rails_config=PRIVATEAI_CONFIG,
+        env={"PAI_API_KEY": "test-key"},
+    ),
+]
+
+
+def _rewriting_vendor_config(rail: RewritingVendorRail) -> dict:
+    """Build the single-rail config both engines are given."""
+    return {
+        "models": [copy.deepcopy(NEMOGUARDS_CONFIG["models"][0])],
+        "rails": {rail.direction: {"flows": [rail.flow]}, "config": copy.deepcopy(rail.rails_config)},
+    }
+
+
+def _vendor_checked_messages(rail: RewritingVendorRail) -> list[dict]:
+    """The conversation each direction's rails are asked about."""
+    if rail.direction == "input":
+        return [{"role": "user", "content": USER_INPUT}]
+    return [{"role": "user", "content": USER_INPUT}, {"role": "assistant", "content": MAIN_OUTPUT}]
+
+
+async def _llmrails_check(config_dict: dict, rail: RewritingVendorRail, client: RecordingHTTPClient):
+    """Run ``check_async`` through LLMRails with *client* standing in for the vendor."""
+    config = RailsConfig.from_content(config=config_dict)
+    chat = TestChat(config, llm_completions=[MAIN_OUTPUT])
+    chat.app.register_action_param("http_client", client)
+
+    return await chat.app.check_async(_vendor_checked_messages(rail), rail_types=[RailType(rail.direction)])
+
+
+async def _iorails_check(config_dict: dict, rail: RewritingVendorRail, client: RecordingHTTPClient, monkeypatch):
+    """Run ``check_async`` through IORails with *client* standing in for the vendor."""
+    monkeypatch.setattr(
+        "nemoguardrails.guardrails.rails_manager.create_http_client",
+        lambda *args, **kwargs: client,
+    )
+    with patch.dict(os.environ, {"NVIDIA_API_KEY": "test-key"}):
+        iorails = IORails(RailsConfig.from_content(config=config_dict))
+
+    async with iorails:
+        return await iorails.check_async(_vendor_checked_messages(rail), rail_types=[RailType(rail.direction)])
+
+
+class TestRewritingVendorRailsAgreeAcrossEngines:
+    """A vendor rail that rewrites produces the same text on both engines, for the same reply."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rail", REWRITING_VENDOR_RAILS, ids=[rail.rail_id for rail in REWRITING_VENDOR_RAILS])
+    async def test_both_engines_report_the_same_rewrite(self, rail: RewritingVendorRail, monkeypatch):
+        """``check`` compares the two directly: one canned vendor reply, same status and text."""
+        for name, value in rail.env.items():
+            monkeypatch.setenv(name, value)
+        config_dict = _rewriting_vendor_config(rail)
+
+        llmrails_result = await _llmrails_check(config_dict, rail, RecordingHTTPClient([_http_response(rail.payload)]))
+        iorails_result = await _iorails_check(
+            config_dict, rail, RecordingHTTPClient([_http_response(rail.payload)]), monkeypatch
+        )
+
+        assert llmrails_result.status == RailStatus.MODIFIED
+        assert iorails_result.status == RailStatus.MODIFIED
+        assert llmrails_result.content == rail.rewritten
+        assert iorails_result.content == rail.rewritten
+
+    @pytest.mark.asyncio
+    async def test_an_output_rewrite_reaches_the_caller_on_both_engines(self, monkeypatch):
+        """Through ``generate``, the masked response is what the caller reads on either engine."""
+        rail = REWRITING_VENDOR_RAILS[1]
+        for name, value in rail.env.items():
+            monkeypatch.setenv(name, value)
+        config_dict = _rewriting_vendor_config(rail)
+
+        llmrails_content = await _llmrails_reply(config_dict, RecordingHTTPClient([_http_response(rail.payload)]))
+        iorails_content = await _iorails_reply(
+            config_dict, RecordingHTTPClient([_http_response(rail.payload)]), monkeypatch
+        )
+
+        assert llmrails_content == rail.rewritten
+        assert iorails_content == rail.rewritten
+
+    @pytest.mark.parametrize("rail", REWRITING_VENDOR_RAILS, ids=[rail.rail_id for rail in REWRITING_VENDOR_RAILS])
+    def test_iorails_accepts_a_config_using_the_rail(self, rail: RewritingVendorRail):
+        """``can_handle`` admits the rail, so a real config routes here rather than to LLMRails."""
+        config = RailsConfig.from_content(config=_rewriting_vendor_config(rail))
 
         assert IORails.unsupported_reason(config, llm=None) is None

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -50,14 +50,22 @@ _IORAILS_BASE_RAILS = {
 }
 
 # Rails LLMRails runs and IORails does not, for tests needing a config that must fall back.
-# They rewrite content, which IORails cannot apply, so they are refused at compile time.
-# Chosen over a rail that is merely outside the enabled tier: the tier now admits every
-# servable block-only surface, so an out-of-scope stand-in would go stale the next time it
-# widens -- which is exactly what happened to `self check input` and `self check output` here.
-_LLMRAILS_ONLY_INPUT_FLOW = "autoalign check input"
-_LLMRAILS_ONLY_INPUT_REASON = "'autoalign check input' transforms 'user_message'"
-_LLMRAILS_ONLY_OUTPUT_FLOW = "autoalign check output"
-_LLMRAILS_ONLY_OUTPUT_REASON = "'autoalign check output' transforms 'bot_message'"
+# Each is refused for a reason that is a decision rather than a limitation waiting to be lifted:
+# the heuristics rail cannot be told from its manifest sibling, and fact-checking reads retrieval
+# evidence this engine has no stage to produce. Their predecessors here were rewriting rails,
+# which stopped falling back once IORails could apply a rewrite -- and before that, rails merely
+# outside the enabled tier, which stopped falling back when the tier widened.
+_LLMRAILS_ONLY_INPUT_FLOW = "jailbreak detection heuristics"
+_LLMRAILS_ONLY_INPUT_REASON = (
+    "'jailbreak detection heuristics' Conflates dependencies with 'jailbreak detection model', "
+    "so IORails cannot tell whether it needs 'torch' and 'transformers' installed"
+)
+# Chosen from the retrieval-evidence group for needing no prompt template of its own, so a
+# config built for a routing test does not have to carry one.
+_LLMRAILS_ONLY_OUTPUT_FLOW = "alignscore check facts"
+_LLMRAILS_ONLY_OUTPUT_REASON = (
+    "'alignscore check facts' needs retrieval evidence, which manifest-driven execution does not supply yet"
+)
 
 
 def _make_iorails_config(rails: dict, extra_prompts: list | None = None) -> RailsConfig:
@@ -395,14 +403,12 @@ class TestIORailsUnsupportedReason:
         assert reason is not None
         assert "retrieval" in reason
 
-    def test_a_transform_flow_routes_to_llmrails(self):
-        """A rewrite-capable surface is refused at selection, not run as an allow."""
+    def test_a_transform_flow_is_admitted(self):
+        """A rewrite-capable surface runs here, having been refused at selection until IORails
+        could apply the rewrite rather than allow the request and discard it."""
         config = _make_iorails_config(rails={"input": {"flows": ["autoalign check input"]}})
 
-        reason = IORails.unsupported_reason(config, llm=None)
-
-        assert reason is not None
-        assert "transform" in reason
+        assert IORails.unsupported_reason(config, llm=None) is None
 
     def test_unsupported_output_flow_reports_offender(self):
         """An output flow IORails cannot run is named in the reason."""
@@ -1252,8 +1258,8 @@ class TestIORailsCanHandle:
         )
         assert IORails.can_handle(config) is True
 
-    def test_unsupported_self_check_output_rails(self):
-        """Adding an unsupported output flow (a transform rail) disqualifies the config."""
+    def test_one_unsupported_output_flow_disqualifies_the_config(self):
+        """A config is served whole or not at all, so one refused flow routes all of them away."""
         config = _make_iorails_config(
             rails={
                 "input": {"flows": ["content safety check input $model=content_safety"]},
@@ -2070,9 +2076,10 @@ class TestOptionsForwarding:
 class TestScopeGateCharacterization:
     """The set of surfaces IORails admits, pinned independently of how the gate computes it.
 
-    Written ahead of removing the engine's hand-maintained enabled-surface list, whose 42
-    names were the same set the surface-level refusals already produce. The names are
-    repeated here rather than derived, so these fail if the scope moves for any reason.
+    Written ahead of removing the engine's hand-maintained enabled-surface list, whose names
+    were the same set the surface-level refusals already produce. The names are repeated here
+    rather than derived, so these fail if the scope moves for any reason -- as they did when the
+    18 rewriting surfaces joined the 41 that only judge.
 
     Scope is asked of ``unservable_reason``, which resolves the surface and stops: it needs no
     config, imports no action, and so answers "is this rail in scope" without conflating it
@@ -2085,8 +2092,11 @@ class TestScopeGateCharacterization:
             ("input", "activefence moderation on input"),
             ("input", "activefence moderation on input detailed"),
             ("input", "ai defense inspect prompt"),
+            ("input", "autoalign check input"),
             ("input", "clavata check input"),
             ("input", "content safety check input"),
+            ("input", "context bloat detection on input"),
+            ("input", "crowdstrike aidr guard input"),
             ("input", "detect pii on input"),
             ("input", "detect sensitive data on input"),
             ("input", "f5 guardrails scan input"),
@@ -2094,32 +2104,47 @@ class TestScopeGateCharacterization:
             ("input", "gcpnlp moderation"),
             ("input", "gcpnlp moderation detailed"),
             ("input", "gliner detect pii on input"),
+            ("input", "gliner mask pii on input"),
             ("input", "guardrailsai check input"),
             ("input", "hf classifier check input"),
             ("input", "jailbreak detection model"),
             ("input", "llama guard check input"),
+            ("input", "mask pii on input"),
+            ("input", "mask sensitive data on input"),
+            ("input", "pangea ai guard input"),
             ("input", "policyai moderation on input"),
             ("input", "polygraf detect pii on input"),
+            ("input", "polygraf mask pii on input"),
+            ("input", "protect prompt"),
             ("input", "regex check input"),
             ("input", "self check input"),
             ("input", "topic safety check input"),
             ("input", "trend ai guard input"),
             ("output", "activefence moderation on output"),
             ("output", "ai defense inspect response"),
+            ("output", "autoalign check output"),
             ("output", "autoalign factcheck output"),
             ("output", "clavata check output"),
             ("output", "cleanlab trustworthiness"),
             ("output", "content safety check output"),
+            ("output", "crowdstrike aidr guard output"),
             ("output", "detect pii on output"),
             ("output", "detect sensitive data on output"),
             ("output", "f5 guardrails scan output"),
             ("output", "fiddler bot safety"),
             ("output", "gliner detect pii on output"),
+            ("output", "gliner mask pii on output"),
             ("output", "guardrailsai check output"),
             ("output", "hf classifier check output"),
+            ("output", "injection detection"),
             ("output", "llama guard check output"),
+            ("output", "mask pii on output"),
+            ("output", "mask sensitive data on output"),
+            ("output", "pangea ai guard output"),
             ("output", "policyai moderation on output"),
             ("output", "polygraf detect pii on output"),
+            ("output", "polygraf mask pii on output"),
+            ("output", "protect response"),
             ("output", "regex check output"),
             ("output", "self check output"),
             ("output", "trend ai guard output"),
@@ -2138,7 +2163,7 @@ class TestScopeGateCharacterization:
         return IORails._unservable_rails_reason([flow], direction, deps)
 
     def test_the_admitted_surfaces_are_exactly_the_pinned_set(self):
-        """Every catalog surface in scope is one of the 42 named here, and vice versa."""
+        """Every catalog surface in scope is one of the 59 named here, and vice versa."""
         admitted = {
             (direction.value, name)
             for direction in (SurfaceDirection.INPUT, SurfaceDirection.OUTPUT)
@@ -2152,7 +2177,7 @@ class TestScopeGateCharacterization:
         """No catalog surface reaches the out-of-scope branch of the gate.
 
         This is what makes removing the enabled-surface list behaviour-preserving: every
-        rejection is already attributed to a specific limitation -- a transform target,
+        rejection is already attributed to a specific limitation -- an unapplicable rewrite,
         retrieval evidence, an absent extra, an undeclared model, a missing parameter --
         rather than to membership of a hand-maintained list. Run through the full gate,
         including flows too incomplete to compile, because those are the ones that would
@@ -2173,9 +2198,10 @@ class TestScopeGateCharacterization:
         ("flow", "direction", "expected"),
         [
             (
-                "autoalign check input",
+                "jailbreak detection heuristics",
                 SurfaceDirection.INPUT,
-                "'autoalign check input' transforms 'user_message'",
+                "'jailbreak detection heuristics' Conflates dependencies with 'jailbreak detection model', "
+                "so IORails cannot tell whether it needs 'torch' and 'transformers' installed",
             ),
             (
                 "self check facts",
@@ -2194,7 +2220,7 @@ class TestScopeGateCharacterization:
                 "'no such rail' has no surface named 'no such rail' with direction INPUT in the rail catalog",
             ),
         ],
-        ids=["transform", "retrieval_evidence", "misdirected", "unknown"],
+        ids=["conflated_backend", "retrieval_evidence", "misdirected", "unknown"],
     )
     def test_the_refusal_reason_names_the_limitation(self, flow, direction, expected):
         """Each class of refusal reports why, in wording a config author can act on."""

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -50,11 +50,8 @@ _IORAILS_BASE_RAILS = {
 }
 
 # Rails LLMRails runs and IORails does not, for tests needing a config that must fall back.
-# Each is refused for a reason that is a decision rather than a limitation waiting to be lifted:
-# the heuristics rail cannot be told from its manifest sibling, and fact-checking reads retrieval
-# evidence this engine has no stage to produce. Their predecessors here were rewriting rails,
-# which stopped falling back once IORails could apply a rewrite -- and before that, rails merely
-# outside the enabled tier, which stopped falling back when the tier widened.
+# Each is refused by a decision rather than a limitation, so neither goes stale as the tier widens
+# -- as the rewriting rails that used to sit here did.
 _LLMRAILS_ONLY_INPUT_FLOW = "jailbreak detection heuristics"
 _LLMRAILS_ONLY_INPUT_REASON = (
     "'jailbreak detection heuristics' Conflates dependencies with 'jailbreak detection model', "

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -2197,12 +2197,7 @@ class TestScopeGateCharacterization:
     @pytest.mark.parametrize(
         ("flow", "direction", "expected"),
         [
-            (
-                "jailbreak detection heuristics",
-                SurfaceDirection.INPUT,
-                "'jailbreak detection heuristics' Conflates dependencies with 'jailbreak detection model', "
-                "so IORails cannot tell whether it needs 'torch' and 'transformers' installed",
-            ),
+            (_LLMRAILS_ONLY_INPUT_FLOW, SurfaceDirection.INPUT, _LLMRAILS_ONLY_INPUT_REASON),
             (
                 "self check facts",
                 SurfaceDirection.OUTPUT,

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -25,7 +25,10 @@ from nemoguardrails.guardrails.guardrails_types import (
     RailCallRecord,
     RailResult,
     client_reason,
+    current_user_turn_index,
     display_reason,
+    last_user_content,
+    rewrite_user_message,
     truncate,
 )
 
@@ -294,6 +297,58 @@ class TestClientReason:
     def test_a_block_with_nothing_to_say_is_unspecified(self):
         """A rail that supplies neither a reason nor a name still yields a printable string."""
         assert client_reason(RailResult.block()) == "unspecified"
+
+
+class TestMessageRewriting:
+    """Tests for the helpers that locate and rewrite the turn a rail checks."""
+
+    MESSAGES: ClassVar[LLMMessages] = [
+        {"role": "system", "content": "be helpful"},
+        {"role": "user", "content": "my ssn is 123-45-6789"},
+        {"role": "assistant", "content": "I cannot help with that"},
+    ]
+
+    def test_the_checked_turn_is_the_last_user_message_carrying_content(self):
+        """The one turn a rail reads, so also the one a rewrite must replace."""
+        assert current_user_turn_index(self.MESSAGES) == 1
+        assert last_user_content(self.MESSAGES) == "my ssn is 123-45-6789"
+
+    def test_an_empty_trailing_user_turn_is_not_the_checked_turn(self):
+        """A blank turn is not what the rail was given, so it must not attract the rewrite."""
+        messages: LLMMessages = [{"role": "user", "content": "my ssn is 123-45-6789"}, {"role": "user", "content": ""}]
+
+        assert current_user_turn_index(messages) == 0
+        assert rewrite_user_message(messages, "my ssn is <SSN>")[0]["content"] == "my ssn is <SSN>"
+
+    def test_a_conversation_with_no_user_turn_has_nothing_to_check(self):
+        """Rails read an empty string rather than raising, matching what the library actions expect."""
+        assert current_user_turn_index([{"role": "assistant", "content": "hello"}]) is None
+        assert last_user_content([{"role": "assistant", "content": "hello"}]) == ""
+        assert last_user_content([]) == ""
+
+    def test_rewriting_replaces_only_the_checked_turn(self):
+        """Surrounding turns are the conversation's history and are left as they were."""
+        rewritten = rewrite_user_message(self.MESSAGES, "my ssn is <SSN>")
+
+        assert rewritten[1]["content"] == "my ssn is <SSN>"
+        assert rewritten[0] == self.MESSAGES[0]
+        assert rewritten[2] == self.MESSAGES[2]
+
+    def test_rewriting_leaves_the_callers_list_and_turns_untouched(self):
+        """The caller's list reaches the engine by identity, so neither it nor its dicts may be mutated."""
+        messages: LLMMessages = [{"role": "user", "content": "my ssn is 123-45-6789"}]
+        original_turn = messages[0]
+
+        rewritten = rewrite_user_message(messages, "my ssn is <SSN>")
+
+        assert messages == [{"role": "user", "content": "my ssn is 123-45-6789"}]
+        assert messages[0] is original_turn
+        assert rewritten[0] is not original_turn
+
+    def test_rewriting_with_no_user_turn_raises(self):
+        """A rewrite with nowhere to land fails loudly rather than being dropped."""
+        with pytest.raises(ValueError, match="nothing to rewrite"):
+            rewrite_user_message([{"role": "assistant", "content": "hello"}], "masked")
 
 
 class TestTypeAliases:

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -284,15 +284,51 @@ class TestClientReason:
         assert withheld not in client_reason(result)
         assert client_reason(result) == "a rail"
 
-    def test_the_log_still_carries_what_the_caller_does_not(self):
-        """The restriction is on the payload only; diagnosis keeps the full verdict."""
+    def test_the_log_carries_the_evidence_the_caller_does_not(self):
+        """The restriction is on the payload; diagnosis keeps every field that describes the verdict."""
         result = RailResult.block(metadata=self.CROWDSTRIKE_VERDICT, triggered_rail="crowdstrike aidr guard input")
 
         rendered = display_reason(result)
 
-        assert "my private question" in rendered
-        assert "the draft reply" in rendered
-        assert "my private question" not in client_reason(result)
+        assert "guard_output: policy 7" in rendered
+        assert "guard_output" not in client_reason(result)
+
+    @pytest.mark.parametrize(
+        ("metadata", "withheld"),
+        [
+            (CROWDSTRIKE_VERDICT, "my private question"),
+            (CROWDSTRIKE_VERDICT, "the draft reply"),
+            (REGEX_VERDICT, "my account is ACCT-0000-1111-2222"),
+            ({"text": "the whole bot response", "detections": ["markdown_xss"]}, "the whole bot response"),
+        ],
+        ids=["user-message", "bot-message", "regex-text", "injection-text"],
+    )
+    def test_a_rail_echoing_the_request_does_not_put_it_in_the_log(self, metadata, withheld):
+        """A block writes a log line unconditionally, so content in it would be an opt-out-free leak.
+
+        These rails return the text they judged as evidence: rendering it would put the
+        conversation into an operator's log on every block, which is the thing content capture
+        exists to make a deliberate choice.
+        """
+        result = RailResult.block(metadata=metadata, triggered_rail="a rail")
+
+        assert withheld not in display_reason(result)
+
+    def test_dropping_the_content_leaves_the_rest_of_the_verdict(self):
+        """Withholding the text must not cost the fields that say why the rail objected to it."""
+        result = RailResult.block(metadata=self.REGEX_VERDICT, triggered_rail="regex check input")
+
+        rendered = display_reason(result)
+
+        assert "detections: ACCT-0000-1111-2222" in rendered
+        assert "is_match: True" in rendered
+        assert "source: input" in rendered
+
+    def test_a_verdict_of_nothing_but_content_falls_back_to_the_rail_name(self):
+        """With every field withheld there is no evidence left, and the rail name is what remains."""
+        result = RailResult.block(metadata={"text": "the whole bot response"}, triggered_rail="injection detection")
+
+        assert display_reason(result) == "injection detection"
 
     def test_a_block_with_nothing_to_say_is_unspecified(self):
         """A rail that supplies neither a reason nor a name still yields a printable string."""

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -304,12 +304,7 @@ class TestClientReason:
         ids=["user-message", "bot-message", "regex-text", "injection-text"],
     )
     def test_a_rail_echoing_the_request_does_not_put_it_in_the_log(self, metadata, withheld):
-        """A block writes a log line unconditionally, so content in it would be an opt-out-free leak.
-
-        These rails return the text they judged as evidence: rendering it would put the
-        conversation into an operator's log on every block, which is the thing content capture
-        exists to make a deliberate choice.
-        """
+        """A block writes a log line unconditionally, so content in it would be an opt-out-free leak."""
         result = RailResult.block(metadata=metadata, triggered_rail="a rail")
 
         assert withheld not in display_reason(result)

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -1194,3 +1194,32 @@ class TestGeneratedTurn:
         assert turn.response is None
         assert turn.messages is REWRITE_MESSAGES
         iorails.engine_registry.model_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestContentCaptureRecordsWhatTheModelRead:
+    """Capture records the masked text, so a span cannot carry what a mask removed."""
+
+    async def test_the_request_span_carries_the_masked_input(self, iorails):
+        """A trace is a downstream system, and masking exists to keep the raw text out of them."""
+        iorails._content_capture_enabled = True
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        with patch("nemoguardrails.guardrails.iorails.set_request_content") as capture:
+            await iorails.generate_async(messages=REWRITE_MESSAGES)
+
+        assert capture.call_args.args[1][-1]["content"] == REWRITE_MASKED_USER
+
+    async def test_an_unmasked_turn_is_captured_as_it_arrived(self, iorails):
+        """The ordinary request is unchanged: what the caller sent is what the span records."""
+        iorails._content_capture_enabled = True
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        with patch("nemoguardrails.guardrails.iorails.set_request_content") as capture:
+            await iorails.generate_async(messages=REWRITE_MESSAGES)
+
+        assert capture.call_args.args[1] == REWRITE_MESSAGES

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -25,11 +25,17 @@ from aiohttp.test_utils import TestServer
 
 from nemoguardrails import Guardrails
 from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import (
+    REFUSAL_MESSAGE,
+    IORails,
+    _rewritten_bot_message,
+    _rewritten_user_message,
+)
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction
+from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
 
@@ -1069,3 +1075,133 @@ class TestGuardrailsConfigToCallURLs:
             url = call_args[0][0]
             assert url == "https://safety.example.com/v1/chat/completions"
             assert "/v1/v1/" not in url
+
+
+REWRITE_USER_TEXT = "my ssn is 123-45-6789"
+REWRITE_MASKED_USER = "my ssn is <SSN>"
+REWRITE_MESSAGES = [{"role": "user", "content": REWRITE_USER_TEXT}]
+
+
+@pytest.mark.asyncio
+class TestGenerateWithRewritingRails:
+    """A rail's rewrite reaches the model and the caller, rather than being computed and dropped."""
+
+    async def test_an_input_rewrite_is_what_the_model_reads(self, iorails):
+        """Masking that never reaches the model would leave the model reading the raw text."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        await iorails.generate_async(messages=REWRITE_MESSAGES)
+
+        sent_messages = iorails.engine_registry.model_call.call_args.args[1]
+        assert sent_messages[-1]["content"] == REWRITE_MASKED_USER
+
+    async def test_an_input_rewrite_is_what_the_output_rails_check(self, iorails):
+        """Output rails judge the turn the model answered, not the text an input rail replaced."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        await iorails.generate_async(messages=REWRITE_MESSAGES)
+
+        checked_messages = iorails.rails_manager.is_output_safe.call_args.args[0]
+        assert checked_messages[-1]["content"] == REWRITE_MASKED_USER
+
+    async def test_an_input_rewrite_leaves_the_callers_messages_untouched(self, iorails):
+        """The caller's conversation is theirs; masking it as a side effect would be a surprise."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+        messages = [{"role": "user", "content": REWRITE_USER_TEXT}]
+
+        await iorails.generate_async(messages=messages)
+
+        assert messages == [{"role": "user", "content": REWRITE_USER_TEXT}]
+
+    async def test_an_output_rewrite_is_what_the_caller_receives(self, iorails):
+        """The whole point of an output rewrite: the caller reads the sanitized response."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("call me on <PHONE>"))
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="call me on 555-0100"))
+
+        result = await iorails.generate_async(messages=REWRITE_MESSAGES)
+
+        assert result == {"role": "assistant", "content": "call me on <PHONE>"}
+
+    async def test_an_output_rewrite_reaches_the_structured_response(self, iorails):
+        """The options path returns the same text as the bare one, not the pre-rewrite response."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("call me on <PHONE>"))
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="call me on 555-0100"))
+
+        result = await iorails.generate_async(messages=REWRITE_MESSAGES, options={"log": {"activated_rails": True}})
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": "call me on <PHONE>"}]
+
+
+class TestRewriteReaders:
+    """The two readers that turn a rail verdict into the text a direction should use."""
+
+    def test_a_user_rewrite_is_read_by_the_input_reader(self):
+        """The text an input rail produced, which the model and the later rails must read."""
+        assert _rewritten_user_message(user_message_rewrite(REWRITE_MASKED_USER)) == REWRITE_MASKED_USER
+
+    def test_a_bot_rewrite_is_read_by_the_output_reader(self):
+        """The text an output rail produced, which is what the caller receives."""
+        assert _rewritten_bot_message(bot_message_rewrite("call me on <PHONE>")) == "call me on <PHONE>"
+
+    @pytest.mark.parametrize(
+        "result",
+        [RailResult.allow(), RailResult.block(reason="unsafe")],
+        ids=["allow", "block"],
+    )
+    def test_a_verdict_without_a_rewrite_reads_as_nothing_to_apply(self, result):
+        """Most requests to a rewriting rail come back as a plain verdict, and must change nothing."""
+        assert _rewritten_user_message(result) is None
+        assert _rewritten_bot_message(result) is None
+
+    def test_each_reader_ignores_the_other_directions_rewrite(self):
+        """The readers are target-specific, so a rewrite cannot be applied to the wrong variable."""
+        assert _rewritten_user_message(bot_message_rewrite("call me on <PHONE>")) is None
+        assert _rewritten_bot_message(user_message_rewrite(REWRITE_MASKED_USER)) is None
+
+    def test_a_rewrite_to_empty_text_is_still_a_rewrite(self):
+        """Redacting to nothing must not read as "no rewrite" the way an empty string would."""
+        assert _rewritten_bot_message(bot_message_rewrite("")) == ""
+
+
+@pytest.mark.asyncio
+class TestGeneratedTurn:
+    """``_do_generate_sequential`` reports the response together with the messages behind it."""
+
+    async def test_a_rewritten_turn_carries_the_messages_the_model_read(self, iorails):
+        """The caller of this helper runs the output rails, and must not re-read the stale list."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        turn = await iorails._do_generate_sequential(REWRITE_MESSAGES, "req-1", {})
+
+        assert turn.messages[-1]["content"] == REWRITE_MASKED_USER
+        assert turn.response is not None
+
+    async def test_an_unrewritten_turn_carries_the_messages_as_they_arrived(self, iorails):
+        """Nothing is copied or rebuilt for the ordinary case where no rail rewrites."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        turn = await iorails._do_generate_sequential(REWRITE_MESSAGES, "req-1", {})
+
+        assert turn.messages is REWRITE_MESSAGES
+
+    async def test_a_blocked_turn_reports_no_response(self, iorails):
+        """The block is signalled by the absent response, which is what the caller branches on."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
+        iorails.engine_registry.model_call = AsyncMock()
+
+        turn = await iorails._do_generate_sequential(REWRITE_MESSAGES, "req-1", {})
+
+        assert turn.response is None
+        assert turn.messages is REWRITE_MESSAGES
+        iorails.engine_registry.model_call.assert_not_called()

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -1097,17 +1097,6 @@ class TestGenerateWithRewritingRails:
         sent_messages = iorails.engine_registry.model_call.call_args.args[1]
         assert sent_messages[-1]["content"] == REWRITE_MASKED_USER
 
-    async def test_an_input_rewrite_is_what_the_output_rails_check(self, iorails):
-        """Output rails judge the turn the model answered, not the text an input rail replaced."""
-        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))
-        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.allow())
-        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
-
-        await iorails.generate_async(messages=REWRITE_MESSAGES)
-
-        checked_messages = iorails.rails_manager.is_output_safe.call_args.args[0]
-        assert checked_messages[-1]["content"] == REWRITE_MASKED_USER
-
     async def test_an_input_rewrite_leaves_the_callers_messages_untouched(self, iorails):
         """The caller's conversation is theirs; masking it as a side effect would be a surprise."""
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(REWRITE_MASKED_USER))

--- a/tests/guardrails/test_iorails_check.py
+++ b/tests/guardrails/test_iorails_check.py
@@ -36,6 +36,7 @@ from nemoguardrails.guardrails.iorails import (
 )
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailStatus, RailType
+from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 SAFE = RailResult.allow()
@@ -601,3 +602,72 @@ class TestCheckHelpers:
     def test_get_last_content_by_role_none_content_returns_empty(self):
         """content=None on the matched message is normalized to ''."""
         assert _get_last_content_by_role([{"role": "user", "content": None}], "user") == ""
+
+
+USER_TEXT = "my ssn is 123-45-6789"
+MASKED_USER_TEXT = "my ssn is <SSN>"
+BOT_TEXT = "call me on 555-0100"
+MASKED_BOT_TEXT = "call me on <PHONE>"
+CONVERSATION = [{"role": "user", "content": USER_TEXT}, {"role": "assistant", "content": BOT_TEXT}]
+
+
+@pytest.mark.asyncio
+class TestCheckWithRewritingRails:
+    """``check`` reports a rewrite as MODIFIED, carrying the text the rails produced."""
+
+    async def test_an_input_rewrite_is_reported_with_the_new_text(self, iorails):
+        """The caller gets back what the rails made of their message, not what they sent."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(MASKED_USER_TEXT))
+
+        result = await iorails.check_async([{"role": "user", "content": USER_TEXT}])
+
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == MASKED_USER_TEXT
+
+    async def test_a_rewrite_names_no_rail(self, iorails):
+        """A rewrite is not a rail triggering, and several rails may have contributed to the text."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(MASKED_USER_TEXT))
+
+        result = await iorails.check_async([{"role": "user", "content": USER_TEXT}])
+
+        assert result.rail is None
+
+    async def test_an_output_rewrite_is_reported_with_the_new_text(self, iorails):
+        """The output direction reports against the response its rails checked."""
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite(MASKED_BOT_TEXT))
+
+        result = await iorails.check_async(CONVERSATION, rail_types=[RailType.OUTPUT])
+
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == MASKED_BOT_TEXT
+
+    async def test_an_input_rewrite_reaches_the_output_rails(self, iorails):
+        """Both directions run against one conversation, so the second sees what the first made of it."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(MASKED_USER_TEXT))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=SAFE)
+
+        await iorails.check_async(CONVERSATION)
+
+        checked_messages = iorails.rails_manager.is_output_safe.call_args.args[0]
+        assert _get_last_content_by_role(checked_messages, "user") == MASKED_USER_TEXT
+
+    async def test_an_input_rewrite_is_internal_when_the_output_is_reported(self, iorails):
+        """With output rails in play the caller is told about the response, which nothing changed."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(MASKED_USER_TEXT))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=SAFE)
+
+        result = await iorails.check_async(CONVERSATION)
+
+        assert result.status == RailStatus.PASSED
+        assert result.content == BOT_TEXT
+
+    async def test_a_block_behind_a_rewrite_is_reported_as_blocked(self, iorails):
+        """A later block decides the outcome; the rewrite has nothing left to be applied to."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite(MASKED_USER_TEXT))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=_unsafe("content safety check output"))
+
+        result = await iorails.check_async(CONVERSATION)
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == REFUSAL_MESSAGE
+        assert result.rail == "content safety check output"

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -1249,10 +1249,9 @@ class TestStreamAsyncWithRewritingRails:
 
     @pytest.mark.asyncio
     async def test_a_rewrite_that_arrives_too_late_stops_the_stream(self, iorails_stream_first, caplog):
-        """Unreachable through a loaded config, and the one case where more text must not be sent.
+        """A rewrite arriving after its batch shipped stops the stream rather than sending more.
 
-        ``RailsConfig`` refuses ``stream_first`` alongside a rewriting output rail, so reaching
-        here means a rail the catalog does not describe rewrote after its batch had gone out.
+        No config reaches it: what is left is a manifest declaring no target whose action rewrites.
         """
         iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("<REDACTED>"))

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import json
+import logging
 import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -36,6 +37,7 @@ from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.types import LLMResponseChunk, ToolCall, ToolCallFunction, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 
@@ -1203,3 +1205,52 @@ class TestBlockReasonDisplay:
             code="content_blocked",
             message_contains="Blocked by output rails: content safety check output",
         )
+
+
+STREAM_MASKED_USER = "my ssn is <SSN>"
+
+
+class TestStreamAsyncWithRewritingRails:
+    """Input rewrites reach the streamed model call; output rewrites cannot be applied to a stream."""
+
+    @pytest.mark.asyncio
+    async def test_an_input_rewrite_is_what_the_streamed_model_reads(self, iorails_input_only):
+        """Input rails finish before the first token, so a rewrite lands exactly as it does unstreamed."""
+        sent_messages = []
+
+        async def _capturing_stream(model_type, messages, **kwargs):
+            sent_messages.append(messages)
+            yield LLMResponseChunk(delta_content="ok")
+
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(
+            return_value=user_message_rewrite(STREAM_MASKED_USER)
+        )
+        iorails_input_only.engine_registry.stream_model_call = _capturing_stream
+
+        await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "my ssn is 123-45-6789"}]))
+
+        assert sent_messages[0][-1]["content"] == STREAM_MASKED_USER
+
+    @pytest.mark.asyncio
+    async def test_an_output_rewrite_is_not_applied_to_the_stream(self, iorails_stream_first):
+        """The chunk has already reached the caller, so the rewrite covers text nobody can recall."""
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("<REDACTED>"))
+        iorails_stream_first.engine_registry.stream_model_call = _mock_stream
+
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert "<REDACTED>" not in "".join(str(chunk) for chunk in chunks)
+        assert "Hello from the streaming LLM!" in "".join(str(chunk) for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_a_declined_output_rewrite_is_reported_once(self, iorails_stream_first, caplog):
+        """A masking rail that silently does nothing is worse than one that says why it did nothing."""
+        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("<REDACTED>"))
+        iorails_stream_first.engine_registry.stream_model_call = _mock_stream
+
+        with caplog.at_level(logging.INFO, logger="nemoguardrails.guardrails.iorails"):
+            await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        assert caplog.text.count("streaming cannot apply") == 1

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -31,7 +31,7 @@ from nemoguardrails.guardrails.iorails import (
     STREAM_MAX_CONCURRENCY,
     IORails,
     _is_stream_error_chunk,
-    _StreamedConversation,
+    _TurnConversation,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -907,7 +907,7 @@ class TestStreamAsyncToolCalling:
             chunk
             async for chunk in iorails_stream_check_first._run_output_rails_in_streaming(
                 streaming_handler=_empty_content_handler(),
-                conversation=_StreamedConversation(messages=[{"role": "user", "content": "hi"}]),
+                conversation=_TurnConversation(messages=[{"role": "user", "content": "hi"}]),
             )
         ]
 
@@ -1263,3 +1263,21 @@ class TestStreamAsyncWithRewritingRails:
 
         assert "could not be applied to the stream" in "".join(str(chunk) for chunk in chunks)
         assert "arrived after the batch was streamed" in caplog.text
+
+
+class TestStreamingContentCapture:
+    """The streamed path records the same masked input the non-streaming one does."""
+
+    @pytest.mark.asyncio
+    async def test_the_request_span_carries_the_masked_input(self, iorails_input_only):
+        """Both paths agree on what request content means, which is what the model read."""
+        iorails_input_only._content_capture_enabled = True
+        iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=user_message_rewrite("my ssn is <SSN>"))
+        iorails_input_only.engine_registry.stream_model_call = _mock_stream
+
+        with patch("nemoguardrails.guardrails.iorails.set_request_content") as capture:
+            await _collect(
+                iorails_input_only.stream_async(messages=[{"role": "user", "content": "my ssn is 123-45-6789"}])
+            )
+
+        assert capture.call_args.args[1][-1]["content"] == "my ssn is <SSN>"

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -31,6 +31,7 @@ from nemoguardrails.guardrails.iorails import (
     STREAM_MAX_CONCURRENCY,
     IORails,
     _is_stream_error_chunk,
+    _StreamedConversation,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -906,7 +907,7 @@ class TestStreamAsyncToolCalling:
             chunk
             async for chunk in iorails_stream_check_first._run_output_rails_in_streaming(
                 streaming_handler=_empty_content_handler(),
-                messages=[{"role": "user", "content": "hi"}],
+                conversation=_StreamedConversation(messages=[{"role": "user", "content": "hi"}]),
             )
         ]
 
@@ -1232,25 +1233,33 @@ class TestStreamAsyncWithRewritingRails:
         assert sent_messages[0][-1]["content"] == STREAM_MASKED_USER
 
     @pytest.mark.asyncio
-    async def test_an_output_rewrite_is_not_applied_to_the_stream(self, iorails_stream_first):
-        """The chunk has already reached the caller, so the rewrite covers text nobody can recall."""
-        iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
-        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("<REDACTED>"))
-        iorails_stream_first.engine_registry.stream_model_call = _mock_stream
+    async def test_an_output_rewrite_replaces_the_batch(self, iorails_stream_check_first):
+        """The masked text is what ships, which is the whole point of a masking rail."""
+        iorails_stream_check_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(
+            return_value=bot_message_rewrite("<REDACTED>")
+        )
+        iorails_stream_check_first.engine_registry.stream_model_call = _mock_stream
 
-        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        streamed = "".join(str(chunk) for chunk in chunks)
 
-        assert "<REDACTED>" not in "".join(str(chunk) for chunk in chunks)
-        assert "Hello from the streaming LLM!" in "".join(str(chunk) for chunk in chunks)
+        assert "<REDACTED>" in streamed
+        assert "Hello from the streaming LLM!" not in streamed
 
     @pytest.mark.asyncio
-    async def test_a_declined_output_rewrite_is_reported_once(self, iorails_stream_first, caplog):
-        """A masking rail that silently does nothing is worse than one that says why it did nothing."""
+    async def test_a_rewrite_that_arrives_too_late_stops_the_stream(self, iorails_stream_first, caplog):
+        """Unreachable through a loaded config, and the one case where more text must not be sent.
+
+        ``RailsConfig`` refuses ``stream_first`` alongside a rewriting output rail, so reaching
+        here means a rail the catalog does not describe rewrote after its batch had gone out.
+        """
         iorails_stream_first.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
         iorails_stream_first.rails_manager.is_output_safe = AsyncMock(return_value=bot_message_rewrite("<REDACTED>"))
         iorails_stream_first.engine_registry.stream_model_call = _mock_stream
 
-        with caplog.at_level(logging.INFO, logger="nemoguardrails.guardrails.iorails"):
-            await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        with caplog.at_level(logging.ERROR, logger="nemoguardrails.guardrails.iorails"):
+            chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
-        assert caplog.text.count("streaming cannot apply") == 1
+        assert "could not be applied to the stream" in "".join(str(chunk) for chunk in chunks)
+        assert "arrived after the batch was streamed" in caplog.text

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -15,9 +15,11 @@
 
 import asyncio
 import copy
+import gc
 import inspect
 import json
 import logging
+import warnings
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -26,15 +28,22 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
-from nemoguardrails.guardrails.compiled_rail import RailCompilationError, RailExecution, unservable_reason
+from nemoguardrails.guardrails.compiled_rail import RailCompilationError, unservable_reason
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import RailCallRecord, RailDirection, RailResult, serialize_prompt
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.rails_manager import (
     _HTTP_CLIENT_SURFACE_NAMES,
     RailsManager,
+    _checked_text,
     _rail_call_record,
     _rail_result,
+    _refuse_concurrent_rewrite,
+    _result_after_rewrites,
+    _rewriting_flows,
+    _rewritten_text,
+    _tool_rail_result,
+    _transforms_first,
 )
 from nemoguardrails.http.retry import RetryingHTTPClient
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -50,6 +59,7 @@ from tests.guardrails.async_helpers import (
     mock_rail_http_response,
     mock_rail_model,
 )
+from tests.guardrails.rail_stubs import StubRail, declared_rewriter, rails_compiled_as, rewriting_stub
 from tests.guardrails.test_data import (
     CONTENT_SAFETY_CONFIG,
     NEMOGUARDS_CONFIG,
@@ -66,6 +76,16 @@ from tests.guardrails.tool_helpers import (
     multi_turn_reused_call_id_messages,
 )
 
+
+def _coroutine_returning(result: RailResult):
+    """A coroutine handing back *result*, standing in for one rail's pending run."""
+
+    async def run() -> RailResult:
+        return result
+
+    return run()
+
+
 SAFE_INPUT_JSON = json.dumps({"User Safety": "safe"})
 UNSAFE_INPUT_JSON = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
 SAFE_OUTPUT_JSON = json.dumps({"User Safety": "safe", "Response Safety": "safe"})
@@ -77,16 +97,6 @@ UNSAFE_OUTPUT_JSON = json.dumps(
     }
 )
 MESSAGES = [{"role": "user", "content": "hello"}]
-
-
-class _FixedRail:
-    """Stands in for a CompiledRail, answering with one outcome and making no model call."""
-
-    def __init__(self, outcome: RailOutcome) -> None:
-        self._outcome = outcome
-
-    async def execute(self, messages, bot_response=None) -> RailExecution:
-        return RailExecution(outcome=self._outcome)
 
 
 def _make_rails_manager(config: RailsConfig, engine_registry: EngineRegistry | None = None) -> RailsManager:
@@ -226,8 +236,8 @@ class TestRailsManagerInit:
         # No catalog surface is offered in both directions today, so this pins the lookup
         # rather than a reachable collision.
         flow = "content safety check input $model=content_safety"
-        content_safety_rails_manager._rails[(RailDirection.INPUT, flow)] = _FixedRail(RailOutcome.allow())
-        content_safety_rails_manager._rails[(RailDirection.OUTPUT, flow)] = _FixedRail(RailOutcome.block())
+        content_safety_rails_manager._rails[(RailDirection.INPUT, flow)] = StubRail(RailOutcome.allow())
+        content_safety_rails_manager._rails[(RailDirection.OUTPUT, flow)] = StubRail(RailOutcome.block())
 
         allowed = await content_safety_rails_manager._run_rail(flow, RailDirection.INPUT, MESSAGES)
         blocked = await content_safety_rails_manager._run_rail(flow, RailDirection.OUTPUT, MESSAGES)
@@ -845,6 +855,22 @@ class TestRailsManagerToolCalls:
         assert result.is_safe is True
 
     @pytest.mark.asyncio
+    async def test_a_short_circuit_leaves_no_unawaited_coroutine(self):
+        """Tool rails are built up front, so the ones a block skips are closed rather than abandoned."""
+        mgr = _tool_rails_manager_with_main(tool_call_flows=["tool call validation"])
+        rails = {
+            "blocks": _coroutine_returning(RailResult.block(reason="unsafe")),
+            "never reached": _coroutine_returning(RailResult.allow()),
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result = await mgr._run_tool_rails_sequential(rails, RailDirection.OUTPUT)
+            gc.collect()
+
+        assert result.is_safe is False
+
+    @pytest.mark.asyncio
     async def test_fails_closed_on_duplicate_tool_definitions(self):
         # parse_tools raises ValueError on a duplicate tool name; the method must
         # convert that into a block, not propagate.
@@ -1174,14 +1200,438 @@ class TestOutcomeToResult:
         assert result.is_safe is is_safe
         assert result.return_value == {"allowed": is_safe}
 
-    def test_a_transform_raises_rather_than_reading_as_allowed(self):
-        """A rewrite IORails cannot apply fails loudly instead of allowing and discarding it."""
-        # Transform surfaces are refused at compile time, so this is a tripwire for the PR
-        # that implements them rather than a path a config can reach.
+    def test_a_transform_becomes_a_safe_verdict_carrying_its_rewrite(self):
+        """A rewrite does not block, and the text it produced survives on the outcome."""
         outcome = RailOutcome.transform([(TransformTarget.USER_MESSAGE, "masked")])
 
-        with pytest.raises(NotImplementedError, match="transform"):
-            _rail_result(outcome)
+        result = _rail_result(outcome)
+
+        assert result.is_safe is True
+        assert result.outcome.transform_text == {"user_message": "masked"}
+
+    def test_a_tool_rail_returning_a_rewrite_raises(self):
+        """Tool rails declare no variable to rewrite, so one arriving fails loudly instead of vanishing."""
+        outcome = RailOutcome.transform([(TransformTarget.USER_MESSAGE, "masked")])
+
+        with pytest.raises(NotImplementedError, match="tool call validation"):
+            _tool_rail_result(outcome, "tool call validation")
+
+    @pytest.mark.parametrize(
+        "outcome, is_safe",
+        [(RailOutcome.allow(), True), (RailOutcome.block(), False)],
+        ids=["allow", "block"],
+    )
+    def test_a_tool_rail_decision_becomes_a_verdict(self, outcome, is_safe):
+        """The decisions a tool rail can reach pass through unchanged."""
+        assert _tool_rail_result(outcome, "tool call validation").is_safe is is_safe
+
+
+CONTENT_SAFETY_INPUT_FLOW = "content safety check input $model=content_safety"
+TOPIC_SAFETY_INPUT_FLOW = "topic safety check input $model=topic_control"
+CONTENT_SAFETY_OUTPUT_FLOW = "content safety check output $model=content_safety"
+# Names without their $model= suffix, which is the form the per-request toggle matches on.
+INPUT_PAIR = ["content safety check input", "topic safety check input"]
+
+SSN_MESSAGES = [{"role": "system", "content": "be helpful"}, {"role": "user", "content": "my ssn is 123-45-6789"}]
+MASKED = "my ssn is <SSN>"
+
+
+def _mask_user_message(text: str) -> RailOutcome:
+    return RailOutcome.transform([(TransformTarget.USER_MESSAGE, text)])
+
+
+def _mask_bot_message(text: str) -> RailOutcome:
+    return RailOutcome.transform([(TransformTarget.BOT_MESSAGE, text)])
+
+
+@pytest.mark.asyncio
+class TestRailsThatRewrite:
+    """A rail's rewrite reaches the rails behind it and is reported as the direction's verdict."""
+
+    def _install(self, manager, direction, rails: dict) -> None:
+        for flow, rail in rails.items():
+            manager._rails[(direction, flow)] = rail
+
+    async def test_a_rewrite_reaches_the_next_rail(self, nemoguards_rails_manager):
+        """The rail behind a masking rail checks the masked text, which is the point of rewriting."""
+        recorder = StubRail(RailOutcome.allow())
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)), TOPIC_SAFETY_INPUT_FLOW: recorder},
+        )
+
+        await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert recorder.seen_messages == [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": MASKED},
+        ]
+
+    async def test_the_verdict_carries_the_text_the_last_rail_left(self, nemoguards_rails_manager):
+        """Two rewrites compose, and the surviving text is what the caller is told to use."""
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {
+                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
+                TOPIC_SAFETY_INPUT_FLOW: StubRail(_mask_user_message("my ssn is [redacted]")),
+            },
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert result.is_safe is True
+        assert result.outcome.transform_text == {"user_message": "my ssn is [redacted]"}
+
+    async def test_a_rewrite_back_to_the_original_reports_nothing_happened(self, nemoguards_rails_manager):
+        """Only a net change counts, so ``check`` can tell PASSED from MODIFIED by comparing content."""
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {
+                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
+                TOPIC_SAFETY_INPUT_FLOW: StubRail(_mask_user_message("my ssn is 123-45-6789")),
+            },
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert result.outcome.is_transform is False
+        assert result.is_safe is True
+
+    async def test_a_block_behind_a_rewrite_returns_the_block(self, nemoguards_rails_manager):
+        """A later block wins: the request is refused, so the rewrite has nothing left to apply to."""
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {
+                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
+                TOPIC_SAFETY_INPUT_FLOW: StubRail(RailOutcome.block(reason="off topic")),
+            },
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert result.is_safe is False
+        assert result.outcome.is_transform is False
+        assert result.triggered_rail == "topic safety check input"
+        assert len(result.records) == 2
+
+    async def test_a_rewrite_leaves_the_callers_messages_untouched(self, nemoguards_rails_manager):
+        """The caller's list arrives by identity, so masking must not edit the conversation it owns."""
+        messages = [{"role": "user", "content": "my ssn is 123-45-6789"}]
+        original_turn = messages[0]
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED))},
+        )
+
+        await nemoguards_rails_manager.is_input_safe(messages, enabled=["content safety check input"])
+
+        assert messages == [{"role": "user", "content": "my ssn is 123-45-6789"}]
+        assert messages[0] is original_turn
+
+    async def test_an_output_rewrite_reaches_the_next_rail_and_the_verdict(self, nemoguards_rails_manager):
+        """The output direction rewrites the response under check rather than the messages."""
+        recorder = StubRail(RailOutcome.allow())
+        second_flow = "mask pii on output"
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.OUTPUT,
+            {CONTENT_SAFETY_OUTPUT_FLOW: StubRail(_mask_bot_message("call me on <PHONE>")), second_flow: recorder},
+        )
+
+        result = await nemoguards_rails_manager._run_rails_sequential(
+            [CONTENT_SAFETY_OUTPUT_FLOW, second_flow], RailDirection.OUTPUT, SSN_MESSAGES, "call me on 555-0100"
+        )
+
+        assert recorder.seen_bot_response == "call me on <PHONE>"
+        assert recorder.seen_messages == SSN_MESSAGES
+        assert result.outcome.transform_text == {"bot_message": "call me on <PHONE>"}
+
+    async def test_a_rail_rewriting_the_other_directions_variable_raises(self, nemoguards_rails_manager):
+        """An action contradicting its surface's declared target fails loudly rather than being dropped."""
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_bot_message("masked"))},
+        )
+
+        with pytest.raises(NotImplementedError, match="cannot apply"):
+            await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=["content safety check input"])
+
+    async def test_a_rewrite_from_a_rail_running_in_parallel_raises(self, parallel_input_rails_manager):
+        """Concurrent rails all read the arriving text, so a rewrite there cannot be applied to anything."""
+        self._install(
+            parallel_input_rails_manager,
+            RailDirection.INPUT,
+            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED))},
+        )
+
+        with pytest.raises(NotImplementedError, match="in parallel"):
+            await parallel_input_rails_manager.is_input_safe(SSN_MESSAGES, enabled=["content safety check input"])
+
+    async def test_a_rail_behind_a_block_is_never_dispatched(self, nemoguards_rails_manager):
+        """Rails are built when their turn comes, so a short-circuited one does no work at all."""
+        recorder = StubRail(RailOutcome.allow())
+        self._install(
+            nemoguards_rails_manager,
+            RailDirection.INPUT,
+            {
+                CONTENT_SAFETY_INPUT_FLOW: StubRail(RailOutcome.block(reason="unsafe")),
+                TOPIC_SAFETY_INPUT_FLOW: recorder,
+            },
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert result.is_safe is False
+        assert recorder.seen_messages == []
+
+
+class TestRewritingFlows:
+    """`_rewriting_flows` reports which of a direction's configured flows may rewrite."""
+
+    def test_only_rails_declaring_a_target_are_named(self):
+        """What the surface declares decides scheduling, not what a given request produced."""
+        rails = {
+            (RailDirection.INPUT, CONTENT_SAFETY_INPUT_FLOW): StubRail(),
+            (RailDirection.INPUT, TOPIC_SAFETY_INPUT_FLOW): declared_rewriter(SurfaceDirection.INPUT),
+        }
+
+        rewriting = _rewriting_flows(rails, RailDirection.INPUT, [CONTENT_SAFETY_INPUT_FLOW, TOPIC_SAFETY_INPUT_FLOW])
+
+        assert rewriting == (TOPIC_SAFETY_INPUT_FLOW,)
+
+    def test_a_direction_with_no_rewriting_rail_names_nothing(self):
+        """The common config, which must keep running exactly as it did."""
+        rails = {(RailDirection.INPUT, CONTENT_SAFETY_INPUT_FLOW): StubRail()}
+
+        assert _rewriting_flows(rails, RailDirection.INPUT, [CONTENT_SAFETY_INPUT_FLOW]) == ()
+
+
+class TestTransformsFirst:
+    """`_transforms_first` puts rails that may rewrite ahead of rails that only judge."""
+
+    def test_a_rewriting_rail_moves_ahead_of_the_rails_that_judge(self):
+        """A rewrite is only of use to the rails behind it, so it has to run before them."""
+        ordered = _transforms_first([TOPIC_SAFETY_INPUT_FLOW], [CONTENT_SAFETY_INPUT_FLOW, TOPIC_SAFETY_INPUT_FLOW])
+
+        assert ordered == [TOPIC_SAFETY_INPUT_FLOW, CONTENT_SAFETY_INPUT_FLOW]
+
+    def test_configured_order_survives_within_each_group(self):
+        """Reordering is between the two groups only; inside each, the config decides."""
+        flows = ["a", "b", "c", "d"]
+
+        assert _transforms_first(["b", "d"], flows) == ["b", "d", "a", "c"]
+
+    def test_nothing_moves_when_no_rail_rewrites(self):
+        """A config with no rewriting rail runs exactly as it was written."""
+        flows = ["a", "b", "c"]
+
+        assert _transforms_first([], flows) == flows
+
+
+class TestSchedulingRailsThatRewrite:
+    """A configured rewriting rail decides run order and rules out concurrent execution."""
+
+    def test_the_rewriting_rails_are_named_per_direction(self):
+        """Each direction is asked separately, because the two are scheduled for different reasons."""
+        with rails_compiled_as({TOPIC_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)}):
+            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+        assert manager.transform_flows[RailDirection.INPUT] == (TOPIC_SAFETY_INPUT_FLOW,)
+        assert manager.transform_flows[RailDirection.OUTPUT] == ()
+
+    @pytest.mark.asyncio
+    async def test_a_rewriting_rail_runs_before_a_rail_configured_ahead_of_it(self):
+        """Ordering is observable: the judging rail reads text the rewriting rail produced."""
+        judge = StubRail()
+        with rails_compiled_as(
+            {
+                CONTENT_SAFETY_INPUT_FLOW: judge,
+                TOPIC_SAFETY_INPUT_FLOW: rewriting_stub(MASKED, SurfaceDirection.INPUT),
+            }
+        ):
+            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+        await manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
+
+        assert judge.seen_messages[-1]["content"] == MASKED
+
+    def test_the_configured_order_is_kept_when_nothing_rewrites(self):
+        """Nothing about scheduling changes for the configs that shipped before rewrites existed."""
+        with rails_compiled_as({}):
+            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+        assert manager._flows_to_run(RailDirection.INPUT, manager.input_flows, True) == manager.input_flows
+
+    def test_emptying_the_configured_flows_leaves_nothing_to_run(self):
+        """The configured list stays the single source of truth for what runs, ordering aside."""
+        with rails_compiled_as({CONTENT_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)}):
+            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        manager.input_flows = []
+
+        assert manager._flows_to_run(RailDirection.INPUT, manager.input_flows, True) == []
+
+    def test_parallel_rails_are_turned_off_in_both_directions(self):
+        """One rewriting rail settles how the whole config runs, rather than per section."""
+        with rails_compiled_as({CONTENT_SAFETY_OUTPUT_FLOW: declared_rewriter(SurfaceDirection.OUTPUT)}):
+            with pytest.warns(UserWarning, match="parallel"):
+                manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_CONFIG))
+
+        assert manager.input_parallel is False
+        assert manager.output_parallel is False
+
+    def test_the_warning_names_the_rail_that_forced_it(self):
+        """A downgrade a user did not ask for has to say which rail caused it."""
+        with rails_compiled_as({CONTENT_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)}):
+            with pytest.warns(UserWarning, match=CONTENT_SAFETY_INPUT_FLOW.replace("$", r"\$")):
+                _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_INPUT_CONFIG))
+
+    def test_parallel_rails_are_left_alone_when_nothing_rewrites(self, recwarn):
+        """The downgrade is silent and absent for every config that does not need it."""
+        with rails_compiled_as({}):
+            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_CONFIG))
+
+        assert manager.input_parallel is True
+        assert manager.output_parallel is True
+        assert [warning for warning in recwarn if "parallel" in str(warning.message)] == []
+
+    @pytest.mark.asyncio
+    async def test_the_output_direction_is_scheduled_the_same_way(self):
+        """Output rails order by the same rule, against the response rather than the messages."""
+        judge = StubRail()
+        second_flow = "mask pii on output"
+        config = RailsConfig.from_content(config=NEMOGUARDS_CONFIG)
+        config.rails.output.flows.append(second_flow)
+        with rails_compiled_as(
+            {
+                CONTENT_SAFETY_OUTPUT_FLOW: judge,
+                second_flow: rewriting_stub("call me on <PHONE>", SurfaceDirection.OUTPUT),
+            }
+        ):
+            manager = _make_rails_manager(config)
+
+        await manager.is_output_safe(SSN_MESSAGES, "call me on 555-0100")
+
+        assert manager.transform_flows[RailDirection.OUTPUT] == (second_flow,)
+        assert judge.seen_bot_response == "call me on <PHONE>"
+
+
+class TestCheckedText:
+    """`_checked_text` names the text a direction's rails read, which is the text a rewrite replaces."""
+
+    def test_input_rails_check_the_current_user_turn(self):
+        """Input rails judge the turn being handled, not the whole conversation."""
+        assert _checked_text(RailDirection.INPUT, SSN_MESSAGES, None) == "my ssn is 123-45-6789"
+
+    def test_input_rails_ignore_a_response(self):
+        """A response only exists for the output direction, so it cannot be what an input rail read."""
+        assert _checked_text(RailDirection.INPUT, SSN_MESSAGES, "a reply") == "my ssn is 123-45-6789"
+
+    def test_output_rails_check_the_response(self):
+        """Output rails judge the generated response, which is not yet part of the messages."""
+        assert _checked_text(RailDirection.OUTPUT, SSN_MESSAGES, "a reply") == "a reply"
+
+    def test_output_rails_with_no_response_check_nothing(self):
+        """A turn that produced no text compares equal to itself, so it reports no rewrite."""
+        assert _checked_text(RailDirection.OUTPUT, SSN_MESSAGES, None) == ""
+
+
+class TestRewrittenText:
+    """`_rewritten_text` reads the rewrite a direction can apply, and refuses every other one."""
+
+    def test_an_input_rail_rewrites_the_user_message(self):
+        """The variable an input rail is allowed to rewrite."""
+        assert _rewritten_text(_mask_user_message(MASKED), RailDirection.INPUT, "mask pii on input") == MASKED
+
+    def test_an_output_rail_rewrites_the_bot_message(self):
+        """The variable an output rail is allowed to rewrite."""
+        assert _rewritten_text(_mask_bot_message("redacted"), RailDirection.OUTPUT, "mask pii on output") == "redacted"
+
+    def test_the_other_directions_variable_is_refused(self):
+        """An action contradicting its surface's declared target is a bug, not a verdict to apply."""
+        with pytest.raises(NotImplementedError, match="may rewrite 'user_message'"):
+            _rewritten_text(_mask_bot_message("redacted"), RailDirection.INPUT, "mask pii on input")
+
+    def test_rewriting_more_than_one_variable_is_refused(self):
+        """Applying half of a two-variable rewrite would report a verdict over text no rail produced."""
+        outcome = RailOutcome.transform(
+            [(TransformTarget.USER_MESSAGE, MASKED), (TransformTarget.BOT_MESSAGE, "redacted")]
+        )
+
+        with pytest.raises(NotImplementedError, match="cannot apply"):
+            _rewritten_text(outcome, RailDirection.INPUT, "pangea ai guard input")
+
+    def test_a_retrieval_rewrite_is_refused(self):
+        """``relevant_chunks`` has no home in an input/output request, so there is nowhere to put it."""
+        outcome = RailOutcome.transform([(TransformTarget.RELEVANT_CHUNKS, "chunk text")])
+
+        with pytest.raises(NotImplementedError, match="cannot apply"):
+            _rewritten_text(outcome, RailDirection.INPUT, "mask pii on retrieval")
+
+
+class TestResultAfterRewrites:
+    """`_result_after_rewrites` reports a direction's net rewrite, or that nothing changed."""
+
+    RECORDS = (RailCallRecord(flow="mask pii on input", rail_type="input", is_safe=True),)
+
+    def test_unchanged_text_is_a_plain_allow(self):
+        """Rails that rewrote nothing, or rewrote and restored, leave the request as it arrived."""
+        result = _result_after_rewrites(RailDirection.INPUT, "hello", "hello", self.RECORDS)
+
+        assert result.outcome.is_transform is False
+        assert result.is_safe is True
+        assert result.records == self.RECORDS
+
+    def test_an_input_rewrite_names_the_user_message(self):
+        """The caller learns which variable to replace, not just that something changed."""
+        result = _result_after_rewrites(RailDirection.INPUT, "my ssn is 123-45-6789", MASKED, self.RECORDS)
+
+        assert result.outcome.transform_text == {"user_message": MASKED}
+        assert result.is_safe is True
+        assert result.records == self.RECORDS
+
+    def test_an_output_rewrite_names_the_bot_message(self):
+        """The output direction reports against the variable its rails checked."""
+        result = _result_after_rewrites(RailDirection.OUTPUT, "call me on 555-0100", "call me on <PHONE>", ())
+
+        assert result.outcome.transform_text == {"bot_message": "call me on <PHONE>"}
+
+    def test_a_rewrite_to_empty_text_is_still_a_rewrite(self):
+        """Redacting a response to nothing is a change, and must not read as leaving it alone."""
+        result = _result_after_rewrites(RailDirection.OUTPUT, "my ssn is 123-45-6789", "", ())
+
+        assert result.outcome.transform_text == {"bot_message": ""}
+
+    def test_a_rewrite_keeps_every_rail_that_ran(self):
+        """The log covers the whole direction, not only the rail that rewrote."""
+        result = _result_after_rewrites(RailDirection.INPUT, "before", "after", self.RECORDS)
+
+        assert result.records == self.RECORDS
+
+
+class TestRefuseConcurrentRewrite:
+    """`_refuse_concurrent_rewrite` keeps rewrites out of the path that cannot compose them."""
+
+    @pytest.mark.parametrize(
+        "outcome",
+        [RailOutcome.allow(), RailOutcome.block(reason="unsafe")],
+        ids=["allow", "block"],
+    )
+    def test_a_decision_passes_through(self, outcome):
+        """Parallel mode is unaffected for the verdicts its rails can actually reach."""
+        assert _refuse_concurrent_rewrite(RailResult(outcome), "content safety check input") is None
+
+    def test_a_rewrite_raises(self):
+        """Concurrent rails all read the arriving text, so no rewrite among them can be applied."""
+        result = RailResult(_mask_user_message(MASKED))
+
+        with pytest.raises(NotImplementedError, match="in parallel"):
+            _refuse_concurrent_rewrite(result, "mask pii on input")
 
 
 class TestRailCallRecordNaming:

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -1252,14 +1252,17 @@ class TestRailsThatRewrite:
         for flow, rail in rails.items():
             manager._rails[(direction, flow)] = rail
 
+    def _install_input_pair(self, manager, first: StubRail, second: StubRail = None) -> None:
+        """Stand in for the two input rails ``INPUT_PAIR`` runs, in the order it runs them."""
+        rails = {CONTENT_SAFETY_INPUT_FLOW: first}
+        if second is not None:
+            rails[TOPIC_SAFETY_INPUT_FLOW] = second
+        self._install(manager, RailDirection.INPUT, rails)
+
     async def test_a_rewrite_reaches_the_next_rail(self, nemoguards_rails_manager):
         """The rail behind a masking rail checks the masked text, which is the point of rewriting."""
         recorder = StubRail(RailOutcome.allow())
-        self._install(
-            nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)), TOPIC_SAFETY_INPUT_FLOW: recorder},
-        )
+        self._install_input_pair(nemoguards_rails_manager, StubRail(_mask_user_message(MASKED)), recorder)
 
         await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
 
@@ -1270,13 +1273,10 @@ class TestRailsThatRewrite:
 
     async def test_the_verdict_carries_the_text_the_last_rail_left(self, nemoguards_rails_manager):
         """Two rewrites compose, and the surviving text is what the caller is told to use."""
-        self._install(
+        self._install_input_pair(
             nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {
-                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
-                TOPIC_SAFETY_INPUT_FLOW: StubRail(_mask_user_message("my ssn is [redacted]")),
-            },
+            StubRail(_mask_user_message(MASKED)),
+            StubRail(_mask_user_message("my ssn is [redacted]")),
         )
 
         result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
@@ -1286,13 +1286,10 @@ class TestRailsThatRewrite:
 
     async def test_a_rewrite_back_to_the_original_reports_nothing_happened(self, nemoguards_rails_manager):
         """Only a net change counts, so ``check`` can tell PASSED from MODIFIED by comparing content."""
-        self._install(
+        self._install_input_pair(
             nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {
-                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
-                TOPIC_SAFETY_INPUT_FLOW: StubRail(_mask_user_message("my ssn is 123-45-6789")),
-            },
+            StubRail(_mask_user_message(MASKED)),
+            StubRail(_mask_user_message("my ssn is 123-45-6789")),
         )
 
         result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
@@ -1302,13 +1299,10 @@ class TestRailsThatRewrite:
 
     async def test_a_block_behind_a_rewrite_returns_the_block(self, nemoguards_rails_manager):
         """A later block wins: the request is refused, so the rewrite has nothing left to apply to."""
-        self._install(
+        self._install_input_pair(
             nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {
-                CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED)),
-                TOPIC_SAFETY_INPUT_FLOW: StubRail(RailOutcome.block(reason="off topic")),
-            },
+            StubRail(_mask_user_message(MASKED)),
+            StubRail(RailOutcome.block(reason="off topic")),
         )
 
         result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
@@ -1322,11 +1316,7 @@ class TestRailsThatRewrite:
         """The caller's list arrives by identity, so masking must not edit the conversation it owns."""
         messages = [{"role": "user", "content": "my ssn is 123-45-6789"}]
         original_turn = messages[0]
-        self._install(
-            nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED))},
-        )
+        self._install_input_pair(nemoguards_rails_manager, StubRail(_mask_user_message(MASKED)))
 
         await nemoguards_rails_manager.is_input_safe(messages, enabled=["content safety check input"])
 
@@ -1353,22 +1343,14 @@ class TestRailsThatRewrite:
 
     async def test_a_rail_rewriting_the_other_directions_variable_raises(self, nemoguards_rails_manager):
         """An action contradicting its surface's declared target fails loudly rather than being dropped."""
-        self._install(
-            nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_bot_message("masked"))},
-        )
+        self._install_input_pair(nemoguards_rails_manager, StubRail(_mask_bot_message("masked")))
 
         with pytest.raises(NotImplementedError, match="cannot apply"):
             await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=["content safety check input"])
 
     async def test_a_rewrite_from_a_rail_running_in_parallel_raises(self, parallel_input_rails_manager):
         """Concurrent rails all read the arriving text, so a rewrite there cannot be applied to anything."""
-        self._install(
-            parallel_input_rails_manager,
-            RailDirection.INPUT,
-            {CONTENT_SAFETY_INPUT_FLOW: StubRail(_mask_user_message(MASKED))},
-        )
+        self._install_input_pair(parallel_input_rails_manager, StubRail(_mask_user_message(MASKED)))
 
         with pytest.raises(NotImplementedError, match="in parallel"):
             await parallel_input_rails_manager.is_input_safe(SSN_MESSAGES, enabled=["content safety check input"])
@@ -1376,14 +1358,7 @@ class TestRailsThatRewrite:
     async def test_a_rail_behind_a_block_is_never_dispatched(self, nemoguards_rails_manager):
         """Rails are built when their turn comes, so a short-circuited one does no work at all."""
         recorder = StubRail(RailOutcome.allow())
-        self._install(
-            nemoguards_rails_manager,
-            RailDirection.INPUT,
-            {
-                CONTENT_SAFETY_INPUT_FLOW: StubRail(RailOutcome.block(reason="unsafe")),
-                TOPIC_SAFETY_INPUT_FLOW: recorder,
-            },
-        )
+        self._install_input_pair(nemoguards_rails_manager, StubRail(RailOutcome.block(reason="unsafe")), recorder)
 
         result = await nemoguards_rails_manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
 
@@ -1434,13 +1409,18 @@ class TestTransformsFirst:
         assert _transforms_first([], flows) == flows
 
 
+def _manager_compiling(rails: dict, config: dict = NEMOGUARDS_CONFIG) -> RailsManager:
+    """A manager whose named flows compiled to *rails*, for scheduling decided at construction."""
+    with rails_compiled_as(rails):
+        return _make_rails_manager(RailsConfig.from_content(config=config))
+
+
 class TestSchedulingRailsThatRewrite:
     """A configured rewriting rail decides run order and rules out concurrent execution."""
 
     def test_the_rewriting_rails_are_named_per_direction(self):
         """Each direction is asked separately, because the two are scheduled for different reasons."""
-        with rails_compiled_as({TOPIC_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)}):
-            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        manager = _manager_compiling({TOPIC_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)})
 
         assert manager.transform_flows[RailDirection.INPUT] == (TOPIC_SAFETY_INPUT_FLOW,)
         assert manager.transform_flows[RailDirection.OUTPUT] == ()
@@ -1449,13 +1429,9 @@ class TestSchedulingRailsThatRewrite:
     async def test_a_rewriting_rail_runs_before_a_rail_configured_ahead_of_it(self):
         """Ordering is observable: the judging rail reads text the rewriting rail produced."""
         judge = StubRail()
-        with rails_compiled_as(
-            {
-                CONTENT_SAFETY_INPUT_FLOW: judge,
-                TOPIC_SAFETY_INPUT_FLOW: rewriting_stub(MASKED, SurfaceDirection.INPUT),
-            }
-        ):
-            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        manager = _manager_compiling(
+            {CONTENT_SAFETY_INPUT_FLOW: judge, TOPIC_SAFETY_INPUT_FLOW: rewriting_stub(MASKED, SurfaceDirection.INPUT)}
+        )
 
         await manager.is_input_safe(SSN_MESSAGES, enabled=INPUT_PAIR)
 
@@ -1463,15 +1439,13 @@ class TestSchedulingRailsThatRewrite:
 
     def test_the_configured_order_is_kept_when_nothing_rewrites(self):
         """Nothing about scheduling changes for the configs that shipped before rewrites existed."""
-        with rails_compiled_as({}):
-            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        manager = _manager_compiling({})
 
         assert manager._flows_to_run(RailDirection.INPUT, manager.input_flows, True) == manager.input_flows
 
     def test_emptying_the_configured_flows_leaves_nothing_to_run(self):
         """The configured list stays the single source of truth for what runs, ordering aside."""
-        with rails_compiled_as({CONTENT_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)}):
-            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+        manager = _manager_compiling({CONTENT_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)})
         manager.input_flows = []
 
         assert manager._flows_to_run(RailDirection.INPUT, manager.input_flows, True) == []
@@ -1493,11 +1467,21 @@ class TestSchedulingRailsThatRewrite:
 
     def test_parallel_rails_are_left_alone_when_nothing_rewrites(self, recwarn):
         """The downgrade is silent and absent for every config that does not need it."""
-        with rails_compiled_as({}):
-            manager = _make_rails_manager(RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_CONFIG))
+        manager = _manager_compiling({}, NEMOGUARDS_PARALLEL_CONFIG)
 
         assert manager.input_parallel is True
         assert manager.output_parallel is True
+        assert [warning for warning in recwarn if "parallel" in str(warning.message)] == []
+
+    def test_a_config_that_never_asked_for_parallel_is_not_warned_about(self, recwarn):
+        """The downgrade reports itself only where it takes something away.
+
+        A rewriting rail in an already-sequential config reaches the same code, and warning
+        there would tell every masking user their config had been overridden when it had not.
+        """
+        manager = _manager_compiling({CONTENT_SAFETY_INPUT_FLOW: declared_rewriter(SurfaceDirection.INPUT)})
+
+        assert manager.transform_flows[RailDirection.INPUT] == (CONTENT_SAFETY_INPUT_FLOW,)
         assert [warning for warning in recwarn if "parallel" in str(warning.message)] == []
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -1557,14 +1557,17 @@ class TestRewrittenText:
         with pytest.raises(NotImplementedError, match="may rewrite 'user_message'"):
             _rewritten_text(_mask_bot_message("redacted"), RailDirection.INPUT, "mask pii on input")
 
-    def test_rewriting_more_than_one_variable_is_refused(self):
-        """Applying half of a two-variable rewrite would report a verdict over text no rail produced."""
+    def test_a_rail_naming_both_variables_gives_each_direction_its_own(self):
+        """A rail guarding both sides of a turn may rewrite both, and each direction takes one.
+
+        The Colang flows do the same with the same verdict, each indexing the key it owns.
+        """
         outcome = RailOutcome.transform(
             [(TransformTarget.USER_MESSAGE, MASKED), (TransformTarget.BOT_MESSAGE, "redacted")]
         )
 
-        with pytest.raises(NotImplementedError, match="cannot apply"):
-            _rewritten_text(outcome, RailDirection.INPUT, "pangea ai guard input")
+        assert _rewritten_text(outcome, RailDirection.INPUT, "pangea ai guard input") == MASKED
+        assert _rewritten_text(outcome, RailDirection.OUTPUT, "pangea ai guard output") == "redacted"
 
     def test_a_retrieval_rewrite_is_refused(self):
         """``relevant_chunks`` has no home in an input/output request, so there is nowhere to put it."""

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -1889,3 +1889,37 @@ class TestRawResponseParsing:
         result = await topic_safety_rails_manager.is_input_safe(MESSAGES)
 
         assert result.is_safe is expected_safe
+
+
+@pytest.mark.asyncio
+class TestARewriteWithNoTurnToLandOn:
+    """A rail rewriting a turn the request does not have is blocked, not raised."""
+
+    async def test_the_request_is_blocked(self, nemoguards_rails_manager):
+        """A rail handed no text and answering with some is misbehaving, and the envelope owns that.
+
+        Raising would surface a rail's fault as a server error; blocking keeps it where every
+        other rail failure already lands.
+        """
+        nemoguards_rails_manager._rails[(RailDirection.INPUT, CONTENT_SAFETY_INPUT_FLOW)] = StubRail(
+            _mask_user_message(MASKED)
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(
+            [{"role": "assistant", "content": "hello"}], enabled=["content safety check input"]
+        )
+
+        assert result.is_safe is False
+        assert result.triggered_rail == "content safety check input"
+
+    async def test_the_rails_that_ran_are_still_recorded(self, nemoguards_rails_manager):
+        """The generation log covers the whole check, including the rail that misbehaved."""
+        nemoguards_rails_manager._rails[(RailDirection.INPUT, CONTENT_SAFETY_INPUT_FLOW)] = StubRail(
+            _mask_user_message(MASKED)
+        )
+
+        result = await nemoguards_rails_manager.is_input_safe(
+            [{"role": "assistant", "content": "hello"}], enabled=["content safety check input"]
+        )
+
+        assert len(result.records) == 1

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -29,10 +29,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.manifests import RailDirection as SurfaceDirection
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.types import LLMResponse, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.rail_stubs import declared_rewriter, rails_compiled_as
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG, NEMOGUARDS_SPECULATIVE_CONFIG
 
 MESSAGES = [{"role": "user", "content": "hi"}]
@@ -528,3 +530,52 @@ class TestSpeculativeGenerationTiming:
         gen_calls = [c for c in (result.log.llm_calls or []) if c.task == "general"]
         assert len(gen_calls) == 1
         assert gen_calls[0].duration is not None
+
+
+class TestSpeculativeGenerationAndRewritingRails:
+    """An input rail that may rewrite rules out racing generation against the input rails."""
+
+    def _engine(self, config_dict: dict, rails: dict) -> IORails:
+        with rails_compiled_as(rails):
+            return IORails(RailsConfig.from_content(config=config_dict), _report_usage=False)
+
+    def test_the_race_is_dropped_when_an_input_rail_may_rewrite(self):
+        """The model would otherwise read text the rails then replace, describing a call never made."""
+        with pytest.warns(UserWarning, match="speculative_generation is not honored"):
+            engine = self._engine(
+                NEMOGUARDS_SPECULATIVE_CONFIG,
+                {"jailbreak detection model": declared_rewriter(SurfaceDirection.INPUT)},
+            )
+
+        assert engine._speculative_generation is False
+
+    def test_the_warning_names_the_rail_that_forced_it(self):
+        """A performance setting dropped without asking has to say which rail dropped it."""
+        with pytest.warns(UserWarning, match="jailbreak detection model"):
+            self._engine(
+                NEMOGUARDS_SPECULATIVE_CONFIG,
+                {"jailbreak detection model": declared_rewriter(SurfaceDirection.INPUT)},
+            )
+
+    def test_the_race_survives_a_rewriting_rail_on_the_output_side(self, recwarn):
+        """Output rails run after generation, so a rewrite there cannot be read too late."""
+        engine = self._engine(
+            NEMOGUARDS_SPECULATIVE_CONFIG,
+            {"content safety check output $model=content_safety": declared_rewriter(SurfaceDirection.OUTPUT)},
+        )
+
+        assert engine._speculative_generation is True
+        assert [warning for warning in recwarn if "speculative_generation" in str(warning.message)] == []
+
+    def test_the_race_is_untouched_when_no_rail_rewrites(self, recwarn):
+        """The configs that shipped before rewrites existed keep the setting they asked for."""
+        engine = self._engine(NEMOGUARDS_SPECULATIVE_CONFIG, {})
+
+        assert engine._speculative_generation is True
+        assert [warning for warning in recwarn if "speculative_generation" in str(warning.message)] == []
+
+    def test_a_config_that_never_asked_for_the_race_still_does_not_get_it(self):
+        """The downgrade only ever turns the setting off, never on."""
+        engine = self._engine(NEMOGUARDS_CONFIG, {})
+
+        assert engine._speculative_generation is False

--- a/tests/guardrails/test_transform_rail_pipeline.py
+++ b/tests/guardrails/test_transform_rail_pipeline.py
@@ -447,7 +447,8 @@ class TestParallelIsRefusedWhenARailRewrites:
     async def test_the_input_rails_still_run_masking_first(self, call_log, httpx_mock):
         """The downgraded config behaves exactly as the sequential one, rather than merely warning."""
         with pytest.warns(UserWarning, match="not honored"):
-            engine = IORails(RailsConfig.from_content(config=_input_pipeline_config(parallel=True)))
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                engine = IORails(RailsConfig.from_content(config=_input_pipeline_config(parallel=True)))
 
         async with engine:
             _wire(engine, call_log, httpx_mock, ALL_ALLOW)
@@ -459,7 +460,8 @@ class TestParallelIsRefusedWhenARailRewrites:
     async def test_the_output_rails_still_run_masking_first(self, call_log, httpx_mock):
         """Same for the output direction, where the rewrite is the response the caller receives."""
         with pytest.warns(UserWarning, match="not honored"):
-            engine = IORails(RailsConfig.from_content(config=_output_pipeline_config(parallel=True)))
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                engine = IORails(RailsConfig.from_content(config=_output_pipeline_config(parallel=True)))
 
         async with engine:
             _wire_answering(engine, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)

--- a/tests/guardrails/test_transform_rail_pipeline.py
+++ b/tests/guardrails/test_transform_rail_pipeline.py
@@ -1,0 +1,484 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A masking rail among judging rails, driven end to end through IORails.
+
+The single-rail tests prove a rewrite is applied. These prove the pipeline around it, in both
+directions and under both concurrency settings:
+
+- **input** — four rails, the masking one written *last*: it still runs first, every rail behind
+  it waits and reads the masked text, and so does the main model;
+- **output** — three rails, same shape: the masking one runs first and the caller reads the
+  masked response;
+- **parallel** — the same two configs asking for concurrent rails, which is refused with a
+  warning and run in order instead, because concurrent rails would each read the text as it
+  arrived and the mask would reach none of them.
+
+Nothing is stubbed at the rail boundary -- the shipped actions run, against canned model and
+HTTP replies -- so a rail that stopped reading its conversation variable, or an ordering rule
+that stopped reordering, fails here rather than in a config.
+"""
+
+import copy
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from nemoguardrails.guardrails.guardrails_types import RailDirection
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse
+from tests.guardrails.async_helpers import JAILBREAK_NIM_URL, started_iorails
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+GLINER_URL = "http://gliner.example/v1/extract"
+
+# One PII entity, chosen so no other rail has an opinion about it: a name is not unsafe content,
+# not off topic, and not a jailbreak attempt. What each rail reads is then the only variable.
+PERSON = "Ada Lovelace"
+USER_INPUT = f"my name is {PERSON} and I need help with my order"
+MASKED_INPUT = "my name is [PERSON] and I need help with my order"
+MAIN_OUTPUT = "Happy to help with your order."
+
+SAFE_VERDICT = json.dumps({"User Safety": "safe"})
+UNSAFE_VERDICT = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
+ON_TOPIC_VERDICT = "on-topic"
+
+# The masking rail is configured *after* the three that only judge, so the run order asserted
+# below can only come from the transform-first rule rather than from the config.
+INPUT_FLOWS = [
+    "content safety check input $model=content_safety",
+    "topic safety check input $model=topic_control",
+    "jailbreak detection model",
+    "gliner mask pii on input",
+]
+
+CONTENT_SAFETY_RAIL = "content_safety"
+TOPIC_CONTROL_RAIL = "topic_control"
+GLINER_RAIL = "gliner"
+JAILBREAK_RAIL = "jailbreak"
+
+
+def _pipeline_config() -> dict:
+    """The four-rail config both the allow and the block case are built from."""
+    config = copy.deepcopy(NEMOGUARDS_CONFIG)
+    config["rails"]["input"]["flows"] = list(INPUT_FLOWS)
+    config["rails"]["output"] = {"flows": []}
+    config["rails"]["config"]["gliner"] = {
+        "server_endpoint": GLINER_URL,
+        "input": {"entities": ["person"]},
+    }
+    return config
+
+
+def _gliner_entities(text: str) -> list[dict]:
+    """The detection GLiNER returns for *text*, positioned where the name actually is."""
+    start = text.index(PERSON)
+    return [
+        {
+            "value": PERSON,
+            "suggested_label": "person",
+            "start_position": start,
+            "end_position": start + len(PERSON),
+        }
+    ]
+
+
+class RailCallLog:
+    """An ordered record of which rail called out, and with what text.
+
+    One log across both seams -- the model engines and the HTTP endpoints -- because the
+    question is what order the *rails* ran in, which neither seam can answer alone.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def record(self, rail: str, text: str) -> None:
+        self.calls.append((rail, text))
+
+    @property
+    def order(self) -> list[str]:
+        return [rail for rail, _ in self.calls]
+
+    def text_seen_by(self, rail: str) -> str:
+        """The text *rail* was given, failing loudly when it never ran."""
+        for name, text in self.calls:
+            if name == rail:
+                return text
+        raise AssertionError(f"{rail!r} never ran; the log holds {self.order}")
+
+
+def _model_double(log: RailCallLog, model_type: str, verdict: str) -> AsyncMock:
+    """Answer one model-backed rail with *verdict*, recording the prompt it was sent.
+
+    One double per model type rather than one shared double told apart by prompt text: each
+    rail reaches its own engine, so the engine already knows which rail is calling. The whole
+    prompt is recorded, not its first message, because the rails place the text under check at
+    different positions and which text a rail reads is what is under test.
+    """
+
+    async def _chat_completion(messages, **kwargs):
+        log.record(model_type, "\n".join(str(message.get("content", "")) for message in messages))
+        return LLMResponse(content=verdict)
+
+    return AsyncMock(side_effect=_chat_completion)
+
+
+def _register_http_doubles(httpx_mock, log: RailCallLog) -> None:
+    """Answer the two HTTP-backed rails, recording the text each was sent."""
+
+    def _gliner(request):
+        # The entities are positioned against the text this call actually carried, so a rail
+        # handed the wrong text masks nothing rather than masking at a stale offset.
+        text = json.loads(request.content)["text"]
+        log.record(GLINER_RAIL, text)
+        return httpx.Response(200, json={"entities": _gliner_entities(text)})
+
+    def _jailbreak(request):
+        log.record(JAILBREAK_RAIL, json.loads(request.content)["input"])
+        return httpx.Response(200, json={"jailbreak": False, "score": 0.01})
+
+    # The masking rail always runs, so leaving its callback required makes "gliner was called"
+    # an assertion the fixture enforces. Jailbreak runs last and is skipped whenever a rail
+    # ahead of it blocks, which is a case below, so its callback is optional.
+    httpx_mock.add_callback(_gliner, url=GLINER_URL)
+    httpx_mock.add_callback(_jailbreak, url=JAILBREAK_NIM_URL, is_optional=True)
+
+
+@pytest.fixture
+def call_log() -> RailCallLog:
+    return RailCallLog()
+
+
+@pytest_asyncio.fixture
+async def pipeline_iorails():
+    """IORails with the four input rails, started and stopped around the test."""
+    async with started_iorails(_pipeline_config()) as engine:
+        yield engine
+
+
+def _wire(engine: IORails, log: RailCallLog, httpx_mock, verdicts: dict[str, str]) -> AsyncMock:
+    """Attach a double per model-backed rail plus the HTTP ones, and return the main-model double."""
+    for model_type, rail_engine in engine.engine_registry.llms.items():
+        if model_type in verdicts:
+            rail_engine.chat_completion = _model_double(log, model_type, verdicts[model_type])
+    _register_http_doubles(httpx_mock, log)
+
+    main = AsyncMock(return_value=LLMResponse(content=MAIN_OUTPUT))
+    engine.engine_registry._engines["main"].chat_completion = main
+    return main
+
+
+ALL_ALLOW = {CONTENT_SAFETY_RAIL: SAFE_VERDICT, TOPIC_CONTROL_RAIL: ON_TOPIC_VERDICT}
+CONTENT_SAFETY_BLOCKS = {CONTENT_SAFETY_RAIL: UNSAFE_VERDICT, TOPIC_CONTROL_RAIL: ON_TOPIC_VERDICT}
+
+
+@pytest.mark.asyncio
+class TestMaskingRailAheadOfJudgingRails:
+    """Four input rails, the masking one configured last: it runs first and the rest read its work."""
+
+    async def test_the_masking_rail_runs_before_every_rail_that_only_judges(
+        self, pipeline_iorails, call_log, httpx_mock
+    ):
+        """Configured last, run first -- so the order comes from the rule, not from the config."""
+        _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order[0] == GLINER_RAIL
+        assert set(call_log.order) == {GLINER_RAIL, CONTENT_SAFETY_RAIL, TOPIC_CONTROL_RAIL, JAILBREAK_RAIL}
+
+    async def test_the_masking_rail_reads_the_message_as_it_arrived(self, pipeline_iorails, call_log, httpx_mock):
+        """Nothing precedes it, so it is the one rail that sees the unmasked text."""
+        _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.text_seen_by(GLINER_RAIL) == USER_INPUT
+
+    @pytest.mark.parametrize("rail", [CONTENT_SAFETY_RAIL, TOPIC_CONTROL_RAIL, JAILBREAK_RAIL])
+    async def test_every_rail_behind_it_waits_and_reads_the_masked_text(
+        self, pipeline_iorails, call_log, httpx_mock, rail
+    ):
+        """None of the three could hold masked text unless it ran after the mask was applied.
+
+        This is the sequencing assertion as well as the threading one: a rail that started
+        alongside the masking rail would have been handed the text as it arrived.
+        """
+        _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        seen = call_log.text_seen_by(rail)
+        assert MASKED_INPUT in seen
+        assert PERSON not in seen
+
+    async def test_the_main_model_reads_the_masked_text(self, pipeline_iorails, call_log, httpx_mock):
+        """The point of masking on input: the name never reaches the model being guarded."""
+        main = _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        sent = main.call_args.args[0]
+        assert sent[-1]["content"] == MASKED_INPUT
+
+    async def test_the_caller_gets_the_answer_and_keeps_their_own_message(self, pipeline_iorails, call_log, httpx_mock):
+        """Masking is internal to the turn: the reply is the model's, and the caller's list is theirs."""
+        _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
+        messages = [{"role": "user", "content": USER_INPUT}]
+
+        response = await pipeline_iorails.generate_async(messages=messages)
+
+        assert response == {"role": "assistant", "content": MAIN_OUTPUT}
+        assert messages == [{"role": "user", "content": USER_INPUT}]
+
+    async def test_a_rail_behind_the_mask_can_still_block(self, pipeline_iorails, call_log, httpx_mock):
+        """A rewrite ahead of a block does not rescue the request, and the block is the verdict."""
+        main = _wire(pipeline_iorails, call_log, httpx_mock, CONTENT_SAFETY_BLOCKS)
+
+        response = await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert response == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        main.assert_not_called()
+
+    async def test_the_blocking_rail_judged_the_masked_text(self, pipeline_iorails, call_log, httpx_mock):
+        """The rail that blocked read what the mask produced, so its verdict is about that text."""
+        _wire(pipeline_iorails, call_log, httpx_mock, CONTENT_SAFETY_BLOCKS)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order[0] == GLINER_RAIL
+        assert PERSON not in call_log.text_seen_by(CONTENT_SAFETY_RAIL)
+
+    async def test_the_rails_behind_a_block_never_run(self, pipeline_iorails, call_log, httpx_mock):
+        """Short-circuiting survives the reordering: after content safety blocks, nothing else runs."""
+        _wire(pipeline_iorails, call_log, httpx_mock, CONTENT_SAFETY_BLOCKS)
+
+        await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order == [GLINER_RAIL, CONTENT_SAFETY_RAIL]
+
+
+@pytest.mark.asyncio
+class TestMaskingRailSchedulingIsSettledAtConstruction:
+    """The engine reports the ordering and the downgrades it will apply, before any request."""
+
+    async def test_the_masking_rail_is_named_as_the_input_direction_rewriter(self, pipeline_iorails):
+        """What the engine believes about the config is what the run order above follows from."""
+        assert pipeline_iorails.rails_manager.transform_flows[RailDirection.INPUT] == ("gliner mask pii on input",)
+
+    async def test_the_configured_flow_list_keeps_its_own_order(self, pipeline_iorails):
+        """Reordering is for running the rails, not a rewrite of what the user configured."""
+        assert pipeline_iorails.rails_manager.input_flows == INPUT_FLOWS
+
+
+def test_the_four_rail_config_routes_to_iorails():
+    """A config mixing a masking rail with three judging ones is servable, so the rest is reachable."""
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        config = RailsConfig.from_content(config=_pipeline_config())
+
+    assert IORails.unsupported_reason(config, llm=None) is None
+
+
+SELF_CHECK_RAIL = "self_check_output"
+SELF_CHECK_PROMPT = (
+    "Should the following bot response be blocked?\n"
+    "Bot response: {{ bot_response }}\n"
+    'Answer "yes" to block and "no" to allow.'
+)
+
+MAIN_OUTPUT_WITH_PII = f"Sure thing, {PERSON} — your order ships tomorrow."
+MASKED_MAIN_OUTPUT = "Sure thing, [PERSON] — your order ships tomorrow."
+
+# Same shape as the input list: the masking rail is written last, so the run order asserted
+# below can only come from the transform-first rule.
+OUTPUT_FLOWS = [
+    "self check output",
+    "content safety check output $model=content_safety",
+    "gliner mask pii on output",
+]
+
+SELF_CHECK_ALLOWS = "no"
+SELF_CHECK_BLOCKS = "yes"
+SAFE_OUTPUT_VERDICT = json.dumps({"User Safety": "safe", "Response Safety": "safe"})
+UNSAFE_OUTPUT_VERDICT = json.dumps(
+    {"User Safety": "safe", "Response Safety": "unsafe", "Safety Categories": "S17: Malware"}
+)
+
+OUTPUT_ALL_ALLOW = {SELF_CHECK_RAIL: SELF_CHECK_ALLOWS, CONTENT_SAFETY_RAIL: SAFE_OUTPUT_VERDICT}
+OUTPUT_CONTENT_SAFETY_BLOCKS = {SELF_CHECK_RAIL: SELF_CHECK_ALLOWS, CONTENT_SAFETY_RAIL: UNSAFE_OUTPUT_VERDICT}
+
+
+def _output_pipeline_config(*, parallel: bool = False) -> dict:
+    """The three-rail output config, optionally asking for the rails to run concurrently."""
+    config = copy.deepcopy(NEMOGUARDS_CONFIG)
+    config["models"].append({"type": SELF_CHECK_RAIL, "engine": "nim", "model": "meta/llama-3.3-70b-instruct"})
+    config["prompts"].append({"task": "self_check_output", "content": SELF_CHECK_PROMPT})
+    config["rails"]["input"] = {"flows": []}
+    config["rails"]["output"] = {"flows": list(OUTPUT_FLOWS), "parallel": parallel}
+    config["rails"]["config"]["gliner"] = {
+        "server_endpoint": GLINER_URL,
+        "output": {"entities": ["person"]},
+    }
+    return config
+
+
+def _input_pipeline_config(*, parallel: bool) -> dict:
+    """The four-rail input config, asking for the rails to run concurrently."""
+    config = _pipeline_config()
+    config["rails"]["input"]["parallel"] = parallel
+    return config
+
+
+@pytest_asyncio.fixture
+async def output_pipeline_iorails():
+    """IORails with the three output rails, started and stopped around the test."""
+    async with started_iorails(_output_pipeline_config()) as engine:
+        yield engine
+
+
+@pytest.mark.asyncio
+class TestMaskingRailAheadOfJudgingOutputRails:
+    """Three output rails, the masking one configured last: it runs first and the rest read its work."""
+
+    async def test_the_masking_rail_runs_before_every_rail_that_only_judges(
+        self, output_pipeline_iorails, call_log, httpx_mock
+    ):
+        """Configured last, run first -- the output direction schedules by the same rule."""
+        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
+            content=MAIN_OUTPUT_WITH_PII
+        )
+
+        await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order == [GLINER_RAIL, SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL]
+
+    async def test_the_masking_rail_reads_the_response_as_generated(
+        self, output_pipeline_iorails, call_log, httpx_mock
+    ):
+        """Nothing precedes it, so it is the one rail that sees the model's unmasked answer."""
+        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
+            content=MAIN_OUTPUT_WITH_PII
+        )
+
+        await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.text_seen_by(GLINER_RAIL) == MAIN_OUTPUT_WITH_PII
+
+    @pytest.mark.parametrize("rail", [SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL])
+    async def test_every_rail_behind_it_waits_and_reads_the_masked_response(
+        self, output_pipeline_iorails, call_log, httpx_mock, rail
+    ):
+        """Neither could hold the masked answer unless it ran after the mask was applied.
+
+        The *response* is what an output mask rewrites; the user's own turn is untouched, and
+        both these rails are handed it as conversation context. So the assertion is that the
+        unmasked answer is gone, not that the name is gone from the prompt entirely.
+        """
+        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
+            content=MAIN_OUTPUT_WITH_PII
+        )
+
+        await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        seen = call_log.text_seen_by(rail)
+        assert MASKED_MAIN_OUTPUT in seen
+        assert MAIN_OUTPUT_WITH_PII not in seen
+
+    async def test_the_caller_reads_the_masked_response(self, output_pipeline_iorails, call_log, httpx_mock):
+        """The point of masking on output: the name never reaches whoever asked."""
+        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
+            content=MAIN_OUTPUT_WITH_PII
+        )
+
+        response = await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert response == {"role": "assistant", "content": MASKED_MAIN_OUTPUT}
+
+    async def test_a_rail_behind_the_mask_can_still_block(self, output_pipeline_iorails, call_log, httpx_mock):
+        """A rewrite ahead of a block does not rescue the response, and nothing behind it runs."""
+        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_CONTENT_SAFETY_BLOCKS).return_value = LLMResponse(
+            content=MAIN_OUTPUT_WITH_PII
+        )
+
+        response = await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert response == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        assert call_log.order == [GLINER_RAIL, SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL]
+
+
+@pytest.mark.asyncio
+class TestParallelIsRefusedWhenARailRewrites:
+    """A config asking for concurrent rails gets sequential ones, because a rewrite cannot compose.
+
+    Concurrent rails all read the text as it arrived, so the masking rail's work would reach
+    none of them. The engine says so at construction and runs them in order instead.
+    """
+
+    @pytest.mark.parametrize(
+        "config_dict, direction, flows",
+        [
+            (_input_pipeline_config(parallel=True), RailDirection.INPUT, INPUT_FLOWS),
+            (_output_pipeline_config(parallel=True), RailDirection.OUTPUT, OUTPUT_FLOWS),
+        ],
+        ids=["input", "output"],
+    )
+    async def test_the_downgrade_is_announced_and_applied(self, config_dict, direction, flows):
+        """Both parallel flags go off together, and the warning names the rail that forced it."""
+        with pytest.warns(UserWarning, match="not honored alongside a rail that rewrites"):
+            async with started_iorails(config_dict) as engine:
+                assert engine.rails_manager.input_parallel is False
+                assert engine.rails_manager.output_parallel is False
+                assert engine.rails_manager.transform_flows[direction] == (flows[-1],)
+
+    async def test_the_input_rails_still_run_masking_first(self, call_log, httpx_mock):
+        """The downgraded config behaves exactly as the sequential one, rather than merely warning."""
+        with pytest.warns(UserWarning, match="not honored"):
+            engine = IORails(RailsConfig.from_content(config=_input_pipeline_config(parallel=True)))
+
+        async with engine:
+            _wire(engine, call_log, httpx_mock, ALL_ALLOW)
+            await engine.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order[0] == GLINER_RAIL
+        assert PERSON not in call_log.text_seen_by(CONTENT_SAFETY_RAIL)
+
+    async def test_the_output_rails_still_run_masking_first(self, call_log, httpx_mock):
+        """Same for the output direction, where the rewrite is the response the caller receives."""
+        with pytest.warns(UserWarning, match="not honored"):
+            engine = IORails(RailsConfig.from_content(config=_output_pipeline_config(parallel=True)))
+
+        async with engine:
+            main = _wire(engine, call_log, httpx_mock, OUTPUT_ALL_ALLOW)
+            main.return_value = LLMResponse(content=MAIN_OUTPUT_WITH_PII)
+            response = await engine.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
+
+        assert call_log.order == [GLINER_RAIL, SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL]
+        assert response == {"role": "assistant", "content": MASKED_MAIN_OUTPUT}
+
+
+def test_a_parallel_config_without_a_rewriting_rail_keeps_its_concurrency():
+    """The downgrade is specific to rewriting rails, not a blanket ban on the parallel setting."""
+    config = copy.deepcopy(NEMOGUARDS_CONFIG)
+    config["rails"]["input"]["parallel"] = True
+
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        engine = IORails(RailsConfig.from_content(config=config))
+
+    assert engine.rails_manager.input_parallel is True

--- a/tests/guardrails/test_transform_rail_pipeline.py
+++ b/tests/guardrails/test_transform_rail_pipeline.py
@@ -15,22 +15,9 @@
 
 """A masking rail among judging rails, driven end to end through IORails.
 
-The single-rail tests prove a rewrite is applied. These prove the pipeline around it, in both
-directions and under both concurrency settings:
-
-- **input** — four rails, the masking one written *last*: it still runs first, every rail behind
-  it waits and reads the masked text, and so does the main model;
-- **output** — three rails, same shape: the masking one runs first and the caller reads the
-  masked response;
-- **parallel** — the same two configs asking for concurrent rails, which is refused with a
-  warning and run in order instead, because concurrent rails would each read the text as it
-  arrived and the mask would reach none of them;
-- **streaming** — masking applied to the batch that ships, judged after masking, and an input
-  rewrite reaching the output rails, which is where a stale conversation would leak it.
-
-Nothing is stubbed at the rail boundary -- the shipped actions run, against canned model and
-HTTP replies -- so a rail that stopped reading its conversation variable, or an ordering rule
-that stopped reordering, fails here rather than in a config.
+Covers both directions, both concurrency settings and streaming. Nothing is stubbed at the rail
+boundary -- the shipped actions run against canned model and HTTP replies -- so a rail that
+stopped reading its conversation variable fails here rather than in a config.
 """
 
 import copy
@@ -89,10 +76,7 @@ def _pipeline_config() -> dict:
 
 
 def _gliner_entities(text: str) -> list[dict]:
-    """The detection GLiNER returns for *text*, positioned where the name actually is.
-
-    Nothing when the name is absent, which is what a streamed batch carrying none of it gets.
-    """
+    """The detection GLiNER returns for *text*, or nothing when the name is absent."""
     start = text.find(PERSON)
     if start == -1:
         return []
@@ -107,11 +91,7 @@ def _gliner_entities(text: str) -> list[dict]:
 
 
 class RailCallLog:
-    """An ordered record of which rail called out, and with what text.
-
-    One log across both seams -- the model engines and the HTTP endpoints -- because the
-    question is what order the *rails* ran in, which neither seam can answer alone.
-    """
+    """An ordered record of which rail called out, and with what text, across both seams."""
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
@@ -132,12 +112,10 @@ class RailCallLog:
 
 
 def _model_double(log: RailCallLog, model_type: str, verdict: str) -> AsyncMock:
-    """Answer one model-backed rail with *verdict*, recording the prompt it was sent.
+    """Answer one model-backed rail with *verdict*, recording the whole prompt it was sent.
 
-    One double per model type rather than one shared double told apart by prompt text: each
-    rail reaches its own engine, so the engine already knows which rail is calling. The whole
-    prompt is recorded, not its first message, because the rails place the text under check at
-    different positions and which text a rail reads is what is under test.
+    The rails place the text under check at different positions, so the first message is not
+    enough.
     """
 
     async def _chat_completion(messages, **kwargs):
@@ -148,11 +126,7 @@ def _model_double(log: RailCallLog, model_type: str, verdict: str) -> AsyncMock:
 
 
 def _register_http_doubles(httpx_mock, log: RailCallLog, *, gliner_runs: bool = True) -> None:
-    """Answer the two HTTP-backed rails, recording the text each was sent.
-
-    *gliner_runs* is False for a config with no masking rail, where the callback would otherwise
-    be registered and never requested.
-    """
+    """Answer the two HTTP-backed rails, recording the text each was sent."""
 
     def _gliner(request):
         # The entities are positioned against the text this call actually carried, so a rail
@@ -234,11 +208,7 @@ class TestMaskingRailAheadOfJudgingRails:
     async def test_every_rail_behind_it_waits_and_reads_the_masked_text(
         self, pipeline_iorails, call_log, httpx_mock, rail
     ):
-        """None of the three could hold masked text unless it ran after the mask was applied.
-
-        This is the sequencing assertion as well as the threading one: a rail that started
-        alongside the masking rail would have been handed the text as it arrived.
-        """
+        """None of the three could hold masked text unless it ran after the mask was applied."""
         _wire(pipeline_iorails, call_log, httpx_mock, ALL_ALLOW)
 
         await pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
@@ -388,9 +358,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
     ):
         """Neither could hold the masked answer unless it ran after the mask was applied.
 
-        The *response* is what an output mask rewrites; the user's own turn is untouched, and
-        both these rails are handed it as conversation context. So the assertion is that the
-        unmasked answer is gone, not that the name is gone from the prompt entirely.
+        Only the response is rewritten; the user's own turn reaches them untouched.
         """
         _wire_answering(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
 
@@ -422,11 +390,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
 
 @pytest.mark.asyncio
 class TestParallelIsRefusedWhenARailRewrites:
-    """A config asking for concurrent rails gets sequential ones, because a rewrite cannot compose.
-
-    Concurrent rails all read the text as it arrived, so the masking rail's work would reach
-    none of them. The engine says so at construction and runs them in order instead.
-    """
+    """A config asking for concurrent rails gets sequential ones, because a rewrite cannot compose."""
 
     @pytest.mark.parametrize(
         "config_dict, direction, flows",

--- a/tests/guardrails/test_transform_rail_pipeline.py
+++ b/tests/guardrails/test_transform_rail_pipeline.py
@@ -24,7 +24,9 @@ directions and under both concurrency settings:
   masked response;
 - **parallel** — the same two configs asking for concurrent rails, which is refused with a
   warning and run in order instead, because concurrent rails would each read the text as it
-  arrived and the mask would reach none of them.
+  arrived and the mask would reach none of them;
+- **streaming** — masking applied to the batch that ships, judged after masking, and an input
+  rewrite reaching the output rails, which is where a stale conversation would leak it.
 
 Nothing is stubbed at the rail boundary -- the shipped actions run, against canned model and
 HTTP replies -- so a rail that stopped reading its conversation variable, or an ordering rule
@@ -42,7 +44,7 @@ import pytest_asyncio
 from nemoguardrails.guardrails.guardrails_types import RailDirection
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
-from nemoguardrails.types import LLMResponse
+from nemoguardrails.types import LLMResponse, LLMResponseChunk
 from tests.guardrails.async_helpers import JAILBREAK_NIM_URL, started_iorails
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
@@ -87,8 +89,13 @@ def _pipeline_config() -> dict:
 
 
 def _gliner_entities(text: str) -> list[dict]:
-    """The detection GLiNER returns for *text*, positioned where the name actually is."""
-    start = text.index(PERSON)
+    """The detection GLiNER returns for *text*, positioned where the name actually is.
+
+    Nothing when the name is absent, which is what a streamed batch carrying none of it gets.
+    """
+    start = text.find(PERSON)
+    if start == -1:
+        return []
     return [
         {
             "value": PERSON,
@@ -140,8 +147,12 @@ def _model_double(log: RailCallLog, model_type: str, verdict: str) -> AsyncMock:
     return AsyncMock(side_effect=_chat_completion)
 
 
-def _register_http_doubles(httpx_mock, log: RailCallLog) -> None:
-    """Answer the two HTTP-backed rails, recording the text each was sent."""
+def _register_http_doubles(httpx_mock, log: RailCallLog, *, gliner_runs: bool = True) -> None:
+    """Answer the two HTTP-backed rails, recording the text each was sent.
+
+    *gliner_runs* is False for a config with no masking rail, where the callback would otherwise
+    be registered and never requested.
+    """
 
     def _gliner(request):
         # The entities are positioned against the text this call actually carried, so a rail
@@ -154,10 +165,10 @@ def _register_http_doubles(httpx_mock, log: RailCallLog) -> None:
         log.record(JAILBREAK_RAIL, json.loads(request.content)["input"])
         return httpx.Response(200, json={"jailbreak": False, "score": 0.01})
 
-    # The masking rail always runs, so leaving its callback required makes "gliner was called"
-    # an assertion the fixture enforces. Jailbreak runs last and is skipped whenever a rail
-    # ahead of it blocks, which is a case below, so its callback is optional.
-    httpx_mock.add_callback(_gliner, url=GLINER_URL)
+    # Where the masking rail is configured, leaving its callback required makes "gliner was
+    # called" an assertion the fixture enforces. Jailbreak runs last and is skipped whenever a
+    # rail ahead of it blocks, which is a case below, so its callback is always optional.
+    httpx_mock.add_callback(_gliner, url=GLINER_URL, is_optional=not gliner_runs)
     httpx_mock.add_callback(_jailbreak, url=JAILBREAK_NIM_URL, is_optional=True)
 
 
@@ -456,3 +467,136 @@ class TestParallelIsRefusedWhenARailRewrites:
 
         assert call_log.order == [GLINER_RAIL, SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL]
         assert response == {"role": "assistant", "content": MASKED_MAIN_OUTPUT}
+
+
+STREAMED_ANSWER = f"Sure thing, {PERSON} — your order ships tomorrow."
+MASKED_STREAMED_ANSWER = "Sure thing, [PERSON] — your order ships tomorrow."
+GLINER_OUTPUT_FLOW = "gliner mask pii on output"
+CONTENT_SAFETY_OUTPUT_FLOW = "content safety check output $model=content_safety"
+
+
+def _streaming_config(flows: list[str], *, stream_first: bool = False, context_size: int = 0) -> dict:
+    """An output-rail streaming config, masking-safe by default per the settings RailsConfig requires."""
+    config = copy.deepcopy(NEMOGUARDS_CONFIG)
+    # No jailbreak flow runs in these configs, and leaving its section in warns on every one.
+    config["rails"]["config"].pop("jailbreak_detection", None)
+    config["rails"]["input"] = {"flows": []}
+    config["rails"]["output"] = {
+        "flows": flows,
+        "streaming": {
+            "enabled": True,
+            "chunk_size": 200,
+            "context_size": context_size,
+            "stream_first": stream_first,
+        },
+    }
+    config["rails"]["config"]["gliner"] = {"server_endpoint": GLINER_URL, "output": {"entities": ["person"]}}
+    return config
+
+
+async def _stream_of(text: str):
+    """A main-model stream delivering *text* in one chunk, so one batch reaches the output rails."""
+
+    async def _stream(model_type, messages, **kwargs):
+        yield LLMResponseChunk(delta_content=text)
+
+    return _stream
+
+
+async def _streamed(engine: IORails) -> str:
+    """Everything the caller received, joined."""
+    chunks = [str(chunk) async for chunk in engine.stream_async(messages=[{"role": "user", "content": USER_INPUT}])]
+    return "".join(chunks)
+
+
+@pytest.mark.asyncio
+class TestMaskingRailWhileStreaming:
+    """A masking output rail applies to what is streamed, rather than being computed and dropped."""
+
+    async def _engine(self, flows: list[str], call_log: RailCallLog, httpx_mock, verdicts: dict, **streaming):
+        engine = IORails(RailsConfig.from_content(config=_streaming_config(flows, **streaming)))
+        for model_type, rail_engine in engine.engine_registry.llms.items():
+            if model_type in verdicts:
+                rail_engine.chat_completion = _model_double(call_log, model_type, verdicts[model_type])
+        _register_http_doubles(httpx_mock, call_log, gliner_runs=GLINER_OUTPUT_FLOW in flows)
+        engine.engine_registry.stream_model_call = await _stream_of(STREAMED_ANSWER)
+        return engine
+
+    async def test_a_single_masking_rail_masks_what_is_streamed(self, call_log, httpx_mock):
+        """The one rail case: the caller reads the masked answer, never the name."""
+        engine = await self._engine([GLINER_OUTPUT_FLOW], call_log, httpx_mock, {})
+
+        async with engine:
+            streamed = await _streamed(engine)
+
+        assert MASKED_STREAMED_ANSWER in streamed
+        assert PERSON not in streamed
+
+    async def test_a_judging_rail_behind_the_mask_reads_the_masked_answer(self, call_log, httpx_mock):
+        """Masking first, judging second — the same order the non-streaming path runs them in."""
+        engine = await self._engine(
+            [CONTENT_SAFETY_OUTPUT_FLOW, GLINER_OUTPUT_FLOW], call_log, httpx_mock, OUTPUT_ALL_ALLOW
+        )
+
+        async with engine:
+            streamed = await _streamed(engine)
+
+        assert call_log.order == [GLINER_RAIL, CONTENT_SAFETY_RAIL]
+        # The response is what an output mask rewrites; the user's own turn reaches this rail as
+        # conversation context and is untouched, since no input mask is configured here.
+        assert MASKED_STREAMED_ANSWER in call_log.text_seen_by(CONTENT_SAFETY_RAIL)
+        assert STREAMED_ANSWER not in call_log.text_seen_by(CONTENT_SAFETY_RAIL)
+        assert MASKED_STREAMED_ANSWER in streamed
+
+    async def test_a_judging_rail_behind_the_mask_can_still_block(self, call_log, httpx_mock):
+        """The masked batch is judged before it ships, so a block stops it reaching the caller."""
+        engine = await self._engine(
+            [CONTENT_SAFETY_OUTPUT_FLOW, GLINER_OUTPUT_FLOW], call_log, httpx_mock, OUTPUT_CONTENT_SAFETY_BLOCKS
+        )
+
+        async with engine:
+            streamed = await _streamed(engine)
+
+        assert MASKED_STREAMED_ANSWER not in streamed
+        assert PERSON not in streamed
+        assert "content_blocked" in streamed
+
+    async def test_a_judging_rail_alone_still_streams_first(self, call_log, httpx_mock):
+        """No masking rail, so the setting that ships chunks before judging them is untouched."""
+        engine = await self._engine(
+            [CONTENT_SAFETY_OUTPUT_FLOW],
+            call_log,
+            httpx_mock,
+            OUTPUT_ALL_ALLOW,
+            stream_first=True,
+            context_size=50,
+        )
+
+        async with engine:
+            streamed = await _streamed(engine)
+
+        assert engine.config.rails.output.streaming.stream_first is True
+        assert STREAMED_ANSWER in streamed
+
+
+@pytest.mark.asyncio
+class TestInputMaskingReachesStreamingOutputRails:
+    """An input rewrite reaches the output rails, which judge the turn the model answered."""
+
+    async def test_the_output_rail_reads_the_masked_user_message(self, call_log, httpx_mock):
+        """Masking input and then handing the raw text to a vendor rail would defeat the mask."""
+        config = _streaming_config([CONTENT_SAFETY_OUTPUT_FLOW])
+        config["rails"]["input"] = {"flows": ["gliner mask pii on input"]}
+        config["rails"]["config"]["gliner"]["input"] = {"entities": ["person"]}
+        engine = IORails(RailsConfig.from_content(config=config))
+        for model_type, rail_engine in engine.engine_registry.llms.items():
+            if model_type in OUTPUT_ALL_ALLOW:
+                rail_engine.chat_completion = _model_double(call_log, model_type, OUTPUT_ALL_ALLOW[model_type])
+        _register_http_doubles(httpx_mock, call_log)
+        engine.engine_registry.stream_model_call = await _stream_of(MAIN_OUTPUT)
+
+        async with engine:
+            await _streamed(engine)
+
+        assert MASKED_INPUT in call_log.text_seen_by(CONTENT_SAFETY_RAIL)
+        assert PERSON not in call_log.text_seen_by(CONTENT_SAFETY_RAIL)

--- a/tests/guardrails/test_transform_rail_pipeline.py
+++ b/tests/guardrails/test_transform_rail_pipeline.py
@@ -173,6 +173,13 @@ async def pipeline_iorails():
         yield engine
 
 
+def _wire_answering(engine: IORails, log: RailCallLog, httpx_mock, verdicts: dict[str, str], answer: str) -> AsyncMock:
+    """Wire the rails and have the main model answer *answer*, which the output rails then judge."""
+    main = _wire(engine, log, httpx_mock, verdicts)
+    main.return_value = LLMResponse(content=answer)
+    return main
+
+
 def _wire(engine: IORails, log: RailCallLog, httpx_mock, verdicts: dict[str, str]) -> AsyncMock:
     """Attach a double per model-backed rail plus the HTTP ones, and return the main-model double."""
     for model_type, rail_engine in engine.engine_registry.llms.items():
@@ -275,19 +282,6 @@ class TestMaskingRailAheadOfJudgingRails:
         assert call_log.order == [GLINER_RAIL, CONTENT_SAFETY_RAIL]
 
 
-@pytest.mark.asyncio
-class TestMaskingRailSchedulingIsSettledAtConstruction:
-    """The engine reports the ordering and the downgrades it will apply, before any request."""
-
-    async def test_the_masking_rail_is_named_as_the_input_direction_rewriter(self, pipeline_iorails):
-        """What the engine believes about the config is what the run order above follows from."""
-        assert pipeline_iorails.rails_manager.transform_flows[RailDirection.INPUT] == ("gliner mask pii on input",)
-
-    async def test_the_configured_flow_list_keeps_its_own_order(self, pipeline_iorails):
-        """Reordering is for running the rails, not a rewrite of what the user configured."""
-        assert pipeline_iorails.rails_manager.input_flows == INPUT_FLOWS
-
-
 def test_the_four_rail_config_routes_to_iorails():
     """A config mixing a masking rail with three judging ones is servable, so the rest is reachable."""
     with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
@@ -361,9 +355,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
         self, output_pipeline_iorails, call_log, httpx_mock
     ):
         """Configured last, run first -- the output direction schedules by the same rule."""
-        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
-            content=MAIN_OUTPUT_WITH_PII
-        )
+        _wire_answering(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
 
         await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
@@ -373,9 +365,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
         self, output_pipeline_iorails, call_log, httpx_mock
     ):
         """Nothing precedes it, so it is the one rail that sees the model's unmasked answer."""
-        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
-            content=MAIN_OUTPUT_WITH_PII
-        )
+        _wire_answering(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
 
         await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
@@ -391,9 +381,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
         both these rails are handed it as conversation context. So the assertion is that the
         unmasked answer is gone, not that the name is gone from the prompt entirely.
         """
-        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
-            content=MAIN_OUTPUT_WITH_PII
-        )
+        _wire_answering(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
 
         await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
@@ -403,9 +391,7 @@ class TestMaskingRailAheadOfJudgingOutputRails:
 
     async def test_the_caller_reads_the_masked_response(self, output_pipeline_iorails, call_log, httpx_mock):
         """The point of masking on output: the name never reaches whoever asked."""
-        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW).return_value = LLMResponse(
-            content=MAIN_OUTPUT_WITH_PII
-        )
+        _wire_answering(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
 
         response = await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
@@ -413,8 +399,8 @@ class TestMaskingRailAheadOfJudgingOutputRails:
 
     async def test_a_rail_behind_the_mask_can_still_block(self, output_pipeline_iorails, call_log, httpx_mock):
         """A rewrite ahead of a block does not rescue the response, and nothing behind it runs."""
-        _wire(output_pipeline_iorails, call_log, httpx_mock, OUTPUT_CONTENT_SAFETY_BLOCKS).return_value = LLMResponse(
-            content=MAIN_OUTPUT_WITH_PII
+        _wire_answering(
+            output_pipeline_iorails, call_log, httpx_mock, OUTPUT_CONTENT_SAFETY_BLOCKS, MAIN_OUTPUT_WITH_PII
         )
 
         response = await output_pipeline_iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
@@ -465,20 +451,8 @@ class TestParallelIsRefusedWhenARailRewrites:
             engine = IORails(RailsConfig.from_content(config=_output_pipeline_config(parallel=True)))
 
         async with engine:
-            main = _wire(engine, call_log, httpx_mock, OUTPUT_ALL_ALLOW)
-            main.return_value = LLMResponse(content=MAIN_OUTPUT_WITH_PII)
+            _wire_answering(engine, call_log, httpx_mock, OUTPUT_ALL_ALLOW, MAIN_OUTPUT_WITH_PII)
             response = await engine.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
         assert call_log.order == [GLINER_RAIL, SELF_CHECK_RAIL, CONTENT_SAFETY_RAIL]
         assert response == {"role": "assistant", "content": MASKED_MAIN_OUTPUT}
-
-
-def test_a_parallel_config_without_a_rewriting_rail_keeps_its_concurrency():
-    """The downgrade is specific to rewriting rails, not a blanket ban on the parallel setting."""
-    config = copy.deepcopy(NEMOGUARDS_CONFIG)
-    config["rails"]["input"]["parallel"] = True
-
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        engine = IORails(RailsConfig.from_content(config=config))
-
-    assert engine.rails_manager.input_parallel is True

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -69,7 +69,6 @@ F5_OUTPUT_BLOCK_ASSISTANT_MESSAGE = (
 # LLMRails counterpart because pytest-recording derives the cassette filename from the test
 # name; this maps the name back to the directory that holds it.
 CASSETTE_SOURCE = {
-    "test_injection_detection_omits_sql_output": "test_injection",
     "test_content_safety_input_allows_safe_user_message": "test_content_safety",
     "test_content_safety_input_blocks_unsafe_user_message": "test_content_safety",
     "test_content_safety_output_blocks_unsafe_assistant_message": "test_content_safety",
@@ -84,10 +83,18 @@ CASSETTE_SOURCE = {
     "test_the_rail_name_drops_its_surface_parameter_on_iorails": "test_content_safety",
 }
 
+# Tests whose rail decides in-process, so no provider reply is replayed and no cassette exists.
+# Named rather than left out of ``CASSETTE_SOURCE``, so a missing entry stays an error.
+NO_CASSETTE = {"test_injection_detection_omits_sql_output"}
+
 
 @pytest.fixture
 def vcr_cassette_dir(request: pytest.FixtureRequest) -> str:
     """Point at the sibling module's cassette directory rather than this module's own."""
+    if request.node.name in NO_CASSETTE:
+        # An empty directory of its own: VCR opens nothing, and pointing at a sibling's
+        # cassettes would suggest a recording this test neither needs nor replays.
+        return str(Path(__file__).parent / "cassettes" / "no_cassette")
     source = CASSETTE_SOURCE.get(request.node.name)
     if source is None:
         raise AssertionError(f"{request.node.name!r} has no CASSETTE_SOURCE entry")

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -327,11 +327,7 @@ async def test_the_rail_name_drops_its_surface_parameter_on_iorails(nvidia_api_k
 
 
 async def test_injection_detection_omits_sql_output(rail_ran_cleanly):
-    """The sanitized output the LLMRails snapshot records is what IORails produces, byte for byte.
-
-    No cassette is replayed: injection detection decides in-process, so this is the one parity
-    case where both engines can be compared without a recorded provider reply at all.
-    """
+    """The sanitized output the LLMRails snapshot records is what IORails produces, byte for byte."""
     result = await check_iorails(
         INJECTION_OMIT_CONFIG,
         [

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -43,6 +43,7 @@ from tests.recorded.rails.library.configs import (
     CONTENT_SAFETY_INVALID_MODEL_CONFIG,
     F5_GUARDRAILS_CONFIG,
     F5_GUARDRAILS_INVALID_KEY_CONFIG,
+    INJECTION_OMIT_CONFIG,
     JAILBREAK_PROMPT,
     NIM_CONTENT_SAFETY_CONFIG,
     NIM_JAILBREAK_CONFIG,
@@ -68,6 +69,7 @@ F5_OUTPUT_BLOCK_ASSISTANT_MESSAGE = (
 # LLMRails counterpart because pytest-recording derives the cassette filename from the test
 # name; this maps the name back to the directory that holds it.
 CASSETTE_SOURCE = {
+    "test_injection_detection_omits_sql_output": "test_injection",
     "test_content_safety_input_allows_safe_user_message": "test_content_safety",
     "test_content_safety_input_blocks_unsafe_user_message": "test_content_safety",
     "test_content_safety_output_blocks_unsafe_assistant_message": "test_content_safety",
@@ -315,3 +317,23 @@ async def test_the_rail_name_drops_its_surface_parameter_on_iorails(nvidia_api_k
     assert result.content == REFUSAL
     assert result.rail == "content safety check input"
     assert "$model=" not in result.rail
+
+
+async def test_injection_detection_omits_sql_output(rail_ran_cleanly):
+    """The sanitized output the LLMRails snapshot records is what IORails produces, byte for byte.
+
+    No cassette is replayed: injection detection decides in-process, so this is the one parity
+    case where both engines can be compared without a recorded provider reply at all.
+    """
+    result = await check_iorails(
+        INJECTION_OMIT_CONFIG,
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "This is a SELECT * FROM users; -- malicious comment in text"},
+        ],
+        (RailType.OUTPUT,),
+    )
+
+    assert result.status is RailStatus.MODIFIED
+    assert result.rail is None
+    assert result.content == "This is a  * FROM usersmalicious comment in text"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -215,8 +215,7 @@ def test_a_judging_rail_keeps_stream_first():
 def test_streaming_ignores_a_flow_the_surface_parser_rejects():
     """A flow this validator cannot parse is left to the validators that own flow names.
 
-    Reached directly rather than through a config, because a config carrying such a flow is
-    refused by an earlier check and would never arrive here.
+    Called directly, because an earlier check refuses such a config before this one runs.
     """
     values = {
         "rails": {

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -122,3 +122,91 @@ def test_passthrough_and_single_call_incompatibility():
 #         LLMRails(config=config)
 #
 #     assert "You must provide a `self_check_facts` prompt" in str(exc_info.value)
+
+
+MASKING_OUTPUT_RAIL = """
+models: []
+rails:
+  config:
+    privateai:
+      server_endpoint: http://privateai.example/process
+      output:
+        entities: [NAME]
+  output:
+    flows:
+      - mask pii on output
+    streaming:
+      enabled: true
+      chunk_size: 5
+      context_size: {context_size}
+      stream_first: {stream_first}
+"""
+
+JUDGING_OUTPUT_RAIL = """
+models: []
+rails:
+  config:
+    regex_detection:
+      output:
+        patterns: ['\\d{3}-\\d{2}-\\d{4}']
+  output:
+    flows:
+      - regex check output
+    streaming:
+      enabled: true
+      chunk_size: 5
+      context_size: 50
+      stream_first: true
+"""
+
+
+@pytest.mark.parametrize(
+    "stream_first, context_size, offending",
+    [("true", 50, "stream_first"), ("false", 50, "context_size"), ("true", 0, "stream_first")],
+    ids=["stream-first", "context-window", "stream-first-with-zero-context"],
+)
+def test_streaming_refuses_a_rewrite_it_could_not_apply(stream_first, context_size, offending):
+    """A masking output rail is refused where streaming would compute the mask and ship the original."""
+    with pytest.raises(ValueError) as exc_info:
+        RailsConfig.from_content(
+            yaml_content=MASKING_OUTPUT_RAIL.format(stream_first=stream_first, context_size=context_size)
+        )
+
+    assert offending in str(exc_info.value)
+    assert "mask pii on output" in str(exc_info.value)
+
+
+def test_streaming_accepts_a_rewrite_it_can_apply():
+    """With the judged window equal to the batch being sent, the mask lands on what is still to come."""
+    config = RailsConfig.from_content(yaml_content=MASKING_OUTPUT_RAIL.format(stream_first="false", context_size=0))
+
+    assert config.rails.output.streaming.enabled is True
+    assert config.rails.output.streaming.context_size == 0
+
+
+def test_a_masking_rail_without_streaming_is_untouched():
+    """The refusal is about streaming, not about masking."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models: []
+        rails:
+          config:
+            privateai:
+              server_endpoint: http://privateai.example/process
+              output:
+                entities: [NAME]
+          output:
+            flows:
+              - mask pii on output
+        """
+    )
+
+    assert config.rails.output.flows == ["mask pii on output"]
+
+
+def test_a_judging_rail_keeps_stream_first():
+    """Nothing changes for the streaming configs that shipped before rewrites existed."""
+    config = RailsConfig.from_content(yaml_content=JUDGING_OUTPUT_RAIL)
+
+    assert config.rails.output.streaming.stream_first is True
+    assert config.rails.output.streaming.context_size == 50

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -210,3 +210,35 @@ def test_a_judging_rail_keeps_stream_first():
 
     assert config.rails.output.streaming.stream_first is True
     assert config.rails.output.streaming.context_size == 50
+
+
+def test_streaming_ignores_a_flow_the_surface_parser_rejects():
+    """A flow this validator cannot parse is left to the validators that own flow names.
+
+    Reached directly rather than through a config, because a config carrying such a flow is
+    refused by an earlier check and would never arrive here.
+    """
+    values = {
+        "rails": {
+            "output": {
+                "flows": ["$model=orphaned"],
+                "streaming": {"enabled": True, "stream_first": True},
+            }
+        }
+    }
+
+    assert RailsConfig.check_streaming_can_apply_output_rewrites(values) is values
+
+
+def test_streaming_ignores_a_flow_the_catalog_does_not_describe():
+    """A custom or Colang-defined output rail declares no transform target, so nothing is refused."""
+    values = {
+        "rails": {
+            "output": {
+                "flows": ["my custom output rail"],
+                "streaming": {"enabled": True, "stream_first": True},
+            }
+        }
+    }
+
+    assert RailsConfig.check_streaming_can_apply_output_rewrites(values) is values

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -2909,21 +2909,48 @@ async def _run_flow_iorails(case: FlowEquivalenceCase) -> dict[str, Any]:
             for engine in iorails.engine_registry._engines.values():
                 if isinstance(engine, ModelEngine):
                     engine.chat_completion = AsyncMock(return_value=LLMResponse(content=NORMAL_OUTPUT))
+            main_engine = iorails.engine_registry._engines["main"]
             response = await iorails.generate_async(messages=[{"role": "user", "content": USER_INPUT}])
 
     if not isinstance(response, dict):
         raise AssertionError(f"Unexpected IORails response type: {response!r}")
-    return response
+    return _IORailsRun(response=response, user_message_sent=_user_message_given_to(main_engine))
 
 
-def _iorails_decision(response: dict[str, Any]) -> FlowDecision:
-    """Classify an IORails reply, which renders every block as one refusal string."""
-    content = response.get("content")
-    if content == NORMAL_OUTPUT:
-        return FlowDecision.ALLOW
+@dataclass(frozen=True)
+class _IORailsRun:
+    """What one IORails run showed: the reply, and the user text the main model was given.
+
+    Two signals rather than one because a rewrite surfaces at a different end depending on the
+    direction: an output rail's shows up in the reply, an input rail's only in what the model
+    was asked. LLMRails proves the latter through ``output_data``, which IORails does not
+    produce -- so it is observed where IORails does apply it.
+    """
+
+    response: dict[str, Any]
+    user_message_sent: str
+
+
+def _user_message_given_to(engine: Any) -> str:
+    """The user text the main model read, or the request's own when it was never called."""
+    call = engine.chat_completion.call_args
+    if call is None:
+        return USER_INPUT
+    messages = call.args[0]
+    user_turns = [message for message in messages if message.get("role") == "user"]
+    return user_turns[-1]["content"] if user_turns else USER_INPUT
+
+
+def _iorails_decision(run: _IORailsRun) -> FlowDecision:
+    """Classify an IORails run, which renders every block as one refusal string."""
+    content = run.response.get("content")
     if content == REFUSAL_MESSAGE:
         return FlowDecision.BLOCK
-    return FlowDecision.TRANSFORM
+    if content != NORMAL_OUTPUT:
+        return FlowDecision.TRANSFORM
+    if run.user_message_sent != USER_INPUT:
+        return FlowDecision.TRANSFORM
+    return FlowDecision.ALLOW
 
 
 def test_every_enabled_surface_has_an_iorails_case():
@@ -2952,9 +2979,9 @@ def test_llmrails_only_fixtures_are_refused_by_the_routing_gate():
 @pytest.mark.parametrize("case", [_iorails_case_param(case) for case in IORAILS_FIXTURES])
 async def test_iorails_flow_gate_matches_rail_outcome(case: FlowEquivalenceCase):
     """IORails reaches the same allow-or-block decision as the rail's RailOutcome."""
-    response = await _run_flow_iorails(case)
+    run = await _run_flow_iorails(case)
 
-    assert _iorails_decision(response) is case.expected_decision
+    assert _iorails_decision(run) is case.expected_decision
     assert _outcome_decision(case.raw_return, case.spec) is case.expected_decision
 
 
@@ -2962,18 +2989,21 @@ def test_enable_rails_exceptions_is_honoured_only_by_llmrails():
     """A blocked rail raises an exception turn on LLMRails and returns the refusal on IORails."""
     # The flag is implemented entirely in each rail's Colang flow, which branches on
     # $config.enable_rails_exceptions to `create event <Rail>Exception`. IORails runs no Colang
-    # runtime, so it has nothing to raise and no per-rail event name to raise it under; 29 of
-    # the 42 enabled rails diverge this way. The decision agrees on both engines -- only the
-    # shape of the block differs -- so this is pinned here rather than left to the table above,
-    # where a decision-level assertion would pass without recording it.
+    # runtime, so it has nothing to raise and no per-rail event name to raise it under; 36 of
+    # the enabled cases carry the flag and diverge this way. The decision agrees on both engines
+    # -- only the shape of the block differs -- so this is pinned here rather than left to the
+    # table above, where a decision-level assertion would pass without recording it.
+    # A rail that rewrites is the one place the decision itself could diverge, because some flows
+    # branch on the flag to block instead: no fixture pairs the two, and the gap is recorded as a
+    # known cross-engine delta rather than closed here.
     case = next(case for case in IORAILS_FIXTURES if case.case_id == "self_check_input_blocks_outcome_block_exception")
 
     # asyncio.run rather than an async test: _run_flow drives LLMRails through the sync
     # generate(), which refuses to run inside an already-running loop.
     llmrails_response, _ = _run_flow(case)
-    iorails_response = asyncio.run(_run_flow_iorails(case))
+    iorails_run = asyncio.run(_run_flow_iorails(case))
 
     assert llmrails_response["role"] == "exception"
-    assert iorails_response == {"role": "assistant", "content": REFUSAL_MESSAGE}
+    assert iorails_run.response == {"role": "assistant", "content": REFUSAL_MESSAGE}
     assert _decision_from_observable(case.expected_observable) is FlowDecision.BLOCK
-    assert _iorails_decision(iorails_response) is FlowDecision.BLOCK
+    assert _iorails_decision(iorails_run) is FlowDecision.BLOCK

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -2921,10 +2921,7 @@ async def _run_flow_iorails(case: FlowEquivalenceCase) -> "_IORailsRun":
 class _IORailsRun:
     """What one IORails run showed: the reply, and the user text the main model was given.
 
-    Two signals rather than one because a rewrite surfaces at a different end depending on the
-    direction: an output rail's shows up in the reply, an input rail's only in what the model
-    was asked. LLMRails proves the latter through ``output_data``, which IORails does not
-    produce -- so it is observed where IORails does apply it.
+    Two signals, because an input rewrite shows up only in what the model was asked.
     """
 
     response: dict[str, Any]
@@ -2993,9 +2990,8 @@ def test_enable_rails_exceptions_is_honoured_only_by_llmrails():
     # the enabled cases carry the flag and diverge this way. The decision agrees on both engines
     # -- only the shape of the block differs -- so this is pinned here rather than left to the
     # table above, where a decision-level assertion would pass without recording it.
-    # A rail that rewrites is the one place the decision itself could diverge, because some flows
-    # branch on the flag to block instead: no fixture pairs the two, and the gap is recorded as a
-    # known cross-engine delta rather than closed here.
+    # A rewriting rail is the one place the decision could diverge, since some flows branch on
+    # the flag to block instead; no fixture pairs the two, and that gap is a known delta.
     case = next(case for case in IORAILS_FIXTURES if case.case_id == "self_check_input_blocks_outcome_block_exception")
 
     # asyncio.run rather than an async test: _run_flow drives LLMRails through the sync

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -2887,7 +2887,7 @@ class _StubAction:
         return self._raw_return
 
 
-async def _run_flow_iorails(case: FlowEquivalenceCase) -> dict[str, Any]:
+async def _run_flow_iorails(case: FlowEquivalenceCase) -> "_IORailsRun":
     """Drive one case through IORails, stubbing the rail's action at its manifest target.
 
     IORails resolves actions through ``resolve_import_ref`` at compile time, which


### PR DESCRIPTION
## Description

This PR enables all transform rails in Guardrails to run under IORails. It

This PR is part of a stack shown below, but isn't implemented using Github's stacks feature since all preceeding PRs are already merged to develop.

PR 1 https://github.com/NVIDIA-NeMo/Guardrails/pull/2241
PR 2 https://github.com/NVIDIA-NeMo/Guardrails/pull/2246
PR 3a https://github.com/NVIDIA-NeMo/Guardrails/pull/2253
PR 3b https://github.com/NVIDIA-NeMo/Guardrails/pull/2261 . Builds on the https://github.com/NVIDIA-NeMo/Guardrails/pull/2253 and migrates from RailAction subclasses to CompiledRail implementations for all currently-supported actions.
PR 4 https://github.com/NVIDIA-NeMo/Guardrails/pull/2264 enable the 49 block-only input/output surfaces via catalog-derived gating
PR 4.5 https://github.com/NVIDIA-NeMo/Guardrails/pull/2286 Use RailOutcome instead of RailResult
PR 5 **THIS PR** #2288


## Related Issue(s)

* [NGUARD-821](https://jirasw.nvidia.com/browse/NGUARD-821)

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/iorails-transform-actions
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7078 items]

ssss.................................................................... [  1%]
.........................ssssssss....................................... [  2%]
........................................................................ [  3%]
............................................ss..s...s................... [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
...............s........................................................ [  9%]
........................................................................ [ 10%]
...........................s..s......................................... [ 11%]
.......................s................................................ [ 12%]
........................................................................ [ 13%]
.......................................................s................ [ 14%]
................................s....s.................................. [ 15%]
........................................................................ [ 16%]
...............ss.ssss.s..........................s..................... [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
.......................s................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
.................................s...................................... [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.....................................................ssss.ssss.......... [ 31%]
............s..ss.s.s.s........s.s...s.................................. [ 32%]
.....ss.ss..ssss........................................................ [ 33%]
........................................................................ [ 34%]
........................................................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
.sssss..........ssssssssssss.ssssss..................................... [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
........sssss........................................................... [ 43%]
........................................................................ [ 44%]
......................................s................................. [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
........................................................................ [ 48%]
........................................................................ [ 49%]
.........s.s.s.ss....................................................... [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
...s.s.ss............................................................... [ 53%]
.................................................s...................... [ 54%]
.s.sssssssssssss......................s................................. [ 55%]
........................................................................ [ 56%]
.....................sssssss............................................ [ 57%]
....sss..s.ss..............................................sss.......... [ 58%]
................................................ss....................ss [ 60%]
........................................................................ [ 61%]
..........sssssssssssss................................................. [ 62%]
........................................................................ [ 63%]
.........................................s......................s....... [ 64%]
...............................................s........................ [ 65%]
........................................................................ [ 66%]
..ss.................................................................... [ 67%]
.s...................................................................... [ 68%]
....................................ss.................................. [ 69%]
......................ss....................s........................... [ 70%]
....................................s................................... [ 71%]
........................................................................ [ 72%]
........................................................................ [ 73%]
........................................................................ [ 74%]
........................................................................ [ 75%]
.....................................sssssssss.ssssssssss............... [ 76%]
.....................s.................................................. [ 77%]
.s...................................................................... [ 78%]
........................................................................ [ 79%]
.......................................s................................ [ 80%]
........................................................................ [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
..........................ssssss.ss.s................................... [ 84%]
....s................................................................... [ 85%]
........................................................................ [ 86%]
.....s..........................................ss...................... [ 87%]
.................................................................s.s.sss [ 88%]
s....................................................................... [ 89%]
...................................................s.................sss [ 90%]
s....................................................ss................. [ 91%]
.....ss................................................................. [ 92%]
........................................................................ [ 93%]
........................................................................ [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
.....sss................................................................ [ 97%]
........................................................................ [ 98%]
.........s.............................................................. [ 99%]
......................                                                   [100%]

════════════════════════════════════════════════════════════════════ inline-snapshot ════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x 
and inline-snapshot will not be able to fix snapshots or generate reports.


====================== 6867 passed, 211 skipped in 39.40s ======================

```


### Integration test with Chat (check for regressions, no transforms applied here)

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config examples/configs/nemoguards
2026-08-13 12:14:21 INFO: Registered model engine: type=main, model=nvidia/nemotron-3.5-lightning-30b-a3b, base_url=https://integrate.api.nvidia.com
2026-08-13 12:14:21 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-08-13 12:14:21 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-08-13 12:14:21 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-08-13 12:14:23 INFO: [316654278d97232f] generate_async called
2026-08-13 12:14:23 INFO: [316654278d97232f] Running tool result rails
2026-08-13 12:14:23 INFO: [316654278d97232f] Running input rails
2026-08-13 12:14:23 INFO: [316654278d97232f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-13 12:14:24 INFO: [316654278d97232f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-08-13 12:14:24 INFO: [316654278d97232f] Calling main LLM
2026-08-13 12:14:24 INFO: [316654278d97232f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-lightning-30b-a3b'
2026-08-13 12:14:25 INFO: [316654278d97232f] Running output rails
2026-08-13 12:14:25 INFO: [316654278d97232f] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-13 12:14:26 INFO: [316654278d97232f] generate_async completed time=2469.6ms
<think>Here's a thinking process:

1.  **Analyze User Input**: The user said "Hello!"
2.  **Identify Intent**: Simple greeting, wants a response
3.  **Determine Appropriate Response**: Friendly greeting, offer help
4.  **Formulate Response**: Say hello back, ask how I can help
5.  **Check Constraints**: No specific constraints mentioned, just a greeting
6.  **Final Output Generation**: Keep it concise and friendly.✅
</think>
Hello! How can I help you today?

> How can I blow up a car?
2026-08-13 12:14:31 INFO: [976250d58f153d5a] generate_async called
2026-08-13 12:14:31 INFO: [976250d58f153d5a] Running tool result rails
2026-08-13 12:14:31 INFO: [976250d58f153d5a] Running input rails
2026-08-13 12:14:31 INFO: [976250d58f153d5a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-08-13 12:14:31 INFO: [976250d58f153d5a] Input flow content safety check input $model=content_safety blocked
2026-08-13 12:14:31 INFO: [976250d58f153d5a] Input blocked: policy_violations: Guns and Illegal Weapons, Criminal Planning/Confessions
2026-08-13 12:14:31 INFO: [976250d58f153d5a] generate_async completed time=478.8ms
I'm sorry, I can't respond to that.
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input and output guardrails can now rewrite user prompts and assistant responses.
  * Rewritten content is passed through subsequent checks and generation while preserving the caller’s original messages.
  * Guardrail results now clearly indicate when content was modified.
  * Sensitive metadata fields are excluded from caller-facing evidence and logs.

* **Behavior Changes**
  * Input transformations disable speculative generation to ensure rewritten prompts are used.
  * Transforming rails run sequentially and take precedence over other rails.
  * Streaming responses report output rewrites but do not alter chunks already delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->