### PR TITLE
fix(llm): preserve streaming usage on final chunks

### DIFF
--- a/nemoguardrails/llm/models/openai_chat.py
+++ b/nemoguardrails/llm/models/openai_chat.py
@@ -264,21 +264,25 @@ class OpenAIChatModel:
         if response.headers:
             provider_metadata["response_headers"] = dict(response.headers)
 
+        usage = None
+        raw_usage = data.get("usage")
+        if raw_usage:
+            input_tokens = raw_usage.get("prompt_tokens", 0)
+            output_tokens = raw_usage.get("completion_tokens", 0)
+            usage = UsageInfo(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=raw_usage.get("total_tokens") or (input_tokens + output_tokens),
+                reasoning_tokens=(raw_usage.get("completion_tokens_details") or {}).get("reasoning_tokens"),
+                cached_tokens=(raw_usage.get("prompt_tokens_details") or {}).get("cached_tokens"),
+            )
+
         choices = data.get("choices", [])
         if not choices:
-            raw_usage = data.get("usage")
-            if raw_usage:
-                input_tokens = raw_usage.get("prompt_tokens", 0)
-                output_tokens = raw_usage.get("completion_tokens", 0)
+            if usage:
                 return LLMResponseChunk(
                     request_id=data.get("id"),
-                    usage=UsageInfo(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=raw_usage.get("total_tokens") or (input_tokens + output_tokens),
-                        reasoning_tokens=(raw_usage.get("completion_tokens_details") or {}).get("reasoning_tokens"),
-                        cached_tokens=(raw_usage.get("prompt_tokens_details") or {}).get("cached_tokens"),
-                    ),
+                    usage=usage,
                     provider_metadata=provider_metadata or None,
                 )
             return None
@@ -297,6 +301,7 @@ class OpenAIChatModel:
             model=data.get("model"),
             finish_reason=finish_reason,
             request_id=data.get("id"),
+            usage=usage,
             provider_metadata=provider_metadata or None,
         )
 

--- a/tests/llm/models/test_openai_chat.py
+++ b/tests/llm/models/test_openai_chat.py
@@ -259,6 +259,32 @@ class TestStream:
         assert results[2].usage.total_tokens == 7
 
     @pytest.mark.asyncio
+    async def test_usage_on_final_content_chunk(self):
+        mc = _mock_client()
+
+        async def mock_stream(*args, **kwargs):
+            yield HTTPResponse(
+                body={
+                    "id": "chatcmpl-123",
+                    "model": "gpt-4o",
+                    "choices": [{"index": 0, "delta": {"content": "Hello"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+                }
+            )
+
+        mc.stream_chat_completion = mock_stream
+        m = _model(mc)
+
+        results = [chunk async for chunk in m.stream_async("Hi")]
+
+        assert len(results) == 1
+        assert results[0].delta_content == "Hello"
+        assert results[0].finish_reason == "stop"
+        assert results[0].usage.input_tokens == 5
+        assert results[0].usage.output_tokens == 1
+        assert results[0].usage.total_tokens == 6
+
+    @pytest.mark.asyncio
     async def test_tool_call_accumulation(self):
         mc = _mock_client()
 


### PR DESCRIPTION
## Description

Preserve token usage when an OpenAI-compatible provider includes `usage` on the final content-bearing SSE chunk.

## Related Issue(s)

NGUARD-882

## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses to preserve token usage details, including reasoning and cached-token counts.
  * Usage information is now retained for both content responses and usage-only updates.
* **Tests**
  * Added coverage to verify usage metadata remains available on the final streamed response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->