### PR TITLE
fix(server): evict model-suffixed cache keys on auto-reload

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -375,6 +375,104 @@ def _generate_cache_key(config_ids: List[str], model_name: Optional[str] = None)
     return key
 
 
+def _cache_key_matches_config_id(cache_key: str, config_id: str) -> bool:
+    """Return True if ``cache_key`` was built from ``config_id``.
+
+    Keys are ``{id}``, ``{id}:{model}``, or hyphen-joined multi-config variants
+    such as ``{id1}-{id2}:{model}``.
+    """
+    config_part = cache_key.split(":", 1)[0]
+    if config_part == config_id:
+        return True
+    return config_id in config_part.split("-")
+
+
+def _evict_cached_rails_for_config(config_id: str) -> bool:
+    """Drop every cached rails instance that includes ``config_id``.
+
+    ``_get_rails`` stores instances under ``_generate_cache_key``, which appends
+    ``:{model}`` whenever a model is present. Eviction must match those keys,
+    not only the bare config directory name.
+    """
+    matching_keys = [key for key in list(llm_rails_instances) if _cache_key_matches_config_id(key, config_id)]
+    if not matching_keys:
+        return False
+
+    for key in matching_keys:
+        instance = llm_rails_instances.pop(key, None)
+        if instance is not None:
+            llm_rails_events_history_cache[key] = instance.events_history_cache
+
+    log.info("Configuration %s has changed. Clearing cache.", config_id)
+    return True
+
+
+def _config_id_for_watched_path(src_path: str) -> Optional[str]:
+    """Map a changed file under the config root to its config id."""
+    src_path_str = os.path.abspath(src_path)
+    base_path = os.path.abspath(app.rails_config_path)
+    try:
+        rel_path = os.path.relpath(src_path_str, base_path)
+    except ValueError:
+        return None
+
+    if rel_path.startswith(".."):
+        return None
+
+    if app.single_config_mode:
+        return app.single_config_id
+
+    parts = rel_path.split(os.path.sep)
+    if not parts or parts[0] in ("", "."):
+        return None
+    return parts[0]
+
+
+def _should_ignore_watched_path(src_path: str) -> bool:
+    parts = os.path.normpath(src_path).split(os.path.sep)
+    if not parts:
+        return True
+    if parts[-1].startswith("."):
+        return True
+    return ".ipynb_checkpoints" in parts
+
+
+def _snapshot_config_mtimes(config_path: str) -> dict[str, float]:
+    """Return a path -> mtime map for files under the config root."""
+    snapshot: dict[str, float] = {}
+    if not config_path or not os.path.isdir(config_path):
+        return snapshot
+
+    for root, dirs, files in os.walk(config_path):
+        dirs[:] = [
+            directory for directory in dirs if directory != ".ipynb_checkpoints" and not directory.startswith(".")
+        ]
+        for name in files:
+            if name.startswith("."):
+                continue
+            path = os.path.abspath(os.path.join(root, name))
+            try:
+                snapshot[path] = os.path.getmtime(path)
+            except OSError:
+                continue
+    return snapshot
+
+
+def _evict_configs_for_mtime_changes(previous: dict[str, float], current: dict[str, float]) -> None:
+    """Evict configs whose files appeared, disappeared, or changed mtime."""
+    changed_paths = {path for path, mtime in current.items() if previous.get(path) != mtime}
+    changed_paths.update(path for path in previous if path not in current)
+
+    evicted: set[str] = set()
+    for path in changed_paths:
+        if _should_ignore_watched_path(path):
+            continue
+        config_id = _config_id_for_watched_path(path)
+        if config_id and config_id not in evicted:
+            if _evict_cached_rails_for_config(config_id):
+                evicted.add(config_id)
+
+
 def _update_models_in_config(config: RailsConfig, main_model: Model) -> RailsConfig:
     """Update the main model in the RailsConfig.
 
@@ -901,54 +999,77 @@ def register_logger(logger: Callable):
     registered_loggers.append(logger)
 
 
+def _start_config_observer(event_handler, config_path: str):
+    """Start a recursive filesystem observer for the config directory."""
+    from watchdog.observers import Observer
+
+    observer = Observer()
+    observer.schedule(event_handler, config_path, recursive=True)
+    observer.start()
+    return observer
+
+
+def _make_reload_event_handler():
+    """Build the watchdog handler that evicts cached rails on config file changes."""
+    from watchdog.events import FileSystemEventHandler
+
+    class Handler(FileSystemEventHandler):
+        def on_any_event(self, event):
+            if event.is_directory:
+                return None
+
+            if event.event_type not in ("created", "modified", "deleted", "moved"):
+                return None
+
+            src_path_str = str(event.src_path)
+            log.info("Watchdog received %s event for file %s", event.event_type, src_path_str)
+
+            paths = [src_path_str]
+            dest_path = getattr(event, "dest_path", None)
+            if dest_path:
+                paths.append(str(dest_path))
+
+            evicted: set[str] = set()
+            for path in paths:
+                if _should_ignore_watched_path(path):
+                    continue
+                config_id = _config_id_for_watched_path(path)
+                if config_id and config_id not in evicted:
+                    if _evict_cached_rails_for_config(config_id):
+                        evicted.add(config_id)
+
+    return Handler()
+
+
 def start_auto_reload_monitoring():
     """Start a thread that monitors the config folder for changes."""
     try:
-        from watchdog.events import FileSystemEventHandler
-        from watchdog.observers import Observer
-
-        class Handler(FileSystemEventHandler):
-            def on_any_event(self, event):
-                if event.is_directory:
-                    return None
-
-                elif event.event_type == "created" or event.event_type == "modified":
-                    log.info(f"Watchdog received {event.event_type} event for file {event.src_path}")
-
-                    # Compute the relative path
-                    src_path_str = str(event.src_path)
-                    rel_path = os.path.relpath(src_path_str, app.rails_config_path)
-
-                    # The config_id is the first component
-                    parts = rel_path.split(os.path.sep)
-                    config_id = parts[0]
-
-                    if (
-                        not parts[-1].startswith(".")
-                        and ".ipynb_checkpoints" not in parts
-                        and os.path.isfile(src_path_str)
-                    ):
-                        # We just remove the config from the cache so that a new one is used next time
-                        if config_id in llm_rails_instances:
-                            instance = llm_rails_instances[config_id]
-                            del llm_rails_instances[config_id]
-                            if instance:
-                                val = instance.events_history_cache
-                                # We save the events history cache, to restore it on the new instance
-                                llm_rails_events_history_cache[config_id] = val
-
-                            log.info(f"Configuration {config_id} has changed. Clearing cache.")
-
-        observer = Observer()
-        event_handler = Handler()
-        observer.schedule(event_handler, app.rails_config_path, recursive=True)
-        observer.start()
+        event_handler = _make_reload_event_handler()
+        observer = _start_config_observer(event_handler, app.rails_config_path)
+        mtime_snapshot = _snapshot_config_mtimes(app.rails_config_path)
         try:
             while not app.stop_signal:
                 time.sleep(5)
+                # Docker bind-mount inotify can stop delivering events with no
+                # error. Periodic mtime polling keeps reload working if that
+                # happens, and also covers the observer thread dying.
+                current_snapshot = _snapshot_config_mtimes(app.rails_config_path)
+                _evict_configs_for_mtime_changes(mtime_snapshot, current_snapshot)
+                mtime_snapshot = current_snapshot
+
+                if not observer.is_alive():
+                    log.warning(
+                        "Config file observer is no longer alive; restarting. "
+                        "mtime polling continues to evict stale configs."
+                    )
+                    try:
+                        observer = _start_config_observer(event_handler, app.rails_config_path)
+                    except Exception:
+                        log.exception("Failed to restart config file observer")
         finally:
-            observer.stop()
-            observer.join()
+            if observer.is_alive():
+                observer.stop()
+                observer.join()
 
     except ImportError:
         # Since this is running in a separate thread, we just print the error.

--- a/tests/server/test_auto_reload.py
+++ b/tests/server/test_auto_reload.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Auto-reload cache eviction for ``nemoguardrails server --auto-reload``.
+
+``_get_rails`` caches instances as ``config_id:model_name``. The watchdog used
+to look up the bare ``config_id``, so real /v1/checks traffic never evicted.
+"""
+
+import os
+
+import pytest
+
+from nemoguardrails.server import api
+
+
+class _FakeRails:
+    def __init__(self, history=None):
+        self.events_history_cache = history if history is not None else {}
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    original_path = api.app.rails_config_path
+    original_single_config_mode = api.app.single_config_mode
+    original_single_config_id = api.app.single_config_id
+    api.app.single_config_mode = False
+    api.app.single_config_id = None
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    yield
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    api.app.rails_config_path = original_path
+    api.app.single_config_mode = original_single_config_mode
+    api.app.single_config_id = original_single_config_id
+
+
+def test_generate_cache_key_appends_model_name():
+    assert api._generate_cache_key(["regex"]) == "regex"
+    assert api._generate_cache_key(["regex"], "gpt-4o") == "regex:gpt-4o"
+    assert api._generate_cache_key(["a", "b"], "gpt-4o") == "a-b:gpt-4o"
+
+
+@pytest.mark.parametrize(
+    ("cache_key", "config_id", "expected"),
+    [
+        ("regex", "regex", True),
+        ("regex:gpt-4o", "regex", True),
+        ("a-b:gpt-4o", "a", True),
+        ("a-b:gpt-4o", "b", True),
+        ("regex:gpt-4o", "other", False),
+        ("regex2:gpt-4o", "regex", False),
+    ],
+)
+def test_cache_key_matches_config_id(cache_key, config_id, expected):
+    assert api._cache_key_matches_config_id(cache_key, config_id) is expected
+
+
+def test_evict_clears_model_suffixed_keys_and_preserves_other_configs():
+    """The reported bug: eviction looked up bare ``regex`` while the live key is ``regex:gpt-4o``."""
+    stale = _FakeRails(history={"thread": ["old"]})
+    other = _FakeRails(history={"thread": ["keep"]})
+    api.llm_rails_instances["regex:gpt-4o"] = stale
+    api.llm_rails_instances["other:gpt-4o"] = other
+
+    evicted = api._evict_cached_rails_for_config("regex")
+
+    assert evicted is True
+    assert "regex:gpt-4o" not in api.llm_rails_instances
+    assert api.llm_rails_instances["other:gpt-4o"] is other
+    assert api.llm_rails_events_history_cache["regex:gpt-4o"] == {"thread": ["old"]}
+
+
+def test_evict_clears_bare_and_multi_config_keys():
+    api.llm_rails_instances["regex"] = _FakeRails()
+    api.llm_rails_instances["regex-extra:gpt-4o"] = _FakeRails()
+    api.llm_rails_instances["unrelated"] = _FakeRails()
+
+    assert api._evict_cached_rails_for_config("regex") is True
+    assert set(api.llm_rails_instances) == {"unrelated"}
+
+
+def test_evict_is_noop_when_config_is_not_cached():
+    api.llm_rails_instances["other:gpt-4o"] = _FakeRails()
+
+    assert api._evict_cached_rails_for_config("regex") is False
+    assert "other:gpt-4o" in api.llm_rails_instances
+
+
+def test_config_id_for_watched_path_uses_first_directory(tmp_path):
+    api.app.rails_config_path = str(tmp_path)
+    config_file = tmp_path / "regex" / "config.yml"
+    config_file.parent.mkdir()
+    config_file.write_text("rails: {}\n", encoding="utf-8")
+
+    assert api._config_id_for_watched_path(str(config_file)) == "regex"
+
+
+def test_config_id_for_watched_path_uses_single_config_id(tmp_path):
+    api.app.rails_config_path = str(tmp_path)
+    api.app.single_config_mode = True
+    api.app.single_config_id = "myconfig"
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("rails: {}\n", encoding="utf-8")
+
+    assert api._config_id_for_watched_path(str(config_file)) == "myconfig"
+
+
+def test_should_ignore_hidden_and_checkpoint_paths():
+    assert api._should_ignore_watched_path(os.path.join("regex", ".hidden.yml")) is True
+    assert api._should_ignore_watched_path(os.path.join("regex", ".ipynb_checkpoints", "config.yml")) is True
+    assert api._should_ignore_watched_path(os.path.join("regex", "config.yml")) is False
+
+
+def test_mtime_polling_evicts_suffixed_cache_after_edit(tmp_path):
+    """Fallback path for Docker bind mounts where inotify can stop delivering events."""
+    api.app.rails_config_path = str(tmp_path)
+    config_dir = tmp_path / "regex"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yml"
+    config_file.write_text("rails: {}\n", encoding="utf-8")
+
+    api.llm_rails_instances["regex:gpt-4o"] = _FakeRails()
+    previous = api._snapshot_config_mtimes(str(tmp_path))
+
+    config_file.write_text("rails: { input: {} }\n", encoding="utf-8")
+    os.utime(config_file, (os.path.getmtime(config_file) + 5, os.path.getmtime(config_file) + 5))
+    current = api._snapshot_config_mtimes(str(tmp_path))
+
+    api._evict_configs_for_mtime_changes(previous, current)
+
+    assert "regex:gpt-4o" not in api.llm_rails_instances
+
+
+def test_mtime_polling_evicts_when_file_is_removed(tmp_path):
+    api.app.rails_config_path = str(tmp_path)
+    config_dir = tmp_path / "regex"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yml"
+    config_file.write_text("rails: {}\n", encoding="utf-8")
+
+    api.llm_rails_instances["regex:gpt-4o"] = _FakeRails()
+    previous = api._snapshot_config_mtimes(str(tmp_path))
+    config_file.unlink()
+    current = api._snapshot_config_mtimes(str(tmp_path))
+
+    api._evict_configs_for_mtime_changes(previous, current)
+
+    assert "regex:gpt-4o" not in api.llm_rails_instances
+
+
+def test_watchdog_handler_evicts_model_suffixed_key(tmp_path):
+    """End-to-end handler path: a modified config.yml must drop ``config:model`` keys."""
+    pytest.importorskip("watchdog")
+    from watchdog.events import FileModifiedEvent
+
+    api.app.rails_config_path = str(tmp_path)
+    config_file = tmp_path / "regex" / "config.yml"
+    config_file.parent.mkdir()
+    config_file.write_text("rails: {}\n", encoding="utf-8")
+    api.llm_rails_instances["regex:gpt-4o"] = _FakeRails()
+
+    handler = api._make_reload_event_handler()
+    handler.on_any_event(FileModifiedEvent(str(config_file)))
+
+    assert "regex:gpt-4o" not in api.llm_rails_instances


### PR DESCRIPTION
## Description

`nemoguardrails server --auto-reload` never applied config edits on a running server. Two bugs:

1. Cache-key mismatch: `_get_rails()` stores instances as `config_id:model_name` (because `GuardrailCheckRequest.model` is required on `/v1/checks`), but the watchdog only deleted the bare `config_id`. Eviction was a silent no-op for real traffic. The events-history restore path had the same mismatch.
2. Docker bind-mount inotify can stop delivering events with no error. The existing 5s monitor loop now polls file mtimes and evicts stale configs, and it restarts the observer if that thread has died.

Eviction now matches every cache key that includes the changed config id (bare, `:model` suffix, and hyphen-joined multi-config keys) and stores events history under those same keys.

## Related Issue(s)

- Fixes #2263
- Issue assignee: unassigned (issue is still `status: needs triage`; happy to wait for assignment if maintainers prefer)

## Verification

- `uv run --locked pytest tests/server/test_auto_reload.py -q` — 16 passed
- Focused unit tests cover model-suffixed eviction, events-history restore keys, single-config path mapping, mtime polling (edit and delete), and the watchdog handler

## AI Assistance

- [x] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
