### PR TITLE
fix(hf-classifier): preserve HTTP retry instrumentation

### DIFF
--- a/nemoguardrails/http/composition.py
+++ b/nemoguardrails/http/composition.py
@@ -45,8 +45,8 @@ def ensure_retrying_http_client(client: HTTPClient, policy: RetryPolicy) -> Clos
     if retrying_client is None:
         retrying_client = RetryingHTTPClient(wrapped_client, policy)
     else:
-        retrying_client = retrying_client.with_wrapped_client(wrapped_client)
+        retrying_client = retrying_client._with_wrapped_client(wrapped_client)
 
     if instrumented_client is None:
         return retrying_client
-    return instrumented_client.with_wrapped_client(retrying_client)
+    return instrumented_client._with_wrapped_client(retrying_client)

--- a/nemoguardrails/http/composition.py
+++ b/nemoguardrails/http/composition.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composition helpers for transport-neutral HTTP clients."""
+
+from nemoguardrails.http.client import ClosableHTTPClient, HTTPClient
+from nemoguardrails.http.instrumented import InstrumentedHTTPClient
+from nemoguardrails.http.retry import RetryingHTTPClient, RetryPolicy
+
+
+def ensure_retrying_http_client(client: HTTPClient, policy: RetryPolicy) -> ClosableHTTPClient:
+    """Apply retry inside instrumentation without compounding known wrappers.
+
+    Existing retry and instrumentation settings take precedence over the
+    fallback retry policy. Multiple retry or instrumentation layers are
+    rejected because their precedence is ambiguous.
+    """
+    instrumented_client: InstrumentedHTTPClient | None = None
+    retrying_client: RetryingHTTPClient | None = None
+    wrapped_client = client
+
+    while isinstance(wrapped_client, (InstrumentedHTTPClient, RetryingHTTPClient)):
+        if isinstance(wrapped_client, InstrumentedHTTPClient):
+            if instrumented_client is not None:
+                raise ValueError("HTTP client has multiple instrumentation layers")
+            instrumented_client = wrapped_client
+        else:
+            if retrying_client is not None:
+                raise ValueError("HTTP client has multiple retry layers")
+            retrying_client = wrapped_client
+        wrapped_client = wrapped_client.wrapped_client
+
+    if retrying_client is None:
+        retrying_client = RetryingHTTPClient(wrapped_client, policy)
+    else:
+        retrying_client = retrying_client.with_wrapped_client(wrapped_client)
+
+    if instrumented_client is None:
+        return retrying_client
+    return instrumented_client.with_wrapped_client(retrying_client)

--- a/nemoguardrails/http/instrumented.py
+++ b/nemoguardrails/http/instrumented.py
@@ -71,6 +71,18 @@ class InstrumentedHTTPClient:
         """Return the underlying client for direct access or re-instrumentation."""
         return self._client
 
+    def with_wrapped_client(self, client: HTTPClient) -> "InstrumentedHTTPClient":
+        """Apply the current instrumentation settings to another client."""
+        if isinstance(client, InstrumentedHTTPClient):
+            client = client.wrapped_client
+        if client is self._client:
+            return self
+        return InstrumentedHTTPClient(
+            client,
+            self._tracer,
+            metrics_enabled=self._metrics_enabled,
+        )
+
     async def request(
         self,
         method: str,

--- a/nemoguardrails/http/instrumented.py
+++ b/nemoguardrails/http/instrumented.py
@@ -71,10 +71,10 @@ class InstrumentedHTTPClient:
         """Return the underlying client for direct access or re-instrumentation."""
         return self._client
 
-    def with_wrapped_client(self, client: HTTPClient) -> "InstrumentedHTTPClient":
+    def _with_wrapped_client(self, client: HTTPClient) -> "InstrumentedHTTPClient":
         """Apply the current instrumentation settings to another client."""
         if isinstance(client, InstrumentedHTTPClient):
-            client = client.wrapped_client
+            raise ValueError("Replacement HTTP client is already instrumented")
         if client is self._client:
             return self
         return InstrumentedHTTPClient(

--- a/nemoguardrails/http/retry.py
+++ b/nemoguardrails/http/retry.py
@@ -147,6 +147,23 @@ class RetryingHTTPClient:
         self._now = now or (lambda: datetime.now(timezone.utc))
         self._closed = False
 
+    @property
+    def wrapped_client(self) -> HTTPClient:
+        """Return the underlying client."""
+        return self._client
+
+    def with_wrapped_client(self, client: HTTPClient) -> "RetryingHTTPClient":
+        """Apply the current retry settings to another client."""
+        if client is self._client:
+            return self
+        return RetryingHTTPClient(
+            client,
+            self._policy,
+            sleep=self._sleep,
+            random_value=self._random_value,
+            now=self._now,
+        )
+
     async def request(
         self,
         method: str,

--- a/nemoguardrails/http/retry.py
+++ b/nemoguardrails/http/retry.py
@@ -152,7 +152,7 @@ class RetryingHTTPClient:
         """Return the underlying client."""
         return self._client
 
-    def with_wrapped_client(self, client: HTTPClient) -> "RetryingHTTPClient":
+    def _with_wrapped_client(self, client: HTTPClient) -> "RetryingHTTPClient":
         """Apply the current retry settings to another client."""
         if client is self._client:
             return self

--- a/nemoguardrails/library/hf_classifier/backends.py
+++ b/nemoguardrails/library/hf_classifier/backends.py
@@ -29,6 +29,7 @@ from nemoguardrails.http import (
     HTTPClient,
     HTTPResponse,
     HTTPTLSConfig,
+    InstrumentedHTTPClient,
     RetryingHTTPClient,
     RetryPolicy,
     create_http_client,
@@ -313,6 +314,15 @@ class _RemoteBackend(ClassifierBackend):
 
     @staticmethod
     def _retrying_http_client(client: HTTPClient) -> HTTPClient:
+        if isinstance(client, RetryingHTTPClient):
+            if isinstance(client.wrapped_client, InstrumentedHTTPClient):
+                instrumented_client = client.wrapped_client
+                retrying_client = client.with_wrapped_client(instrumented_client.wrapped_client)
+                return instrumented_client.with_wrapped_client(retrying_client)
+            return client
+        if isinstance(client, InstrumentedHTTPClient):
+            retrying_client = _RemoteBackend._retrying_http_client(client.wrapped_client)
+            return client.with_wrapped_client(retrying_client)
         return RetryingHTTPClient(client, _HF_RETRY_POLICY)
 
     def _create_http_client(self) -> HTTPClient:

--- a/nemoguardrails/library/hf_classifier/backends.py
+++ b/nemoguardrails/library/hf_classifier/backends.py
@@ -29,12 +29,11 @@ from nemoguardrails.http import (
     HTTPClient,
     HTTPResponse,
     HTTPTLSConfig,
-    InstrumentedHTTPClient,
-    RetryingHTTPClient,
     RetryPolicy,
     create_http_client,
     http_call,
 )
+from nemoguardrails.http.composition import ensure_retrying_http_client
 
 if TYPE_CHECKING:
     from nemoguardrails.rails.llm.config import (
@@ -314,16 +313,7 @@ class _RemoteBackend(ClassifierBackend):
 
     @staticmethod
     def _retrying_http_client(client: HTTPClient) -> HTTPClient:
-        if isinstance(client, RetryingHTTPClient):
-            if isinstance(client.wrapped_client, InstrumentedHTTPClient):
-                instrumented_client = client.wrapped_client
-                retrying_client = client.with_wrapped_client(instrumented_client.wrapped_client)
-                return instrumented_client.with_wrapped_client(retrying_client)
-            return client
-        if isinstance(client, InstrumentedHTTPClient):
-            retrying_client = _RemoteBackend._retrying_http_client(client.wrapped_client)
-            return client.with_wrapped_client(retrying_client)
-        return RetryingHTTPClient(client, _HF_RETRY_POLICY)
+        return ensure_retrying_http_client(client, _HF_RETRY_POLICY)
 
     def _create_http_client(self) -> HTTPClient:
         return self._retrying_http_client(

--- a/tests/http/test_composition.py
+++ b/tests/http/test_composition.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.http.composition import ensure_retrying_http_client
+from nemoguardrails.http.instrumented import InstrumentedHTTPClient
+from nemoguardrails.http.retry import RetryingHTTPClient, RetryPolicy
+from nemoguardrails.http.types import HTTPResponse
+from nemoguardrails.testing.http import RecordingHTTPClient
+
+
+def test_retry_composition_wraps_transport():
+    transport = RecordingHTTPClient()
+
+    client = ensure_retrying_http_client(transport, RetryPolicy())
+
+    assert isinstance(client, RetryingHTTPClient)
+    assert client.wrapped_client is transport
+
+
+def test_retry_composition_places_retry_inside_instrumentation():
+    transport = RecordingHTTPClient()
+    instrumented = InstrumentedHTTPClient(transport, None)
+
+    client = ensure_retrying_http_client(instrumented, RetryPolicy())
+
+    assert isinstance(client, InstrumentedHTTPClient)
+    assert isinstance(client.wrapped_client, RetryingHTTPClient)
+    assert client.wrapped_client.wrapped_client is transport
+
+
+def test_retry_composition_preserves_canonical_client():
+    retrying = RetryingHTTPClient(RecordingHTTPClient())
+    instrumented = InstrumentedHTTPClient(retrying, None)
+
+    client = ensure_retrying_http_client(instrumented, RetryPolicy())
+
+    assert client is instrumented
+
+
+@pytest.mark.asyncio
+async def test_retry_composition_normalizes_reverse_order_and_preserves_policy():
+    transport = RecordingHTTPClient(
+        [
+            HTTPResponse(status_code=503),
+            HTTPResponse(status_code=503),
+            HTTPResponse(status_code=200),
+        ]
+    )
+    delays: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        delays.append(delay)
+
+    retrying = RetryingHTTPClient(
+        InstrumentedHTTPClient(transport, None),
+        RetryPolicy(max_attempts=2, initial_delay=0.25, max_delay=0.25),
+        sleep=sleep,
+        random_value=lambda: 1.0,
+    )
+
+    client = ensure_retrying_http_client(
+        retrying,
+        RetryPolicy(max_attempts=3, initial_delay=1.0, max_delay=1.0),
+    )
+    response = await client.request("GET", "https://example.com/check")
+
+    assert isinstance(client, InstrumentedHTTPClient)
+    assert isinstance(client.wrapped_client, RetryingHTTPClient)
+    assert client.wrapped_client.wrapped_client is transport
+    assert response.status_code == 503
+    assert len(transport.requests) == 2
+    assert delays == [0.25]
+
+
+def test_retry_composition_rejects_multiple_retry_layers():
+    transport = RecordingHTTPClient()
+    client = RetryingHTTPClient(RetryingHTTPClient(transport))
+
+    with pytest.raises(ValueError, match="multiple retry layers"):
+        ensure_retrying_http_client(client, RetryPolicy())

--- a/tests/http/test_instrumentation.py
+++ b/tests/http/test_instrumentation.py
@@ -140,27 +140,28 @@ async def test_instrumented_client_creates_one_observation_for_all_retry_attempt
 @pytest.mark.asyncio
 async def test_instrumented_client_can_replace_wrapped_client(otel, metric_reader):
     tracer, exporter = otel
-    replacement_exporter = InMemorySpanExporter()
-    replacement_provider = TracerProvider()
-    replacement_provider.add_span_processor(SimpleSpanProcessor(replacement_exporter))
     original = RecordingHTTPClient()
     replacement_transport = RecordingHTTPClient([HTTPResponse(status_code=200)])
-    replacement = InstrumentedHTTPClient(
-        replacement_transport,
-        replacement_provider.get_tracer("replacement"),
-    )
     client = InstrumentedHTTPClient(original, tracer, metrics_enabled=True)
 
-    recomposed = client.with_wrapped_client(replacement)
+    recomposed = client._with_wrapped_client(replacement_transport)
     await recomposed.request("GET", "https://example.com/check")
 
     assert recomposed is not client
-    assert recomposed is not replacement
     assert recomposed.wrapped_client is replacement_transport
     assert original.requests == []
     assert len(exporter.get_finished_spans()) == 1
-    assert replacement_exporter.get_finished_spans() == ()
     assert len(collect_metric_points(metric_reader)["http.client.request.duration"]) == 1
+
+
+def test_instrumented_client_rejects_instrumented_replacement(otel):
+    tracer, _ = otel
+    replacement_tracer = TracerProvider().get_tracer("replacement")
+    original = InstrumentedHTTPClient(RecordingHTTPClient(), tracer, metrics_enabled=True)
+    replacement = InstrumentedHTTPClient(RecordingHTTPClient(), replacement_tracer)
+
+    with pytest.raises(ValueError, match="already instrumented"):
+        original._with_wrapped_client(replacement)
 
 
 @pytest.mark.asyncio

--- a/tests/http/test_instrumentation.py
+++ b/tests/http/test_instrumentation.py
@@ -138,6 +138,32 @@ async def test_instrumented_client_creates_one_observation_for_all_retry_attempt
 
 
 @pytest.mark.asyncio
+async def test_instrumented_client_can_replace_wrapped_client(otel, metric_reader):
+    tracer, exporter = otel
+    replacement_exporter = InMemorySpanExporter()
+    replacement_provider = TracerProvider()
+    replacement_provider.add_span_processor(SimpleSpanProcessor(replacement_exporter))
+    original = RecordingHTTPClient()
+    replacement_transport = RecordingHTTPClient([HTTPResponse(status_code=200)])
+    replacement = InstrumentedHTTPClient(
+        replacement_transport,
+        replacement_provider.get_tracer("replacement"),
+    )
+    client = InstrumentedHTTPClient(original, tracer, metrics_enabled=True)
+
+    recomposed = client.with_wrapped_client(replacement)
+    await recomposed.request("GET", "https://example.com/check")
+
+    assert recomposed is not client
+    assert recomposed is not replacement
+    assert recomposed.wrapped_client is replacement_transport
+    assert original.requests == []
+    assert len(exporter.get_finished_spans()) == 1
+    assert replacement_exporter.get_finished_spans() == ()
+    assert len(collect_metric_points(metric_reader)["http.client.request.duration"]) == 1
+
+
+@pytest.mark.asyncio
 async def test_instrumented_client_records_status_errors(otel):
     tracer, exporter = otel
     client = InstrumentedHTTPClient(RecordingHTTPClient([HTTPResponse(status_code=503)]), tracer)

--- a/tests/test_hf_classifier.py
+++ b/tests/test_hf_classifier.py
@@ -26,11 +26,21 @@ from unittest import mock
 
 import httpx
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import TypeAdapter, ValidationError
 from pytest_httpx import HTTPXMock
 
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
-from nemoguardrails.http import HTTPConnectionError, HTTPResponse, HTTPTimeoutError
+from nemoguardrails.http import (
+    HTTPConnectionError,
+    HTTPResponse,
+    HTTPTimeoutError,
+    InstrumentedHTTPClient,
+    RetryingHTTPClient,
+    RetryPolicy,
+)
 from nemoguardrails.library.hf_classifier import backends as backends_mod
 from nemoguardrails.library.hf_classifier.actions import (
     _classify_and_check,
@@ -103,6 +113,14 @@ def _clear_caches():
     backends_mod._ssl_cache.clear()
     backends_mod._warned_env_vars.clear()
     backends_mod._backend_instances.clear()
+
+
+@pytest.fixture
+def http_otel():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("test"), exporter
 
 
 class TestConfig:
@@ -331,6 +349,106 @@ class TestVLLMBackend:
 
         assert result == [ClassificationResult(label="safe", score=0.95)]
         assert len(client.requests) == 2
+
+    @pytest.mark.asyncio
+    async def test_injected_instrumented_client_observes_all_retry_attempts(self, http_otel):
+        tracer, exporter = http_otel
+        transport = RecordingHTTPClient(
+            [
+                HTTPTimeoutError("timeout"),
+                HTTPResponse(
+                    status_code=200,
+                    content=b'{"data":[{"label":"safe","probs":[0.95]}]}',
+                ),
+            ]
+        )
+        client = InstrumentedHTTPClient(transport, tracer)
+        backend = VLLMBackend(
+            _remote(engine="vllm", base_url="http://vllm:8000"),
+            http_client=client,
+        )
+
+        result = await backend.classify("text")
+
+        assert result == [ClassificationResult(label="safe", score=0.95)]
+        assert len(transport.requests) == 2
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["http.request.resend_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_injected_retry_policy_is_not_compounded(self, http_otel):
+        tracer, exporter = http_otel
+        transport = RecordingHTTPClient(
+            [
+                HTTPTimeoutError("first timeout"),
+                HTTPTimeoutError("second timeout"),
+                HTTPResponse(
+                    status_code=200,
+                    content=b'{"data":[{"label":"safe","probs":[0.95]}]}',
+                ),
+            ]
+        )
+        retrying = RetryingHTTPClient(
+            transport,
+            RetryPolicy(
+                max_attempts=2,
+                retryable_methods=frozenset({"POST"}),
+                retryable_status_codes=frozenset(),
+                initial_delay=0,
+                max_delay=0,
+            ),
+        )
+        client = InstrumentedHTTPClient(retrying, tracer)
+        backend = VLLMBackend(
+            _remote(engine="vllm", base_url="http://vllm:8000"),
+            http_client=client,
+        )
+
+        with pytest.raises(HTTPTimeoutError, match="second timeout"):
+            await backend.classify("text")
+
+        assert len(transport.requests) == 2
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["http.request.resend_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_injected_retrying_instrumented_client_is_normalized(self, http_otel):
+        tracer, exporter = http_otel
+        transport = RecordingHTTPClient(
+            [
+                HTTPTimeoutError("first timeout"),
+                HTTPTimeoutError("second timeout"),
+                HTTPResponse(
+                    status_code=200,
+                    content=b'{"data":[{"label":"safe","probs":[0.95]}]}',
+                ),
+            ]
+        )
+        instrumented = InstrumentedHTTPClient(transport, tracer)
+        client = RetryingHTTPClient(
+            instrumented,
+            RetryPolicy(
+                max_attempts=3,
+                retryable_methods=frozenset({"POST"}),
+                retryable_status_codes=frozenset(),
+                initial_delay=0,
+                max_delay=0,
+            ),
+        )
+        backend = VLLMBackend(
+            _remote(engine="vllm", base_url="http://vllm:8000"),
+            http_client=client,
+        )
+
+        result = await backend.classify("text")
+
+        assert result == [ClassificationResult(label="safe", score=0.95)]
+        assert len(transport.requests) == 3
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["http.request.resend_count"] == 2
 
 
 class TestKServeBackend:


### PR DESCRIPTION
## Description

Fix HF classifier HTTP client composition so one span covers all retry attempts and injected retry policies are not compounded.

## Related Issue(s)

NGUARD-868


## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved HTTP client instrumentation when applying retry policies.
  * Preserved tracing and metrics across retried HTTP requests.
  * Prevented duplicate retry handling when instrumented clients are reused.

* **Bug Fixes**
  * Ensured replacement transports use the configured retry behavior without affecting the original client.

* **Tests**
  * Added coverage for tracing, metrics, retries, and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->