### PR TITLE
refactor(rails): make shared action dependencies explicit

### DIFF
--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -190,6 +190,18 @@ class CompiledRail:
         self._deps = deps
         self._accepted = accepted
 
+    def with_runtime_dependencies(self, deps: RailDependencies) -> "CompiledRail":
+        """Return the same execution plan with its runtime collaborators finalized."""
+        return CompiledRail(
+            flow=self.flow,
+            surface=self.surface,
+            action=self._action,
+            bound=self._bound,
+            context_bound=self._context_bound,
+            deps=deps,
+            accepted=self._accepted,
+        )
+
     @property
     def surface_name(self) -> str:
         """The manifest surface name, without any ``$param=`` suffix."""

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -48,6 +48,7 @@ from nemoguardrails.manifests import (
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
 
+    from nemoguardrails.http import HTTPClient
     from nemoguardrails.logging.explain import LLMCallInfo
     from nemoguardrails.manifests import RailCatalog
 
@@ -75,6 +76,7 @@ class RailDependencies:
     llm_task_manager: Any
     config: Any
     model_caches: Optional[Mapping[str, Any]] = None
+    http_client: Optional["HTTPClient"] = None
     tracer: Optional["Tracer"] = None
 
 
@@ -175,7 +177,6 @@ class CompiledRail:
         context_bound: tuple[_ContextParameter, ...],
         deps: RailDependencies,
         accepted: frozenset[str],
-        http_client: Any = None,
     ) -> None:
         """Store the frozen execution plan. Build through :func:`compile_rail`.
 
@@ -189,7 +190,6 @@ class CompiledRail:
         self._context_bound = context_bound
         self._deps = deps
         self._accepted = accepted
-        self._http_client = http_client
 
     @property
     def surface_name(self) -> str:
@@ -257,21 +257,11 @@ class CompiledRail:
             "llm": self._deps.llms.get("main"),
             "llm_task_manager": self._deps.llm_task_manager,
             "config": self._deps.config,
-            "http_client": self._http_client,
+            "http_client": self._deps.http_client,
             "model_caches": self._deps.model_caches,
             "context": context,
             "events": messages_to_events(messages),
         }
-
-    async def close(self) -> None:
-        """Close the rail's HTTP client, if it owns one.
-
-        Failures propagate: releasing one client is the whole job here, and the caller
-        closing a whole set of rails is the only layer that can decide a leak is
-        survivable. Repeat calls are safe, as a closed client's ``close()`` is a no-op.
-        """
-        if self._http_client is not None:
-            await self._http_client.close()
 
 
 def _accepted_parameters(action: Callable[..., Any]) -> frozenset[str]:
@@ -595,7 +585,6 @@ def compile_rail(
     direction: RailDirection,
     deps: RailDependencies,
     *,
-    http_client: Any = None,
     catalog: Optional["RailCatalog"] = None,
 ) -> CompiledRail:
     """Compile one configured flow string into an executable rail.
@@ -641,5 +630,4 @@ def compile_rail(
         context_bound=context_bound,
         deps=deps,
         accepted=accepted,
-        http_client=http_client,
     )

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -333,13 +333,6 @@ def _context_parameters(surface: RailSurface, flow: str) -> tuple[_ContextParame
     same as injecting the whole ``context`` dict: ``user_message`` reaches an action that
     calls the parameter ``text`` or ``user_prompt``.
     """
-    unsupported = _unsupported_context_keys(surface)
-    if unsupported:
-        raise RailCompilationError(
-            f"{flow!r} needs context variable(s) {', '.join(repr(key) for key in unsupported)}, "
-            f"which IORails does not supply; it has {list(_CONTEXT_KEYS)}"
-        )
-
     bound: list[_ContextParameter] = []
     for binding in surface.bindings:
         if binding.kind != "context":

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -99,7 +99,7 @@ _SYSTEM_MESSAGE_EVENT = "SystemMessage"
 def _history_before_current_turn(messages: LLMMessages) -> LLMMessages:
     """The turns preceding the one being checked.
 
-    Actions append the checked turn themselves, from ``context["user_message"]``, and always
+    Actions append the checked turn themselves, from their bound ``user_message``, and always
     at the end. So the history stops short of it: emitting it here would hand the model the
     same turn twice, and emitting what follows it — an assistant reply in a ``check()``
     transcript, say — would place a later turn ahead of it and reorder the conversation.
@@ -154,8 +154,7 @@ class _ContextParameter:
     key: str
 
 
-# The conversation variables a context binding may name. Also the keys of the ``context``
-# dict injected wholesale into actions that declare it, so the two cannot drift.
+# The conversation variables IORails can supply to explicit context bindings.
 _CONTEXT_KEYS = ("user_message", "bot_message")
 
 
@@ -239,18 +238,14 @@ class CompiledRail:
     def _call_kwargs(self, messages: LLMMessages, bot_response: Optional[str]) -> dict[str, Any]:
         """Assemble the action's arguments from its declared parameters and the manifest."""
         context = _request_context(messages, bot_response)
-        kwargs = {
-            name: value
-            for name, value in self._request_dependencies(messages, context).items()
-            if name in self._accepted
-        }
+        kwargs = {name: value for name, value in self._request_dependencies(messages).items() if name in self._accepted}
         for bound in self._bound:
             kwargs[bound.action_param] = bound.value
         for context_bound in self._context_bound:
             kwargs[context_bound.action_param] = context[context_bound.key]
         return kwargs
 
-    def _request_dependencies(self, messages: LLMMessages, context: Mapping[str, str]) -> dict[str, Any]:
+    def _request_dependencies(self, messages: LLMMessages) -> dict[str, Any]:
         """Every value injectable by parameter name; the caller filters against the signature."""
         return {
             "llms": self._deps.llms,
@@ -259,7 +254,6 @@ class CompiledRail:
             "config": self._deps.config,
             "http_client": self._deps.http_client,
             "model_caches": self._deps.model_caches,
-            "context": context,
             "events": messages_to_events(messages),
         }
 
@@ -339,18 +333,20 @@ def _context_parameters(surface: RailSurface, flow: str) -> tuple[_ContextParame
     same as injecting the whole ``context`` dict: ``user_message`` reaches an action that
     calls the parameter ``text`` or ``user_prompt``.
     """
+    unsupported = _unsupported_context_keys(surface)
+    if unsupported:
+        raise RailCompilationError(
+            f"{flow!r} needs context variable(s) {', '.join(repr(key) for key in unsupported)}, "
+            f"which IORails does not supply; it has {list(_CONTEXT_KEYS)}"
+        )
+
     bound: list[_ContextParameter] = []
     for binding in surface.bindings:
         if binding.kind != "context":
             continue
         key = _binding_source_key(binding, flow)
-        if key not in _CONTEXT_KEYS:
-            # Refused rather than passed an empty value: the rail would otherwise return a
-            # verdict computed over evidence IORails never supplied.
-            raise RailCompilationError(
-                f"{flow!r} binds {binding.action_param!r} to context variable {key!r}, "
-                f"which IORails does not supply; it has {list(_CONTEXT_KEYS)}"
-            )
+        if key not in _CONTEXT_KEYS and not binding.required:
+            continue
         bound.append(_ContextParameter(binding.action_param, key))
     return tuple(bound)
 
@@ -375,27 +371,25 @@ def _unapplicable_transform_reason(surface: RailSurface) -> Optional[str]:
     return f"rewrites {surface.transform_target.value!r}, which a {surface.direction.value} rail cannot apply here"
 
 
-# Surfaces whose actions read retrieval evidence out of the request context: ``relevant_chunks``,
-# ``relevant_chunks_sep``, or the Colang-internal ``_last_bot_prompt``. Keyed by direction as well
-# as name, because one rail can surface in both directions.
-_RETRIEVAL_CONTEXT_SURFACES: frozenset[tuple[RailDirection, str]] = frozenset(
-    {
-        (RailDirection.OUTPUT, "alignscore check facts"),
-        (RailDirection.OUTPUT, "autoalign groundedness output"),
-        (RailDirection.OUTPUT, "fiddler bot faithfulness"),
-        (RailDirection.OUTPUT, "patronus api check output"),
-        (RailDirection.OUTPUT, "patronus lynx check output hallucination"),
-        (RailDirection.OUTPUT, "self check facts"),
-        (RailDirection.OUTPUT, "self check hallucination"),
+def _unsupported_context_keys(surface: RailSurface) -> tuple[str, ...]:
+    """Return declared context variables that IORails cannot construct."""
+    keys = {
+        binding.key
+        for binding in surface.bindings
+        if binding.kind == "context"
+        and binding.required
+        and binding.key is not None
+        and binding.key not in _CONTEXT_KEYS
     }
-)
+    return tuple(sorted(keys))
 
 
-def _retrieval_context_reason(surface: RailSurface) -> Optional[str]:
-    """Report a surface needing retrieval evidence IORails has no source for."""
-    if (surface.direction, surface.name) not in _RETRIEVAL_CONTEXT_SURFACES:
+def _unsupported_context_reason(surface: RailSurface) -> Optional[str]:
+    """Report context requirements outside IORails' request contract."""
+    keys = _unsupported_context_keys(surface)
+    if not keys:
         return None
-    return "needs retrieval evidence, which manifest-driven execution does not supply yet"
+    return f"needs context variable(s) {', '.join(repr(key) for key in keys)}, which IORails does not supply"
 
 
 def _unsupported_rail_reason(surface: RailSurface) -> Optional[str]:
@@ -415,7 +409,7 @@ def _unsupported_rail_reason(surface: RailSurface) -> Optional[str]:
 # lifting its limitation lands, as the blanket transform refusal did.
 _SURFACE_SUPPORT_CHECKS: tuple[Callable[[RailSurface], Optional[str]], ...] = (
     _unapplicable_transform_reason,
-    _retrieval_context_reason,
+    _unsupported_context_reason,
     _unsupported_rail_reason,
 )
 

--- a/nemoguardrails/guardrails/compiled_rail.py
+++ b/nemoguardrails/guardrails/compiled_rail.py
@@ -37,6 +37,7 @@ from nemoguardrails.guardrails.telemetry import action_span
 from nemoguardrails.logging.processing_log import processing_log_var
 from nemoguardrails.manifests import (
     Binding,
+    BindingResource,
     RailDirection,
     RailSurface,
     default_rail_catalog,
@@ -136,6 +137,7 @@ class _BoundParameter:
 
     action_param: str
     value: Any
+    resource: Optional[BindingResource] = None
 
 
 @dataclass(frozen=True)
@@ -322,13 +324,13 @@ def _frozen_parameters(surface: RailSurface, params: Mapping[str, str], flow: st
     bound: list[_BoundParameter] = []
     for binding in surface.bindings:
         if binding.kind == "literal":
-            bound.append(_BoundParameter(binding.action_param, binding.value))
+            bound.append(_BoundParameter(binding.action_param, binding.value, binding.resource))
             continue
 
         key = _binding_source_key(binding, flow)
         if binding.kind == "surface_param":
             if key in params:
-                bound.append(_BoundParameter(binding.action_param, params[key]))
+                bound.append(_BoundParameter(binding.action_param, params[key], binding.resource))
             elif binding.required:
                 raise RailCompilationError(f"{flow!r} is missing required parameter ${key}=")
             continue
@@ -469,26 +471,15 @@ def _reject_unaccepted_bindings(
     )
 
 
-# The parameter library actions resolve against ``llms``, by convention: an action needing a
-# model declares ``model_name`` and indexes ``llms[model_name]``.
-_MODEL_NAME_PARAM = "model_name"
-
-
 def _reject_unconfigured_models(bound: tuple[_BoundParameter, ...], deps: RailDependencies, flow: str) -> None:
     """Fail compilation when a rail names a model type the configuration does not declare.
 
-    The live gap is the *literal* binding. ``RailsConfig`` already rejects a ``$model=``
-    naming an undeclared type (``check_model_exists_for_input_rails``), but it finds the model
-    by parsing that suffix — so a rail whose model is baked into the manifest, such as
-    ``llama guard check input``, passes config validation and then fails per request, where
-    the fail-closed envelope reports the missing model as a rail block.
+    Model bindings identify this dependency explicitly. This covers both a configurable
+    ``$model=`` and a model type baked into the manifest without coupling compilation to the
+    action parameter's name.
     """
     missing = sorted(
-        {
-            str(param.value)
-            for param in bound
-            if param.action_param == _MODEL_NAME_PARAM and param.value not in deps.llms
-        }
+        {str(param.value) for param in bound if param.resource == "model" and param.value not in deps.llms}
     )
     if not missing:
         return

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -260,8 +260,7 @@ class RailsManager:
 
         self._http_client = create_http_client()
         runtime_deps = replace(deps, http_client=self._http_client)
-        for rail in self._rails.values():
-            rail._deps = runtime_deps
+        self._rails = {key: rail.with_runtime_dependencies(runtime_deps) for key, rail in self._rails.items()}
 
         log.info(
             "RailsManager initialized: input_flows=%s, output_flows=%s, tool_call_flows=%s, "

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -42,7 +42,6 @@ from nemoguardrails.guardrails.tool_schema import ToolExchange, Toolset
 from nemoguardrails.http.runtime import create_http_client
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.manifests import RailDirection as SurfaceDirection
-from nemoguardrails.manifests import parse_configured_surface
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
 from nemoguardrails.types import ToolCall, UsageInfo
 
@@ -71,82 +70,6 @@ _TOOL_ACTION_CLASSES: dict[str, type[ToolRailAction]] = {
 }
 
 _ToolActionT = TypeVar("_ToolActionT", bound=ToolRailAction)
-
-# Integrations requiring API calls (rather than LLM inference). They should wrap
-# plain http_client with server-side retry, timeout, max_attempts requirements
-# TODO: Encode these in RailManifest
-_HTTP_CLIENT_SURFACE_NAMES: frozenset[str] = frozenset(
-    {
-        # activefence
-        "activefence moderation on input",
-        "activefence moderation on input detailed",
-        "activefence moderation on output",
-        # ai_defense
-        "ai defense inspect prompt",
-        "ai defense inspect response",
-        # autoalign
-        "autoalign check input",
-        "autoalign check output",
-        "autoalign factcheck output",
-        "autoalign groundedness output",
-        # clavata
-        "clavata check input",
-        "clavata check output",
-        # crowdstrike_aidr
-        "crowdstrike aidr guard input",
-        "crowdstrike aidr guard output",
-        # f5
-        "f5 guardrails scan input",
-        "f5 guardrails scan output",
-        # fiddler
-        "fiddler bot faithfulness",
-        "fiddler bot safety",
-        "fiddler user safety",
-        # gliner
-        "gliner detect pii on input",
-        "gliner detect pii on output",
-        "gliner detect pii on retrieval",
-        "gliner mask pii on input",
-        "gliner mask pii on output",
-        "gliner mask pii on retrieval",
-        # hf_classifier
-        "hf classifier check input",
-        "hf classifier check output",
-        "hf classifier check retrieval",
-        # jailbreak_detection
-        "jailbreak detection heuristics",
-        "jailbreak detection model",
-        # pangea
-        "pangea ai guard input",
-        "pangea ai guard output",
-        # patronusai
-        "patronus api check output",
-        # policyai
-        "policyai moderation on input",
-        "policyai moderation on output",
-        # polygraf
-        "polygraf detect pii on input",
-        "polygraf detect pii on output",
-        "polygraf detect pii on retrieval",
-        "polygraf mask pii on input",
-        "polygraf mask pii on output",
-        "polygraf mask pii on retrieval",
-        # privateai
-        "detect pii on input",
-        "detect pii on output",
-        "detect pii on retrieval",
-        "mask pii on input",
-        "mask pii on output",
-        "mask pii on retrieval",
-        # prompt_security
-        "protect prompt",
-        "protect response",
-        # trend_micro
-        "trend ai guard input",
-        "trend ai guard output",
-    }
-)
-
 
 # The conversation variable each direction's rails may rewrite; anything else is refused.
 _REWRITABLE_TARGET = {
@@ -319,14 +242,7 @@ class RailsManager:
         configured = ((RailDirection.INPUT, self.input_flows), (RailDirection.OUTPUT, self.output_flows))
         for direction, flows in configured:
             for flow in flows:
-                try:
-                    surface_name, _ = parse_configured_surface(flow)
-                except ValueError:
-                    surface_name = flow
-                http_client = create_http_client() if surface_name in _HTTP_CLIENT_SURFACE_NAMES else None
-                self._rails[(direction, flow)] = compile_rail(
-                    flow, _SURFACE_DIRECTIONS[direction], deps, http_client=http_client
-                )
+                self._rails[(direction, flow)] = compile_rail(flow, _SURFACE_DIRECTIONS[direction], deps)
 
         # Which rails may rewrite decides whether this config can run its rails concurrently at
         # all, which is settled once, here. The order they run in is not: it follows from the
@@ -341,6 +257,11 @@ class RailsManager:
         # Tool Result Actions run on the results of executing Tool Calls in the harness
         self._tool_call_actions = self._build_tool_actions(self.tool_call_flows, ToolCallRailAction)
         self._tool_result_actions = self._build_tool_actions(self.tool_result_flows, ToolResultRailAction)
+
+        self._http_client = create_http_client()
+        runtime_deps = replace(deps, http_client=self._http_client)
+        for rail in self._rails.values():
+            rail._deps = runtime_deps
 
         log.info(
             "RailsManager initialized: input_flows=%s, output_flows=%s, tool_call_flows=%s, "
@@ -377,23 +298,8 @@ class RailsManager:
         )
 
     async def stop(self) -> None:
-        """Close the HTTP clients owned by compiled rails.
-
-        Every rail is closed even if an earlier one fails, so one stuck client cannot
-        leak the pools behind it; the failures are reported together afterwards.
-        Repeat calls are safe, because a closed client's ``close()`` is a no-op.
-        """
-        errors: dict[str, Exception] = {}
-        for (direction, flow), rail in self._rails.items():
-            try:
-                await rail.close()
-            except Exception as e:
-                errors[f"{direction.value} rail '{flow}'"] = e
-                log.error("Error closing the HTTP client for %s rail '%s': %s", direction.value, flow, e)
-
-        if errors:
-            error_string = ", ".join(f"{component}: exception {exception}" for component, exception in errors.items())
-            raise RuntimeError(f"Failed to close rail HTTP clients: {error_string}")
+        """Close the runtime-owned pooled HTTP client."""
+        await self._http_client.close()
 
     def _build_tool_actions(self, flows: list[str], expected_cls: type[_ToolActionT]) -> dict[str, _ToolActionT]:
         """Instantiate the tool rails for *flows*, checking each resolves to *expected_cls*.

--- a/nemoguardrails/library/autoalign/actions.py
+++ b/nemoguardrails/library/autoalign/actions.py
@@ -271,6 +271,7 @@ async def autoalign_factcheck_infer(
 async def autoalign_input_api(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     show_autoalign_message: bool = True,
     show_toxic_phrases: bool = False,
     http_client: Optional[HTTPClient] = None,
@@ -293,7 +294,8 @@ async def autoalign_input_api(
     Returns:
         An allow, block, or user-message transform outcome.
     """
-    user_message = context.get("user_message")
+    context = context or {}
+    user_message = user_message if user_message is not None else context.get("user_message")
     autoalign_config = llm_task_manager.config.rails.config.autoalign
     autoalign_api_url = autoalign_config.parameters.get("endpoint")
     multi_language = autoalign_config.parameters.get("multi_language", False)
@@ -329,6 +331,7 @@ async def autoalign_input_api(
 async def autoalign_output_api(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    bot_message: Optional[str] = None,
     show_autoalign_message: bool = True,
     show_toxic_phrases: bool = False,
     http_client: Optional[HTTPClient] = None,
@@ -351,7 +354,8 @@ async def autoalign_output_api(
     Returns:
         An allow, block, or bot-message transform outcome.
     """
-    bot_message = context.get("bot_message")
+    context = context or {}
+    bot_message = bot_message if bot_message is not None else context.get("bot_message")
     autoalign_config = llm_task_manager.config.rails.config.autoalign
     autoalign_api_url = autoalign_config.parameters.get("endpoint")
     multi_language = autoalign_config.parameters.get("multi_language", False)
@@ -384,6 +388,8 @@ async def autoalign_groundedness_output_api(
     context: Optional[dict] = None,
     factcheck_threshold: float = 0.0,
     show_autoalign_message: bool = True,
+    bot_message: Optional[str] = None,
+    relevant_chunks_sep: Optional[List[str]] = None,
     http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
@@ -405,8 +411,9 @@ async def autoalign_groundedness_output_api(
         An allow or block outcome containing the score and threshold.
     """
 
-    bot_message = context.get("bot_message")
-    documents = context.get("relevant_chunks_sep", [])
+    context = context or {}
+    bot_message = bot_message if bot_message is not None else context.get("bot_message")
+    documents = relevant_chunks_sep if relevant_chunks_sep is not None else context.get("relevant_chunks_sep", [])
 
     autoalign_config = llm_task_manager.config.rails.config.autoalign
     autoalign_groundedness_api_url = autoalign_config.parameters.get("groundedness_check_endpoint")
@@ -432,6 +439,8 @@ async def autoalign_groundedness_output_api(
 async def autoalign_factcheck_output_api(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
     factcheck_threshold: float = 0.0,
     show_autoalign_message: bool = True,
     http_client: Optional[HTTPClient] = None,
@@ -452,8 +461,9 @@ async def autoalign_factcheck_output_api(
         An allow or block outcome containing the score and threshold.
     """
 
-    user_message = context.get("user_message")
-    bot_message = context.get("bot_message")
+    context = context or {}
+    user_message = user_message if user_message is not None else context.get("user_message")
+    bot_message = bot_message if bot_message is not None else context.get("bot_message")
     autoalign_config = llm_task_manager.config.rails.config.autoalign
     autoalign_factcheck_api_url = autoalign_config.parameters.get("fact_check_endpoint")
     multi_language = autoalign_config.parameters.get("multi_language", False)

--- a/nemoguardrails/library/autoalign/rail.py
+++ b/nemoguardrails/library/autoalign/rail.py
@@ -95,14 +95,20 @@ RAIL = RailManifest(
                 name="autoalign check input",
                 direction=RailDirection.INPUT,
                 action=AUTOALIGN_INPUT_API,
-                bindings=(Binding.literal("show_autoalign_message", True),),
+                bindings=(
+                    Binding.context("user_message", "user_message"),
+                    Binding.literal("show_autoalign_message", True),
+                ),
                 transform_target=TransformTarget.USER_MESSAGE,
             ),
             RailSurface(
                 name="autoalign check output",
                 direction=RailDirection.OUTPUT,
                 action=AUTOALIGN_OUTPUT_API,
-                bindings=(Binding.literal("show_autoalign_message", True),),
+                bindings=(
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.literal("show_autoalign_message", True),
+                ),
                 transform_target=TransformTarget.BOT_MESSAGE,
             ),
             RailSurface(
@@ -110,6 +116,8 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=AUTOALIGN_GROUNDEDNESS_OUTPUT_API,
                 bindings=(
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("relevant_chunks_sep", "relevant_chunks_sep"),
                     Binding.literal("factcheck_threshold", 0.5),
                     Binding.literal("show_autoalign_message", True),
                 ),
@@ -119,6 +127,8 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=AUTOALIGN_FACTCHECK_OUTPUT_API,
                 bindings=(
+                    Binding.context("user_message", "user_message"),
+                    Binding.context("bot_message", "bot_message"),
                     Binding.literal("factcheck_threshold", 0.5),
                     Binding.literal("show_autoalign_message", True),
                 ),

--- a/nemoguardrails/library/cleanlab/actions.py
+++ b/nemoguardrails/library/cleanlab/actions.py
@@ -36,6 +36,8 @@ def _cleanlab_outcome(trustworthiness_score: float) -> RailOutcome:
 )
 async def call_cleanlab_api(
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     api_key = os.environ.get("CLEANLAB_API_KEY")
@@ -49,8 +51,8 @@ async def call_cleanlab_api(
         raise ImportError("Please install cleanlab-studio using 'pip install --upgrade cleanlab-studio' command")
 
     context = context or {}
-    bot_response = context.get("bot_message")
-    user_input = context.get("user_message")
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
+    user_input = user_message if user_message is not None else context.get("user_message")
 
     studio = Studio(api_key)
     cleanlab_tlm = studio.TLM()

--- a/nemoguardrails/library/cleanlab/rail.py
+++ b/nemoguardrails/library/cleanlab/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     EnvVar,
     RailActions,
     RailDirection,
@@ -47,7 +48,15 @@ RAIL = RailManifest(
         flows=RailFlows(flow_names=("cleanlab trustworthiness",)),
         actions=RailActions(refs=(CALL_CLEANLAB_API,)),
         surfaces=(
-            RailSurface(name="cleanlab trustworthiness", direction=RailDirection.OUTPUT, action=CALL_CLEANLAB_API),
+            RailSurface(
+                name="cleanlab trustworthiness",
+                direction=RailDirection.OUTPUT,
+                action=CALL_CLEANLAB_API,
+                bindings=(
+                    Binding.context("user_message", "user_message", required=False),
+                    Binding.context("bot_message", "bot_message"),
+                ),
+            ),
         ),
         requirements=RailRequirements(
             env_vars=(EnvVar(name="CLEANLAB_API_KEY", required=True),),

--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -45,14 +45,16 @@ async def content_safety_check_input(
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     model_caches: Optional[Dict[str, CacheInterface]] = None,
     **kwargs,
 ) -> RailOutcome:
     _MAX_TOKENS = 1024
-    user_input: str = ""
+    user_input = user_message or ""
 
     if context is not None:
-        user_input = context.get("user_message", "")
+        if user_message is None:
+            user_input = context.get("user_message", "")
         model_name = model_name or context.get("model", None)
 
     if model_name is None:
@@ -134,16 +136,20 @@ async def content_safety_check_output(
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
     model_caches: Optional[Dict[str, CacheInterface]] = None,
     **kwargs,
 ) -> RailOutcome:
     _MAX_TOKENS = 1024
-    user_input: str = ""
-    bot_response: str = ""
+    user_input = user_message or ""
+    bot_response = bot_message or ""
 
     if context is not None:
-        user_input = context.get("user_message", "")
-        bot_response = context.get("bot_message", "")
+        if user_message is None:
+            user_input = context.get("user_message", "")
+        if bot_message is None:
+            bot_response = context.get("bot_message", "")
         model_name = model_name or context.get("model", None)
 
     if model_name is None:

--- a/nemoguardrails/library/content_safety/rail.py
+++ b/nemoguardrails/library/content_safety/rail.py
@@ -70,13 +70,20 @@ RAIL = RailManifest(
                 name="content safety check input",
                 direction=RailDirection.INPUT,
                 action=CONTENT_SAFETY_CHECK_INPUT,
-                bindings=(Binding.surface_param("model_name", "model"),),
+                bindings=(
+                    Binding.surface_param("model_name", "model"),
+                    Binding.context("user_message", "user_message"),
+                ),
             ),
             RailSurface(
                 name="content safety check output",
                 direction=RailDirection.OUTPUT,
                 action=CONTENT_SAFETY_CHECK_OUTPUT,
-                bindings=(Binding.surface_param("model_name", "model"),),
+                bindings=(
+                    Binding.surface_param("model_name", "model"),
+                    Binding.context("user_message", "user_message", required=False),
+                    Binding.context("bot_message", "bot_message"),
+                ),
             ),
         ),
         privacy=RailPrivacy(sends_user_text=True, sends_bot_text=True),

--- a/nemoguardrails/library/content_safety/rail.py
+++ b/nemoguardrails/library/content_safety/rail.py
@@ -71,7 +71,7 @@ RAIL = RailManifest(
                 direction=RailDirection.INPUT,
                 action=CONTENT_SAFETY_CHECK_INPUT,
                 bindings=(
-                    Binding.surface_param("model_name", "model"),
+                    Binding.model_param("model_name", "model"),
                     Binding.context("user_message", "user_message"),
                 ),
             ),
@@ -80,7 +80,7 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=CONTENT_SAFETY_CHECK_OUTPUT,
                 bindings=(
-                    Binding.surface_param("model_name", "model"),
+                    Binding.model_param("model_name", "model"),
                     Binding.context("user_message", "user_message", required=False),
                     Binding.context("bot_message", "bot_message"),
                 ),

--- a/nemoguardrails/library/factchecking/align_score/actions.py
+++ b/nemoguardrails/library/factchecking/align_score/actions.py
@@ -34,6 +34,8 @@ async def alignscore_check_facts(
     context: Optional[dict] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
+    relevant_chunks: Optional[list] = None,
+    bot_message: Optional[str] = None,
     http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
@@ -44,8 +46,8 @@ async def alignscore_check_facts(
     alignscore_api_url = fact_checking_config.parameters.get("endpoint")
 
     context = context or {}
-    evidence = context.get("relevant_chunks", [])
-    response = context.get("bot_message")
+    evidence = relevant_chunks if relevant_chunks is not None else context.get("relevant_chunks", [])
+    response = bot_message if bot_message is not None else context.get("bot_message")
 
     alignscore = await alignscore_request(
         alignscore_api_url,
@@ -56,7 +58,14 @@ async def alignscore_check_facts(
     if alignscore is None:
         log.warning("AlignScore endpoint not set up properly. Falling back to the ask_llm approach for fact-checking.")
         if fallback_to_self_check:
-            return await self_check_facts(llm_task_manager, context, llm, config)
+            return await self_check_facts(
+                llm_task_manager,
+                context,
+                llm,
+                config,
+                relevant_chunks=evidence,
+                bot_message=response,
+            )
         else:
             return _fact_check_outcome(1.0)
     else:

--- a/nemoguardrails/library/factchecking/align_score/rail.py
+++ b/nemoguardrails/library/factchecking/align_score/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     RailActions,
     RailDirection,
     RailFlows,
@@ -50,7 +51,15 @@ RAIL = RailManifest(
         flows=RailFlows(flow_names=("alignscore check facts",)),
         actions=RailActions(refs=(ALIGNSCORE_CHECK_FACTS, ALIGNSCORE_REQUEST)),
         surfaces=(
-            RailSurface(name="alignscore check facts", direction=RailDirection.OUTPUT, action=ALIGNSCORE_CHECK_FACTS),
+            RailSurface(
+                name="alignscore check facts",
+                direction=RailDirection.OUTPUT,
+                action=ALIGNSCORE_CHECK_FACTS,
+                bindings=(
+                    Binding.context("relevant_chunks", "relevant_chunks", required=False),
+                    Binding.context("bot_message", "bot_message"),
+                ),
+            ),
         ),
         requirements=RailRequirements(services=(ServiceRequirement(name="AlignScore HTTP service", required=True),)),
         privacy=RailPrivacy(

--- a/nemoguardrails/library/factchecking/align_score/rail.py
+++ b/nemoguardrails/library/factchecking/align_score/rail.py
@@ -56,7 +56,7 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=ALIGNSCORE_CHECK_FACTS,
                 bindings=(
-                    Binding.context("relevant_chunks", "relevant_chunks", required=False),
+                    Binding.context("relevant_chunks", "relevant_chunks"),
                     Binding.context("bot_message", "bot_message"),
                 ),
             ),

--- a/nemoguardrails/library/fiddler/actions.py
+++ b/nemoguardrails/library/fiddler/actions.py
@@ -119,6 +119,7 @@ async def call_fiddler_guardrail(
 async def call_fiddler_safety_user(
     config: RailsConfig,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """Check the user message with the Fiddler safety guardrail.
@@ -145,7 +146,7 @@ async def call_fiddler_safety_user(
         log.error("Fiddler endpoint not set in config")
         return RailOutcome.allow(metadata={"blocked": False})
 
-    user_message = context.get("user_message", "")
+    user_message = user_message if user_message is not None else context.get("user_message", "")
     if not user_message:
         log.error("Fiddler Jailbreak Guardrails could not be run. User message must be provided.")
         return RailOutcome.allow(metadata={"blocked": False})
@@ -168,6 +169,7 @@ async def call_fiddler_safety_user(
 async def call_fiddler_safety_bot(
     config: RailsConfig,
     context: Optional[dict] = None,
+    bot_message: Optional[str] = None,
     http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """Check the bot message with the Fiddler safety guardrail.
@@ -194,7 +196,7 @@ async def call_fiddler_safety_bot(
         log.error("Fiddler endpoint not set in config")
         return RailOutcome.allow(metadata={"blocked": False})
 
-    bot_message = context.get("bot_message", "")
+    bot_message = bot_message if bot_message is not None else context.get("bot_message", "")
     if not bot_message:
         log.error("Fiddler Safety Guardrails could not be run. Bot message must be provided.")
         return RailOutcome.allow(metadata={"blocked": False})
@@ -217,6 +219,8 @@ async def call_fiddler_safety_bot(
 async def call_fiddler_faithfulness(
     config: RailsConfig,
     context: Optional[dict] = None,
+    bot_message: Optional[str] = None,
+    relevant_chunks: Optional[str] = None,
     http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """Check the bot message with the Fiddler faithfulness guardrail.
@@ -244,8 +248,8 @@ async def call_fiddler_faithfulness(
         log.error("Fiddler endpoint not set in config")
         return RailOutcome.allow(metadata={"blocked": False})
 
-    bot_message = context.get("bot_message", "")
-    knowledge = context.get("relevant_chunks", "")
+    bot_message = bot_message if bot_message is not None else context.get("bot_message", "")
+    knowledge = relevant_chunks if relevant_chunks is not None else context.get("relevant_chunks", "")
     if not bot_message:
         log.error("Fiddler Faithfulness Guardrails could not be run. Chatbot message must be provided.")
         return RailOutcome.allow(metadata={"blocked": False})

--- a/nemoguardrails/library/fiddler/rail.py
+++ b/nemoguardrails/library/fiddler/rail.py
@@ -80,7 +80,7 @@ RAIL = RailManifest(
                 action=FIDDLER_FAITHFULNESS,
                 bindings=(
                     Binding.context("bot_message", "bot_message"),
-                    Binding.context("relevant_chunks", "relevant_chunks", required=False),
+                    Binding.context("relevant_chunks", "relevant_chunks"),
                 ),
             ),
         ),

--- a/nemoguardrails/library/fiddler/rail.py
+++ b/nemoguardrails/library/fiddler/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     ConfigSpecRef,
     EnvVar,
     RailActions,
@@ -61,9 +62,27 @@ RAIL = RailManifest(
         flows=RailFlows(flow_names=("fiddler user safety", "fiddler bot safety", "fiddler bot faithfulness")),
         actions=RailActions(refs=(FIDDLER_USER, FIDDLER_BOT, FIDDLER_FAITHFULNESS)),
         surfaces=(
-            RailSurface(name="fiddler user safety", direction=RailDirection.INPUT, action=FIDDLER_USER),
-            RailSurface(name="fiddler bot safety", direction=RailDirection.OUTPUT, action=FIDDLER_BOT),
-            RailSurface(name="fiddler bot faithfulness", direction=RailDirection.OUTPUT, action=FIDDLER_FAITHFULNESS),
+            RailSurface(
+                name="fiddler user safety",
+                direction=RailDirection.INPUT,
+                action=FIDDLER_USER,
+                bindings=(Binding.context("user_message", "user_message"),),
+            ),
+            RailSurface(
+                name="fiddler bot safety",
+                direction=RailDirection.OUTPUT,
+                action=FIDDLER_BOT,
+                bindings=(Binding.context("bot_message", "bot_message"),),
+            ),
+            RailSurface(
+                name="fiddler bot faithfulness",
+                direction=RailDirection.OUTPUT,
+                action=FIDDLER_FAITHFULNESS,
+                bindings=(
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("relevant_chunks", "relevant_chunks", required=False),
+                ),
+            ),
         ),
         requirements=RailRequirements(
             env_vars=(EnvVar(name="FIDDLER_API_KEY", required=True),),

--- a/nemoguardrails/library/gcp_moderate_text/actions.py
+++ b/nemoguardrails/library/gcp_moderate_text/actions.py
@@ -83,6 +83,7 @@ def _gcp_text_moderation_outcome(
 )
 async def call_gcp_text_moderation_api(
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     threshold_mode: Literal["simple", "detailed"] = "simple",
     **kwargs,
 ) -> RailOutcome:
@@ -104,7 +105,7 @@ async def call_gcp_text_moderation_api(
         )
 
     context = context or {}
-    user_message = context.get("user_message")
+    user_message = user_message if user_message is not None else context.get("user_message")
     client = language_v2.LanguageServiceAsyncClient()
 
     # Initialize request argument(s)

--- a/nemoguardrails/library/gcp_moderate_text/rail.py
+++ b/nemoguardrails/library/gcp_moderate_text/rail.py
@@ -52,13 +52,19 @@ RAIL = RailManifest(
                 name="gcpnlp moderation",
                 direction=RailDirection.INPUT,
                 action=CALL_GCP_TEXT_MODERATION_API,
-                bindings=(Binding.literal("threshold_mode", "simple"),),
+                bindings=(
+                    Binding.context("user_message", "user_message"),
+                    Binding.literal("threshold_mode", "simple"),
+                ),
             ),
             RailSurface(
                 name="gcpnlp moderation detailed",
                 direction=RailDirection.INPUT,
                 action=CALL_GCP_TEXT_MODERATION_API,
-                bindings=(Binding.literal("threshold_mode", "detailed"),),
+                bindings=(
+                    Binding.context("user_message", "user_message"),
+                    Binding.literal("threshold_mode", "detailed"),
+                ),
             ),
         ),
         requirements=RailRequirements(

--- a/nemoguardrails/library/hallucination/actions.py
+++ b/nemoguardrails/library/hallucination/actions.py
@@ -46,14 +46,17 @@ async def self_check_hallucination(
     context: Optional[dict] = None,
     use_llm_checking: bool = True,
     config: Optional[RailsConfig] = None,
+    bot_message: Optional[str] = None,
+    last_bot_prompt: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks if the last bot response is a hallucination by checking multiple completions for self-consistency.
 
     :return: A blocking outcome if hallucination is detected, otherwise an allowing outcome.
     """
-    bot_response = context.get("bot_message")
-    last_bot_prompt_string = context.get("_last_bot_prompt")
+    context = context or {}
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
+    last_bot_prompt_string = last_bot_prompt if last_bot_prompt is not None else context.get("_last_bot_prompt")
 
     if bot_response and last_bot_prompt_string:
         num_responses = HALLUCINATION_NUM_EXTRA_RESPONSES

--- a/nemoguardrails/library/hallucination/rail.py
+++ b/nemoguardrails/library/hallucination/rail.py
@@ -53,7 +53,7 @@ RAIL = RailManifest(
                 action=SELF_CHECK_HALLUCINATION,
                 bindings=(
                     Binding.context("bot_message", "bot_message"),
-                    Binding.context("last_bot_prompt", "_last_bot_prompt", required=False),
+                    Binding.context("last_bot_prompt", "_last_bot_prompt"),
                 ),
             ),
         ),

--- a/nemoguardrails/library/hallucination/rail.py
+++ b/nemoguardrails/library/hallucination/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     ModelRequirement,
     RailActions,
     RailDirection,
@@ -47,7 +48,13 @@ RAIL = RailManifest(
         actions=RailActions(refs=(SELF_CHECK_HALLUCINATION,)),
         surfaces=(
             RailSurface(
-                name="self check hallucination", direction=RailDirection.OUTPUT, action=SELF_CHECK_HALLUCINATION
+                name="self check hallucination",
+                direction=RailDirection.OUTPUT,
+                action=SELF_CHECK_HALLUCINATION,
+                bindings=(
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("last_bot_prompt", "_last_bot_prompt", required=False),
+                ),
             ),
         ),
         requirements=RailRequirements(models=(ModelRequirement(type="llm", required=True),)),

--- a/nemoguardrails/library/hf_classifier/actions.py
+++ b/nemoguardrails/library/hf_classifier/actions.py
@@ -101,10 +101,12 @@ async def hf_classifier_check_input(
     classifier: str,
     config: Any | None = None,
     context: Optional[dict] = None,
+    text: Optional[str] = None,
     http_client: HTTPClient | None = None,
     **kwargs,
 ) -> RailOutcome:
-    allowed = await _classify_and_check(classifier, _extract_text(context, "user_message"), config, http_client)
+    text = text if text is not None else _extract_text(context, "user_message")
+    allowed = await _classify_and_check(classifier, text, config, http_client)
     return _hf_classifier_outcome(allowed)
 
 
@@ -114,6 +116,7 @@ async def hf_classifier_check_output(
     config: Any | None = None,
     context: Optional[dict] = None,
     model_name: Optional[str] = None,
+    text: Optional[str] = None,
     http_client: HTTPClient | None = None,
     **kwargs,
 ) -> RailOutcome:
@@ -122,7 +125,8 @@ async def hf_classifier_check_output(
     # engine extracts from the flow_id.
     if classifier.startswith("$") and model_name:
         classifier = model_name
-    allowed = await _classify_and_check(classifier, _extract_text(context, "bot_message"), config, http_client)
+    text = text if text is not None else _extract_text(context, "bot_message")
+    allowed = await _classify_and_check(classifier, text, config, http_client)
     return _hf_classifier_outcome(allowed)
 
 
@@ -131,8 +135,10 @@ async def hf_classifier_check_retrieval(
     classifier: str,
     config: Any | None = None,
     context: Optional[dict] = None,
+    text: Optional[str] = None,
     http_client: HTTPClient | None = None,
     **kwargs,
 ) -> RailOutcome:
-    allowed = await _classify_and_check(classifier, _extract_text(context, "relevant_chunks"), config, http_client)
+    text = text if text is not None else _extract_text(context, "relevant_chunks")
+    allowed = await _classify_and_check(classifier, text, config, http_client)
     return _hf_classifier_retrieval_outcome(allowed)

--- a/nemoguardrails/library/hf_classifier/rail.py
+++ b/nemoguardrails/library/hf_classifier/rail.py
@@ -77,19 +77,28 @@ RAIL = RailManifest(
                 name="hf classifier check input",
                 direction=RailDirection.INPUT,
                 action=HF_CLASSIFIER_CHECK_INPUT,
-                bindings=(Binding.surface_param("classifier", "classifier"),),
+                bindings=(
+                    Binding.surface_param("classifier", "classifier"),
+                    Binding.context("text", "user_message"),
+                ),
             ),
             RailSurface(
                 name="hf classifier check output",
                 direction=RailDirection.OUTPUT,
                 action=HF_CLASSIFIER_CHECK_OUTPUT,
-                bindings=(Binding.surface_param("classifier", "classifier"),),
+                bindings=(
+                    Binding.surface_param("classifier", "classifier"),
+                    Binding.context("text", "bot_message"),
+                ),
             ),
             RailSurface(
                 name="hf classifier check retrieval",
                 direction=RailDirection.RETRIEVAL,
                 action=HF_CLASSIFIER_CHECK_RETRIEVAL,
-                bindings=(Binding.surface_param("classifier", "classifier"),),
+                bindings=(
+                    Binding.surface_param("classifier", "classifier"),
+                    Binding.context("text", "relevant_chunks"),
+                ),
                 transform_target=TransformTarget.RELEVANT_CHUNKS,
             ),
         ),

--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 async def jailbreak_detection_heuristics(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     http_client: Optional[HTTPClient] = None,
     **kwargs,
 ) -> RailOutcome:
@@ -68,7 +69,9 @@ async def jailbreak_detection_heuristics(
     lp_threshold = jailbreak_config.length_per_perplexity_threshold
     ps_ppl_threshold = jailbreak_config.prefix_suffix_perplexity_threshold
 
-    prompt = context.get("user_message")
+    context = context or {}
+    prompt = user_message if user_message is not None else context.get("user_message")
+    prompt = prompt or ""
 
     if not jailbreak_api_url:
         from nemoguardrails.library.jailbreak_detection.heuristics.checks import (
@@ -101,11 +104,11 @@ async def jailbreak_detection_heuristics(
 async def jailbreak_detection_model(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     model_caches: Optional[Dict[str, CacheInterface]] = None,
     http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """Uses a trained classifier to determine if a user input is a jailbreak attempt"""
-    prompt: str = ""
     jailbreak_config = llm_task_manager.config.rails.config.jailbreak_detection
 
     jailbreak_api_url = jailbreak_config.server_endpoint
@@ -113,8 +116,9 @@ async def jailbreak_detection_model(
     nim_classification_path = jailbreak_config.nim_server_endpoint
     nim_auth_token = jailbreak_config.get_api_key()
 
-    if context is not None:
-        prompt = context.get("user_message", "")
+    context = context or {}
+    prompt = user_message if user_message is not None else context.get("user_message")
+    prompt = prompt or ""
 
     # we do this as a hack to treat this action as an LLM call for tracing
     llm_call_info_var.set(LLMCallInfo(task="jailbreak_detection_model"))

--- a/nemoguardrails/library/jailbreak_detection/rail.py
+++ b/nemoguardrails/library/jailbreak_detection/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     ConfigSpecRef,
     EnvVar,
     RailActions,
@@ -67,11 +68,13 @@ RAIL = RailManifest(
                 name="jailbreak detection heuristics",
                 direction=RailDirection.INPUT,
                 action=JAILBREAK_DETECTION_HEURISTICS,
+                bindings=(Binding.context("user_message", "user_message"),),
             ),
             RailSurface(
                 name="jailbreak detection model",
                 direction=RailDirection.INPUT,
                 action=JAILBREAK_DETECTION_MODEL,
+                bindings=(Binding.context("user_message", "user_message"),),
             ),
         ),
         requirements=RailRequirements(

--- a/nemoguardrails/library/llama_guard/actions.py
+++ b/nemoguardrails/library/llama_guard/actions.py
@@ -75,6 +75,7 @@ async def llama_guard_check_input(
     llms: Mapping[str, LLMModel],
     model_name: str,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """
@@ -82,7 +83,7 @@ async def llama_guard_check_input(
     and the configured prompt containing the safety guidelines.
     """
     context = context or {}
-    user_input = context.get("user_message")
+    user_input = user_message if user_message is not None else context.get("user_message")
     llm = _get_llama_guard_model(llms, model_name)
     check_input_prompt = llm_task_manager.render_task_prompt(
         task=Task.LLAMA_GUARD_CHECK_INPUT,
@@ -107,14 +108,16 @@ async def llama_guard_check_output(
     llms: Mapping[str, LLMModel],
     model_name: str,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
 ) -> RailOutcome:
     """
     Check the bot response using the configured Llama Guard model
     and the configured prompt containing the safety guidelines.
     """
     context = context or {}
-    user_input = context.get("user_message")
-    bot_response = context.get("bot_message")
+    user_input = user_message if user_message is not None else context.get("user_message")
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
     llm = _get_llama_guard_model(llms, model_name)
 
     check_output_prompt = llm_task_manager.render_task_prompt(

--- a/nemoguardrails/library/llama_guard/rail.py
+++ b/nemoguardrails/library/llama_guard/rail.py
@@ -55,13 +55,20 @@ RAIL = RailManifest(
                 name="llama guard check input",
                 direction=RailDirection.INPUT,
                 action=LLAMA_GUARD_CHECK_INPUT,
-                bindings=(Binding.literal("model_name", "llama_guard"),),
+                bindings=(
+                    Binding.literal("model_name", "llama_guard"),
+                    Binding.context("user_message", "user_message"),
+                ),
             ),
             RailSurface(
                 name="llama guard check output",
                 direction=RailDirection.OUTPUT,
                 action=LLAMA_GUARD_CHECK_OUTPUT,
-                bindings=(Binding.literal("model_name", "llama_guard"),),
+                bindings=(
+                    Binding.literal("model_name", "llama_guard"),
+                    Binding.context("user_message", "user_message", required=False),
+                    Binding.context("bot_message", "bot_message"),
+                ),
             ),
         ),
         requirements=RailRequirements(models=(ModelRequirement(type="llama_guard", required=True),)),

--- a/nemoguardrails/library/llama_guard/rail.py
+++ b/nemoguardrails/library/llama_guard/rail.py
@@ -56,7 +56,7 @@ RAIL = RailManifest(
                 direction=RailDirection.INPUT,
                 action=LLAMA_GUARD_CHECK_INPUT,
                 bindings=(
-                    Binding.literal("model_name", "llama_guard"),
+                    Binding.model("model_name", "llama_guard"),
                     Binding.context("user_message", "user_message"),
                 ),
             ),
@@ -65,7 +65,7 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=LLAMA_GUARD_CHECK_OUTPUT,
                 bindings=(
-                    Binding.literal("model_name", "llama_guard"),
+                    Binding.model("model_name", "llama_guard"),
                     Binding.context("user_message", "user_message", required=False),
                     Binding.context("bot_message", "bot_message"),
                 ),

--- a/nemoguardrails/library/patronusai/actions.py
+++ b/nemoguardrails/library/patronusai/actions.py
@@ -83,15 +83,19 @@ async def patronus_lynx_check_output_hallucination(
     llms: Mapping[str, LLMModel],
     model_name: str,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
+    relevant_chunks: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """
     Check the bot response for hallucinations based on the given chunks
     using the configured Patronus Lynx model.
     """
-    user_input = context.get("user_message")
-    bot_response = context.get("bot_message")
-    provided_context = context.get("relevant_chunks")
+    context = context or {}
+    user_input = user_message if user_message is not None else context.get("user_message")
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
+    provided_context = relevant_chunks if relevant_chunks is not None else context.get("relevant_chunks")
 
     if not provided_context or not isinstance(provided_context, str) or not provided_context.strip():
         log.error("Could not run Patronus Lynx. `relevant_chunks` must be passed as a non-empty string.")
@@ -224,15 +228,19 @@ async def patronus_evaluate_request(
 async def patronus_api_check_output(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
+    relevant_chunks: Optional[Union[str, List[str]]] = None,
     http_client: Optional[HTTPClient] = None,
 ) -> RailOutcome:
     """
     Check the user message, bot response, and/or provided context
     for issues based on the Patronus Evaluate API
     """
-    user_input = context.get("user_message")
-    bot_response = context.get("bot_message")
-    provided_context = context.get("relevant_chunks")
+    context = context or {}
+    user_input = user_message if user_message is not None else context.get("user_message")
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
+    provided_context = relevant_chunks if relevant_chunks is not None else context.get("relevant_chunks")
 
     patronus_config = llm_task_manager.config.rails.config.patronus.output
     evaluate_config = getattr(patronus_config, "evaluate_config", {})

--- a/nemoguardrails/library/patronusai/rail.py
+++ b/nemoguardrails/library/patronusai/rail.py
@@ -63,10 +63,22 @@ RAIL = RailManifest(
                 name="patronus lynx check output hallucination",
                 direction=RailDirection.OUTPUT,
                 action=PATRONUS_LYNX_CHECK_OUTPUT_HALLUCINATION,
-                bindings=(Binding.literal("model_name", "patronus_lynx"),),
+                bindings=(
+                    Binding.literal("model_name", "patronus_lynx"),
+                    Binding.context("user_message", "user_message"),
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("relevant_chunks", "relevant_chunks"),
+                ),
             ),
             RailSurface(
-                name="patronus api check output", direction=RailDirection.OUTPUT, action=PATRONUS_API_CHECK_OUTPUT
+                name="patronus api check output",
+                direction=RailDirection.OUTPUT,
+                action=PATRONUS_API_CHECK_OUTPUT,
+                bindings=(
+                    Binding.context("user_message", "user_message"),
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("relevant_chunks", "relevant_chunks"),
+                ),
             ),
         ),
         requirements=RailRequirements(

--- a/nemoguardrails/library/patronusai/rail.py
+++ b/nemoguardrails/library/patronusai/rail.py
@@ -64,7 +64,7 @@ RAIL = RailManifest(
                 direction=RailDirection.OUTPUT,
                 action=PATRONUS_LYNX_CHECK_OUTPUT_HALLUCINATION,
                 bindings=(
-                    Binding.literal("model_name", "patronus_lynx"),
+                    Binding.model("model_name", "patronus_lynx"),
                     Binding.context("user_message", "user_message"),
                     Binding.context("bot_message", "bot_message"),
                     Binding.context("relevant_chunks", "relevant_chunks"),

--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -43,13 +43,15 @@ async def self_check_facts(
     context: Optional[dict] = None,
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
+    relevant_chunks: Optional[list] = None,
+    bot_message: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks the facts for the bot response by appropriately prompting the base llm."""
     _MAX_TOKENS = 1024
     context = context or {}
-    evidence = context.get("relevant_chunks", [])
-    response = context.get("bot_message")
+    evidence = relevant_chunks if relevant_chunks is not None else context.get("relevant_chunks", [])
+    response = bot_message if bot_message is not None else context.get("bot_message")
 
     if not evidence:
         return _fact_check_outcome(1.0)

--- a/nemoguardrails/library/self_check/facts/rail.py
+++ b/nemoguardrails/library/self_check/facts/rail.py
@@ -15,6 +15,7 @@
 
 from nemoguardrails.manifests import (
     ActionRef,
+    Binding,
     ModelRequirement,
     RailActions,
     RailDirection,
@@ -45,7 +46,17 @@ RAIL = RailManifest(
     spec=RailSpec(
         flows=RailFlows(flow_names=("self check facts",)),
         actions=RailActions(refs=(SELF_CHECK_FACTS,)),
-        surfaces=(RailSurface(name="self check facts", direction=RailDirection.OUTPUT, action=SELF_CHECK_FACTS),),
+        surfaces=(
+            RailSurface(
+                name="self check facts",
+                direction=RailDirection.OUTPUT,
+                action=SELF_CHECK_FACTS,
+                bindings=(
+                    Binding.context("relevant_chunks", "relevant_chunks"),
+                    Binding.context("bot_message", "bot_message"),
+                ),
+            ),
+        ),
         requirements=RailRequirements(models=(ModelRequirement(type="llm", required=True),)),
         privacy=RailPrivacy(sends_bot_text=True, sends_retrieved_chunks=True),
     ),

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -47,6 +47,7 @@ async def self_check_input(
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     variant: Optional[str] = None,
+    user_message: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks the input from the user.
@@ -59,7 +60,7 @@ async def self_check_input(
     """
 
     context = context or {}
-    user_input = context.get("user_message")
+    user_input = user_message if user_message is not None else context.get("user_message")
 
     task = resolve_self_check_task(
         variant,

--- a/nemoguardrails/library/self_check/input_check/rail.py
+++ b/nemoguardrails/library/self_check/input_check/rail.py
@@ -51,7 +51,10 @@ RAIL = RailManifest(
                 name="self check input",
                 direction=RailDirection.INPUT,
                 action=SELF_CHECK_INPUT,
-                bindings=(Binding.surface_param(action_param="variant", name="variant", required=False),),
+                bindings=(
+                    Binding.surface_param(action_param="variant", name="variant", required=False),
+                    Binding.context("user_message", "user_message"),
+                ),
             ),
         ),
         requirements=RailRequirements(models=(ModelRequirement(type="llm", required=True),)),

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -47,6 +47,9 @@ async def self_check_output(
     llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     variant: Optional[str] = None,
+    user_message: Optional[str] = None,
+    bot_message: Optional[str] = None,
+    bot_thinking: Optional[str] = None,
     **kwargs,
 ) -> RailOutcome:
     """Checks if the output from the bot.
@@ -62,9 +65,9 @@ async def self_check_output(
     """
 
     context = context or {}
-    bot_response = context.get("bot_message")
-    user_input = context.get("user_message")
-    bot_thinking = context.get("bot_thinking")
+    bot_response = bot_message if bot_message is not None else context.get("bot_message")
+    user_input = user_message if user_message is not None else context.get("user_message")
+    bot_thinking = bot_thinking if bot_thinking is not None else context.get("bot_thinking")
 
     task = resolve_self_check_task(
         variant,

--- a/nemoguardrails/library/self_check/output_check/rail.py
+++ b/nemoguardrails/library/self_check/output_check/rail.py
@@ -51,7 +51,12 @@ RAIL = RailManifest(
                 name="self check output",
                 direction=RailDirection.OUTPUT,
                 action=SELF_CHECK_OUTPUT,
-                bindings=(Binding.surface_param(action_param="variant", name="variant", required=False),),
+                bindings=(
+                    Binding.surface_param(action_param="variant", name="variant", required=False),
+                    Binding.context("user_message", "user_message", required=False),
+                    Binding.context("bot_message", "bot_message"),
+                    Binding.context("bot_thinking", "bot_thinking", required=False),
+                ),
             ),
         ),
         requirements=RailRequirements(models=(ModelRequirement(type="llm", required=True),)),

--- a/nemoguardrails/library/topic_safety/actions.py
+++ b/nemoguardrails/library/topic_safety/actions.py
@@ -49,15 +49,17 @@ async def topic_safety_check_input(
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
+    user_message: Optional[str] = None,
     events: Optional[List[dict]] = None,
     model_caches: Optional[Dict[str, CacheInterface]] = None,
     **kwargs,
 ) -> RailOutcome:
-    user_input: str = ""
+    user_input = user_message or ""
     conversation_history: List[dict] = []
 
     if context is not None:
-        user_input = context.get("user_message", "")
+        if user_message is None:
+            user_input = context.get("user_message", "")
         model_name = model_name or context.get("model", None)
 
     if events is not None:

--- a/nemoguardrails/library/topic_safety/rail.py
+++ b/nemoguardrails/library/topic_safety/rail.py
@@ -52,7 +52,10 @@ RAIL = RailManifest(
                 name="topic safety check input",
                 direction=RailDirection.INPUT,
                 action=TOPIC_SAFETY_CHECK_INPUT,
-                bindings=(Binding.surface_param("model_name", "model"),),
+                bindings=(
+                    Binding.surface_param("model_name", "model"),
+                    Binding.context("user_message", "user_message"),
+                ),
             ),
         ),
         requirements=RailRequirements(models=(ModelRequirement(type="topic_control", required=True),)),

--- a/nemoguardrails/library/topic_safety/rail.py
+++ b/nemoguardrails/library/topic_safety/rail.py
@@ -53,7 +53,7 @@ RAIL = RailManifest(
                 direction=RailDirection.INPUT,
                 action=TOPIC_SAFETY_CHECK_INPUT,
                 bindings=(
-                    Binding.surface_param("model_name", "model"),
+                    Binding.model_param("model_name", "model"),
                     Binding.context("user_message", "user_message"),
                 ),
             ),

--- a/nemoguardrails/manifests/__init__.py
+++ b/nemoguardrails/manifests/__init__.py
@@ -19,6 +19,7 @@ from nemoguardrails.manifests.catalog import RailCatalog, RailManifestRecord
 from nemoguardrails.manifests.manifest import (
     ActionRef,
     Binding,
+    BindingResource,
     ConfigSpecRef,
     EnvVar,
     ImportRef,
@@ -54,6 +55,7 @@ from nemoguardrails.manifests.surface_reference import (
 __all__ = [
     "ActionRef",
     "Binding",
+    "BindingResource",
     "ConfigSpecRef",
     "EnvVar",
     "ImportRef",

--- a/nemoguardrails/manifests/manifest.py
+++ b/nemoguardrails/manifests/manifest.py
@@ -55,6 +55,7 @@ RailCapability = Literal[
 ]
 RailLifecycle = Literal["stable", "experimental", "deprecated"]
 BindingKind = Literal["surface_param", "context", "literal"]
+BindingResource = Literal["model"]
 
 
 class RailDirection(str, Enum):
@@ -163,7 +164,9 @@ class Binding(BaseModel):
 
     Each binding tells the runtime where one argument of a surface's action comes
     from. Prefer the constructor classmethods over building instances directly, as
-    they set `kind` and the relevant fields correctly.
+    they set `kind` and the relevant fields correctly. A `resource` classifies the
+    resolved value for runtime validation; use `model` and `model_param` when that
+    value identifies a configured model type.
     """
 
     kind: BindingKind
@@ -171,6 +174,7 @@ class Binding(BaseModel):
     key: Optional[str] = None
     value: Any = None
     required: bool = True
+    resource: Optional[BindingResource] = None
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -180,6 +184,8 @@ class Binding(BaseModel):
             raise ValueError("Literal bindings cannot declare a source key.")
         if self.kind != "literal" and self.key is None:
             raise ValueError(f"{self.kind} bindings must declare a source key.")
+        if self.resource == "model" and self.kind == "context":
+            raise ValueError("Model bindings cannot read the model type from request context.")
         return self
 
     @classmethod
@@ -222,6 +228,50 @@ class Binding(BaseModel):
             A `literal` binding.
         """
         return cls(kind="literal", action_param=action_param, value=value)
+
+    @classmethod
+    def model_param(cls, action_param: str, name: str, *, required: bool = True) -> "Binding":
+        """Bind an action parameter to a configurable model type.
+
+        The returned binding reads the model type from a configured surface
+        parameter and sets `resource="model"`, allowing the runtime to validate
+        the resolved model before invoking the action. For example,
+        `Binding.model_param("model_name", "model")` binds `$model=content_safety`
+        to `model_name="content_safety"`.
+
+        Args:
+            action_param: Name of the action parameter receiving the model type.
+            name: Name of the surface parameter that selects the model type.
+            required: Whether the surface parameter must be provided.
+
+        Returns:
+            A model resource binding backed by a surface parameter.
+        """
+        return cls(
+            kind="surface_param",
+            action_param=action_param,
+            key=name,
+            required=required,
+            resource="model",
+        )
+
+    @classmethod
+    def model(cls, action_param: str, model_type: str) -> "Binding":
+        """Bind an action parameter to a fixed model type.
+
+        The returned literal binding sets `resource="model"`, allowing the
+        runtime to validate a model that is selected by the manifest rather than
+        the configured flow. For example, `Binding.model("model_name",
+        "llama_guard")` always supplies `model_name="llama_guard"`.
+
+        Args:
+            action_param: Name of the action parameter receiving the model type.
+            model_type: Configured model type supplied to the action.
+
+        Returns:
+            A model resource binding with a fixed value.
+        """
+        return cls(kind="literal", action_param=action_param, value=model_type, resource="model")
 
 
 class RailSurface(BaseModel):

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -49,6 +49,10 @@ class StubRail:
         self.call_count += 1
         return RailExecution(outcome=self.outcome)
 
+    def with_runtime_dependencies(self, deps: Any) -> "StubRail":
+        """Model dependency finalization while retaining this behavior-only test double."""
+        return self
+
     async def close(self) -> None:
         """A compiled rail may own an HTTP client; a stub has nothing to release."""
 

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -29,7 +29,6 @@ import pytest
 
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.guardrails.compiled_rail import (
-    _RETRIEVAL_CONTEXT_SURFACES,
     CompiledRail,
     RailCompilationError,
     RailDependencies,
@@ -84,22 +83,13 @@ EXECUTABLE_SURFACES = {
     "jailbreak detection model",
 }
 
-# Surfaces whose actions read retrieval evidence from the request context —
-# ``relevant_chunks``, ``relevant_chunks_sep``, or the Colang-internal ``_last_bot_prompt``.
-# Keyed by direction as well as name, because one rail can surface in both directions.
-# Held here independently of the production deny-list so the two cross-check each other.
-# Blocked by decision rather than by anything the manifest declares. Held here independently
-# of the production blocklist so the two cross-check each other.
 UNSUPPORTED_RAIL_SURFACES = {(RailDirection.INPUT, "jailbreak detection heuristics")}
 
-RETRIEVAL_DEPENDENT_SURFACES = {
-    (RailDirection.OUTPUT, "alignscore check facts"),
+UNSUPPORTED_CONTEXT_SURFACES = {
     (RailDirection.OUTPUT, "autoalign groundedness output"),
-    (RailDirection.OUTPUT, "fiddler bot faithfulness"),
     (RailDirection.OUTPUT, "patronus api check output"),
     (RailDirection.OUTPUT, "patronus lynx check output hallucination"),
     (RailDirection.OUTPUT, "self check facts"),
-    (RailDirection.OUTPUT, "self check hallucination"),
 }
 
 
@@ -525,27 +515,25 @@ class TestSurfacesOutsideTheTier:
 
     @pytest.mark.parametrize(
         "direction, flow",
-        sorted(RETRIEVAL_DEPENDENT_SURFACES, key=lambda surface: surface[1]),
+        sorted(UNSUPPORTED_CONTEXT_SURFACES, key=lambda surface: surface[1]),
         ids=lambda value: value if isinstance(value, str) else value.value,
     )
-    def test_retrieval_dependent_surfaces_do_not_compile(self, deps, direction, flow):
-        """A surface reading retrieval evidence is refused; IORails supplies none."""
-        with pytest.raises(RailCompilationError, match="retrieval"):
+    def test_required_unsupported_context_surfaces_do_not_compile(self, deps, direction, flow):
+        """A surface requiring unavailable context is refused before execution."""
+        with pytest.raises(RailCompilationError, match="does not supply"):
             compile_rail(flow, direction, deps)
 
-    def test_the_deny_list_names_only_real_surfaces(self):
-        """Every refused surface exists in the catalog, so no entry can rot into a no-op."""
+    def test_refused_surfaces_declare_required_unsupported_context(self):
+        """The manifest, rather than an IORails surface list, explains each refusal."""
         surfaces = default_rail_catalog().surfaces()
-        missing = sorted(
-            f"{direction.value} {name!r}"
-            for direction, name in _RETRIEVAL_CONTEXT_SURFACES
-            if (direction, name) not in surfaces
-        )
+        supported_context = {"user_message", "bot_message"}
 
-        assert not missing, f"deny-list names surfaces the catalog does not have: {missing}"
+        for surface_key in UNSUPPORTED_CONTEXT_SURFACES:
+            declared_context = {binding.key for binding in surfaces[surface_key].bindings if binding.kind == "context"}
+            assert declared_context - supported_context
 
     def test_the_input_output_tier_splits_into_servable_and_refused(self):
-        """59 servable -- 41 judging and 18 rewriting -- against the 8 refused, pinned by name.
+        """62 servable against the five refused surfaces, pinned by name.
 
         A predicate would follow the code it is checking; a new manifest surface fails here.
         """
@@ -556,8 +544,8 @@ class TestSurfacesOutsideTheTier:
             bucket = refused if unsupported_surface_reason(surface) is not None else servable
             bucket.append((direction, name))
 
-        assert sorted(refused) == sorted(RETRIEVAL_DEPENDENT_SURFACES | UNSUPPORTED_RAIL_SURFACES)
-        assert len(servable) == 59
+        assert sorted(refused) == sorted(UNSUPPORTED_CONTEXT_SURFACES | UNSUPPORTED_RAIL_SURFACES)
+        assert len(servable) == 62
 
     def test_the_rewriting_surfaces_are_all_servable(self):
         """The eighteen this work exists for, nine each way, with no direction half-enabled."""
@@ -580,7 +568,7 @@ class TestSurfacesOutsideTheTier:
 
         monkeypatch.setattr("nemoguardrails.guardrails.compiled_rail.resolve_import_ref", unreachable)
 
-        with pytest.raises(RailCompilationError, match="retrieval"):
+        with pytest.raises(RailCompilationError, match="relevant_chunks"):
             compile_rail("self check facts", RailDirection.OUTPUT, deps)
 
 
@@ -641,11 +629,12 @@ class TestBindingResolution:
         assert content_safety_action.kwargs["model_name"] == "content_safety"
 
     @pytest.mark.asyncio
-    async def test_context_carries_the_request_messages(self, deps, content_safety_action):
-        """The per-request context dict exposes user_message for context-bound actions."""
+    async def test_manifest_binding_carries_the_request_message(self, deps, content_safety_action):
+        """The declared user_message binding supplies request text without a context dict."""
         await compile_rail(CONTENT_SAFETY_INPUT, RailDirection.INPUT, deps).run(USER_MESSAGES)
 
-        assert content_safety_action.kwargs["context"]["user_message"] == "hello there"
+        assert content_safety_action.kwargs["user_message"] == "hello there"
+        assert "context" not in content_safety_action.kwargs
 
     @pytest.mark.asyncio
     async def test_literal_binding_supplies_a_constant(self, deps, content_safety_action):
@@ -666,31 +655,30 @@ class TestBindingResolution:
     async def test_user_message_is_empty_when_the_request_has_no_user_turn(self, deps, content_safety_action):
         """A request with no user turn yields an empty user_message instead of raising.
 
-        Matches the library actions, which read ``context.get(...)`` with a default and call
-        the model with empty text. The hand-written rails raised here and failed closed.
+        Matches the library actions, which call the model with empty text. The hand-written
+        rails raised here and failed closed.
         """
         await compile_rail(CONTENT_SAFETY_INPUT, RailDirection.INPUT, deps).run([{"role": "system", "content": "hi"}])
 
-        assert content_safety_action.kwargs["context"]["user_message"] == ""
+        assert content_safety_action.kwargs["user_message"] == ""
 
     @pytest.mark.asyncio
     async def test_bot_response_reaches_an_output_rail_as_bot_message(self, deps, monkeypatch):
-        """An output rail's context carries the generated response under bot_message."""
+        """An output rail's binding carries the generated response under bot_message."""
         action = RecordingAction(signature_of=content_safety_check_output)
         monkeypatch.setattr("nemoguardrails.library.content_safety.actions.content_safety_check_output", action)
 
         rail = compile_rail("content safety check output $model=content_safety", RailDirection.OUTPUT, deps)
         await rail.run(USER_MESSAGES, bot_response="the reply")
 
-        assert action.kwargs["context"]["bot_message"] == "the reply"
+        assert action.kwargs["bot_message"] == "the reply"
 
 
 class TestContextBindingResolution:
     """A context binding maps one conversation variable onto a differently named parameter.
 
-    This is the kind 3a refused and PR 4 implements. It is not "pass the context dict" — the
-    dict is already injected under ``context`` for actions that declare it. A context binding
-    names *one* variable and *one* action parameter, and 25 block-only surfaces need it.
+    A context binding names one request variable and one action parameter. IORails does not
+    inject its whole request context, so every action input must be declared here.
     """
 
     @pytest.fixture
@@ -723,6 +711,20 @@ class TestContextBindingResolution:
         await rail.run(USER_MESSAGES, bot_response="the reply")
 
         assert text_action.kwargs["text"] == "the reply"
+
+    @pytest.mark.asyncio
+    async def test_an_optional_unavailable_context_variable_is_omitted(self, deps, monkeypatch):
+        """Optional state outside IORails' request contract does not disable the rail."""
+        action = RecordingAction(signature_of=takes_text)
+        monkeypatch.setattr(CONTENT_SAFETY_ACTION, action)
+        surface = synthetic_surface(
+            CONTENT_SAFETY_ACTION_REF,
+            (Binding.context("text", "bot_thinking", required=False),),
+        )
+
+        await compile_rail(SYNTHETIC_FLOW, RailDirection.INPUT, deps, catalog=StubCatalog(surface)).run(USER_MESSAGES)
+
+        assert "text" not in action.kwargs
 
     @pytest.mark.asyncio
     async def test_the_value_is_resolved_per_request(self, deps, text_action):
@@ -1008,9 +1010,10 @@ class TestDependencyInjection:
         """
         captured = {}
 
-        async def narrow_action(llm_task_manager, model_name):
+        async def narrow_action(llm_task_manager, model_name, user_message):
             captured["llm_task_manager"] = llm_task_manager
             captured["model_name"] = model_name
+            captured["user_message"] = user_message
             return RailOutcome.allow()
 
         monkeypatch.setattr(TOPIC_SAFETY_ACTION, narrow_action)
@@ -1018,7 +1021,11 @@ class TestDependencyInjection:
         outcome = await compile_rail(TOPIC_SAFETY_INPUT, RailDirection.INPUT, deps).run(USER_MESSAGES)
 
         assert not outcome.is_blocked
-        assert captured == {"llm_task_manager": deps.llm_task_manager, "model_name": "topic_control"}
+        assert captured == {
+            "llm_task_manager": deps.llm_task_manager,
+            "model_name": "topic_control",
+            "user_message": "hello there",
+        }
 
     @pytest.mark.asyncio
     async def test_events_are_supplied_to_actions_that_declare_them(self, deps, monkeypatch):
@@ -1042,7 +1049,7 @@ class TestDependencyInjection:
     async def test_events_stop_at_the_checked_turn_for_an_assistant_terminated_transcript(self, deps, monkeypatch):
         """A check() transcript ending in an assistant turn leaves that turn out of the history.
 
-        The action appends the checked turn last, from context, so an assistant turn that
+        The action appends the checked turn last, from the bound user message, so an assistant turn that
         followed it in the transcript would otherwise be classified ahead of it.
         """
         action = RecordingAction(signature_of=topic_safety_check_input)
@@ -1060,7 +1067,8 @@ class TestDependencyInjection:
             {"type": "UserMessage", "text": "an earlier question"},
             {"type": "StartUtteranceBotAction", "script": "an earlier answer"},
         ]
-        assert action.kwargs["context"]["user_message"] == "hello there"
+        assert action.kwargs["user_message"] == "hello there"
+        assert "context" not in action.kwargs
 
     @pytest.mark.asyncio
     async def test_http_client_is_supplied_to_vendor_actions(self, deps, monkeypatch):

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -1085,6 +1085,21 @@ class TestDependencyInjection:
 
         assert action.kwargs["http_client"] is mock_client
 
+    @pytest.mark.asyncio
+    async def test_runtime_dependencies_finalize_without_mutating_the_compiled_plan(self, deps, monkeypatch):
+        """Finalizing transport returns a new rail and leaves the validated plan unchanged."""
+        action = RecordingAction(signature_of=jailbreak_detection_model)
+        monkeypatch.setattr("nemoguardrails.library.jailbreak_detection.actions.jailbreak_detection_model", action)
+        compiled = compile_rail(JAILBREAK_INPUT, RailDirection.INPUT, deps)
+        mock_client = MagicMock()
+
+        finalized = compiled.with_runtime_dependencies(replace(deps, http_client=mock_client))
+        await finalized.run(USER_MESSAGES)
+
+        assert finalized is not compiled
+        assert compiled._deps.http_client is None
+        assert action.kwargs["http_client"] is mock_client
+
 
 class TestOutcomePassthrough:
     """The action's RailOutcome is returned unmodified; CompiledRail invents nothing."""

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -86,10 +86,13 @@ EXECUTABLE_SURFACES = {
 UNSUPPORTED_RAIL_SURFACES = {(RailDirection.INPUT, "jailbreak detection heuristics")}
 
 UNSUPPORTED_CONTEXT_SURFACES = {
+    (RailDirection.OUTPUT, "alignscore check facts"),
     (RailDirection.OUTPUT, "autoalign groundedness output"),
+    (RailDirection.OUTPUT, "fiddler bot faithfulness"),
     (RailDirection.OUTPUT, "patronus api check output"),
     (RailDirection.OUTPUT, "patronus lynx check output hallucination"),
     (RailDirection.OUTPUT, "self check facts"),
+    (RailDirection.OUTPUT, "self check hallucination"),
 }
 
 
@@ -533,7 +536,7 @@ class TestSurfacesOutsideTheTier:
             assert declared_context - supported_context
 
     def test_the_input_output_tier_splits_into_servable_and_refused(self):
-        """62 servable against the five refused surfaces, pinned by name.
+        """59 servable against the eight refused surfaces, pinned by name.
 
         A predicate would follow the code it is checking; a new manifest surface fails here.
         """
@@ -545,7 +548,7 @@ class TestSurfacesOutsideTheTier:
             bucket.append((direction, name))
 
         assert sorted(refused) == sorted(UNSUPPORTED_CONTEXT_SURFACES | UNSUPPORTED_RAIL_SURFACES)
-        assert len(servable) == 62
+        assert len(servable) == 59
 
     def test_the_rewriting_surfaces_are_all_servable(self):
         """The eighteen this work exists for, nine each way, with no direction half-enabled."""

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -23,7 +23,7 @@ sink rather than read from a contextvar afterwards.
 import inspect
 from dataclasses import replace
 from typing import Any, Callable, Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -1064,31 +1064,15 @@ class TestDependencyInjection:
 
     @pytest.mark.asyncio
     async def test_http_client_is_supplied_to_vendor_actions(self, deps, monkeypatch):
-        """jailbreak_detection_model declares http_client and receives the one compiled into the rail."""
+        """An action declaring http_client receives the runtime-owned shared client."""
         action = RecordingAction(signature_of=jailbreak_detection_model)
         monkeypatch.setattr("nemoguardrails.library.jailbreak_detection.actions.jailbreak_detection_model", action)
         mock_client = MagicMock()
+        deps = replace(deps, http_client=mock_client)
 
-        await compile_rail(JAILBREAK_INPUT, RailDirection.INPUT, deps, http_client=mock_client).run(USER_MESSAGES)
+        await compile_rail(JAILBREAK_INPUT, RailDirection.INPUT, deps).run(USER_MESSAGES)
 
         assert action.kwargs["http_client"] is mock_client
-
-    @pytest.mark.asyncio
-    async def test_close_calls_http_client_close(self, deps):
-        """close() forwards to the rail's HTTP client so the connection pool is released."""
-        mock_client = AsyncMock()
-        rail = compile_rail(JAILBREAK_INPUT, RailDirection.INPUT, deps, http_client=mock_client)
-
-        await rail.close()
-
-        mock_client.close.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_close_is_a_no_op_when_no_http_client(self, deps):
-        """close() on a rail with no HTTP client (LLM-backed) does not raise."""
-        rail = compile_rail(CONTENT_SAFETY_INPUT, RailDirection.INPUT, deps)
-
-        await rail.close()
 
 
 class TestOutcomePassthrough:

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -834,6 +834,25 @@ class TestModelDependencyValidation:
 
         assert compile_rail("llama guard check input", RailDirection.INPUT, deps_with_llama_guard) is not None
 
+    def test_model_validation_is_not_inferred_from_the_parameter_name(self, deps):
+        """An ordinary binding named model_name does not silently become a model dependency."""
+        surface = synthetic_surface(
+            CONTENT_SAFETY_ACTION_REF,
+            (Binding.literal("model_name", "not-a-model-resource"),),
+        )
+
+        assert compile_rail(SYNTHETIC_FLOW, RailDirection.INPUT, deps, catalog=StubCatalog(surface)) is not None
+
+    def test_model_validation_follows_the_declared_resource(self, deps):
+        """A model binding is validated even when its action parameter has another name."""
+        surface = synthetic_surface(
+            CONTENT_SAFETY_ACTION_REF,
+            (Binding.model("threshold_mode", "absent_model"),),
+        )
+
+        with pytest.raises(RailCompilationError, match="absent_model"):
+            compile_rail(SYNTHETIC_FLOW, RailDirection.INPUT, deps, catalog=StubCatalog(surface))
+
 
 class TestMissingOptionalDependencies:
     """A rail whose declared distribution is absent is refused at compile time.

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -2123,7 +2123,6 @@ class TestScopeGateCharacterization:
             ("input", "trend ai guard input"),
             ("output", "activefence moderation on output"),
             ("output", "ai defense inspect response"),
-            ("output", "alignscore check facts"),
             ("output", "autoalign check output"),
             ("output", "autoalign factcheck output"),
             ("output", "clavata check output"),
@@ -2134,7 +2133,6 @@ class TestScopeGateCharacterization:
             ("output", "detect sensitive data on output"),
             ("output", "f5 guardrails scan output"),
             ("output", "fiddler bot safety"),
-            ("output", "fiddler bot faithfulness"),
             ("output", "gliner detect pii on output"),
             ("output", "gliner mask pii on output"),
             ("output", "guardrailsai check output"),
@@ -2150,7 +2148,6 @@ class TestScopeGateCharacterization:
             ("output", "protect response"),
             ("output", "regex check output"),
             ("output", "self check output"),
-            ("output", "self check hallucination"),
             ("output", "trend ai guard output"),
         }
     )
@@ -2167,7 +2164,7 @@ class TestScopeGateCharacterization:
         return IORails._unservable_rails_reason([flow], direction, deps)
 
     def test_the_admitted_surfaces_are_exactly_the_pinned_set(self):
-        """Every catalog surface in scope is one of the 62 named here, and vice versa."""
+        """Every catalog surface in scope is one of the 59 named here, and vice versa."""
         admitted = {
             (direction.value, name)
             for direction in (SurfaceDirection.INPUT, SurfaceDirection.OUTPUT)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -57,12 +57,12 @@ _LLMRAILS_ONLY_INPUT_REASON = (
     "'jailbreak detection heuristics' Conflates dependencies with 'jailbreak detection model', "
     "so IORails cannot tell whether it needs 'torch' and 'transformers' installed"
 )
-# Chosen from the retrieval-evidence group for needing no prompt template of its own, so a
-# config built for a routing test does not have to carry one.
-_LLMRAILS_ONLY_OUTPUT_FLOW = "alignscore check facts"
+# Chosen from the surfaces that still require retrieval evidence unavailable to IORails.
+_LLMRAILS_ONLY_OUTPUT_FLOW = "self check facts"
 _LLMRAILS_ONLY_OUTPUT_REASON = (
-    "'alignscore check facts' needs retrieval evidence, which manifest-driven execution does not supply yet"
+    "'self check facts' needs context variable(s) 'relevant_chunks', which IORails does not supply"
 )
+_LLMRAILS_ONLY_OUTPUT_PROMPT = {"task": "self_check_facts", "content": "placeholder"}
 
 
 def _make_iorails_config(rails: dict, extra_prompts: list | None = None) -> RailsConfig:
@@ -398,7 +398,7 @@ class TestIORailsUnsupportedReason:
         reason = IORails.unsupported_reason(config, llm=None)
 
         assert reason is not None
-        assert "retrieval" in reason
+        assert "relevant_chunks_sep" in reason
 
     def test_a_transform_flow_is_admitted(self):
         """A rewrite-capable surface runs here, having been refused at selection until IORails
@@ -414,6 +414,7 @@ class TestIORailsUnsupportedReason:
                 "input": {"flows": ["content safety check input $model=content_safety"]},
                 "output": {"flows": [_LLMRAILS_ONLY_OUTPUT_FLOW]},
             },
+            extra_prompts=[_LLMRAILS_ONLY_OUTPUT_PROMPT],
         )
         reason = IORails.unsupported_reason(config, llm=None)
         assert reason == _LLMRAILS_ONLY_OUTPUT_REASON
@@ -1267,7 +1268,10 @@ class TestIORailsCanHandle:
                     ]
                 },
             },
-            extra_prompts=[{"task": "self_check_output", "content": "placeholder"}],
+            extra_prompts=[
+                {"task": "self_check_output", "content": "placeholder"},
+                _LLMRAILS_ONLY_OUTPUT_PROMPT,
+            ],
         )
         assert IORails.can_handle(config) is False
 
@@ -2119,6 +2123,7 @@ class TestScopeGateCharacterization:
             ("input", "trend ai guard input"),
             ("output", "activefence moderation on output"),
             ("output", "ai defense inspect response"),
+            ("output", "alignscore check facts"),
             ("output", "autoalign check output"),
             ("output", "autoalign factcheck output"),
             ("output", "clavata check output"),
@@ -2129,6 +2134,7 @@ class TestScopeGateCharacterization:
             ("output", "detect sensitive data on output"),
             ("output", "f5 guardrails scan output"),
             ("output", "fiddler bot safety"),
+            ("output", "fiddler bot faithfulness"),
             ("output", "gliner detect pii on output"),
             ("output", "gliner mask pii on output"),
             ("output", "guardrailsai check output"),
@@ -2144,6 +2150,7 @@ class TestScopeGateCharacterization:
             ("output", "protect response"),
             ("output", "regex check output"),
             ("output", "self check output"),
+            ("output", "self check hallucination"),
             ("output", "trend ai guard output"),
         }
     )
@@ -2160,7 +2167,7 @@ class TestScopeGateCharacterization:
         return IORails._unservable_rails_reason([flow], direction, deps)
 
     def test_the_admitted_surfaces_are_exactly_the_pinned_set(self):
-        """Every catalog surface in scope is one of the 59 named here, and vice versa."""
+        """Every catalog surface in scope is one of the 62 named here, and vice versa."""
         admitted = {
             (direction.value, name)
             for direction in (SurfaceDirection.INPUT, SurfaceDirection.OUTPUT)
@@ -2198,7 +2205,7 @@ class TestScopeGateCharacterization:
             (
                 "self check facts",
                 SurfaceDirection.OUTPUT,
-                "'self check facts' needs retrieval evidence, which manifest-driven execution does not supply yet",
+                "'self check facts' needs context variable(s) 'relevant_chunks', which IORails does not supply",
             ),
             (
                 "content safety check output",

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -16,7 +16,6 @@
 import asyncio
 import copy
 import gc
-import inspect
 import json
 import logging
 import warnings
@@ -28,12 +27,11 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
-from nemoguardrails.guardrails.compiled_rail import RailCompilationError, unservable_reason
+from nemoguardrails.guardrails.compiled_rail import RailCompilationError
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import RailCallRecord, RailDirection, RailResult, serialize_prompt
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.guardrails.rails_manager import (
-    _HTTP_CLIENT_SURFACE_NAMES,
     RailsManager,
     _checked_text,
     _rail_call_record,
@@ -49,7 +47,6 @@ from nemoguardrails.http.retry import RetryingHTTPClient
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.manifests import RailDirection as SurfaceDirection
-from nemoguardrails.manifests import default_rail_catalog, resolve_import_ref
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.tracing.constants import GuardrailsAttributes
 from nemoguardrails.types import LLMResponse, ToolCall, ToolCallFunction
@@ -195,14 +192,35 @@ class TestRailsManagerInit:
         assert mgr.input_flows == []
         assert mgr.output_flows == []
 
-    def test_unsupported_flow_raises(self):
+    def test_unsupported_flow_does_not_allocate_http_client(self):
         config_with_unknown = {
             **CONTENT_SAFETY_CONFIG,
             "rails": {"input": {"flows": ["unknown rail $model=content_safety"]}},
         }
-        with pytest.raises(RailCompilationError, match="no surface named"):
-            config = RailsConfig.from_content(config=config_with_unknown)
-            _make_rails_manager(config)
+        with (
+            patch("nemoguardrails.guardrails.rails_manager.create_http_client") as create_client,
+            pytest.raises(RailCompilationError, match="no surface named"),
+        ):
+            _make_rails_manager(RailsConfig.from_content(config=config_with_unknown))
+
+        create_client.assert_not_called()
+
+    def test_invalid_tool_flow_does_not_allocate_http_client(
+        self, content_safety_rails_config, content_safety_engine_registry
+    ):
+        with (
+            patch("nemoguardrails.guardrails.rails_manager.create_http_client") as create_client,
+            pytest.raises(RuntimeError, match="not supported"),
+        ):
+            RailsManager(
+                engine_registry=content_safety_engine_registry,
+                task_manager=LLMTaskManager(content_safety_rails_config),
+                input_flows=[],
+                output_flows=[],
+                tool_call_flows=["unknown tool rail"],
+            )
+
+        create_client.assert_not_called()
 
     def test_unparseable_flow_raises(self, content_safety_rails_config, content_safety_engine_registry):
         """A flow the surface parser rejects fails compilation instead of raising a raw ValueError."""
@@ -262,35 +280,26 @@ class _RecordingClient:
             raise self.close_error
 
 
-def _give_every_rail_a_client(manager: RailsManager) -> list[_RecordingClient]:
-    """Swap in a recording client for every compiled rail, returned in dispatch order."""
-    clients = [_RecordingClient() for _ in manager._rails]
-    for rail, client in zip(manager._rails.values(), clients):
-        rail._http_client = client
-    return clients
+class TestRailsManagerHTTPClient:
+    """The manager owns one pooled client shared by all compiled rail actions."""
 
+    def test_every_compiled_rail_borrows_the_runtime_client(self, nemoguards_rails_manager):
+        """HTTP transport is runtime infrastructure, independent of the selected rail."""
+        clients = {rail._deps.http_client for rail in nemoguards_rails_manager._rails.values()}
 
-class TestRailsManagerStop:
-    """Only API-backed rails own an HTTP client, and stop() releases every one of them."""
-
-    def test_only_api_backed_rails_are_given_a_client(self, nemoguards_rails_manager):
-        """A vendor API surface compiles with its own client; an LLM-backed surface gets none."""
-        clients = {flow: rail._http_client for (_, flow), rail in nemoguards_rails_manager._rails.items()}
-
-        assert clients["jailbreak detection model"] is not None
-        assert clients["content safety check input $model=content_safety"] is None
+        assert clients == {nemoguards_rails_manager._http_client}
 
     def test_the_injected_client_carries_no_retry_policy(self, nemoguards_rails_manager):
         """The injected client pools connections only; retry stays the vendor action's to apply."""
         # Vendor actions wrap whatever client they are handed -- clavata and f5 build a
         # RetryingHTTPClient around it -- so a retrying client here would nest inside theirs
         # and multiply attempts against an API that is already rate-limiting us.
-        client = nemoguards_rails_manager._rails[(RailDirection.INPUT, "jailbreak detection model")]._http_client
+        client = nemoguards_rails_manager._http_client
 
         assert not isinstance(client, RetryingHTTPClient)
 
-    def test_each_api_backed_rail_gets_its_own_client(self):
-        """Two API-backed flows get separate clients, so one vendor's pool cannot starve another."""
+    def test_api_backed_rails_share_one_connection_pool(self):
+        """Two vendor rails borrow one transport whose pool separates connections by origin."""
         config_dict = {
             **NEMOGUARDS_CONFIG,
             "rails": {
@@ -303,74 +312,37 @@ class TestRailsManagerStop:
         }
         manager = _make_rails_manager(RailsConfig.from_content(config=config_dict))
 
-        clients = [rail._http_client for rail in manager._rails.values()]
+        clients = [rail._deps.http_client for rail in manager._rails.values()]
 
         assert len(clients) == 2
-        assert clients[0] is not clients[1]
+        assert clients[0] is clients[1] is manager._http_client
 
     @pytest.mark.asyncio
-    async def test_stop_closes_every_client(self, nemoguards_rails_manager):
-        """Shutdown releases each rail's connection pool."""
-        clients = _give_every_rail_a_client(nemoguards_rails_manager)
+    async def test_stop_closes_the_shared_client_once(self, nemoguards_rails_manager):
+        """Shutdown releases the manager's connection pool once, not once per rail."""
+        client = _RecordingClient()
+        nemoguards_rails_manager._http_client = client
 
         await nemoguards_rails_manager.stop()
 
-        assert [client.close_count for client in clients] == [1] * len(clients)
+        assert client.close_count == 1
 
     @pytest.mark.asyncio
-    async def test_a_failing_close_still_releases_the_remaining_clients(self, nemoguards_rails_manager):
-        """One client raising does not leak the pools behind it in the dispatch order."""
-        clients = _give_every_rail_a_client(nemoguards_rails_manager)
-        clients[0].close_error = RuntimeError("Event loop is closed")
+    async def test_a_failing_close_propagates(self, nemoguards_rails_manager):
+        """The owner exposes a shared-client shutdown failure to its caller."""
+        client = _RecordingClient(RuntimeError("socket stuck"))
+        nemoguards_rails_manager._http_client = client
 
-        with pytest.raises(RuntimeError, match="Failed to close rail HTTP clients"):
+        with pytest.raises(RuntimeError, match="socket stuck"):
             await nemoguards_rails_manager.stop()
 
-        assert [client.close_count for client in clients] == [1] * len(clients)
-
-    @pytest.mark.asyncio
-    async def test_stop_names_the_rail_whose_client_failed(self, nemoguards_rails_manager):
-        """The combined error names the flow, so a leaked pool is attributable."""
-        clients = _give_every_rail_a_client(nemoguards_rails_manager)
-        clients[0].close_error = RuntimeError("socket stuck")
-
-        with pytest.raises(RuntimeError, match="socket stuck") as excinfo:
-            await nemoguards_rails_manager.stop()
-
-        failed_flow = list(nemoguards_rails_manager._rails)[0][1]
-        assert failed_flow in str(excinfo.value)
+        assert client.close_count == 1
 
     @pytest.mark.asyncio
     async def test_second_stop_is_safe(self, nemoguards_rails_manager):
-        """stop() is idempotent, because a closed client's close() is a no-op."""
+        """stop() is idempotent because the managed client's close() is a no-op."""
         await nemoguards_rails_manager.stop()
         await nemoguards_rails_manager.stop()
-
-
-class TestPooledClientCoverage:
-    """Every rail IORails enables that speaks HTTP is named in the pooling list."""
-
-    # _HTTP_CLIENT_SURFACE_NAMES is hand-maintained while the set of rails IORails runs is
-    # derived from the catalog, so nothing holds the two in agreement. Enabling a vendor rail
-    # without adding it here regresses silently rather than loudly: http_call builds an owned
-    # client per request when it receives None, so the rail still returns the right verdict
-    # and only the connection pooling is lost. The pooling list may name surfaces IORails has
-    # not enabled -- it is deliberately ahead of the tier -- so only this direction is checked.
-
-    def test_every_enabled_http_surface_is_pooled(self):
-        """A rail in the enabled tier whose action declares http_client is compiled with one."""
-        declares_http_client = {
-            name
-            for (direction, name), surface in default_rail_catalog().surfaces().items()
-            if direction is not SurfaceDirection.RETRIEVAL
-            and unservable_reason(name, direction) is None
-            and "http_client" in inspect.signature(resolve_import_ref(surface.action)).parameters
-        }
-
-        unpooled = sorted(declares_http_client - _HTTP_CLIENT_SURFACE_NAMES)
-
-        assert declares_http_client, "no enabled surface declares http_client; this test is broken, not the tier"
-        assert not unpooled, f"enabled rails absent from _HTTP_CLIENT_SURFACE_NAMES: {unpooled}"
 
 
 # --- Sequential input/output tests ---

--- a/tests/manifests/test_manifest.py
+++ b/tests/manifests/test_manifest.py
@@ -147,6 +147,26 @@ def test_binding_source_matches_binding_kind(factory):
         factory()
 
 
+def test_model_bindings_identify_fixed_and_configurable_model_types():
+    assert Binding.model("model_name", "llama_guard") == Binding(
+        kind="literal",
+        action_param="model_name",
+        value="llama_guard",
+        resource="model",
+    )
+    assert Binding.model_param("model_name", "model") == Binding(
+        kind="surface_param",
+        action_param="model_name",
+        key="model",
+        resource="model",
+    )
+
+
+def test_model_binding_rejects_request_context_as_its_source():
+    with pytest.raises(ValidationError, match="cannot read the model type"):
+        Binding(kind="context", action_param="model_name", key="model", resource="model")
+
+
 def test_surface_rejects_duplicate_action_parameter_bindings():
     with pytest.raises(ValidationError, match="more than once"):
         RailSurface(

--- a/tests/rails/llm/test_builtin_rail_manifests.py
+++ b/tests/rails/llm/test_builtin_rail_manifests.py
@@ -194,10 +194,29 @@ def test_named_model_surfaces_bind_literal_model_names():
     manifests = all_rail_manifests()
 
     for surface in manifests["llama_guard"].surfaces:
-        assert surface.bindings[0] == Binding.literal("model_name", "llama_guard")
+        assert surface.bindings[0] == Binding.model("model_name", "llama_guard")
 
     patronus_surfaces = manifests["patronusai"].surfaces
-    assert patronus_surfaces[0].bindings[0] == Binding.literal("model_name", "patronus_lynx")
+    assert patronus_surfaces[0].bindings[0] == Binding.model("model_name", "patronus_lynx")
+
+
+def test_model_dependent_surfaces_declare_model_bindings():
+    surfaces = default_rail_catalog().surfaces()
+    expected = {
+        (RailDirection.INPUT, "content safety check input"),
+        (RailDirection.OUTPUT, "content safety check output"),
+        (RailDirection.INPUT, "llama guard check input"),
+        (RailDirection.OUTPUT, "llama guard check output"),
+        (RailDirection.OUTPUT, "patronus lynx check output hallucination"),
+        (RailDirection.INPUT, "topic safety check input"),
+    }
+    declared = {
+        surface_key
+        for surface_key, surface in surfaces.items()
+        if any(binding.resource == "model" for binding in surface.bindings)
+    }
+
+    assert declared == expected
 
 
 def test_retrieval_dependent_surfaces_declare_context_inputs():

--- a/tests/rails/llm/test_builtin_rail_manifests.py
+++ b/tests/rails/llm/test_builtin_rail_manifests.py
@@ -175,20 +175,97 @@ def test_every_manifested_action_is_declared_in_its_manifest():
 def test_self_check_surfaces_bind_optional_variant():
     manifests = all_rail_manifests()
 
-    for rail_name in ("self_check.input_check", "self_check.output_check"):
-        surface = manifests[rail_name].surfaces[0]
-        assert surface.bindings == (Binding.surface_param(action_param="variant", name="variant", required=False),)
+    input_surface = manifests["self_check.input_check"].surfaces[0]
+    assert input_surface.bindings == (
+        Binding.surface_param(action_param="variant", name="variant", required=False),
+        Binding.context("user_message", "user_message"),
+    )
+
+    output_surface = manifests["self_check.output_check"].surfaces[0]
+    assert output_surface.bindings == (
+        Binding.surface_param(action_param="variant", name="variant", required=False),
+        Binding.context("user_message", "user_message", required=False),
+        Binding.context("bot_message", "bot_message"),
+        Binding.context("bot_thinking", "bot_thinking", required=False),
+    )
 
 
 def test_named_model_surfaces_bind_literal_model_names():
     manifests = all_rail_manifests()
 
     for surface in manifests["llama_guard"].surfaces:
-        assert surface.bindings == (Binding.literal("model_name", "llama_guard"),)
+        assert surface.bindings[0] == Binding.literal("model_name", "llama_guard")
 
     patronus_surfaces = manifests["patronusai"].surfaces
-    assert patronus_surfaces[0].bindings == (Binding.literal("model_name", "patronus_lynx"),)
-    assert patronus_surfaces[1].bindings == ()
+    assert patronus_surfaces[0].bindings[0] == Binding.literal("model_name", "patronus_lynx")
+
+
+def test_retrieval_dependent_surfaces_declare_context_inputs():
+    surfaces = default_rail_catalog().surfaces()
+    expected = {
+        (RailDirection.OUTPUT, "alignscore check facts"): (
+            Binding.context("relevant_chunks", "relevant_chunks", required=False),
+            Binding.context("bot_message", "bot_message"),
+        ),
+        (RailDirection.OUTPUT, "autoalign groundedness output"): (
+            Binding.context("bot_message", "bot_message"),
+            Binding.context("relevant_chunks_sep", "relevant_chunks_sep"),
+        ),
+        (RailDirection.OUTPUT, "fiddler bot faithfulness"): (
+            Binding.context("bot_message", "bot_message"),
+            Binding.context("relevant_chunks", "relevant_chunks", required=False),
+        ),
+        (RailDirection.OUTPUT, "patronus api check output"): (
+            Binding.context("user_message", "user_message"),
+            Binding.context("bot_message", "bot_message"),
+            Binding.context("relevant_chunks", "relevant_chunks"),
+        ),
+        (RailDirection.OUTPUT, "patronus lynx check output hallucination"): (
+            Binding.context("user_message", "user_message"),
+            Binding.context("bot_message", "bot_message"),
+            Binding.context("relevant_chunks", "relevant_chunks"),
+        ),
+        (RailDirection.OUTPUT, "self check facts"): (
+            Binding.context("relevant_chunks", "relevant_chunks"),
+            Binding.context("bot_message", "bot_message"),
+        ),
+        (RailDirection.OUTPUT, "self check hallucination"): (
+            Binding.context("bot_message", "bot_message"),
+            Binding.context("last_bot_prompt", "_last_bot_prompt", required=False),
+        ),
+    }
+
+    for surface_key, bindings in expected.items():
+        declared = surfaces[surface_key].bindings
+        assert all(binding in declared for binding in bindings)
+
+
+def test_legacy_context_actions_declare_message_inputs():
+    surfaces = default_rail_catalog().surfaces()
+    expected = {
+        (RailDirection.INPUT, "autoalign check input"): {"user_message"},
+        (RailDirection.OUTPUT, "autoalign check output"): {"bot_message"},
+        (RailDirection.OUTPUT, "autoalign factcheck output"): {"user_message", "bot_message"},
+        (RailDirection.OUTPUT, "cleanlab trustworthiness"): {"user_message", "bot_message"},
+        (RailDirection.INPUT, "content safety check input"): {"user_message"},
+        (RailDirection.OUTPUT, "content safety check output"): {"user_message", "bot_message"},
+        (RailDirection.INPUT, "fiddler user safety"): {"user_message"},
+        (RailDirection.OUTPUT, "fiddler bot safety"): {"bot_message"},
+        (RailDirection.INPUT, "gcpnlp moderation"): {"user_message"},
+        (RailDirection.INPUT, "gcpnlp moderation detailed"): {"user_message"},
+        (RailDirection.INPUT, "hf classifier check input"): {"user_message"},
+        (RailDirection.OUTPUT, "hf classifier check output"): {"bot_message"},
+        (RailDirection.RETRIEVAL, "hf classifier check retrieval"): {"relevant_chunks"},
+        (RailDirection.INPUT, "llama guard check input"): {"user_message"},
+        (RailDirection.OUTPUT, "llama guard check output"): {"user_message", "bot_message"},
+        (RailDirection.INPUT, "self check input"): {"user_message"},
+        (RailDirection.OUTPUT, "self check output"): {"user_message", "bot_message", "bot_thinking"},
+        (RailDirection.INPUT, "topic safety check input"): {"user_message"},
+    }
+
+    for surface_key, expected_keys in expected.items():
+        declared_keys = {binding.key for binding in surfaces[surface_key].bindings if binding.kind == "context"}
+        assert declared_keys == expected_keys
 
 
 def test_configurable_api_key_requirements_document_shipped_names():
@@ -266,9 +343,11 @@ def test_builtin_surfaces_preserve_flow_contracts():
         Binding.literal("threshold_mode", "detailed")
     )
     assert surfaces[(RailDirection.INPUT, "gcpnlp moderation")].bindings == (
+        Binding.context("user_message", "user_message"),
         Binding.literal("threshold_mode", "simple"),
     )
     assert surfaces[(RailDirection.INPUT, "gcpnlp moderation detailed")].bindings == (
+        Binding.context("user_message", "user_message"),
         Binding.literal("threshold_mode", "detailed"),
     )
     assert surfaces[(RailDirection.RETRIEVAL, "hf classifier check retrieval")].transform_target == (

--- a/tests/rails/llm/test_builtin_rail_manifests.py
+++ b/tests/rails/llm/test_builtin_rail_manifests.py
@@ -275,6 +275,8 @@ def test_legacy_context_actions_declare_message_inputs():
         (RailDirection.INPUT, "hf classifier check input"): {"user_message"},
         (RailDirection.OUTPUT, "hf classifier check output"): {"bot_message"},
         (RailDirection.RETRIEVAL, "hf classifier check retrieval"): {"relevant_chunks"},
+        (RailDirection.INPUT, "jailbreak detection heuristics"): {"user_message"},
+        (RailDirection.INPUT, "jailbreak detection model"): {"user_message"},
         (RailDirection.INPUT, "llama guard check input"): {"user_message"},
         (RailDirection.OUTPUT, "llama guard check output"): {"user_message", "bot_message"},
         (RailDirection.INPUT, "self check input"): {"user_message"},

--- a/tests/rails/llm/test_builtin_rail_manifests.py
+++ b/tests/rails/llm/test_builtin_rail_manifests.py
@@ -223,7 +223,7 @@ def test_retrieval_dependent_surfaces_declare_context_inputs():
     surfaces = default_rail_catalog().surfaces()
     expected = {
         (RailDirection.OUTPUT, "alignscore check facts"): (
-            Binding.context("relevant_chunks", "relevant_chunks", required=False),
+            Binding.context("relevant_chunks", "relevant_chunks"),
             Binding.context("bot_message", "bot_message"),
         ),
         (RailDirection.OUTPUT, "autoalign groundedness output"): (
@@ -232,7 +232,7 @@ def test_retrieval_dependent_surfaces_declare_context_inputs():
         ),
         (RailDirection.OUTPUT, "fiddler bot faithfulness"): (
             Binding.context("bot_message", "bot_message"),
-            Binding.context("relevant_chunks", "relevant_chunks", required=False),
+            Binding.context("relevant_chunks", "relevant_chunks"),
         ),
         (RailDirection.OUTPUT, "patronus api check output"): (
             Binding.context("user_message", "user_message"),
@@ -250,7 +250,7 @@ def test_retrieval_dependent_surfaces_declare_context_inputs():
         ),
         (RailDirection.OUTPUT, "self check hallucination"): (
             Binding.context("bot_message", "bot_message"),
-            Binding.context("last_bot_prompt", "_last_bot_prompt", required=False),
+            Binding.context("last_bot_prompt", "_last_bot_prompt"),
         ),
     }
 

--- a/tests/test_jailbreak_actions.py
+++ b/tests/test_jailbreak_actions.py
@@ -26,6 +26,42 @@ class TestJailbreakDetectionActions:
     """Test suite for jailbreak detection actions with comprehensive coverage of PR changes."""
 
     @pytest.mark.asyncio
+    async def test_missing_user_message_is_normalized_for_both_actions(self, monkeypatch):
+        from nemoguardrails.library.jailbreak_detection.actions import (
+            jailbreak_detection_heuristics,
+            jailbreak_detection_model,
+        )
+
+        heuristics_request = mock.AsyncMock(return_value=False)
+        model_request = mock.AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "nemoguardrails.library.jailbreak_detection.actions.jailbreak_detection_heuristics_request",
+            heuristics_request,
+        )
+        monkeypatch.setattr(
+            "nemoguardrails.library.jailbreak_detection.actions.jailbreak_detection_model_request",
+            model_request,
+        )
+        config = RailsConfig.from_content(
+            config={
+                "rails": {
+                    "config": {
+                        "jailbreak_detection": {
+                            "server_endpoint": "http://localhost:1337/check",
+                        }
+                    }
+                }
+            }
+        )
+        task_manager = LLMTaskManager(config=config)
+
+        await jailbreak_detection_heuristics(task_manager, {"user_message": None})
+        await jailbreak_detection_model(task_manager, {"user_message": None})
+
+        assert heuristics_request.await_args.args[0] == ""
+        assert model_request.await_args.kwargs["prompt"] == ""
+
+    @pytest.mark.asyncio
     async def test_jailbreak_detection_heuristics_forwards_http_client(self, monkeypatch):
         from nemoguardrails.library.jailbreak_detection.actions import (
             jailbreak_detection_heuristics,

--- a/tests/test_vendor_block_actions.py
+++ b/tests/test_vendor_block_actions.py
@@ -13,17 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.library.activefence.actions import ACTIVEFENCE_DETAILED_RULES, _activefence_outcome
 from nemoguardrails.library.ai_defense.actions import _ai_defense_outcome
 from nemoguardrails.library.clavata.actions import _clavata_outcome
-from nemoguardrails.library.cleanlab.actions import _cleanlab_outcome
+from nemoguardrails.library.cleanlab.actions import _cleanlab_outcome, call_cleanlab_api
 from nemoguardrails.library.fiddler.actions import _fiddler_outcome
 from nemoguardrails.library.gcp_moderate_text.actions import (
     GCP_TEXT_DETAILED_THRESHOLDS,
     _gcp_text_moderation_outcome,
+    call_gcp_text_moderation_api,
 )
 from nemoguardrails.library.trend_micro.actions import GuardResult, _trend_micro_outcome
 
@@ -55,6 +60,37 @@ def test_trend_micro_outcome_preserves_action_and_reason(guard_result, expected)
 )
 def test_cleanlab_outcome_pins_threshold(score, expected):
     assert _cleanlab_outcome(score) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("context", "explicit", "expected"),
+    [
+        (
+            {"user_message": "legacy prompt", "bot_message": "legacy response"},
+            {"user_message": "bound prompt", "bot_message": "bound response"},
+            ("bound prompt", "bound response"),
+        ),
+        (
+            {"user_message": "legacy prompt", "bot_message": "legacy response"},
+            {},
+            ("legacy prompt", "legacy response"),
+        ),
+    ],
+)
+async def test_cleanlab_prefers_bound_messages_and_retains_context_fallback(monkeypatch, context, explicit, expected):
+    score = AsyncMock(return_value={"trustworthiness_score": 0.9})
+    studio = MagicMock()
+    studio.TLM.return_value = SimpleNamespace(get_trustworthiness_score_async=score)
+    studio_factory = MagicMock(return_value=studio)
+    cleanlab_studio = ModuleType("cleanlab_studio")
+    setattr(cleanlab_studio, "Studio", studio_factory)
+    monkeypatch.setitem(sys.modules, "cleanlab_studio", cleanlab_studio)
+    monkeypatch.setenv("CLEANLAB_API_KEY", "test-key")
+
+    await call_cleanlab_api(context=context, **explicit)
+
+    score.assert_awaited_once_with(expected[0], response=expected[1])
 
 
 @pytest.mark.parametrize(
@@ -144,6 +180,37 @@ def test_gcp_text_moderation_outcome_pins_simple_and_detailed_thresholds(
         "Derogatory" if threshold_mode == "detailed" and expected_blocked else None
     )
     assert bool(outcome.reason) is expected_blocked
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("context", "explicit_user_message", "expected"),
+    [
+        ({"user_message": "legacy prompt"}, "bound prompt", "bound prompt"),
+        ({"user_message": "legacy prompt"}, None, "legacy prompt"),
+    ],
+)
+async def test_gcp_moderation_prefers_bound_message_and_retains_context_fallback(
+    monkeypatch, context, explicit_user_message, expected
+):
+    class Document:
+        class Type:
+            PLAIN_TEXT = "plain_text"
+
+    moderate_text = AsyncMock(return_value=SimpleNamespace(moderation_categories=[]))
+    client_factory = MagicMock(return_value=SimpleNamespace(moderate_text=moderate_text))
+    language_v2 = ModuleType("google.cloud.language_v2")
+    setattr(language_v2, "Document", Document)
+    setattr(language_v2, "LanguageServiceAsyncClient", client_factory)
+    google_cloud = ModuleType("google.cloud")
+    setattr(google_cloud, "language_v2", language_v2)
+    monkeypatch.setitem(sys.modules, "google.cloud", google_cloud)
+    monkeypatch.setitem(sys.modules, "google.cloud.language_v2", language_v2)
+
+    await call_gcp_text_moderation_api(context=context, user_message=explicit_user_message)
+
+    document = moderate_text.await_args.kwargs["document"]
+    assert document.content == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Make the inputs and model dependencies of shared library actions explicit in rail manifests, then have IORails compile those declarations instead of maintaining rail-specific knowledge. HTTP remains generic runtime infrastructure: `RailsManager` owns one pooled client, and signature filtering injects it only into actions that accept `http_client`.

This is intentionally one PR rather than a stack. Its four implementation commits are self-contained review units, and the sequence below is the recommended review order.

### Review by commit

1. `refactor(library): declare action context inputs`
   Declares user, bot, and retrieval inputs across shared library actions. Explicit parameters serve manifest-driven runtimes while the existing `context` path remains as an LLMRails fallback.
2. `feat(manifests): declare model resource bindings`
   Marks fixed and configurable model bindings explicitly so compilation validates model requirements without inferring them from a parameter named `model_name`.
3. `refactor(iorails): share managed HTTP client`
   Removes per-surface HTTP classification and per-rail clients. `RailsManager` owns and closes one pooled client shared by compiled rails; manifests do not gain a `requires_http_client` allocation flag.
4. `refactor(iorails): consume manifest-bound action inputs`
   Replaces hard-coded retrieval capability lists and whole-context injection. IORails derives required inputs from each surface and passes only declared bindings plus accepted runtime dependencies.

### LLMRails compatibility

LLMRails does not consume the new execution bindings, and its dispatch path is unchanged. Updated actions accept explicit inputs for IORails but continue to fall back to the existing `context` argument used by LLMRails. Model resource markers are manifest metadata only. LLMRails can also continue registering an `http_client`, or use the existing per-call fallback when none is registered.

Cross-engine tests execute the same model-backed and HTTP-backed actions through both engines and assert equivalent results. This addresses the non-jailbreak portions of #2279 without requiring an LLMRails managed-client lifecycle.

### Out of scope

The local and NIM jailbreak backends still need separate requirements and execution contracts. That work remains tracked in #2285.

## Related Issue(s)

- Addresses #2279


## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] My PR title follows the project commit convention.
- [x] I've added tests where applicable.
- [x] I did not update generated changelog files manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Guardrails now pass user, bot, and retrieval content explicitly to safety and validation checks.
  - Added clearer model-binding support for configurable guardrail models.
  - Expanded support for message and evidence inputs across built-in integrations.

- **Bug Fixes**
  - Improved handling of missing optional context values.
  - Required unsupported inputs are now identified earlier with clearer validation feedback.
  - API-backed guardrails now share a single connection pool for more consistent resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->