### PR TITLE
fix(content-safety): surface response parsing errors

### DIFF
--- a/nemoguardrails/llm/output_parsers.py
+++ b/nemoguardrails/llm/output_parsers.py
@@ -154,20 +154,20 @@ def nemoguard_parse_prompt_safety(response: str) -> Sequence[Union[bool, str]]:
     Returns:
         Sequence[Union[bool, str]]: A sequence where the first element is a boolean indicating the safety of the content (True if safe, False otherwise),
         and the remaining elements are strings representing violated policies, if any.
+
+    Raises:
+        ValueError: If the model response cannot be parsed as a content safety verdict.
     """
     try:
         # try parsing it as json
         parsed_json_result = json.loads(response)
-        assert "User Safety" in parsed_json_result
         result = parsed_json_result["User Safety"].lower()
         if "Safety Categories" in parsed_json_result:
             safety_categories = [cat.strip() for cat in parsed_json_result["Safety Categories"].split(",")]
         else:
             safety_categories = []
-    except Exception:
-        # If there is an error, and we can't parse the response, we return unsafe assuming this is a potential jailbreaking attempt
-        result = "unsafe"
-        safety_categories = ["JSON parsing failed"]
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        raise ValueError("Failed to parse content safety model response") from exc
 
     is_safe = result == "safe"
     if is_safe:
@@ -193,20 +193,20 @@ def nemoguard_parse_response_safety(response: str) -> Sequence[Union[bool, str]]
     Returns:
         Sequence[Union[bool, str]]: A sequence where the first element is a boolean indicating the safety of the content (True if safe, False otherwise),
         and the remaining elements are strings representing violated policies, if any.
+
+    Raises:
+        ValueError: If the model response cannot be parsed as a content safety verdict.
     """
     try:
         # try parsing it as json
         parsed_json_result = json.loads(response)
-        assert "Response Safety" in parsed_json_result
         result = parsed_json_result["Response Safety"].lower()
         if "Safety Categories" in parsed_json_result:
             safety_categories = [cat.strip() for cat in parsed_json_result["Safety Categories"].split(",")]
         else:
             safety_categories = []
-    except Exception:
-        # If there is an error, and we can't parse the response, we return unsafe assuming this is a potential jailbreaking attempt
-        result = "unsafe"
-        safety_categories = ["JSON parsing failed"]
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        raise ValueError("Failed to parse content safety model response") from exc
 
     is_safe = result == "safe"
     if is_safe:

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -25,6 +25,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.actions.rail_outcome import RailOutcome
+from nemoguardrails.guardrails.compiled_rail import RailDependencies, compile_rail
 from nemoguardrails.library.content_safety.actions import (
     content_safety_check_input,
     content_safety_check_output,
@@ -36,6 +38,7 @@ from nemoguardrails.llm.output_parsers import (
     nemotron_reasoning_parse_prompt_safety,
     nemotron_reasoning_parse_response_safety,
 )
+from nemoguardrails.manifests import RailDirection
 from tests.utils import FakeLLMModel, TestChat
 
 
@@ -205,19 +208,40 @@ class TestContentSafetyParserIntegration:
         assert result.is_blocked == (not expected_allowed)
         assert result.metadata["policy_violations"] == expected_violations
 
+    @pytest.mark.parametrize(
+        ("action", "parser", "context"),
+        [
+            (content_safety_check_input, nemoguard_parse_prompt_safety, _create_input_context("Some content")),
+            (content_safety_check_output, nemoguard_parse_response_safety, _create_output_context()),
+        ],
+        ids=["input", "output"],
+    )
     @pytest.mark.asyncio
-    async def test_content_safety_input_propagates_parser_error(self):
+    async def test_content_safety_action_propagates_parser_error(self, action, parser, context):
         llms, mock_task_manager = _create_mock_setup([""], None)
-        mock_task_manager.parse_task_output.side_effect = lambda task, output: nemoguard_parse_prompt_safety(output)
-        context = _create_input_context("Some content")
+        mock_task_manager.parse_task_output.side_effect = lambda task, output: parser(output)
 
         with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            await content_safety_check_input(
+            await action(
                 llms=llms,
                 llm_task_manager=mock_task_manager,
                 model_name="test_model",
                 context=context,
             )
+
+    @pytest.mark.asyncio
+    async def test_content_safety_parser_error_fails_closed_through_compiled_rail(self):
+        llms, mock_task_manager = _create_mock_setup([""], None)
+        mock_task_manager.parse_task_output.side_effect = lambda task, output: nemoguard_parse_prompt_safety(output)
+        dependencies = RailDependencies(llms=llms, llm_task_manager=mock_task_manager, config=MagicMock())
+
+        outcome = await compile_rail(
+            "content safety check input $model=test_model", RailDirection.INPUT, dependencies
+        ).run([{"role": "user", "content": "Some content"}])
+
+        assert outcome == RailOutcome.block(
+            reason="content safety check input error: Failed to parse content safety model response"
+        )
 
 
 class TestIterableUnpackingIntegration:

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -206,24 +206,18 @@ class TestContentSafetyParserIntegration:
         assert result.metadata["policy_violations"] == expected_violations
 
     @pytest.mark.asyncio
-    async def test_content_safety_input_with_nemoguard_parser_json_parsing_failed(
-        self,
-    ):
-        """Test input action with nemoguard_parse_prompt_safety parser; JSON parsing failure."""
-        invalid_json = '{"invalid": json}'
-        parsed_result = nemoguard_parse_prompt_safety(invalid_json)
-        llms, mock_task_manager = _create_mock_setup([invalid_json], parsed_result)
+    async def test_content_safety_input_propagates_parser_error(self):
+        llms, mock_task_manager = _create_mock_setup([""], None)
+        mock_task_manager.parse_task_output.side_effect = lambda task, output: nemoguard_parse_prompt_safety(output)
         context = _create_input_context("Some content")
 
-        result = await content_safety_check_input(
-            llms=llms,
-            llm_task_manager=mock_task_manager,
-            model_name="test_model",
-            context=context,
-        )
-
-        assert result.is_blocked is True
-        assert result.metadata["policy_violations"] == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            await content_safety_check_input(
+                llms=llms,
+                llm_task_manager=mock_task_manager,
+                model_name="test_model",
+                context=context,
+            )
 
 
 class TestIterableUnpackingIntegration:
@@ -261,12 +255,11 @@ class TestIterableUnpackingIntegration:
                 False,
                 ["Violence", "Hate"],
             ),
-            ("invalid json", False, ["JSON parsing failed"]),
         ],
     )
     def test_iterable_unpacking_with_nemoguard_outputs(self, json_response, expected_safe, expected_violations):
         """Test iterable unpacking directly with real NemoGuard parser outputs."""
-        if "User Safety" in json_response or json_response == "invalid json":
+        if "User Safety" in json_response:
             result = nemoguard_parse_prompt_safety(json_response)
         else:
             result = nemoguard_parse_response_safety(json_response)

--- a/tests/test_content_safety_output_parsers.py
+++ b/tests/test_content_safety_output_parsers.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+import pytest
+
 from nemoguardrails.llm.output_parsers import (
     _extract_harm_value,
     _strip_think_tags,
@@ -172,19 +174,15 @@ class TestNemoguardParsePromptSafety:
         assert is_safe is False
         assert violated_policies == []
 
-    def test_invalid_json_defaults_to_unsafe(self):
-        """Test that invalid JSON defaults to unsafe with error message."""
-        response = '{"invalid": json}'
-        is_safe, *violated_policies = nemoguard_parse_prompt_safety(response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+    @pytest.mark.parametrize("response", ["", '{"invalid": json}'])
+    def test_invalid_response_raises_parsing_error(self, response):
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_prompt_safety(response)
 
     def test_missing_user_safety_field(self):
-        """Test parsing when User Safety field is missing."""
         response = '{"Response Safety": "safe"}'
-        is_safe, *violated_policies = nemoguard_parse_prompt_safety(response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_prompt_safety(response)
 
     def test_single_category(self):
         """Test parsing with single safety category."""
@@ -252,19 +250,15 @@ class TestNemoguardParseResponseSafety:
         assert is_safe is False
         assert violated_policies == []
 
-    def test_invalid_json_defaults_to_unsafe(self):
-        """Test that invalid JSON defaults to unsafe with error message."""
-        response = '{"invalid": json}'
-        is_safe, *violated_policies = nemoguard_parse_response_safety(response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+    @pytest.mark.parametrize("response", ["", '{"invalid": json}'])
+    def test_invalid_response_raises_parsing_error(self, response):
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_response_safety(response)
 
     def test_missing_response_safety_field(self):
-        """Test parsing when Response Safety field is missing."""
         response = '{"User Safety": "safe"}'
-        is_safe, *violated_policies = nemoguard_parse_response_safety(response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_response_safety(response)
 
     def test_full_nemoguard_response(self):
         """Test parsing a full NemoGuard response with both user and response safety."""
@@ -275,11 +269,9 @@ class TestNemoguardParseResponseSafety:
         assert "S8" in violated_policies
 
     def test_malformed_json_with_extra_text(self):
-        """Test parsing malformed JSON with extra characters."""
         response = '{"Response Safety": "unsafe", "Safety Categories": "S1"} extra text'
-        is_safe, *violated_policies = nemoguard_parse_response_safety(response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_response_safety(response)
 
 
 class TestOutputParsersRealWorldScenarios:
@@ -322,19 +314,16 @@ class TestOutputParsersRealWorldScenarios:
         assert violated_policies == []
 
     def test_parser_robustness(self):
-        """Test parser robustness with various edge cases."""
         invalid_response = "The model refused to answer"
 
         is_safe, *violated_policies = is_content_safe(invalid_response)
         assert is_safe is False
 
-        is_safe, *violated_policies = nemoguard_parse_prompt_safety(invalid_response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_prompt_safety(invalid_response)
 
-        is_safe, *violated_policies = nemoguard_parse_response_safety(invalid_response)
-        assert is_safe is False
-        assert violated_policies == ["JSON parsing failed"]
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemoguard_parse_response_safety(invalid_response)
 
     def test_starred_unpacking_compatibility(self):
         """Test that parser outputs are compatible with starred unpacking logic."""


### PR DESCRIPTION
## Description

Surface malformed content-safety model responses as parsing errors instead of reporting `JSON parsing failed` as a policy category. Rails continue to fail closed through the existing error envelope.

## Related Issue(s)

NGUARD-883

## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed or incomplete safety-check responses now raise a clear parsing error instead of being silently marked unsafe.
  * Parsing errors now propagate consistently through content safety checks.
  * Improved handling of empty responses, missing fields, extra text, and invalid JSON.

* **Tests**
  * Updated coverage to verify parsing errors for both prompt and response safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->