### PR TITLE
feat(llm): add public api_key property for in-place credential rotation

### DIFF
--- a/nemoguardrails/llm/clients/base.py
+++ b/nemoguardrails/llm/clients/base.py
@@ -137,6 +137,23 @@ class BaseClient:
     def provider_url(self) -> Optional[str]:
         return None
 
+    @property
+    def api_key(self) -> Optional[str]:
+        """The bearer token/API key used for the Authorization header."""
+        return self._api_key
+
+    @api_key.setter
+    def api_key(self, value: Optional[str]) -> None:
+        """Update the API key in place.
+
+        Safe to call between requests on an in-flight client: headers are
+        rebuilt fresh per call in ``_build_headers()``, so this only affects
+        requests started after the assignment. Intended for callers that hold
+        one long-lived client/model across many short-lived credential
+        rotations (e.g. OAuth client-credentials tokens).
+        """
+        self._api_key = value
+
     def _error_context(self) -> ErrorContext:
         return ErrorContext(
             model_name=None,

--- a/nemoguardrails/llm/models/instrumented.py
+++ b/nemoguardrails/llm/models/instrumented.py
@@ -94,6 +94,20 @@ class InstrumentedLLMModel:
         return self._model.provider_url
 
     @property
+    def api_key(self) -> Optional[str]:
+        """The wrapped model's bearer token/API key, if it exposes one.
+
+        Raises ``AttributeError`` for wrapped models without one, so
+        ``hasattr(rails.llm, "api_key")`` still reports support correctly
+        through this decorator.
+        """
+        return getattr(self._model, "api_key")
+
+    @api_key.setter
+    def api_key(self, value: Optional[str]) -> None:
+        setattr(self._model, "api_key", value)
+
+    @property
     def wrapped_model(self) -> LLMModel:
         """Return the underlying model for direct access or re-instrumentation."""
         return self._model

--- a/nemoguardrails/llm/models/openai_chat.py
+++ b/nemoguardrails/llm/models/openai_chat.py
@@ -73,6 +73,15 @@ class OpenAIChatModel:
     def provider_url(self) -> Optional[str]:
         return self._client.provider_url
 
+    @property
+    def api_key(self) -> Optional[str]:
+        """The bearer token/API key used by the underlying HTTP client."""
+        return self._client.api_key
+
+    @api_key.setter
+    def api_key(self, value: Optional[str]) -> None:
+        self._client.api_key = value
+
     def _enrich(self, exc: LLMClientError) -> LLMClientError:
         exc.provider_name = self._provider_name
         exc.model_name = self._model

--- a/nemoguardrails/types.py
+++ b/nemoguardrails/types.py
@@ -252,6 +252,10 @@ class LLMModel(Protocol):
     objects. Adapters convert ``ChatMessage`` to whatever their SDK expects.
     ``**kwargs`` are forwarded to the underlying SDK (e.g. temperature,
     max_tokens).
+
+    Bearer-token backends (e.g. ``OpenAIChatModel``) additionally expose a
+    settable ``api_key`` property for in-place credential rotation; this is
+    not part of the protocol, so check with ``hasattr`` before relying on it.
     """
 
     async def generate_async(

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -101,6 +101,26 @@ class TestCustomQuery:
             assert client._custom_query == {"api-version": "2024-02-01"}
 
 
+class TestApiKey:
+    @pytest.mark.asyncio
+    async def test_getter_returns_constructor_value(self):
+        async with _make_client() as client:
+            assert client.api_key == "sk-test"
+
+    @pytest.mark.asyncio
+    async def test_setter_updates_value(self):
+        async with _make_client() as client:
+            client.api_key = "sk-rotated"
+            assert client.api_key == "sk-rotated"
+
+    @pytest.mark.asyncio
+    async def test_setter_reflected_in_next_request_headers(self):
+        async with _make_client() as client:
+            client.api_key = "sk-rotated"
+            headers = client._build_headers()
+            assert headers["Authorization"] == "Bearer sk-rotated"
+
+
 class TestHttpClientInjection:
     @pytest.mark.asyncio
     async def test_uses_injected_client(self):

--- a/tests/llm/models/test_instrumented.py
+++ b/tests/llm/models/test_instrumented.py
@@ -358,6 +358,25 @@ async def test_instrumentation_is_idempotent_and_does_not_own_model(span_exporte
     assert not hasattr(first, "aclose")
 
 
+def test_api_key_delegates_to_wrapped_model_when_supported():
+    class KeyedModel(RecordingModel):
+        api_key = "sk-initial"
+
+    model = KeyedModel()
+    instrumented = InstrumentedLLMModel(model, metrics_enabled=True)
+
+    assert instrumented.api_key == "sk-initial"
+
+    instrumented.api_key = "sk-rotated"
+    assert model.api_key == "sk-rotated"
+
+
+def test_api_key_hasattr_false_when_wrapped_model_lacks_it():
+    instrumented = InstrumentedLLMModel(RecordingModel(), metrics_enabled=True)
+
+    assert not hasattr(instrumented, "api_key")
+
+
 @pytest.mark.asyncio
 async def test_stream_cleanup_runs_outside_duration_metric(metric_reader):
     close_delay = 0.2

--- a/tests/llm/models/test_openai_chat.py
+++ b/tests/llm/models/test_openai_chat.py
@@ -872,3 +872,15 @@ class TestProperties:
         mc.provider_url = "https://example.com/v1"
         m = _model(mc)
         assert m.provider_url == "https://example.com/v1"
+
+    def test_api_key_getter_delegates_to_client(self):
+        mc = _mock_client()
+        mc.api_key = "sk-initial"
+        m = _model(mc)
+        assert m.api_key == "sk-initial"
+
+    def test_api_key_setter_delegates_to_client(self):
+        mc = _mock_client()
+        m = _model(mc)
+        m.api_key = "sk-rotated"
+        assert mc.api_key == "sk-rotated"


### PR DESCRIPTION
## Description

Applications that build one long-lived `LLMRails`/`OpenAIChatModel` instance at process startup (a common pattern for services that don't want per-request construction overhead) and authenticate against their LLM provider with a short-lived, rotating bearer token (OAuth client-credentials, AWS STS-style tokens, internal gateway tokens, etc.) currently have no supported way to update that credential in place.

Today the only two options are:
- Reach into private attributes two levels deep (`rails.llm._client._api_key`), which is unsupported and can silently break on any minor/patch upgrade with no type or import error — just silent 401s from the provider.
- Rebuild the model via `DefaultFramework.create_model()` and swap it in with `LLMRails.update_llm()`. This "looks" like the supported path, but `DefaultFramework._clients` caches `OpenAICompatibleClient` instances keyed by `(base_url, api_key, ...)` and never evicts entries, so every token rotation leaks a new `httpx.AsyncClient` connection pool for the life of the process.

This PR adds a small, purely additive `api_key` property (with setter) so callers have a public, documented way to rotate the credential on an already-built model without either workaround.

## Related Issue(s)

- Fixes #2299 

## Verification

Ran pytest and pre-commit checks successfully.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: GitHub Copilot / Claude).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
