### PR TITLE
fix(iorails): Propagate `default_query` parameter in HTTP requests

### DIFF
--- a/docs/configure-rails/yaml-schema/model-configuration.mdx
+++ b/docs/configure-rails/yaml-schema/model-configuration.mdx
@@ -317,3 +317,45 @@ Header values must be strings; a bare numeric or boolean value in YAML, such as 
 Keep secrets such as API keys in environment variables through `api_key_env_var` rather than hardcoding them in `default_headers` in a checked-in `config.yml`.
 
 This behavior is the same for both the IORails and LLMRails engines.
+
+### Model-Level Query Parameters
+
+Set `parameters.default_query` to attach query-string parameters to every request a model sends to its provider endpoint.
+This is useful for API versioning, multi-tenant routing, or trace correlation when the provider or gateway reads the query string rather than the headers.
+Query parameters are configured per model: each model sends only the parameters declared in its own `parameters` block, so a parameter you want on several models must be repeated under each one.
+
+```yaml
+models:
+  - type: main
+    engine: nim
+    model: meta/llama-3.3-70b-instruct
+    parameters:
+      default_query:
+        tenant: acme-corp
+        routing-pool: main-llm
+
+  - type: content_safety
+    engine: nim
+    model: nvidia/llama-3.1-nemoguard-8b-content-safety
+    parameters:
+      default_query:
+        tenant: acme-corp
+        routing-pool: safety-pool
+```
+
+The configured parameters are appended to the chat-completions URL, so the main model above posts to `/v1/chat/completions?tenant=acme-corp&routing-pool=main-llm`.
+Configured parameters appear only in the URL and never in the request body.
+
+Values follow these rules:
+
+- A string or a number is used as written, so `retries: 3` becomes `retries=3`.
+- A boolean uses its lowercase wire form, so `beta: true` becomes `beta=true` rather than `beta=True`.
+- A list repeats the parameter once per element in the configured order, so `tag: [red, blue]` becomes `tag=red&tag=blue`.
+- An empty value becomes a parameter with no value, so `flag:` becomes `flag=`.
+- A nested object is rejected when the engine is initialized, because a query string has no standard encoding for one. Flatten it into separate parameters instead.
+
+Keep secrets such as API keys in environment variables through `api_key_env_var` rather than hardcoding them in `default_query` in a checked-in `config.yml`.
+Provider and proxy access logs commonly record full request URLs, so a query parameter is a poor place for a sensitive value.
+
+For the value types above, this behavior is the same for both the IORails and LLMRails engines.
+The nested-object case differs: IORails rejects the configuration when the engine is initialized, and LLMRails forwards the object as an encoded Python representation that most servers cannot interpret.

--- a/nemoguardrails/guardrails/_http.py
+++ b/nemoguardrails/guardrails/_http.py
@@ -15,7 +15,8 @@
 
 """Shared aiohttp helpers for IORails engine HTTP clients."""
 
-from typing import Mapping, Optional
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
 
 import aiohttp
 
@@ -39,6 +40,42 @@ def merge_headers_case_insensitive(base: Mapping[str, str], overrides: Optional[
             del merged[existing]
         merged[name] = value
     return merged
+
+
+def normalize_query_params(query: Any) -> tuple[tuple[str, str], ...]:
+    """Normalize a configured ``default_query`` mapping into ``(name, value)`` pairs for aiohttp's ``params=``."""
+    if query is None:
+        return ()
+    if not isinstance(query, Mapping):
+        raise ValueError(f"default_query must be a mapping of parameter names to values, got {type(query).__name__}.")
+
+    pairs: list[tuple[str, str]] = []
+    for key, value in query.items():
+        name = str(key)
+        # A list repeats the key, as httpx does; str and bytes are scalars, not
+        # sequences of characters or ints.
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            pairs.extend((name, _query_value_to_str(name, element)) for element in value)
+        else:
+            pairs.append((name, _query_value_to_str(name, value)))
+    return tuple(pairs)
+
+
+def _query_value_to_str(name: str, value: Any) -> str:
+    """Coerce one query-parameter value to the string form httpx would put on the wire."""
+    # httpx lowercases booleans and renders None as an empty value; yarl raises
+    # TypeError on both, so the coercion happens here to keep the two engines in
+    # step.  bool is an int subclass, so it must be tested before the str() fallback.
+    if isinstance(value, Mapping):
+        raise ValueError(
+            f"default_query['{name}'] must be a scalar or a list of scalars, not a nested object. "
+            "Flatten nested values into separate query parameters."
+        )
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    return str(value)
 
 
 async def safe_read_body(response: aiohttp.ClientResponse, max_chars: int = 500) -> str:

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -37,6 +37,7 @@ from nemoguardrails.guardrails._http import (
     DEFAULT_TIMEOUT_CONNECT,
     DEFAULT_TIMEOUT_TOTAL,
     merge_headers_case_insensitive,
+    normalize_query_params,
     safe_read_body,
 )
 from nemoguardrails.guardrails.base_engine import BaseEngine
@@ -124,6 +125,7 @@ class _RequestParams(NamedTuple):
     url: str
     headers: dict[str, str]
     body: dict[str, Any]
+    params: tuple[tuple[str, str], ...]
 
 
 # TODO: duplicates OpenAIChatModel._to_messages in
@@ -543,7 +545,7 @@ class ModelEngine(BaseEngine):
         metrics_enabled: bool = False,
         content_capture_enabled: bool = False,
     ) -> None:
-        """Resolve base URL, API key, and retry settings from the model config.
+        """Resolve base URL, API key, retry settings, and per-request defaults from the model config.
 
         The telemetry arguments carry the OTEL instrumentation for every call
         this engine makes.  They live here rather than one level up in
@@ -568,6 +570,8 @@ class ModelEngine(BaseEngine):
         self.default_headers: Mapping[str, str] = MappingProxyType(
             {str(key): str(value) for key, value in (params.get("default_headers") or {}).items()}
         )
+
+        self.default_query: tuple[tuple[str, str], ...] = normalize_query_params(params.get("default_query"))
 
         # Default `llm_params` used on inference are the subset of Model.parameters after
         # filtering out keys in _RESERVED_LLM_PARAMETERS.  Exposed as a read-only
@@ -654,7 +658,7 @@ class ModelEngine(BaseEngine):
             )
 
     def _prepare_request(self, messages: LLMMessages, **kwargs: Any) -> _RequestParams:
-        """Build the client, URL, headers, and body common to every request."""
+        """Build the client, URL, headers, query params, and body common to every request."""
         client = cast(RetryClient, self._client)
         url = self.base_url + _CHAT_COMPLETIONS_ENDPOINT
 
@@ -664,7 +668,7 @@ class ModelEngine(BaseEngine):
         headers = merge_headers_case_insensitive(headers, self.default_headers)
 
         body: dict[str, Any] = {"model": self.model_name, "messages": messages, **kwargs}
-        return _RequestParams(client=client, url=url, headers=headers, body=body)
+        return _RequestParams(client=client, url=url, headers=headers, body=body, params=self.default_query)
 
     async def _raise_for_status(self, response: aiohttp.ClientResponse, req_id: str, t0: float) -> None:
         """Raise ``ModelEngineError`` if the HTTP status indicates an error."""
@@ -722,7 +726,9 @@ class ModelEngine(BaseEngine):
 
         t0 = time.monotonic()
         try:
-            async with req.client.post(req.url, json=req.body, headers=req.headers) as response:
+            async with req.client.post(
+                req.url, json=req.body, headers=req.headers, params=req.params or None
+            ) as response:
                 await self._raise_for_status(response, req_id, t0)
 
                 elapsed_ms = (time.monotonic() - t0) * 1000
@@ -805,7 +811,9 @@ class ModelEngine(BaseEngine):
 
         t0 = time.monotonic()
         try:
-            async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
+            async with req.client.post(
+                req.url, json=req.body, headers=req.headers, params=req.params or None, timeout=stream_timeout
+            ) as response:
                 await self._raise_for_status(response, req_id, t0)
 
                 # Surface response headers on every chunk as provider_metadata['response_headers'],

--- a/tests/guardrails/test__http.py
+++ b/tests/guardrails/test__http.py
@@ -25,6 +25,7 @@ from nemoguardrails.guardrails._http import (
     DEFAULT_TIMEOUT_TOTAL,
     RETRYABLE_STATUS_CODES,
     merge_headers_case_insensitive,
+    normalize_query_params,
     safe_read_body,
 )
 
@@ -111,6 +112,77 @@ class TestMergeHeadersCaseInsensitive:
         auth_keys = [key for key in result if key.lower() == "authorization"]
         assert auth_keys == ["Authorization"]
         assert result["Authorization"] == "override"
+
+
+class TestNormalizeQueryParams:
+    """Test coercion of configured default_query values into wire-form (name, value) pairs."""
+
+    def test_none_yields_no_pairs(self):
+        """An unset default_query normalizes to an empty tuple."""
+        assert normalize_query_params(None) == ()
+
+    def test_empty_mapping_yields_no_pairs(self):
+        """An empty default_query block normalizes to an empty tuple."""
+        assert normalize_query_params({}) == ()
+
+    def test_string_value_yields_one_pair(self):
+        """A string value becomes a single pair."""
+        assert normalize_query_params({"tenant": "acme"}) == (("tenant", "acme"),)
+
+    def test_numeric_values_stringify(self):
+        """Int and float values are stringified."""
+        assert normalize_query_params({"retries": 3, "ratio": 1.5}) == (("retries", "3"), ("ratio", "1.5"))
+
+    def test_bool_values_lowercase(self):
+        """Booleans use the wire form 'true'/'false' rather than Python's 'True'/'False'."""
+        assert normalize_query_params({"beta": True, "cache": False}) == (("beta", "true"), ("cache", "false"))
+
+    def test_none_value_becomes_empty_string(self):
+        """A null value becomes a valueless parameter."""
+        assert normalize_query_params({"flag": None}) == (("flag", ""),)
+
+    def test_list_value_repeats_the_key_in_order(self):
+        """A list value yields one pair per element, preserving order."""
+        assert normalize_query_params({"tag": ["b", "a"]}) == (("tag", "b"), ("tag", "a"))
+
+    def test_list_elements_are_coerced_individually(self):
+        """Elements of a list value get the same scalar coercion as a bare value."""
+        assert normalize_query_params({"tag": [True, 2, None]}) == (("tag", "true"), ("tag", "2"), ("tag", ""))
+
+    def test_string_value_is_not_split_into_characters(self):
+        """A string is treated as one scalar, not as a sequence of characters."""
+        assert normalize_query_params({"tenant": "abc"}) == (("tenant", "abc"),)
+
+    def test_bytes_value_is_not_split_into_ints(self):
+        """A bytes value is treated as one scalar, not as a sequence of ints."""
+        assert normalize_query_params({"raw": b"ab"}) == (("raw", "b'ab'"),)
+
+    def test_non_string_keys_stringify(self):
+        """A non-string key, such as a bare YAML number, is stringified."""
+        assert normalize_query_params({2024: "x"}) == (("2024", "x"),)
+
+    def test_key_order_is_preserved(self):
+        """Pairs follow the configured key order."""
+        assert normalize_query_params({"b": "1", "a": "2"}) == (("b", "1"), ("a", "2"))
+
+    def test_nested_mapping_value_raises_naming_the_key(self):
+        """A nested object value is rejected with a message naming the field and the offending key."""
+        with pytest.raises(ValueError) as exc_info:
+            normalize_query_params({"meta": {"region": "us"}})
+        assert "default_query" in str(exc_info.value)
+        assert "meta" in str(exc_info.value)
+
+    def test_nested_mapping_inside_a_list_raises_naming_the_key(self):
+        """A nested object inside a list value is rejected the same way as a bare one."""
+        with pytest.raises(ValueError) as exc_info:
+            normalize_query_params({"meta": ["ok", {"region": "us"}]})
+        assert "meta" in str(exc_info.value)
+
+    def test_non_mapping_query_raises(self):
+        """A default_query that is not a mapping at all is rejected."""
+        with pytest.raises(ValueError) as exc_info:
+            normalize_query_params("tenant=acme")
+        assert "default_query" in str(exc_info.value)
 
 
 class TestSharedConstants:

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -208,6 +208,68 @@ class TestConfigDefaultHeadersOverHTTP:
         assert "X-Tenant" not in captured["body"]
 
 
+class TestConfigDefaultQueryOverHTTP:
+    """True end-to-end: run generate_async over a real loopback HTTP server and
+    assert on the query string the aiohttp client actually put on the wire."""
+
+    @staticmethod
+    async def _capture_request(default_query: dict) -> dict:
+        """Run one generate_async against a loopback server and return what the server received."""
+        captured: dict = {}
+
+        async def handler(request):
+            captured["path"] = request.path
+            captured["query"] = list(request.rel_url.query.items())
+            captured["body"] = await request.json()
+            return web.json_response({"choices": [{"message": {"role": "assistant", "content": "ok"}}]})
+
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", handler)
+        server = TestServer(app)
+        await server.start_server()
+        try:
+            config = RailsConfig.from_content(
+                config={
+                    "models": [
+                        {
+                            "type": "main",
+                            "engine": "openai",
+                            "model": "test-model",
+                            "parameters": {
+                                "base_url": str(server.make_url("/")),
+                                "default_query": default_query,
+                            },
+                        }
+                    ]
+                }
+            )
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+                iorails = IORails(config)
+            async with iorails:
+                captured["result"] = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
+        finally:
+            await server.close()
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_config_default_query_sent_on_the_wire(self):
+        """Configured query parameters reach the provider request URL, leaving the path and the JSON body alone."""
+        captured = await self._capture_request({"tenant": "acme-corp", "api-version": "2024-10-21"})
+
+        assert captured["result"] == {"role": "assistant", "content": "ok"}
+        assert captured["query"] == [("tenant", "acme-corp"), ("api-version", "2024-10-21")]
+        assert captured["path"] == "/v1/chat/completions"
+        assert "tenant" not in captured["body"]
+        assert "default_query" not in captured["body"]
+
+    @pytest.mark.asyncio
+    async def test_list_and_bool_query_values_survive_the_wire(self):
+        """A list value repeats the key on the wire and a boolean arrives lowercased."""
+        captured = await self._capture_request({"tag": ["red", "blue"], "beta": True})
+
+        assert captured["query"] == [("tag", "red"), ("tag", "blue"), ("beta", "true")]
+
+
 class TestGenerateAsync:
     """Test the generate_async input-check → LLM → output-check pipeline."""
 

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -102,6 +102,8 @@ def _mock_streaming_response(raw_lines, status=200, headers=None):
 
 _OK_COMPLETION = {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
 
+_SSE_OK_LINES = [b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n', b"data: [DONE]\n\n"]
+
 
 def _mock_chat_client(payload: dict | None = None, status: int = 200):
     """Create a mock aiohttp client whose post() returns a chat-completion payload.
@@ -467,9 +469,7 @@ class TestModelEngineBodyParamDefaults:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "key"})
     def test_excludes_client_only_keys(self):
-        """default_headers / default_query configure the OpenAI-compatible
-        client, not the chat-completion body, so they never reach the body
-        defaults; a sampling param alongside them is kept."""
+        """default_headers and default_query are excluded from body_param_defaults, while a sampling param is kept."""
         engine = ModelEngine(
             _make_model(
                 parameters={
@@ -611,7 +611,7 @@ class TestModelEngineCall:
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_successful_call(self):
-        """Successful call returns parsed JSON and posts to correct URL with headers."""
+        """Successful call returns parsed JSON and posts to the correct URL with base headers and no query params."""
         model = _make_model()
         engine = ModelEngine(model)
 
@@ -640,7 +640,9 @@ class TestModelEngineCall:
         expected_url = _ENGINE_BASE_URLS[model.engine] + "/v1/chat/completions"
         expected_json = {"messages": messages, "model": model.model}
         expected_headers = {"Content-Type": "application/json", "Authorization": "Bearer test-key"}
-        mock_client.post.assert_called_once_with(expected_url, json=expected_json, headers=expected_headers)
+        mock_client.post.assert_called_once_with(
+            expected_url, json=expected_json, headers=expected_headers, params=None
+        )
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -779,6 +781,24 @@ class TestModelEngineDefaultHeaders:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
+    async def test_config_default_headers_merged_into_stream_request(self):
+        """A configured default_header reaches the streaming request, not only the non-streaming one."""
+        engine = ModelEngine(_make_model(parameters={"default_headers": {"X-Tenant": "acme"}}))
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(_SSE_OK_LINES))
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            pass
+
+        headers = self._headers_from(mock_client)
+        assert headers["X-Tenant"] == "acme"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Authorization"] == "Bearer test-key"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
     async def test_config_default_header_overrides_authorization_case_insensitive(self):
         """A configured 'authorization' header replaces the api_key-derived Authorization."""
         engine = ModelEngine(_make_model(parameters={"default_headers": {"authorization": "Bearer custom"}}))
@@ -834,6 +854,131 @@ class TestModelEngineDefaultHeaders:
         headers: Any = engine.default_headers
         with pytest.raises(TypeError):
             headers["X-Injected"] = "nope"
+
+
+class TestModelEngineDefaultQuery:
+    """Test that config-level parameters.default_query reaches outbound requests."""
+
+    @staticmethod
+    def _mock_client():
+        """Build a mock aiohttp client whose post() records call args."""
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        return mock_client
+
+    @staticmethod
+    def _mock_stream_client():
+        """Build a mock aiohttp client whose post() returns a one-chunk SSE stream."""
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(_SSE_OK_LINES))
+        mock_client.closed = False
+        return mock_client
+
+    @staticmethod
+    def _params_from(mock_client):
+        """Extract the query params passed to the mocked post()."""
+        return mock_client.post.call_args[1]["params"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_query_applied_to_request(self):
+        """A configured default_query is sent as query parameters on the non-streaming request."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"tenant": "acme-corp"}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert self._params_from(engine._client) == (("tenant", "acme-corp"),)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_query_applied_to_stream_request(self):
+        """A configured default_query is sent as query parameters on the streaming request."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"tenant": "acme-corp"}}))
+        engine._client = self._mock_stream_client()
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            pass
+
+        assert self._params_from(engine._client) == (("tenant", "acme-corp"),)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_bool_value_serializes_lowercase(self):
+        """A YAML boolean becomes the wire form 'true'/'false', matching httpx, not Python's 'True'/'False'."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"beta": True, "cache": False}}))
+        assert engine.default_query == (("beta", "true"), ("cache", "false"))
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_numeric_values_stringify(self):
+        """Int and float values are stringified."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"retries": 3, "ratio": 1.5}}))
+        assert engine.default_query == (("retries", "3"), ("ratio", "1.5"))
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_none_value_becomes_empty_string(self):
+        """A null value becomes a valueless parameter rather than the string 'None'."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"flag": None}}))
+        assert engine.default_query == (("flag", ""),)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_list_value_expands_to_one_pair_per_element(self):
+        """A list value repeats the key once per element, in order, instead of stringifying the list."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"tag": ["b", "a"], "tenant": "acme"}}))
+        assert engine.default_query == (("tag", "b"), ("tag", "a"), ("tenant", "acme"))
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def test_nested_mapping_value_raises_at_construction(self):
+        """A nested object value is rejected when the engine is built, naming the field and the offending key."""
+        with pytest.raises(ValueError) as exc_info:
+            ModelEngine(_make_model(parameters={"default_query": {"meta": {"region": "us"}}}))
+        assert "default_query" in str(exc_info.value)
+        assert "meta" in str(exc_info.value)
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_absent_default_query_sends_no_params(self):
+        """Without default_query the request carries params=None rather than an empty collection."""
+        engine = ModelEngine(_make_model())
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert self._params_from(engine._client) is None
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_empty_default_query_sends_no_params(self):
+        """An empty default_query block is equivalent to omitting it."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert self._params_from(engine._client) is None
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_config_default_query_absent_from_body(self):
+        """default_query configures the URL, never the JSON request body."""
+        engine = ModelEngine(_make_model(parameters={"default_query": {"tenant": "acme-corp"}}))
+        engine._client = self._mock_client()
+        engine._running = True
+
+        await engine.call([{"role": "user", "content": "Hi"}])
+
+        body = engine._client.post.call_args[1]["json"]
+        assert "default_query" not in body
+        assert "tenant" not in body
 
 
 class TestModelEngineStreamCall:


### PR DESCRIPTION
## Description

PR #2220 Added the capability to add HTTP header fields to a Guardrails config. This allows per-model configuration of static header values. LLMRails has the capability to add `default_query` which is [applied in the http call](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/llm/frameworks/default.py#L132). This PR adds that feature to IORails for parity.

## Related Issue(s)

* [NGUARD-817](https://jirasw.nvidia.com/browse/NGUARD-817)
* https://nvbugs/6537689 

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test

env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-parameters-default-query
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7128 items]

........................................................................ [  1%]
.................................................................ss.ss.. [  2%]
sss.....................................................s.ss...ss....s.. [  3%]
.sss......s...s.....s................................................... [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
..............................s......................................... [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
.....................................................................s.. [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
...................s.............s..s................................... [ 30%]
..............s....s..s..s..s..s.s...................................... [ 31%]
s....................................................................... [ 32%]
........................................................................ [ 33%]
...........................................................s............ [ 34%]
...................................................................sssss [ 35%]
........s.ssssss.ssssss.s.ssss.......................................... [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
..............................................................s.ssss.... [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
........................................................................ [ 43%]
...........sss.s..sss..s...............sss.sss...ss............s........ [ 44%]
..............ss..............ss.s.ssss.s............................... [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
........................................................................ [ 48%]
.................................................................s.s.... [ 49%]
........................................................................ [ 50%]
.....................................................................sss [ 51%]
s.......................................s............................... [ 52%]
........................................................................ [ 53%]
..........................s................ssssss....................... [ 54%]
........................................................................ [ 55%]
.........sss............................................................ [ 56%]
......................................................ss................ [ 57%]
.......ss............................................................... [ 58%]
...........................................sssssss.ssssss............... [ 59%]
............................s........................................... [ 60%]
...................................................s.................... [ 61%]
................s....................................................... [ 62%]
..............................s......................................... [ 63%]
........................................................................ [ 64%]
................................................s....................... [ 65%]
....................................................................ssss [ 66%]
s....................................................................... [ 67%]
........................................................................ [ 68%]
....s...................s.......s....................................... [ 69%]
...............s................................s....................... [ 70%]
........................................................................ [ 71%]
.....................................................................s.s [ 72%]
.ssss.sssss.s..sss...................................................... [ 73%]
........sssssss......................................................... [ 74%]
........................................................................ [ 75%]
........................................................................ [ 76%]
......................................................ss.s.ssssss..sssss [ 77%]
s.ssss.................................................................. [ 78%]
........................................................................ [ 79%]
........................................................................ [ 80%]
........................................................................ [ 81%]
...........s............................................................ [ 82%]
.......................................................................s [ 83%]
.sssss..................sssss.sss.................................ssss.. [ 84%]
...........................ss...........ss................ss............ [ 85%]
........................................................................ [ 86%]
........................................................................ [ 87%]
........................................s....ssss....................... [ 88%]
........................................................................ [ 89%]
..................................................................s..... [ 90%]
........................................................................ [ 91%]
...........................s............................................ [ 92%]
........................................................................ [ 93%]
........................................................................ [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
........................................................................ [ 97%]
.......................................s................................ [ 98%]
........................................................................ [100%]

══════════════════════════════════════════════════════════════════════════════════ inline-snapshot ══════════════════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and inline-snapshot will not
be able to fix snapshots or generate reports.

====================== 6917 passed, 211 skipped in 53.53s ======================

```


### Integration test with [`e2e_test_default_query.py`](https://gist.github.com/tgasser-nv/8a48a638cd8cebd3abcf5ab0c5e63978)

```
$ uv run --locked python ~/utils/http_calls/e2e_test_default_query.py

Config passed to both IORails and LLMRails
  config.yml form:
    models:
    - type: main
      engine: openai
      model: test-model
      parameters:
        base_url: http://127.0.0.1:52404/v1
        default_query:
          tenant: acme-corp
          api-version: '2024-10-21'
          retries: 3
          ratio: 1.5
          beta: true
          cache: false
          flag: null
          tag:
          - red
          - blue
  models[0].parameters after RailsConfig validation:
    {
      "base_url": "http://127.0.0.1:52404/v1",
      "default_query": {
        "tenant": "acme-corp",
        "api-version": "2024-10-21",
        "retries": 3,
        "ratio": 1.5,
        "beta": true,
        "cache": false,
        "flag": null,
        "tag": [
          "red",
          "blue"
        ]
      }
    }

IORails leg
  path            : /v1/chat/completions
  query string    : tenant=acme-corp&api-version=2024-10-21&retries=3&ratio=1.5&beta=true&cache=false&flag=&tag=red&tag=blue
  [PASS] posted to /v1/chat/completions
  [PASS] query parameters match the expected wire form
  [PASS] no query parameter leaked into the JSON body (leaked: none)

LLMRails leg
  path            : /v1/chat/completions
  query string    : tenant=acme-corp&api-version=2024-10-21&retries=3&ratio=1.5&beta=true&cache=false&flag=&tag=red&tag=blue
  [PASS] posted to /v1/chat/completions
  [PASS] query parameters match the expected wire form
  [PASS] no query parameter leaked into the JSON body (leaked: none)

Equivalence
  [PASS] both engines produced identical query parameters

Intentional divergence: nested object value
  default_query   : {'meta': {'region': 'us'}}
  IORails         : ValueError: default_query['meta'] must be a scalar or a list of scalars, not a nested object. Flatten nested values into separate query parameters.
  [PASS] IORails names the offending key in the error
  LLMRails        : meta={'region': 'us'}
  [PASS] LLMRails forwards it as an encoded representation (documented divergence)

VERDICT: default_query reached the wire on IORails: True
PASSED
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring default query parameters for model requests.
  * Query parameters now work with standard and streaming requests, including lists, booleans, and empty values.
  * Added validation for unsupported nested query objects.

* **Documentation**
  * Documented configuration, URL behavior, value serialization, secret handling, and framework-specific differences.

* **Tests**
  * Added coverage for query parameter serialization and end-to-end delivery to provider URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->