### PR TITLE
draft(iorails): Support per-tool input and output rails

### DIFF
--- a/nemoguardrails/guardrails/actions/per_tool_check_action.py
+++ b/nemoguardrails/guardrails/actions/per_tool_check_action.py
@@ -84,10 +84,12 @@ class PerToolCheckAction(RailAction):
         tool_result: Optional[str] = None,
     ) -> RailResult:
         """Evaluate a tool call or result against the named prompt task."""
+        # Clear model-call data left by an earlier rail on the same async task.
         _rail_llm_call_var.set(None)
         with action_span(self._tracer, self.action_name) as span:
             req_id = get_request_id()
 
+            # Resolve the prompt task and optional model from the configured flow.
             _, params = parse_configured_surface(flow)
             check_name = params.get("check")
             if not check_name:
@@ -102,6 +104,7 @@ class PerToolCheckAction(RailAction):
             if tool_call is not None:
                 tool_call_json = json.dumps(tool_call.to_dict())
 
+            # Expose the current tool traffic and user message to the prompt.
             user_message = self._last_user_content_or_empty(messages)
 
             context: dict[str, Any] = {
@@ -120,6 +123,7 @@ class PerToolCheckAction(RailAction):
             prompt_messages = self._prompt_to_messages(prompt)
             log.debug("[%s] check tool call: task=%s model=%s", req_id, check_name, model_type)
 
+            # Run the policy model and convert its final verdict into a rail result.
             try:
                 response = await self._get_llm_response(model_type, prompt_messages)
                 text = (response.content or "").strip()

--- a/nemoguardrails/guardrails/actions/per_tool_check_action.py
+++ b/nemoguardrails/guardrails/actions/per_tool_check_action.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from typing import Any, Optional
+
+from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailResult, get_request_id
+from nemoguardrails.guardrails.rail_action import RailAction, _rail_llm_call_var
+from nemoguardrails.guardrails.telemetry import action_span, record_span_error
+from nemoguardrails.llm.clients._errors import _redact_secrets
+from nemoguardrails.manifests.surface_reference import parse_configured_surface
+from nemoguardrails.types import ToolCall
+
+log = logging.getLogger(__name__)
+
+
+def _parse_verdict(text: str) -> bool:
+    """Return True (safe/ALLOW) if last non-empty line is ALLOW; False (block) for BLOCK.
+
+    Strips trailing punctuation and whitespace before comparing so responses
+    like "BLOCK." or "ALLOW " are handled correctly. Fails closed: returns
+    False when no clear verdict is found.
+    """
+    for line in reversed(text.strip().splitlines()):
+        token = line.strip().rstrip(".!: ").upper()
+        if token == "ALLOW":
+            return True
+        if token == "BLOCK":
+            return False
+    return False
+
+
+class PerToolCheckAction(RailAction):
+    """LLM-based per-tool policy check for IORails.
+
+    Evaluates a single tool call or tool result against a named prompt task.
+    Flow name format: ``check tool call $check=<task_name>`` with optional
+    ``$model=<model_type>`` (defaults to ``"main"``).
+    """
+
+    action_name = "check tool call"
+    fallback_model = "main"
+    requires_model = False
+
+    def _extract_messages(self, messages: LLMMessages, bot_response: Optional[str]) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _create_prompt(self, model_type: Optional[str], extracted: dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+    async def _get_response(self, model_type: Optional[str], prompt: Any) -> Any:
+        raise NotImplementedError
+
+    def _parse_response(self, response: Any) -> RailResult:
+        text = (response or "").strip()
+        is_safe = _parse_verdict(text)
+        if is_safe:
+            return RailResult(is_safe=True)
+        return RailResult(is_safe=False, reason=f"check tool call blocked: {text}")
+
+    # run() is overridden directly because the base class signature does not
+    # support per-tool kwargs (tool_call, tool_name, tool_result); the four
+    # abstract pipeline methods are unused stubs.
+    async def run(
+        self,
+        flow: str,
+        messages: LLMMessages,
+        bot_response: Optional[str] = None,
+        *,
+        tool_call: Optional[ToolCall] = None,
+        tool_name: Optional[str] = None,
+        tool_result: Optional[str] = None,
+    ) -> RailResult:
+        """Evaluate a tool call or result against the named prompt task."""
+        _rail_llm_call_var.set(None)
+        with action_span(self._tracer, self.action_name) as span:
+            req_id = get_request_id()
+
+            _, params = parse_configured_surface(flow)
+            check_name = params.get("check")
+            if not check_name:
+                return RailResult(
+                    is_safe=False,
+                    reason=f"'check tool call' requires a $check= parameter in flow '{flow}'",
+                )
+
+            model_type = params.get("model") or self.fallback_model
+
+            tool_call_json = ""
+            if tool_call is not None:
+                tool_call_json = json.dumps(tool_call.to_dict())
+
+            user_message = self._last_user_content_or_empty(messages)
+
+            context: dict[str, Any] = {
+                "tool_call": tool_call_json,
+                "tool_name": tool_name or "",
+                "tool_result": tool_result or "",
+                "user_message": user_message,
+            }
+
+            try:
+                prompt = self.task_manager.render_task_prompt(task=check_name, context=context)
+            except Exception as e:
+                log.error("[%s] check tool call: prompt render failed for task '%s': %s", req_id, check_name, e)
+                return RailResult(is_safe=False, reason=_redact_secrets(f"prompt render error: {e}"))
+
+            prompt_messages = self._prompt_to_messages(prompt)
+            log.debug("[%s] check tool call: task=%s model=%s", req_id, check_name, model_type)
+
+            try:
+                response = await self._get_llm_response(model_type, prompt_messages)
+                text = (response.content or "").strip()
+                log.debug("[%s] check tool call: response=%r", req_id, text)
+                return self._parse_response(text)
+            except Exception as e:
+                record_span_error(span, e)
+                log.error("[%s] check tool call failed: %s", req_id, e)
+                return RailResult(is_safe=False, reason=_redact_secrets(f"check tool call error: {e}"))

--- a/nemoguardrails/guardrails/actions/per_tool_check_action.py
+++ b/nemoguardrails/guardrails/actions/per_tool_check_action.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, Optional
 
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailResult, get_request_id
+from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.rail_action import RailAction, _rail_llm_call_var
 from nemoguardrails.guardrails.telemetry import action_span, record_span_error
 from nemoguardrails.llm.clients._errors import _redact_secrets
@@ -34,13 +35,11 @@ def _parse_verdict(text: str) -> bool:
     like "BLOCK." or "ALLOW " are handled correctly. Fails closed: returns
     False when no clear verdict is found.
     """
-    for line in reversed(text.strip().splitlines()):
-        token = line.strip().rstrip(".!: ").upper()
-        if token == "ALLOW":
-            return True
-        if token == "BLOCK":
-            return False
-    return False
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return False
+    token = lines[-1].rstrip(".!: ").upper()
+    return token == "ALLOW"
 
 
 class PerToolCheckAction(RailAction):
@@ -126,6 +125,13 @@ class PerToolCheckAction(RailAction):
                 text = (response.content or "").strip()
                 log.debug("[%s] check tool call: response=%r", req_id, text)
                 return self._parse_response(text)
+            except ModelEngineError as e:
+                record_span_error(span, e)
+                if e.status is not None:
+                    log.error("[%s] check tool call failed (HTTP %d): %s", req_id, e.status, e)
+                    raise
+                log.error("[%s] check tool call failed: %s", req_id, e)
+                return RailResult(is_safe=False, reason=_redact_secrets(f"check tool call error: {e}"))
             except Exception as e:
                 record_span_error(span, e)
                 log.error("[%s] check tool call failed: %s", req_id, e)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -535,8 +535,8 @@ class IORails(BaseGuardrails):
     # tool-call validator and tool_input only the tool-result validator. The
     # supported sets double as the direction check so a misdirected flow falls
     # back to LLMRails rather than raising in RailsManager at construction.
-    SUPPORTED_TOOL_OUTPUT_FLOWS = frozenset({"tool call validation"})
-    SUPPORTED_TOOL_INPUT_FLOWS = frozenset({"tool result validation"})
+    SUPPORTED_TOOL_OUTPUT_FLOWS = frozenset({"tool call validation", "check tool call"})
+    SUPPORTED_TOOL_INPUT_FLOWS = frozenset({"tool result validation", "check tool call"})
 
     @classmethod
     def unsupported_reason(cls, config: RailsConfig, llm: Optional[LLMModel] = None) -> Optional[str]:
@@ -576,6 +576,17 @@ class IORails(BaseGuardrails):
             reason = _duplicate_flows_reason(tool_flows, label)
             if reason is not None:
                 return reason
+
+        # Validate per_tool flow names against the supported LLM tool action set.
+
+        for label, per_tool, supported in (
+            ("tool output", config.rails.tool_output.per_tool, cls.SUPPORTED_TOOL_OUTPUT_FLOWS),
+            ("tool input", config.rails.tool_input.per_tool, cls.SUPPORTED_TOOL_INPUT_FLOWS),
+        ):
+            for tool_name, flows in per_tool.items():
+                reason = _unsupported_flows_reason(flows, supported, f"{label} per_tool[{tool_name!r}]")
+                if reason is not None:
+                    return reason
 
         return None
 
@@ -623,6 +634,8 @@ class IORails(BaseGuardrails):
             output_parallel=config.rails.output.parallel or False,
             tool_call_flows=config.rails.tool_output.flows,
             tool_result_flows=config.rails.tool_input.flows,
+            per_tool_output=dict(config.rails.tool_output.per_tool),
+            per_tool_input=dict(config.rails.tool_input.per_tool),
             tracer=self._tracer,
             content_capture_enabled=self._content_capture_enabled,
         )
@@ -932,7 +945,7 @@ class IORails(BaseGuardrails):
         # Symmetric with OUTPUT rails
         if response.tool_calls:
             tool_call = await self.rails_manager.are_tool_calls_safe(
-                response.tool_calls, llm_kwargs, enabled=tool_output_enabled
+                response.tool_calls, llm_kwargs, enabled=tool_output_enabled, messages=list(messages)
             )
             records.extend(tool_call.records)
             if not tool_call.is_safe:
@@ -1543,7 +1556,10 @@ class IORails(BaseGuardrails):
                                     if accumulated_tool_calls and not error_emitted:
                                         # ToolCallRail checks tool calls from the main LLM (OUTPUT)
                                         tool_call = await self.rails_manager.are_tool_calls_safe(
-                                            accumulated_tool_calls, llm_kwargs, enabled=tool_output_enabled
+                                            accumulated_tool_calls,
+                                            llm_kwargs,
+                                            enabled=tool_output_enabled,
+                                            messages=list(messages),
                                         )
                                         if not tool_call.is_safe:
                                             log.info(

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from nemoguardrails.actions.llm.utils import _extract_and_remove_think_tags
 from nemoguardrails.base_guardrails import BaseGuardrails
-from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.exceptions import InvalidRailsConfigurationError, StreamingNotSupportedError
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import (
@@ -68,6 +68,7 @@ from nemoguardrails.llm.clients._errors import (
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.manifests.surface_reference import parse_configured_surface
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
@@ -535,12 +536,40 @@ class IORails(BaseGuardrails):
     # tool-call validator and tool_input only the tool-result validator. The
     # supported sets double as the direction check so a misdirected flow falls
     # back to LLMRails rather than raising in RailsManager at construction.
-    SUPPORTED_TOOL_OUTPUT_FLOWS = frozenset({"tool call validation", "check tool call"})
-    SUPPORTED_TOOL_INPUT_FLOWS = frozenset({"tool result validation", "check tool call"})
+    SUPPORTED_TOOL_OUTPUT_FLOWS = frozenset({"tool call validation"})
+    SUPPORTED_TOOL_INPUT_FLOWS = frozenset({"tool result validation"})
+    SUPPORTED_PER_TOOL_FLOWS = frozenset({"check tool call"})
+
+    @classmethod
+    def _validate_per_tool_flows(cls, config: RailsConfig) -> None:
+        for label, per_tool in (
+            ("tool output", config.rails.tool_output.per_tool),
+            ("tool input", config.rails.tool_input.per_tool),
+        ):
+            for tool_name, flows in per_tool.items():
+                for flow in flows:
+                    try:
+                        action_name, params = parse_configured_surface(flow)
+                    except ValueError as exc:
+                        raise InvalidRailsConfigurationError(
+                            f"Invalid {label} per_tool[{tool_name!r}] flow {flow!r}: {exc}"
+                        ) from exc
+                    if action_name not in cls.SUPPORTED_PER_TOOL_FLOWS:
+                        available = sorted(cls.SUPPORTED_PER_TOOL_FLOWS)
+                        raise InvalidRailsConfigurationError(
+                            f"Unsupported {label} per_tool[{tool_name!r}] action {action_name!r}. "
+                            f"Available: {available}"
+                        )
+                    if not params.get("check"):
+                        raise InvalidRailsConfigurationError(
+                            f"{label} per_tool[{tool_name!r}] flow {flow!r} requires a $check= parameter"
+                        )
 
     @classmethod
     def unsupported_reason(cls, config: RailsConfig, llm: Optional[LLMModel] = None) -> Optional[str]:
         """Return None if IORails can handle (config, llm), else a human-readable reason."""
+        cls._validate_per_tool_flows(config)
+
         if llm is not None:
             return "an `llm` argument was provided; IORails does not accept a custom LLM"
 
@@ -576,17 +605,6 @@ class IORails(BaseGuardrails):
             reason = _duplicate_flows_reason(tool_flows, label)
             if reason is not None:
                 return reason
-
-        # Validate per_tool flow names against the supported LLM tool action set.
-
-        for label, per_tool, supported in (
-            ("tool output", config.rails.tool_output.per_tool, cls.SUPPORTED_TOOL_OUTPUT_FLOWS),
-            ("tool input", config.rails.tool_input.per_tool, cls.SUPPORTED_TOOL_INPUT_FLOWS),
-        ):
-            for tool_name, flows in per_tool.items():
-                reason = _unsupported_flows_reason(flows, supported, f"{label} per_tool[{tool_name!r}]")
-                if reason is not None:
-                    return reason
 
         return None
 

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -46,7 +46,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.rail_action import RailAction, RailLLMCall, get_and_clear_rail_llm_call_contextvar
 from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span, set_rail_content
 from nemoguardrails.guardrails.tool_rail_action import ToolRailAction
-from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
+from nemoguardrails.guardrails.tool_schema import ToolExchange, ToolResult, Toolset
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
 from nemoguardrails.types import ToolCall
@@ -311,6 +311,12 @@ class RailsManager:
             return RailResult(is_safe=True)
 
         active = self._enabled_flows(list(self._tool_call_actions), enabled)
+        active_per_tool = {
+            tool_name: self._enabled_flows(flows, enabled) for tool_name, flows in self.per_tool_output.items()
+        }
+        if not active and not any(active_per_tool.values()):
+            return RailResult(is_safe=True)
+
         if active:
             try:
                 toolset = self.engine_registry.parse_tools(model_type, llm_params)
@@ -325,14 +331,14 @@ class RailsManager:
         else:
             result = RailResult(is_safe=True)
 
-        if not self.per_tool_output:
+        if not any(active_per_tool.values()):
             return result
 
         collected = list(result.records)
         conv_messages = messages or []
         for tc in tool_calls:
             tool_name = tc.function.name or tc.type or ""
-            flows = self.per_tool_output.get(tool_name, [])
+            flows = active_per_tool.get(tool_name, [])
             for flow in flows:
                 per_result = await self._run_per_tool_check_rail(
                     flow, conv_messages, tool_call=tc, tool_name=tool_name, direction=RailDirection.OUTPUT
@@ -365,37 +371,37 @@ class RailsManager:
         per-tool LLM checks run after the global structural validators pass.
         """
         active = self._enabled_flows(list(self._tool_result_actions), enabled)
-        has_results = False
+        active_per_tool = {
+            tool_name: self._enabled_flows(flows, enabled) for tool_name, flows in self.per_tool_input.items()
+        }
+        if not active and not any(active_per_tool.values()):
+            return RailResult(is_safe=True)
+
         collected: list[RailCallRecord] = []
 
+        try:
+            exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
+        except Exception as e:
+            log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
+            return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
+
+        if not any(exchange.results for exchange in exchanges):
+            return RailResult(is_safe=True)
+
         if active:
-            try:
-                exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
-            except Exception as e:
-                log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
-                return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
-            has_results = any(exchange.results for exchange in exchanges)
-            if has_results:
-                rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
-                result = await self._run_rails_sequential(rails, RailDirection.INPUT)
-                collected.extend(result.records)
-                if not result.is_safe:
-                    return result
+            rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
+            result = await self._run_rails_sequential(rails, RailDirection.INPUT)
+            collected.extend(result.records)
+            if not result.is_safe:
+                return result
 
-        if not self.per_tool_input:
+        if not any(active_per_tool.values()):
             return RailResult(is_safe=True, records=tuple(collected))
-
-        if not active:
-            try:
-                exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
-            except Exception as e:
-                log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
-                return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
 
         for exchange in exchanges:
             for tool_result in exchange.results:
-                tool_name = tool_result.name or ""
-                flows = self.per_tool_input.get(tool_name, [])
+                tool_name = self._resolve_tool_result_name(exchange, tool_result)
+                flows = active_per_tool.get(tool_name, [])
                 for flow in flows:
                     per_result = await self._run_per_tool_check_rail(
                         flow,
@@ -414,6 +420,15 @@ class RailsManager:
                         )
 
         return RailResult(is_safe=True, records=tuple(collected))
+
+    @staticmethod
+    def _resolve_tool_result_name(exchange: ToolExchange, tool_result: ToolResult) -> str:
+        if tool_result.name:
+            return tool_result.name
+        matching_calls = [call for call in exchange.calls if call.id == tool_result.call_id]
+        if len(matching_calls) == 1:
+            return matching_calls[0].function.name
+        return ""
 
     @staticmethod
     def _enabled_flows(configured: list[str], enabled: Union[bool, list[str]]) -> list[str]:

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -32,6 +32,7 @@ from nemoguardrails.guardrails.actions.content_safety_action import (
     ContentSafetyOutputAction,
 )
 from nemoguardrails.guardrails.actions.jailbreak_detection_action import JailbreakDetectionAction
+from nemoguardrails.guardrails.actions.per_tool_check_action import PerToolCheckAction
 from nemoguardrails.guardrails.actions.tool_call_action import ToolCallRailAction
 from nemoguardrails.guardrails.actions.tool_result_action import ToolResultRailAction
 from nemoguardrails.guardrails.actions.topic_safety_action import TopicSafetyInputAction
@@ -75,6 +76,12 @@ _TOOL_ACTION_CLASSES: dict[str, type[ToolRailAction]] = {
         ToolCallRailAction,
         ToolResultRailAction,
     ]
+}
+
+# LLM-based per-tool check actions. Registered separately because they require
+# engine_registry and task_manager at construction (unlike model-free ToolRailAction).
+_LLM_TOOL_ACTION_CLASSES: dict[str, type[PerToolCheckAction]] = {
+    PerToolCheckAction.action_name: PerToolCheckAction,
 }
 
 _ToolActionT = TypeVar("_ToolActionT", bound=ToolRailAction)
@@ -132,6 +139,8 @@ class RailsManager:
         output_parallel: bool = False,
         tool_call_flows: Optional[list[str]] = None,
         tool_result_flows: Optional[list[str]] = None,
+        per_tool_output: Optional[dict[str, list[str]]] = None,
+        per_tool_input: Optional[dict[str, list[str]]] = None,
         tracer: Optional["Tracer"] = None,
         content_capture_enabled: bool = False,
     ) -> None:
@@ -159,6 +168,8 @@ class RailsManager:
 
         self.tool_call_flows: list[str] = list(tool_call_flows or [])
         self.tool_result_flows: list[str] = list(tool_result_flows or [])
+        self.per_tool_output: dict[str, list[str]] = dict(per_tool_output or {})
+        self.per_tool_input: dict[str, list[str]] = dict(per_tool_input or {})
 
         # Build action instances for each configured flow
         self._actions: dict[str, RailAction] = {}
@@ -171,13 +182,20 @@ class RailsManager:
         self._tool_call_actions = self._build_tool_actions(self.tool_call_flows, ToolCallRailAction)
         self._tool_result_actions = self._build_tool_actions(self.tool_result_flows, ToolResultRailAction)
 
+        # Per-tool LLM check actions, keyed by flow string
+        self._per_tool_check_actions: dict[str, PerToolCheckAction] = self._build_per_tool_check_actions(
+            self.per_tool_output, self.per_tool_input
+        )
+
         log.info(
             "RailsManager initialized: input_flows=%s, output_flows=%s, tool_call_flows=%s, "
-            "tool_result_flows=%s, input_parallel=%s, output_parallel=%s",
+            "tool_result_flows=%s, per_tool_output=%s, per_tool_input=%s, input_parallel=%s, output_parallel=%s",
             self.input_flows,
             self.output_flows,
             self.tool_call_flows,
             self.tool_result_flows,
+            list(self.per_tool_output),
+            list(self.per_tool_input),
             self.input_parallel,
             self.output_parallel,
         )
@@ -189,6 +207,29 @@ class RailsManager:
             available = sorted(_ACTION_CLASSES.keys())
             raise RuntimeError(f"Rail flow '{base_name}' not supported. Available: {available}")
         return action_cls(self.engine_registry, self.task_manager, tracer=self._tracer)
+
+    def _build_per_tool_check_actions(
+        self,
+        per_tool_output: dict[str, list[str]],
+        per_tool_input: dict[str, list[str]],
+    ) -> dict[str, PerToolCheckAction]:
+        """Instantiate a PerToolCheckAction for every unique flow string across per_tool configs."""
+        actions: dict[str, PerToolCheckAction] = {}
+        all_flows = [f for flows in per_tool_output.values() for f in flows]
+        all_flows += [f for flows in per_tool_input.values() for f in flows]
+        for flow in all_flows:
+            if flow not in actions:
+                base_name = _get_flow_name(flow) or flow
+                action_cls = _LLM_TOOL_ACTION_CLASSES.get(base_name)
+                if action_cls is None:
+                    available = sorted(_LLM_TOOL_ACTION_CLASSES.keys())
+                    raise RuntimeError(
+                        f"Per-tool flow '{base_name}' is not a supported LLM-based check action. "
+                        f"'per_tool' only supports LLM-based checks; structural validators such as "
+                        f"'tool call validation' belong in 'flows'. Available: {available}"
+                    )
+                actions[flow] = action_cls(self.engine_registry, self.task_manager, tracer=self._tracer)
+        return actions
 
     def _build_tool_actions(self, flows: list[str], expected_cls: type[_ToolActionT]) -> dict[str, _ToolActionT]:
         """Instantiate the tool rails for *flows*, checking each resolves to *expected_cls*.
@@ -257,24 +298,55 @@ class RailsManager:
         *,
         enabled: Union[bool, list[str]] = True,
         model_type: str = "main",
+        messages: Optional[list[dict]] = None,
     ) -> RailResult:
         """Validate the model's emitted tool calls (OUTPUT-direction tool rail).
 
         The tool-call counterpart to :meth:`is_output_safe`: takes the model's output
         (``tool_calls``) plus the request's declared tools (``llm_params``) and returns
-        a ``RailResult``.
+        a ``RailResult``. When ``per_tool_output`` is configured, per-tool LLM checks
+        run after the global structural validators pass.
         """
-        active = self._enabled_flows(list(self._tool_call_actions), enabled)
-        if not active or not tool_calls:
+        if not tool_calls:
             return RailResult(is_safe=True)
-        try:
-            toolset = self.engine_registry.parse_tools(model_type, llm_params)
-        except Exception as e:
-            log.warning("[%s] tool parsing failed; blocking tool calls: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"tool parsing failed: {e}")
 
-        rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in active}
-        return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
+        active = self._enabled_flows(list(self._tool_call_actions), enabled)
+        if active:
+            try:
+                toolset = self.engine_registry.parse_tools(model_type, llm_params)
+            except Exception as e:
+                log.warning("[%s] tool parsing failed; blocking tool calls: %s", get_request_id(), e)
+                return RailResult(is_safe=False, reason=f"tool parsing failed: {e}")
+
+            rails = {flow: self._run_tool_call_rail(flow, tool_calls, toolset) for flow in active}
+            result = await self._run_rails_sequential(rails, RailDirection.OUTPUT)
+            if not result.is_safe:
+                return result
+        else:
+            result = RailResult(is_safe=True)
+
+        if not self.per_tool_output:
+            return result
+
+        collected = list(result.records)
+        conv_messages = messages or []
+        for tc in tool_calls:
+            tool_name = tc.function.name or tc.type or ""
+            flows = self.per_tool_output.get(tool_name, [])
+            for flow in flows:
+                per_result = await self._run_per_tool_check_rail(
+                    flow, conv_messages, tool_call=tc, tool_name=tool_name, direction=RailDirection.OUTPUT
+                )
+                collected.extend(per_result.records)
+                if not per_result.is_safe:
+                    return RailResult(
+                        is_safe=False,
+                        reason=per_result.reason,
+                        triggered_rail=per_result.triggered_rail,
+                        records=tuple(collected),
+                    )
+
+        return RailResult(is_safe=True, records=tuple(collected))
 
     async def are_tool_results_safe(
         self,
@@ -289,21 +361,59 @@ class RailsManager:
         ``messages`` and returns a ``RailResult``. Groups the conversation into per-turn
         ``(calls, results)`` exchanges via the engine adapter and validates each result
         against its own turn's calls, so call ids reused across turns (spec-allowed) are
-        not flagged as ambiguous duplicates.
+        not flagged as ambiguous duplicates. When ``per_tool_input`` is configured,
+        per-tool LLM checks run after the global structural validators pass.
         """
         active = self._enabled_flows(list(self._tool_result_actions), enabled)
-        if not active:
-            return RailResult(is_safe=True)
-        try:
-            exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
-        except Exception as e:
-            log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
-            return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
-        if not any(exchange.results for exchange in exchanges):
-            return RailResult(is_safe=True)
+        has_results = False
+        collected: list[RailCallRecord] = []
 
-        rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
-        return await self._run_rails_sequential(rails, RailDirection.INPUT)
+        if active:
+            try:
+                exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
+            except Exception as e:
+                log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
+                return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
+            has_results = any(exchange.results for exchange in exchanges)
+            if has_results:
+                rails = {flow: self._run_tool_result_rail(flow, exchanges) for flow in active}
+                result = await self._run_rails_sequential(rails, RailDirection.INPUT)
+                collected.extend(result.records)
+                if not result.is_safe:
+                    return result
+
+        if not self.per_tool_input:
+            return RailResult(is_safe=True, records=tuple(collected))
+
+        if not active:
+            try:
+                exchanges = self.engine_registry.extract_tool_exchanges(model_type, messages)
+            except Exception as e:
+                log.warning("[%s] tool exchange extraction failed; blocking: %s", get_request_id(), e)
+                return RailResult(is_safe=False, reason=f"tool exchange extraction failed: {e}")
+
+        for exchange in exchanges:
+            for tool_result in exchange.results:
+                tool_name = tool_result.name or ""
+                flows = self.per_tool_input.get(tool_name, [])
+                for flow in flows:
+                    per_result = await self._run_per_tool_check_rail(
+                        flow,
+                        messages,
+                        tool_name=tool_name,
+                        tool_result=str(tool_result.content or ""),
+                        direction=RailDirection.INPUT,
+                    )
+                    collected.extend(per_result.records)
+                    if not per_result.is_safe:
+                        return RailResult(
+                            is_safe=False,
+                            reason=per_result.reason,
+                            triggered_rail=per_result.triggered_rail,
+                            records=tuple(collected),
+                        )
+
+        return RailResult(is_safe=True, records=tuple(collected))
 
     @staticmethod
     def _enabled_flows(configured: list[str], enabled: Union[bool, list[str]]) -> list[str]:
@@ -398,6 +508,40 @@ class RailsManager:
                             {"call_id": r.call_id, "name": r.name, "is_error": r.is_error} for r in all_results
                         ]
                     },
+                    reason=result.reason if not result.is_safe else None,
+                )
+            return result
+
+    async def _run_per_tool_check_rail(
+        self,
+        flow: str,
+        messages: list[dict],
+        *,
+        tool_call: Optional[ToolCall] = None,
+        tool_name: Optional[str] = None,
+        tool_result: Optional[str] = None,
+        direction: RailDirection,
+    ) -> RailResult:
+        """Dispatch a per-tool LLM check action for a single tool call or result."""
+        rail_type = "tool_output" if direction == RailDirection.OUTPUT else "tool_input"
+        with rail_span(self._tracer, flow, direction) as span:
+            action = self._per_tool_check_actions[flow]
+            result = await action.run(
+                flow,
+                messages,
+                tool_call=tool_call,
+                tool_name=tool_name,
+                tool_result=tool_result,
+            )
+            call = get_and_clear_rail_llm_call_contextvar()
+            if not result.is_safe and result.triggered_rail is None:
+                result = replace(result, triggered_rail=_get_flow_name(flow) or flow)
+            result = replace(result, records=(_rail_call_record(flow, rail_type, result, call),))
+            mark_rail_stop(span, result.is_safe)
+            if self._content_capture_enabled:
+                set_rail_content(
+                    span,
+                    {"tool_call": tool_call.to_dict() if tool_call else None, "tool_result": tool_result},
                     reason=result.reason if not result.is_safe else None,
                 )
             return result

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -448,6 +448,10 @@ class ToolOutputRails(BaseModel):
         default_factory=list,
         description="The names of all the flows that implement tool output rails.",
     )
+    per_tool: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description="Per-tool rail flows, mapping a tool name to an ordered list of flow names.",
+    )
     parallel: Optional[bool] = Field(
         default=False,
         description="If True, the tool output rails are executed in parallel.",
@@ -464,6 +468,10 @@ class ToolInputRails(BaseModel):
     flows: List[str] = Field(
         default_factory=list,
         description="The names of all the flows that implement tool input rails.",
+    )
+    per_tool: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description="Per-tool rail flows, mapping a tool name to an ordered list of flow names.",
     )
     parallel: Optional[bool] = Field(
         default=False,

--- a/tests/test_per_tool_iorails.py
+++ b/tests/test_per_tool_iorails.py
@@ -19,7 +19,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from nemoguardrails import Guardrails
+from nemoguardrails.exceptions import InvalidRailsConfigurationError
+from nemoguardrails.guardrails.actions.per_tool_check_action import _parse_verdict
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
+from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.guardrails.tool_schema import Tool, Toolset
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -99,6 +104,7 @@ async def test_per_tool_output_matching_tool_blocked():
     result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
 
     assert not result.is_safe
+    assert result.reason is not None
     assert "block" in result.reason.lower()
 
 
@@ -168,12 +174,16 @@ async def test_per_tool_output_global_flows_still_run():
         per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]},
     )
     mgr = _make_manager(config)
-    mgr.engine_registry.parse_tools = lambda *_: Toolset(
-        [Tool(name="run_sql", arguments_schema={"type": "object", "properties": {"query": {"type": "string"}}})]
-    )
     mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ALLOW"))
 
-    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+    with patch.object(
+        mgr.engine_registry,
+        "parse_tools",
+        return_value=Toolset(
+            [Tool(name="run_sql", arguments_schema={"type": "object", "properties": {"query": {"type": "string"}}})]
+        ),
+    ):
+        result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
 
     assert result.is_safe
     assert len(result.records) == 2
@@ -195,11 +205,118 @@ async def test_per_tool_input_matching_tool_blocked():
         },
         {"role": "tool", "tool_call_id": "call_1", "name": "run_sql", "content": "sensitive data"},
     ]
-    mgr.engine_registry.extract_tool_exchanges = mgr.engine_registry.extract_tool_exchanges
 
     result = await mgr.are_tool_results_safe(messages)
 
     assert not result.is_safe
+
+
+@pytest.mark.asyncio
+async def test_per_tool_input_resolves_missing_name_from_prior_call():
+    config = _make_config(per_tool_input={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+    messages = [
+        {"role": "user", "content": "Run a query"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "run_sql", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "sensitive data"},
+    ]
+
+    result = await mgr.are_tool_results_safe(messages)
+
+    assert not result.is_safe
+    mgr.engine_registry.model_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["output", "input"])
+async def test_disabled_boundary_skips_per_tool_checks(boundary):
+    flow = f"check tool call $check={_PROMPT_TASK}"
+    config = _make_config(
+        per_tool_output={"run_sql": [flow]} if boundary == "output" else None,
+        per_tool_input={"run_sql": [flow]} if boundary == "input" else None,
+    )
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    if boundary == "output":
+        result = await mgr.are_tool_calls_safe([_sql_call()], {}, enabled=False, messages=MESSAGES)
+    else:
+        result = await mgr.are_tool_results_safe(
+            [
+                {"role": "user", "content": "Run a query"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "call_1", "type": "function", "function": {"name": "run_sql", "arguments": "{}"}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "name": "run_sql", "content": "sensitive data"},
+            ],
+            enabled=False,
+        )
+
+    assert result.is_safe
+    mgr.engine_registry.model_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enabled_list_filters_per_tool_checks():
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    result = await mgr.are_tool_calls_safe(
+        [_sql_call()],
+        {},
+        enabled=["tool call validation"],
+        messages=MESSAGES,
+    )
+
+    assert result.is_safe
+    mgr.engine_registry.model_call.assert_not_called()
+
+
+def test_invalid_per_tool_action_raises_configuration_error():
+    config = _make_config(per_tool_output={"run_sql": ["typo tool check"]})
+
+    with pytest.raises(InvalidRailsConfigurationError, match="typo tool check"):
+        Guardrails(config)
+
+
+def test_structural_validator_in_per_tool_raises_configuration_error():
+    config = _make_config(per_tool_output={"run_sql": ["tool call validation"]})
+
+    with pytest.raises(InvalidRailsConfigurationError, match="tool call validation"):
+        IORails.unsupported_reason(config)
+
+
+def test_global_check_action_routes_away_from_iorails():
+    config = _make_config(flows=[f"check tool call $check={_PROMPT_TASK}"])
+
+    assert IORails.unsupported_reason(config) is not None
+
+
+def test_parse_verdict_requires_verdict_on_final_non_empty_line():
+    assert _parse_verdict("Reasoning\nALLOW")
+    assert not _parse_verdict("ALLOW\nUncertain")
+
+
+@pytest.mark.asyncio
+async def test_per_tool_provider_http_error_propagates():
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(
+        side_effect=ModelEngineError("unauthorized", model_name="gpt-4o", status=401)
+    )
+
+    with pytest.raises(ModelEngineError, match="unauthorized"):
+        await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
 
 
 @pytest.mark.asyncio
@@ -260,8 +377,7 @@ async def test_per_tool_model_override():
         captured_model_types.append(model_type)
         return LLMResponse(content="ALLOW")
 
-    mgr.engine_registry.model_call = _capture
-
-    await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+    with patch.object(mgr.engine_registry, "model_call", side_effect=_capture):
+        await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
 
     assert captured_model_types == ["safety_classifier"]

--- a/tests/test_per_tool_iorails.py
+++ b/tests/test_per_tool_iorails.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for per-tool LLM-based rails on IORails (PerToolCheckAction + RailsManager wiring)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nemoguardrails.guardrails.engine_registry import EngineRegistry
+from nemoguardrails.guardrails.rails_manager import RailsManager
+from nemoguardrails.guardrails.tool_schema import Tool, Toolset
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.types import LLMResponse, ToolCall, ToolCallFunction
+
+MESSAGES = [{"role": "user", "content": "Run a SQL query"}]
+
+_BASE_CONFIG = {
+    "models": [{"type": "main", "engine": "openai", "model": "gpt-4o"}],
+}
+
+_PROMPT_TASK = "blocked_tables"
+_PROMPT_YAML = f"""
+prompts:
+  - task: {_PROMPT_TASK}
+    content: |
+      Block if SQL reads from users or payments.
+      Tool call: {{{{ tool_call }}}}
+      Respond with ALLOW or BLOCK on the last line.
+"""
+
+
+def _make_config(per_tool_output=None, per_tool_input=None, flows=None):
+    rails: dict = {}
+    if per_tool_output is not None or flows is not None:
+        rails["tool_output"] = {}
+        if per_tool_output is not None:
+            rails["tool_output"]["per_tool"] = per_tool_output
+        if flows is not None:
+            rails["tool_output"]["flows"] = flows
+    if per_tool_input is not None:
+        rails["tool_input"] = {"per_tool": per_tool_input}
+    cfg = {**_BASE_CONFIG}
+    if rails:
+        cfg["rails"] = rails
+    return RailsConfig.from_content(yaml_content=_PROMPT_YAML, config=cfg)
+
+
+def _make_manager(config: RailsConfig) -> RailsManager:
+    registry = EngineRegistry(config.models, config.rails.config)
+    return RailsManager(
+        engine_registry=registry,
+        task_manager=LLMTaskManager(config),
+        input_flows=config.rails.input.flows,
+        output_flows=config.rails.output.flows,
+        tool_call_flows=config.rails.tool_output.flows,
+        tool_result_flows=config.rails.tool_input.flows,
+        per_tool_output=dict(config.rails.tool_output.per_tool),
+        per_tool_input=dict(config.rails.tool_input.per_tool),
+    )
+
+
+def _sql_call(query: str = "SELECT * FROM users") -> ToolCall:
+    return ToolCall(
+        id="call_1",
+        type="function",
+        function=ToolCallFunction(name="run_sql", arguments={"query": query}),
+    )
+
+
+def _other_call() -> ToolCall:
+    return ToolCall(
+        id="call_2",
+        type="function",
+        function=ToolCallFunction(name="list_tables", arguments={}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_matching_tool_blocked():
+    """Matching tool triggers the check and BLOCK verdict blocks the call."""
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+    assert "block" in result.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_matching_tool_allowed():
+    """Matching tool with ALLOW verdict passes through."""
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ALLOW"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert result.is_safe
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_non_matching_tool_passes():
+    """Tool not in per_tool skips the check and passes."""
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    result = await mgr.are_tool_calls_safe([_other_call()], {}, messages=MESSAGES)
+
+    assert result.is_safe
+    mgr.engine_registry.model_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_multiple_checks_first_blocks():
+    """First BLOCK in a two-check sequence stops evaluation."""
+    config = _make_config(
+        per_tool_output={
+            "run_sql": [
+                f"check tool call $check={_PROMPT_TASK}",
+                f"check tool call $check={_PROMPT_TASK}",
+            ]
+        }
+    )
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+    mgr.engine_registry.model_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_only_config_no_global_flows():
+    """per_tool-only config (no global flows) works correctly."""
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    assert mgr.tool_call_flows == []
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+
+
+@pytest.mark.asyncio
+async def test_per_tool_output_global_flows_still_run():
+    """Global tool_call_validation flow runs before per-tool check."""
+    config = _make_config(
+        flows=["tool call validation"],
+        per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]},
+    )
+    mgr = _make_manager(config)
+    mgr.engine_registry.parse_tools = lambda *_: Toolset(
+        [Tool(name="run_sql", arguments_schema={"type": "object", "properties": {"query": {"type": "string"}}})]
+    )
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ALLOW"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert result.is_safe
+    assert len(result.records) == 2
+
+
+@pytest.mark.asyncio
+async def test_per_tool_input_matching_tool_blocked():
+    """per_tool_input check blocks a matching tool result."""
+    config = _make_config(per_tool_input={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="BLOCK"))
+
+    messages = [
+        {"role": "user", "content": "Run a query"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "run_sql", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "run_sql", "content": "sensitive data"},
+    ]
+    mgr.engine_registry.extract_tool_exchanges = mgr.engine_registry.extract_tool_exchanges
+
+    result = await mgr.are_tool_results_safe(messages)
+
+    assert not result.is_safe
+
+
+@pytest.mark.asyncio
+async def test_per_tool_missing_check_param():
+    """Flow string without $check= fails closed without calling the model."""
+    config = _make_config(per_tool_output={"run_sql": ["check tool call"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ALLOW"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+    mgr.engine_registry.model_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_per_tool_unknown_prompt_task():
+    """Missing prompt task fails closed without crashing."""
+    config = _make_config(per_tool_output={"run_sql": ["check tool call $check=nonexistent_task"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="ALLOW"))
+
+    with patch.object(
+        mgr._per_tool_check_actions["check tool call $check=nonexistent_task"].task_manager,
+        "render_task_prompt",
+        side_effect=Exception("task not found"),
+    ):
+        result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+    mgr.engine_registry.model_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_per_tool_model_call_failure():
+    """Model call failure fails closed."""
+    config = _make_config(per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK}"]})
+    mgr = _make_manager(config)
+    mgr.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("connection timeout"))
+
+    result = await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert not result.is_safe
+    assert result.reason is not None
+
+
+@pytest.mark.asyncio
+async def test_per_tool_model_override():
+    """$model= override is passed to the model call instead of 'main'."""
+    config = _make_config(
+        per_tool_output={"run_sql": [f"check tool call $check={_PROMPT_TASK} $model=safety_classifier"]}
+    )
+    mgr = _make_manager(config)
+
+    captured_model_types: list[str] = []
+
+    async def _capture(model_type, messages, **kwargs):
+        captured_model_types.append(model_type)
+        return LLMResponse(content="ALLOW")
+
+    mgr.engine_registry.model_call = _capture
+
+    await mgr.are_tool_calls_safe([_sql_call()], {}, messages=MESSAGES)
+
+    assert captured_model_types == ["safety_classifier"]


### PR DESCRIPTION
## Summary

Adds initial IORails support for applying LLM-based guardrails to specific tool calls and tool results.

`per_tool` lives under the existing `rails.tool_output` and `rails.tool_input` sections. These map to `config.rails.tool_output.per_tool` and `config.rails.tool_input.per_tool` on `RailsConfig`.

```yaml
models:
  - type: main
    engine: nim
    model: meta/llama-3.1-70b-instruct

rails:
  tool_output:
    flows:
      - tool call validation
    per_tool:
      run_sql:
        - check tool call $check=blocked_tables
      export_data:
        - check tool call $check=external_export $model=main

  tool_input:
    flows:
      - tool result validation
    per_tool:
      run_sql:
        - check tool call $check=sensitive_result

prompts:
  - task: blocked_tables
    content: |-
      Block SQL that reads from protected tables.
      Tool call: {{ tool_call }}
      Respond with ALLOW or BLOCK on the final line.

  - task: external_export
    content: |-
      Block exports to external destinations.
      Tool call: {{ tool_call }}
      Respond with ALLOW or BLOCK on the final line.

  - task: sensitive_result
    content: |-
      Block tool results containing sensitive data.
      Tool result: {{ tool_result }}
      Respond with ALLOW or BLOCK on the final line.
```

## What's included

- Per-tool configuration for both tool boundaries
- Prompt-based `check tool call` action
- Sequential block-if-any execution
- Composition with existing structural tool rails
- Request-level enable/disable and filtering
- Configuration validation
- Tool-name recovery from `tool_call_id`
- Fail-closed verdict handling
- Focused unit and regression tests

## Remaining work
- [ ] Ensure flows can be run in parallel (i.e. Implement `parallel: true`)
- [ ] Add `tool_name` to generation-log records
- [ ] Refactor of `PerToolCheckAction` to use the standard `RailAction` pipeline so per-tool context can reuse shared tracing, model selection, call recording, and error handling instead of duplicating that logic in a custom `run()`.
- [ ] [Tests] Add top-level streaming and non-streaming integration tests
- [ ] [Validation] Decide whether prompt and model references require load-time validation
- [ ] [Validation] Define behavior when configuration forces fallback to LLMRails
- [ ] [Docs] Add user-facing documentation and examples
- [ ] Any additional changes requested in the RFC