### PR TITLE
fix(iorails): Client error message fixes

### DIFF
--- a/nemoguardrails/guardrails/_http.py
+++ b/nemoguardrails/guardrails/_http.py
@@ -41,10 +41,16 @@ def merge_headers_case_insensitive(base: Mapping[str, str], overrides: Optional[
     return merged
 
 
-async def safe_read_body(response: aiohttp.ClientResponse, max_chars: int = 500) -> str:
-    """Read response body for error messages, truncating if too large."""
+async def safe_read_body(response: aiohttp.ClientResponse, max_chars: Optional[int] = 500) -> str:
+    """Read response body for error messages, truncating unless ``max_chars`` is None.
+
+    Error classification passes None: a body cut mid-JSON no longer parses, and the
+    provider's ``message``/``code``/``param`` would be lost in favour of the raw text.
+    """
     try:
         text = await response.text()
-        return text[:max_chars] if len(text) > max_chars else text
+        if max_chars is not None and len(text) > max_chars:
+            return text[:max_chars]
+        return text
     except Exception:
         return "<could not read response body>"

--- a/nemoguardrails/guardrails/_http.py
+++ b/nemoguardrails/guardrails/_http.py
@@ -41,16 +41,10 @@ def merge_headers_case_insensitive(base: Mapping[str, str], overrides: Optional[
     return merged
 
 
-async def safe_read_body(response: aiohttp.ClientResponse, max_chars: Optional[int] = 500) -> str:
-    """Read response body for error messages, truncating unless ``max_chars`` is None.
-
-    Error classification passes None: a body cut mid-JSON no longer parses, and the
-    provider's ``message``/``code``/``param`` would be lost in favour of the raw text.
-    """
+async def safe_read_body(response: aiohttp.ClientResponse, max_chars: int = 500) -> str:
+    """Read response body for error messages, truncating if too large."""
     try:
         text = await response.text()
-        if max_chars is not None and len(text) > max_chars:
-            return text[:max_chars]
-        return text
+        return text[:max_chars] if len(text) > max_chars else text
     except Exception:
         return "<could not read response body>"

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -20,6 +20,7 @@ OpenAI-compatible /v1/chat/completions endpoint via aiohttp.
 Retries are handled by aiohttp-retry (ExponentialRetry).
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -32,6 +33,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, cast
 import aiohttp
 from aiohttp_retry import RetryClient
 
+from nemoguardrails.exceptions import LLMClientError, LLMConnectionError, LLMTimeoutError
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
@@ -48,6 +50,7 @@ from nemoguardrails.guardrails.telemetry import (
     set_llm_response_attributes,
 )
 from nemoguardrails.guardrails.tool_schema import Tool, ToolExchange, ToolResult, Toolset
+from nemoguardrails.llm.clients._errors import ErrorContext, raise_for_sse_error, raise_for_status
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.tracing.constants import (
     llm_operation_duration,
@@ -504,9 +507,21 @@ _TOOL_EXCHANGE_EXTRACTORS = {
 class ModelEngineError(Exception):
     """Raised when a model engine call fails."""
 
-    def __init__(self, message: str, model_name: str, status: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        model_name: str,
+        status: int | None = None,
+        *,
+        inner_exception: BaseException | None = None,
+    ) -> None:
         self.model_name = model_name
         self.status = status
+        # The typed LLMClientError this failure was classified into, when it came from a
+        # provider response. ``nemoguardrails.llm.clients._errors.as_client_error`` reads
+        # this attribute, which is how the server renders the provider's own message, code,
+        # param, and Retry-After instead of falling back to ``str(exception)``.
+        self.inner_exception = inner_exception
         super().__init__(message)
 
     @property
@@ -666,11 +681,71 @@ class ModelEngine(BaseEngine):
         body: dict[str, Any] = {"model": self.model_name, "messages": messages, **kwargs}
         return _RequestParams(client=client, url=url, headers=headers, body=body)
 
+    @property
+    def _error_context(self) -> ErrorContext:
+        """Identify this engine's model to the shared error classifier."""
+        return ErrorContext(
+            model_name=self.model_name,
+            provider_name=self.provider_name,
+            base_url=self.base_url,
+        )
+
+    def _wrap_client_error(self, client_error: LLMClientError, summary: str) -> ModelEngineError:
+        """Carry a classified provider error inside the ``ModelEngineError`` this engine raises.
+
+        The message keeps the model name for the server log; it is the inner error, not this
+        text, that the server renders for the caller, so the raw upstream body is left out
+        rather than concatenated in.
+        """
+        if client_error.status_code > 0:
+            status = client_error.status_code
+        else:
+            status = None
+        return ModelEngineError(
+            f"{summary} from model '{self.model_name}': {client_error.error_message}",
+            model_name=self.model_name,
+            status=status,
+            inner_exception=client_error,
+        )
+
+    def _classify_error_response(self, status: int, body: str, headers: Any, req_id: str) -> LLMClientError | None:
+        """Return the typed provider error for a failed response, or None if it cannot be classified."""
+        try:
+            raise_for_status(status, body, headers, self._error_context)
+        except LLMClientError as client_error:
+            return client_error
+        except Exception:
+            # A classifier failure must not cost the caller the upstream status. Letting this
+            # escape would strip it in ``call``'s catch-all, and the server would report 500
+            # for what was really a 429 or 503, which SDKs retry differently.
+            log.warning(
+                "[%s] could not classify HTTP %s from model '%s'",
+                req_id,
+                status,
+                self.model_name,
+                exc_info=True,
+            )
+        return None
+
+    def _raise_for_sse_error(self, raw_chunk: dict, headers: Any) -> None:
+        """Raise ``ModelEngineError`` for a provider error frame carried inside a stream.
+
+        Mirrors ``BaseClient._check_sse_error``. Anything ``raise_for_sse_error`` raises other
+        than an ``LLMClientError`` still terminates the stream through ``stream_call``'s
+        catch-all, so the frame is never silently dropped.
+        """
+        try:
+            raise_for_sse_error(raw_chunk, headers, self._error_context)
+        except LLMClientError as client_error:
+            raise self._wrap_client_error(client_error, "Stream error") from client_error
+
     async def _raise_for_status(self, response: aiohttp.ClientResponse, req_id: str, t0: float) -> None:
         """Raise ``ModelEngineError`` if the HTTP status indicates an error."""
         if response.status >= 400:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            error_body = await safe_read_body(response)
+            # Read in full: raise_for_status parses this as JSON to recover the provider's
+            # message, code and param, and a truncated body would fall back to raw text.
+            error_body = await safe_read_body(response, max_chars=None)
             log.warning(
                 "[%s] HTTP %s from model '%s' time=%.1fms",
                 req_id,
@@ -678,11 +753,31 @@ class ModelEngine(BaseEngine):
                 self.model_name,
                 elapsed_ms,
             )
+            client_error = self._classify_error_response(response.status, error_body, response.headers, req_id)
+            if client_error is not None:
+                raise self._wrap_client_error(client_error, f"HTTP {response.status}") from client_error
+            # The body is left out deliberately: unclassified is exactly the case where it
+            # could be anything, and it must not reach the caller.
             raise ModelEngineError(
-                f"HTTP {response.status} from model '{self.model_name}': {error_body}",
+                f"HTTP {response.status} from model '{self.model_name}'",
                 model_name=self.model_name,
                 status=response.status,
             )
+
+    def _classify_transport_failure(self, exc: Exception) -> LLMClientError | None:
+        """Return the typed client error for a timeout or connection failure, or None for anything else.
+
+        Mirrors the httpx mapping in ``nemoguardrails.llm.clients.base``, so the same
+        transport failure reads the same to a caller whichever engine served the request.
+        No HTTP response arrived, hence status 0.
+        """
+        # Order matters: aiohttp's ServerTimeoutError subclasses ClientConnectionError, so
+        # testing for a connection failure first would report every timeout as one.
+        if isinstance(exc, (asyncio.TimeoutError, aiohttp.ServerTimeoutError)):
+            return LLMTimeoutError(0, f"Request timed out: {exc}", **self._error_context.as_kwargs())
+        if isinstance(exc, aiohttp.ClientConnectionError):
+            return LLMConnectionError(0, f"Connection error: {exc}", **self._error_context.as_kwargs())
+        return None
 
     def _wrap_exception(self, exc: Exception, req_id: str, t0: float, label: str = "Request") -> ModelEngineError:
         """Wrap an unexpected exception in a ``ModelEngineError``."""
@@ -691,6 +786,7 @@ class ModelEngine(BaseEngine):
         return ModelEngineError(
             f"{label} to model '{self.model_name}' failed: {exc}",
             model_name=self.model_name,
+            inner_exception=self._classify_transport_failure(exc),
         )
 
     async def call(
@@ -846,6 +942,13 @@ class ModelEngine(BaseEngine):
                     except json.JSONDecodeError:
                         log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
                         continue
+
+                    # A provider can report a failure in a frame rather than in the HTTP
+                    # status, and the stream would otherwise end as though generation had
+                    # completed. Only a top-level "error" key counts, so model output that
+                    # merely looks like an error object stays ordinary content.
+                    if isinstance(raw_chunk, dict) and "error" in raw_chunk:
+                        self._raise_for_sse_error(raw_chunk, response.headers)
 
                     last_chunk_id = raw_chunk.get("id") or last_chunk_id
                     _accumulate_tool_call_delta(tool_calls, raw_chunk)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -498,6 +498,13 @@ def _extract_tool_exchanges_nim(messages: LLMMessages) -> list[ToolExchange]:
     return _extract_tool_exchanges_openai(messages)
 
 
+# How much of a failed response to read for error classification. Large enough that any
+# realistic provider error body parses as JSON and yields its message/code/param, bounded
+# because an unparseable body (an HTML proxy error page) becomes the client-facing message
+# verbatim, and must not be forwarded whole.
+_ERROR_BODY_MAX_CHARS = 8192
+
+
 _TOOL_EXCHANGE_EXTRACTORS = {
     "openai": _extract_tool_exchanges_openai,
     "nim": _extract_tool_exchanges_nim,
@@ -743,9 +750,7 @@ class ModelEngine(BaseEngine):
         """Raise ``ModelEngineError`` if the HTTP status indicates an error."""
         if response.status >= 400:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            # Read in full: raise_for_status parses this as JSON to recover the provider's
-            # message, code and param, and a truncated body would fall back to raw text.
-            error_body = await safe_read_body(response, max_chars=None)
+            error_body = await safe_read_body(response, max_chars=_ERROR_BODY_MAX_CHARS)
             log.warning(
                 "[%s] HTTP %s from model '%s' time=%.1fms",
                 req_id,

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -33,7 +33,12 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional, cast
 import aiohttp
 from aiohttp_retry import RetryClient
 
-from nemoguardrails.exceptions import LLMClientError, LLMConnectionError, LLMTimeoutError
+from nemoguardrails.exceptions import (
+    LLMClientError,
+    LLMConnectionError,
+    LLMResponseValidationError,
+    LLMTimeoutError,
+)
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
@@ -673,6 +678,7 @@ class ModelEngine(BaseEngine):
             raise ModelEngineError(
                 f"ModelEngine for '{self.model_name}' has not been started. Call start() first.",
                 model_name=self.model_name,
+                inner_exception=self._generic_client_error(0, "The model engine is not running."),
             )
 
     def _prepare_request(self, messages: LLMMessages, **kwargs: Any) -> _RequestParams:
@@ -696,6 +702,17 @@ class ModelEngine(BaseEngine):
             provider_name=self.provider_name,
             base_url=self.base_url,
         )
+
+    def _generic_client_error(self, status_code: int, message: str) -> LLMClientError:
+        """Build a caller-safe client error for a failure the shared classifier cannot type.
+
+        Every ``ModelEngineError`` needs one of these, because ``client_facing_message`` falls
+        back to ``str(exception)`` without it, and this engine's messages name the model.
+        The model context still travels for diagnostics: it reaches logs through
+        ``LLMClientError.__str__``, never the client envelope, which renders
+        ``error_message`` alone.
+        """
+        return LLMClientError(status_code, message, **self._error_context.as_kwargs())
 
     def _wrap_client_error(self, client_error: LLMClientError, summary: str) -> ModelEngineError:
         """Carry a classified provider error inside the ``ModelEngineError`` this engine raises.
@@ -759,15 +776,11 @@ class ModelEngine(BaseEngine):
                 elapsed_ms,
             )
             client_error = self._classify_error_response(response.status, error_body, response.headers, req_id)
-            if client_error is not None:
-                raise self._wrap_client_error(client_error, f"HTTP {response.status}") from client_error
-            # The body is left out deliberately: unclassified is exactly the case where it
-            # could be anything, and it must not reach the caller.
-            raise ModelEngineError(
-                f"HTTP {response.status} from model '{self.model_name}'",
-                model_name=self.model_name,
-                status=response.status,
-            )
+            if client_error is None:
+                # The body is left out deliberately: unclassified is exactly the case where it
+                # could be anything, and it must not reach the caller. The status still does.
+                client_error = self._generic_client_error(response.status, f"HTTP {response.status}")
+            raise self._wrap_client_error(client_error, f"HTTP {response.status}") from client_error
 
     def _classify_transport_failure(self, exc: Exception) -> LLMClientError | None:
         """Return the typed client error for a timeout or connection failure, or None for anything else.
@@ -788,10 +801,13 @@ class ModelEngine(BaseEngine):
         """Wrap an unexpected exception in a ``ModelEngineError``."""
         elapsed_ms = (time.monotonic() - t0) * 1000
         log.warning("[%s] %s to model '%s' failed time=%.1fms", req_id, label, self.model_name, elapsed_ms)
+        client_error = self._classify_transport_failure(exc)
+        if client_error is None:
+            client_error = self._generic_client_error(0, f"{label} failed: {exc}")
         return ModelEngineError(
             f"{label} to model '{self.model_name}' failed: {exc}",
             model_name=self.model_name,
-            inner_exception=self._classify_transport_failure(exc),
+            inner_exception=client_error,
         )
 
     async def call(
@@ -950,9 +966,11 @@ class ModelEngine(BaseEngine):
 
                     # A provider can report a failure in a frame rather than in the HTTP
                     # status, and the stream would otherwise end as though generation had
-                    # completed. Only a top-level "error" key counts, so model output that
-                    # merely looks like an error object stays ordinary content.
-                    if isinstance(raw_chunk, dict) and "error" in raw_chunk:
+                    # completed. The value must be non-null, not merely present: a gateway
+                    # that emits "error": null on every frame would otherwise end a healthy
+                    # stream. Only a top-level key counts, so model output that merely looks
+                    # like an error object stays ordinary content.
+                    if isinstance(raw_chunk, dict) and raw_chunk.get("error") is not None:
                         self._raise_for_sse_error(raw_chunk, response.headers)
 
                     last_chunk_id = raw_chunk.get("id") or last_chunk_id
@@ -1031,6 +1049,11 @@ class ModelEngine(BaseEngine):
             raise ModelEngineError(
                 f"Unexpected response format from model '{self.model_name}': {exc}",
                 model_name=self.model_name,
+                inner_exception=LLMResponseValidationError(
+                    f"Unexpected response format from the model: {exc}",
+                    response_data=response,
+                    **self._error_context.as_kwargs(),
+                ),
             ) from exc
 
     async def stream_chat_completion(

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -787,25 +787,33 @@ class ModelEngine(BaseEngine):
 
         Mirrors the httpx mapping in ``nemoguardrails.llm.clients.base``, so the same
         transport failure reads the same to a caller whichever engine served the request.
-        No HTTP response arrived, hence status 0.
+        No HTTP response arrived, hence status 0. Exception details stay on the cause
+        chain instead of entering the client-facing message.
         """
         # Order matters: aiohttp's ServerTimeoutError subclasses ClientConnectionError, so
         # testing for a connection failure first would report every timeout as one.
         if isinstance(exc, (asyncio.TimeoutError, aiohttp.ServerTimeoutError)):
-            return LLMTimeoutError(0, f"Request timed out: {exc}", **self._error_context.as_kwargs())
+            return LLMTimeoutError(0, "Request timed out.", **self._error_context.as_kwargs())
         if isinstance(exc, aiohttp.ClientConnectionError):
-            return LLMConnectionError(0, f"Connection error: {exc}", **self._error_context.as_kwargs())
+            return LLMConnectionError(0, "Connection error.", **self._error_context.as_kwargs())
         return None
 
     def _wrap_exception(self, exc: Exception, req_id: str, t0: float, label: str = "Request") -> ModelEngineError:
         """Wrap an unexpected exception in a ``ModelEngineError``."""
         elapsed_ms = (time.monotonic() - t0) * 1000
-        log.warning("[%s] %s to model '%s' failed time=%.1fms", req_id, label, self.model_name, elapsed_ms)
+        log.warning(
+            "[%s] %s to model '%s' failed time=%.1fms",
+            req_id,
+            label,
+            self.model_name,
+            elapsed_ms,
+            exc_info=exc,
+        )
         client_error = self._classify_transport_failure(exc)
         if client_error is None:
-            client_error = self._generic_client_error(0, f"{label} failed: {exc}")
+            client_error = self._generic_client_error(0, f"{label} failed.")
         return ModelEngineError(
-            f"{label} to model '{self.model_name}' failed: {exc}",
+            client_error.error_message,
             model_name=self.model_name,
             inner_exception=client_error,
         )

--- a/nemoguardrails/guardrails/rail_guard.py
+++ b/nemoguardrails/guardrails/rail_guard.py
@@ -34,7 +34,7 @@ from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.guardrails.guardrails_types import get_request_id
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.telemetry import record_span_error
-from nemoguardrails.llm.clients._errors import _redact_secrets
+from nemoguardrails.llm.clients._errors import _redact_secrets, client_facing_message
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -57,9 +57,13 @@ def _upstream_http_status(exc: Exception) -> Optional[int]:
 def _blocked_reason_or_reraise(span: Optional["Span"], action_name: str, exc: Exception) -> str:
     """Record *exc* on *span* and return a redacted block reason, or re-raise on an HTTP status.
 
-    The text is redacted once and that form is what reaches the log on both paths: a provider
-    error can carry a credential in its message (CWE-532). *exc* itself propagates unmodified,
-    so an operator still sees the real text in a traceback.
+    The log keeps the full text, redacted once: a provider error can carry a credential in its
+    message (CWE-532). *exc* itself propagates unmodified, so an operator still sees the real
+    text in a traceback.
+
+    The returned reason is the client-facing form instead, because it is rendered into the
+    streaming violation payload through ``client_reason``. ``str(exc)`` there would disclose
+    the internal rail model to an API caller.
 
     The span error is recorded only on the blocking path. Callers run inside ``action_span``,
     which records anything escaping it, so recording here too would double up.
@@ -77,7 +81,7 @@ def _blocked_reason_or_reraise(span: Optional["Span"], action_name: str, exc: Ex
 
     record_span_error(span, exc)
     log.error("[%s] %s failed: %s", request_id, action_name, detail)
-    return f"{action_name} error: {detail}"
+    return f"{action_name} error: {_redact_secrets(client_facing_message(exc))}"
 
 
 def rail_error_outcome(span: Optional["Span"], action_name: str, exc: Exception) -> RailOutcome:

--- a/nemoguardrails/llm/clients/_errors.py
+++ b/nemoguardrails/llm/clients/_errors.py
@@ -177,12 +177,17 @@ STREAM_ERROR_TYPES = frozenset(
 
 
 def as_client_error(exception: BaseException) -> Optional[LLMClientError]:
-    """Return the underlying :class:`LLMClientError`, unwrapping ``LLMCallException``."""
-    inner = getattr(exception, "inner_exception", None)
-    if isinstance(inner, LLMClientError):
-        return inner
-    if isinstance(exception, LLMClientError):
-        return exception
+    """Return the underlying :class:`LLMClientError`, following nested ``inner_exception`` links."""
+    # The chain can be more than one link deep: a library rail reaching an IORails model
+    # raises ModelEngineError carrying the client error, and ``llm_call`` then wraps that
+    # again into LLMCallException. ``seen`` guards a wrapper that references itself.
+    seen = set()
+    current: Any = exception
+    while current is not None and id(current) not in seen:
+        if isinstance(current, LLMClientError):
+            return current
+        seen.add(id(current))
+        current = getattr(current, "inner_exception", None)
     return None
 
 

--- a/tests/guardrails/test__http.py
+++ b/tests/guardrails/test__http.py
@@ -67,12 +67,12 @@ class TestSafeReadBody:
         assert len(result) == 500
 
     @pytest.mark.asyncio
-    async def test_max_chars_none_reads_the_whole_body(self):
-        """No truncation when max_chars is None, so an oversized JSON error body still parses."""
+    async def test_explicit_max_chars_overrides_the_default(self):
+        """Error classification reads further than the default, so an oversized JSON body still parses."""
         text = "a" * 5000
         mock_response = AsyncMock()
         mock_response.text = AsyncMock(return_value=text)
-        result = await safe_read_body(mock_response, max_chars=None)
+        result = await safe_read_body(mock_response, max_chars=8192)
         assert result == text
 
 

--- a/tests/guardrails/test__http.py
+++ b/tests/guardrails/test__http.py
@@ -66,6 +66,15 @@ class TestSafeReadBody:
         result = await safe_read_body(mock_response)
         assert len(result) == 500
 
+    @pytest.mark.asyncio
+    async def test_max_chars_none_reads_the_whole_body(self):
+        """No truncation when max_chars is None, so an oversized JSON error body still parses."""
+        text = "a" * 5000
+        mock_response = AsyncMock()
+        mock_response.text = AsyncMock(return_value=text)
+        result = await safe_read_body(mock_response, max_chars=None)
+        assert result == text
+
 
 class TestMergeHeadersCaseInsensitive:
     """Test case-insensitive header merging (override wins, base preserved)."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -833,12 +833,20 @@ class TestModelEngineCall:
     @pytest.mark.parametrize(
         "transport_error,expected_type,expected_message",
         [
-            (aiohttp.ServerTimeoutError("read timed out"), LLMTimeoutError, "Request timed out: read timed out"),
-            (asyncio.TimeoutError(), LLMTimeoutError, "Request timed out: "),
             (
-                aiohttp.ClientConnectionError("cannot connect"),
+                aiohttp.ServerTimeoutError("read timed out at https://private.example/v1/chat/completions"),
+                LLMTimeoutError,
+                "Request timed out.",
+            ),
+            (
+                asyncio.TimeoutError("POST https://private.example/v1/chat/completions"),
+                LLMTimeoutError,
+                "Request timed out.",
+            ),
+            (
+                aiohttp.ClientConnectionError("cannot connect to https://private.example/v1/chat/completions"),
                 LLMConnectionError,
-                "Connection error: cannot connect",
+                "Connection error.",
             ),
         ],
         ids=["server-timeout", "asyncio-timeout", "connection-error"],
@@ -846,34 +854,46 @@ class TestModelEngineCall:
     async def test_call_transport_failure_carries_a_typed_client_error(
         self, transport_error, expected_type, expected_message
     ):
-        """A timeout or connection failure is classified, so the caller sees no internal model name."""
+        """Transport details stay out of both wrapped and client-facing messages."""
         engine = _started_engine(_mock_failing_client(transport_error))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
 
-        assert isinstance(exc_info.value.inner_exception, expected_type)
-        assert exc_info.value.status is None
-        message = client_facing_message(exc_info.value)
-        assert message.startswith(expected_message)
-        assert "meta/llama-3.3-70b-instruct" not in message
+        error = exc_info.value
+        client_error = error.inner_exception
+        assert isinstance(client_error, expected_type)
+        assert error.status is None
+        assert str(error) == expected_message
+        assert client_error.error_message == expected_message
+        assert client_facing_message(error) == expected_message
+        assert "private.example" not in str(error)
+        assert "private.example" not in client_error.error_message
+        assert "private.example" not in client_facing_message(error)
+        assert error.__cause__ is transport_error
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_call_unclassifiable_failure_still_hides_the_model(self):
-        """A failure that is not a transport error still reaches the caller without the model name.
-
-        Without an inner client error, ``client_facing_message`` falls back to ``str(exc)``,
-        and this engine's wrap message names the model.
-        """
-        engine = _started_engine(_mock_failing_client(ValueError("something else")))
+    async def test_call_unclassifiable_failure_uses_a_fixed_client_message(self, caplog):
+        """Unexpected failure details remain available in logs and the cause chain."""
+        endpoint = "https://private.example/v1/chat/completions"
+        original_error = ValueError(f"cannot POST {endpoint}")
+        engine = _started_engine(_mock_failing_client(original_error))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
 
-        message = client_facing_message(exc_info.value)
-        assert message == "Request failed: something else"
-        assert "meta/llama-3.3-70b-instruct" not in message
+        error = exc_info.value
+        client_error = error.inner_exception
+        assert isinstance(client_error, LLMClientError)
+        assert str(error) == "Request failed."
+        assert client_error.error_message == "Request failed."
+        assert client_facing_message(error) == "Request failed."
+        assert endpoint not in str(error)
+        assert endpoint not in client_error.error_message
+        assert endpoint not in client_facing_message(error)
+        assert error.__cause__ is original_error
+        assert endpoint in caplog.text
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -887,7 +907,7 @@ class TestModelEngineCall:
         engine._client = mock_client
         engine._running = True
 
-        with pytest.raises(ModelEngineError, match="connection dropped"):
+        with pytest.raises(ModelEngineError, match=r"^Request failed\.$"):
             await engine.call([{"role": "user", "content": "Hi"}])
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
@@ -1078,7 +1098,8 @@ class TestModelEngineStreamCall:
 
         assert isinstance(exc_info.value.inner_exception, LLMTimeoutError)
         message = client_facing_message(exc_info.value)
-        assert message.startswith("Request timed out: ")
+        assert str(exc_info.value) == "Request timed out."
+        assert message == "Request timed out."
         assert "meta/llama-3.3-70b-instruct" not in message
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
@@ -1456,7 +1477,7 @@ class TestModelEngineStreamCall:
         engine._client = mock_client
         engine._running = True
 
-        with pytest.raises(ModelEngineError, match="connection dropped"):
+        with pytest.raises(ModelEngineError, match=r"^Stream request failed\.$"):
             await anext(engine.stream_call([{"role": "user", "content": "Hi"}]))
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -132,6 +132,28 @@ def _mock_chat_client(payload: dict | None = None, status: int = 200):
     return mock_client
 
 
+def _mock_error_client(body: str, status: int):
+    """Create a mock aiohttp client whose post() returns a failed response carrying ``body``."""
+    mock_response = AsyncMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.status = status
+    mock_response.text = AsyncMock(return_value=body)
+    mock_response.headers = {}
+
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(return_value=mock_response)
+    mock_client.closed = False
+    return mock_client
+
+
+def _mock_failing_client(exc: BaseException):
+    """Create a mock aiohttp client whose post() raises ``exc`` instead of responding."""
+    mock_client = AsyncMock()
+    mock_client.post = MagicMock(side_effect=exc)
+    mock_client.closed = False
+    return mock_client
+
+
 def _started_engine(client, **model_kwargs) -> ModelEngine:
     """Create a ModelEngine wired to ``client`` and marked as started."""
     engine = ModelEngine(_make_model(**model_kwargs))
@@ -739,19 +761,7 @@ class TestModelEngineCall:
         body = json.dumps(
             {"error": {"message": long_message, "type": "invalid_request_error", "param": "temperature", "code": "bad"}}
         )
-        engine = ModelEngine(_make_model())
-
-        mock_response = AsyncMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.status = 400
-        mock_response.text = AsyncMock(return_value=body)
-        mock_response.headers = {}
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(return_value=mock_response)
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_error_client(body, status=400))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
@@ -769,19 +779,7 @@ class TestModelEngineCall:
 
         A proxy returning an HTML page would otherwise be forwarded to the caller whole.
         """
-        engine = ModelEngine(_make_model())
-
-        mock_response = AsyncMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.status = 502
-        mock_response.text = AsyncMock(return_value="<html>" + "x" * 20000 + "</html>")
-        mock_response.headers = {}
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(return_value=mock_response)
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_error_client("<html>" + "x" * 20000 + "</html>", status=502))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
@@ -796,19 +794,7 @@ class TestModelEngineCall:
         These reach logs through ``LLMClientError.__str__``, never the client envelope, which
         renders ``error_message`` alone.
         """
-        engine = ModelEngine(_make_model())
-
-        mock_response = AsyncMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.status = 400
-        mock_response.text = AsyncMock(return_value='{"error": {"message": "bad request"}}')
-        mock_response.headers = {}
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(return_value=mock_response)
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_error_client('{"error": {"message": "bad request"}}', status=400))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
@@ -827,19 +813,7 @@ class TestModelEngineCall:
         Letting it escape would strip the status in call()'s catch-all, and the server would
         report 500 for what was really a 429.
         """
-        engine = ModelEngine(_make_model())
-
-        mock_response = AsyncMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.status = 429
-        mock_response.text = AsyncMock(return_value='{"error": {"message": "slow down"}}')
-        mock_response.headers = {}
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(return_value=mock_response)
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_error_client('{"error": {"message": "slow down"}}', status=429))
 
         with patch(
             "nemoguardrails.guardrails.model_engine.raise_for_status",
@@ -871,13 +845,7 @@ class TestModelEngineCall:
         self, transport_error, expected_type, expected_message
     ):
         """A timeout or connection failure is classified, so the caller sees no internal model name."""
-        engine = ModelEngine(_make_model())
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(side_effect=transport_error)
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_failing_client(transport_error))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
@@ -892,13 +860,7 @@ class TestModelEngineCall:
     @pytest.mark.asyncio
     async def test_call_unclassifiable_failure_carries_no_client_error(self):
         """An exception that is not a transport failure is wrapped without an inner client error."""
-        engine = ModelEngine(_make_model())
-
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(side_effect=ValueError("something else"))
-        mock_client.closed = False
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_failing_client(ValueError("something else")))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
@@ -1101,11 +1063,7 @@ class TestModelEngineStreamCall:
         ``_wrap_exception`` is reached with a different label here, so the streaming branch
         needs its own case.
         """
-        engine = ModelEngine(_make_model())
-        mock_client = AsyncMock()
-        mock_client.post = MagicMock(side_effect=aiohttp.ServerTimeoutError("read timed out"))
-        engine._client = mock_client
-        engine._running = True
+        engine = _started_engine(_mock_failing_client(aiohttp.ServerTimeoutError("read timed out")))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await anext(engine.stream_call([{"role": "user", "content": "Hi"}]))

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -823,8 +823,10 @@ class TestModelEngineCall:
                 await engine.call([{"role": "user", "content": "Hi"}])
 
         assert exc_info.value.status == 429
-        assert exc_info.value.inner_exception is None
         assert "slow down" not in str(exc_info.value)
+        message = client_facing_message(exc_info.value)
+        assert message == "HTTP 429"
+        assert "meta/llama-3.3-70b-instruct" not in message
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -858,14 +860,20 @@ class TestModelEngineCall:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
-    async def test_call_unclassifiable_failure_carries_no_client_error(self):
-        """An exception that is not a transport failure is wrapped without an inner client error."""
+    async def test_call_unclassifiable_failure_still_hides_the_model(self):
+        """A failure that is not a transport error still reaches the caller without the model name.
+
+        Without an inner client error, ``client_facing_message`` falls back to ``str(exc)``,
+        and this engine's wrap message names the model.
+        """
         engine = _started_engine(_mock_failing_client(ValueError("something else")))
 
         with pytest.raises(ModelEngineError) as exc_info:
             await engine.call([{"role": "user", "content": "Hi"}])
 
-        assert exc_info.value.inner_exception is None
+        message = client_facing_message(exc_info.value)
+        assert message == "Request failed: something else"
+        assert "meta/llama-3.3-70b-instruct" not in message
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -1072,6 +1080,23 @@ class TestModelEngineStreamCall:
         message = client_facing_message(exc_info.value)
         assert message.startswith("Request timed out: ")
         assert "meta/llama-3.3-70b-instruct" not in message
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_null_error_field_is_not_a_failure(self):
+        """A gateway that emits ``error: null`` on every frame must not end a healthy stream.
+
+        Testing key presence rather than value also echoed the frame back to the caller: with
+        no usable message, classification falls back to the serialized chunk, putting the
+        model's own output inside an error envelope.
+        """
+        engine = self._streaming_engine(
+            self._make_sse_payloads([{"error": None, "choices": [{"delta": {"content": "Hello"}}]}])
+        )
+
+        chunks = [chunk async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert [c.delta_content for c in chunks] == ["Hello"]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails._http import (
 from nemoguardrails.guardrails.model_engine import (
     _CHAT_COMPLETIONS_ENDPOINT,
     _ENGINE_BASE_URLS,
+    _ERROR_BODY_MAX_CHARS,
     ModelEngine,
     ModelEngineError,
     _parse_chat_completion,
@@ -763,6 +764,63 @@ class TestModelEngineCall:
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
+    async def test_call_unparseable_error_body_is_bounded(self):
+        """An unparseable body becomes the client message, so its length must be bounded.
+
+        A proxy returning an HTML page would otherwise be forwarded to the caller whole.
+        """
+        engine = ModelEngine(_make_model())
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 502
+        mock_response.text = AsyncMock(return_value="<html>" + "x" * 20000 + "</html>")
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert len(client_facing_message(exc_info.value)) <= _ERROR_BODY_MAX_CHARS
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_error_identifies_the_model_to_the_classifier(self):
+        """The classified error carries the engine's model, provider and endpoint for diagnostics.
+
+        These reach logs through ``LLMClientError.__str__``, never the client envelope, which
+        renders ``error_message`` alone.
+        """
+        engine = ModelEngine(_make_model())
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 400
+        mock_response.text = AsyncMock(return_value='{"error": {"message": "bad request"}}')
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.call([{"role": "user", "content": "Hi"}])
+
+        client_error = exc_info.value.inner_exception
+        assert isinstance(client_error, LLMClientError)
+        assert client_error.model_name == "meta/llama-3.3-70b-instruct"
+        assert client_error.provider_name == engine.provider_name
+        assert client_error.base_url == engine.base_url
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
     async def test_call_unclassifiable_error_response_keeps_the_status(self):
         """A classifier failure must not cost the caller the upstream status.
 
@@ -1034,6 +1092,28 @@ class TestModelEngineStreamCall:
 
         assert exc_info.value.status is None
         assert client_facing_message(exc_info.value) == "something broke"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_transport_failure_carries_a_typed_client_error(self):
+        """Opening a stream shares the non-streaming path's transport classification.
+
+        ``_wrap_exception`` is reached with a different label here, so the streaming branch
+        needs its own case.
+        """
+        engine = ModelEngine(_make_model())
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(side_effect=aiohttp.ServerTimeoutError("read timed out"))
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await anext(engine.stream_call([{"role": "user", "content": "Hi"}]))
+
+        assert isinstance(exc_info.value.inner_exception, LLMTimeoutError)
+        message = client_facing_message(exc_info.value)
+        assert message.startswith("Request timed out: ")
+        assert "meta/llama-3.3-70b-instruct" not in message
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -24,7 +24,7 @@ import aiohttp
 import pytest
 
 from nemoguardrails.context import llm_call_info_var, llm_stats_var
-from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.exceptions import LLMCallException, LLMConnectionError, LLMRateLimitError, LLMTimeoutError
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
@@ -40,6 +40,7 @@ from nemoguardrails.guardrails.model_engine import (
 )
 from nemoguardrails.guardrails.tool_schema import Toolset
 from nemoguardrails.llm.call import llm_call
+from nemoguardrails.llm.clients._errors import client_facing_message
 from nemoguardrails.rails.llm.config import Model
 from nemoguardrails.types import (
     ChatMessage,
@@ -114,6 +115,9 @@ def _mock_chat_client(payload: dict | None = None, status: int = 200):
     mock_response.status = status
     mock_response.json = AsyncMock(return_value=payload if payload is not None else _OK_COMPLETION)
     mock_response.text = AsyncMock(return_value='{"error": "boom"}')
+    # A real ClientResponse exposes a mapping here. Left as an auto-created AsyncMock,
+    # error classification cannot read it and falls back to an unclassified error.
+    mock_response.headers = {}
 
     mock_client = AsyncMock()
     mock_client.post = MagicMock(return_value=mock_response)
@@ -702,6 +706,7 @@ class TestModelEngineCall:
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.status = 400
         mock_response.text = AsyncMock(return_value='{"error": "bad request"}')
+        mock_response.headers = {}
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)
@@ -714,6 +719,59 @@ class TestModelEngineCall:
 
         assert exc_info.value.status == 400
         assert exc_info.value.model_name == "meta/llama-3.3-70b-instruct"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "transport_error,expected_type,expected_message",
+        [
+            (aiohttp.ServerTimeoutError("read timed out"), LLMTimeoutError, "Request timed out: read timed out"),
+            (asyncio.TimeoutError(), LLMTimeoutError, "Request timed out: "),
+            (
+                aiohttp.ClientConnectionError("cannot connect"),
+                LLMConnectionError,
+                "Connection error: cannot connect",
+            ),
+        ],
+        ids=["server-timeout", "asyncio-timeout", "connection-error"],
+    )
+    async def test_call_transport_failure_carries_a_typed_client_error(
+        self, transport_error, expected_type, expected_message
+    ):
+        """A timeout or connection failure is classified, so the caller sees no internal model name."""
+        engine = ModelEngine(_make_model())
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(side_effect=transport_error)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert isinstance(exc_info.value.inner_exception, expected_type)
+        assert exc_info.value.status is None
+        message = client_facing_message(exc_info.value)
+        assert message.startswith(expected_message)
+        assert "meta/llama-3.3-70b-instruct" not in message
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_unclassifiable_failure_carries_no_client_error(self):
+        """An exception that is not a transport failure is wrapped without an inner client error."""
+        engine = ModelEngine(_make_model())
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(side_effect=ValueError("something else"))
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.inner_exception is None
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -848,6 +906,71 @@ class TestModelEngineStreamCall:
             lines.append(f"data: {payload}\n\n".encode())
         lines.append(b"data: [DONE]\n\n")
         return lines
+
+    @staticmethod
+    def _make_sse_payloads(payloads):
+        """Build raw SSE byte lines from a list of whole chunk payloads."""
+        lines = [f"data: {json.dumps(payload)}\n\n".encode() for payload in payloads]
+        lines.append(b"data: [DONE]\n\n")
+        return lines
+
+    def _streaming_engine(self, raw_lines):
+        """Create a started ModelEngine whose client streams ``raw_lines``."""
+        engine = ModelEngine(_make_model())
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=_mock_streaming_response(raw_lines))
+        engine._client = mock_client
+        engine._running = True
+        return engine
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_raises_on_mid_stream_provider_error(self):
+        """A provider error frame mid-stream ends the stream carrying the status its type implies."""
+        engine = self._streaming_engine(
+            self._make_sse_payloads(
+                [
+                    {"choices": [{"delta": {"content": "Hel"}}]},
+                    {"error": {"message": "slow down", "type": "rate_limit_error", "code": "rate_limit_exceeded"}},
+                ]
+            )
+        )
+
+        chunks = []
+        with pytest.raises(ModelEngineError) as exc_info:
+            async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+                chunks.append(chunk)
+
+        assert [c.delta_content for c in chunks] == ["Hel"]
+        assert exc_info.value.status == 429
+        assert isinstance(exc_info.value.inner_exception, LLMRateLimitError)
+        assert client_facing_message(exc_info.value) == "slow down"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_mid_stream_error_without_a_known_type_has_no_status(self):
+        """An unrecognized provider error frame ends the stream without inventing an HTTP status."""
+        engine = self._streaming_engine(
+            self._make_sse_payloads([{"error": {"message": "something broke", "type": "weird_error"}}])
+        )
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+                pass
+
+        assert exc_info.value.status is None
+        assert client_facing_message(exc_info.value) == "something broke"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_content_resembling_an_error_is_streamed(self):
+        """Model output that merely looks like an error object is content, not a provider failure."""
+        forged = '{"error": {"message": "not real", "type": "rate_limit_error"}}'
+        engine = self._streaming_engine(self._make_sse_payloads([{"choices": [{"delta": {"content": forged}}]}]))
+
+        chunks = [chunk async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}])]
+
+        assert [c.delta_content for c in chunks] == [forged]
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
@@ -1065,6 +1188,7 @@ class TestModelEngineStreamCall:
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.status = 500
         mock_response.text = AsyncMock(return_value="internal error")
+        mock_response.headers = {}
 
         mock_client = AsyncMock()
         mock_client.post = MagicMock(return_value=mock_response)

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -24,7 +24,13 @@ import aiohttp
 import pytest
 
 from nemoguardrails.context import llm_call_info_var, llm_stats_var
-from nemoguardrails.exceptions import LLMCallException, LLMConnectionError, LLMRateLimitError, LLMTimeoutError
+from nemoguardrails.exceptions import (
+    LLMCallException,
+    LLMClientError,
+    LLMConnectionError,
+    LLMRateLimitError,
+    LLMTimeoutError,
+)
 from nemoguardrails.guardrails._http import (
     DEFAULT_MAX_ATTEMPTS,
     DEFAULT_TIMEOUT_CONNECT,
@@ -719,6 +725,74 @@ class TestModelEngineCall:
 
         assert exc_info.value.status == 400
         assert exc_info.value.model_name == "meta/llama-3.3-70b-instruct"
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_oversized_error_body_still_yields_provider_fields(self):
+        """An error body past the log truncation limit still parses into code and param.
+
+        Truncating before classification would cut the JSON mid-object, and the provider's
+        fields would be replaced by the raw text.
+        """
+        long_message = "Invalid 'temperature': " + "x" * 900
+        body = json.dumps(
+            {"error": {"message": long_message, "type": "invalid_request_error", "param": "temperature", "code": "bad"}}
+        )
+        engine = ModelEngine(_make_model())
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 400
+        mock_response.text = AsyncMock(return_value=body)
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            await engine.call([{"role": "user", "content": "Hi"}])
+
+        client_error = exc_info.value.inner_exception
+        assert isinstance(client_error, LLMClientError)
+        assert client_error.error_code == "bad"
+        assert client_error.param == "temperature"
+        assert client_facing_message(exc_info.value) == long_message
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_call_unclassifiable_error_response_keeps_the_status(self):
+        """A classifier failure must not cost the caller the upstream status.
+
+        Letting it escape would strip the status in call()'s catch-all, and the server would
+        report 500 for what was really a 429.
+        """
+        engine = ModelEngine(_make_model())
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 429
+        mock_response.text = AsyncMock(return_value='{"error": {"message": "slow down"}}')
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        mock_client.closed = False
+        engine._client = mock_client
+        engine._running = True
+
+        with patch(
+            "nemoguardrails.guardrails.model_engine.raise_for_status",
+            side_effect=RuntimeError("classifier blew up"),
+        ):
+            with pytest.raises(ModelEngineError) as exc_info:
+                await engine.call([{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.status == 429
+        assert exc_info.value.inner_exception is None
+        assert "slow down" not in str(exc_info.value)
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio

--- a/tests/guardrails/test_rail_guard.py
+++ b/tests/guardrails/test_rail_guard.py
@@ -30,7 +30,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import Tracer
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
-from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.exceptions import LLMCallException, LLMTimeoutError
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.rail_guard import rail_error_outcome
 from nemoguardrails.guardrails.telemetry import action_span
@@ -91,6 +91,25 @@ class TestFailsClosed:
         outcome = rail_error_outcome(None, ACTION_NAME, RuntimeError("auth rejected token nvapi-abc123secret"))
 
         assert outcome.reason == "content safety check input error: auth rejected token nvapi-***"
+
+    def test_reason_does_not_disclose_the_rail_model(self):
+        """A classified transport failure reaches the caller as the provider message alone.
+
+        The reason is rendered into the streaming violation payload through ``client_reason``,
+        so ``str(exc)`` here would disclose the internal rail model to an API caller.
+        """
+        transport_error = LLMTimeoutError(0, "Request timed out: read timed out")
+        exc = ModelEngineError(
+            "Request to model 'internal-guard-model' failed: read timed out",
+            model_name="internal-guard-model",
+            inner_exception=transport_error,
+        )
+
+        outcome = rail_error_outcome(None, ACTION_NAME, exc)
+
+        assert outcome.is_blocked
+        assert outcome.reason == "content safety check input error: Request timed out: read timed out"
+        assert "internal-guard-model" not in outcome.reason
 
     def test_blocking_verdict_records_the_span_error(self):
         """A blocked rail marks its span, so the failure is visible in the trace."""

--- a/tests/guardrails/test_rail_guard.py
+++ b/tests/guardrails/test_rail_guard.py
@@ -30,7 +30,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import Tracer
 
 from nemoguardrails.actions.rail_outcome import RailOutcome
-from nemoguardrails.exceptions import LLMCallException, LLMTimeoutError
+from nemoguardrails.exceptions import LLMCallException, LLMClientError, LLMTimeoutError
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.guardrails.rail_guard import rail_error_outcome
 from nemoguardrails.guardrails.telemetry import action_span
@@ -109,6 +109,25 @@ class TestFailsClosed:
 
         assert outcome.is_blocked
         assert outcome.reason == "content safety check input error: Request timed out: read timed out"
+        assert "internal-guard-model" not in outcome.reason
+
+    def test_reason_does_not_disclose_the_rail_model_when_unclassified(self):
+        """A failure the classifier cannot type is still rendered without the rail model.
+
+        This is the shape ``_wrap_exception`` produces for anything that is not a transport
+        failure, and it reaches the caller through the same streaming violation payload.
+        """
+        generic_error = LLMClientError(0, "Request failed: bad payload", model_name="internal-guard-model")
+        exc = ModelEngineError(
+            "Request to model 'internal-guard-model' failed: bad payload",
+            model_name="internal-guard-model",
+            inner_exception=generic_error,
+        )
+
+        outcome = rail_error_outcome(None, ACTION_NAME, exc)
+
+        assert outcome.is_blocked
+        assert outcome.reason == "content safety check input error: Request failed: bad payload"
         assert "internal-guard-model" not in outcome.reason
 
     def test_blocking_verdict_records_the_span_error(self):

--- a/tests/llm/clients/test_errors.py
+++ b/tests/llm/clients/test_errors.py
@@ -15,7 +15,73 @@
 
 import pytest
 
-from nemoguardrails.llm.clients._errors import _redact_secrets
+from nemoguardrails.exceptions import LLMBadRequestError, LLMCallException, LLMClientError
+from nemoguardrails.guardrails.model_engine import ModelEngineError
+from nemoguardrails.llm.clients._errors import _redact_secrets, as_client_error, client_facing_message
+
+
+class TestAsClientError:
+    """Unwrapping the client error out of whatever wrapped it."""
+
+    def test_bare_client_error_is_returned(self):
+        """An LLMClientError that was never wrapped resolves to itself."""
+        error = LLMBadRequestError(400, "bad request")
+
+        assert as_client_error(error) is error
+
+    def test_single_wrapper_is_unwrapped(self):
+        """The LLMRails path wraps the client error once, in LLMCallException."""
+        error = LLMBadRequestError(400, "bad request")
+
+        assert as_client_error(LLMCallException(error, status=400)) is error
+
+    def test_two_wrappers_are_unwrapped(self):
+        """The IORails library-rail path nests twice: LLMCallException -> ModelEngineError -> client error.
+
+        Stopping at the first link would null the provider's code and param for every rail
+        that reaches its model through ``llm_call``.
+        """
+        error = LLMBadRequestError(400, "bad request")
+        engine_error = ModelEngineError("HTTP 400 from model 'm'", model_name="m", status=400, inner_exception=error)
+
+        assert as_client_error(LLMCallException(engine_error, status=400)) is error
+
+    def test_wrapper_without_a_client_error_resolves_to_none(self):
+        """A transport failure that could not be classified carries no client error."""
+        engine_error = ModelEngineError("something failed", model_name="m")
+
+        assert as_client_error(LLMCallException(engine_error)) is None
+
+    def test_unrelated_exception_resolves_to_none(self):
+        """An exception with no inner_exception attribute at all is not a client error."""
+        assert as_client_error(RuntimeError("boom")) is None
+
+    def test_string_inner_exception_resolves_to_none(self):
+        """LLMCallException accepts a str inner_exception, which must not break the walk."""
+        assert as_client_error(LLMCallException("upstream refused")) is None
+
+    def test_self_referencing_chain_terminates(self):
+        """A wrapper pointing at itself must not spin the walk forever."""
+
+        class SelfReferencing(Exception):
+            inner_exception: Exception
+
+        exc = SelfReferencing()
+        exc.inner_exception = exc
+
+        assert as_client_error(exc) is None
+
+    def test_message_prefers_the_nested_client_error(self):
+        """Through two wrappers the caller still sees the provider's message, not str(exc)."""
+        error = LLMClientError(404, "model not found", model_name="internal-model")
+        engine_error = ModelEngineError(
+            "HTTP 404 from model 'internal-model'", model_name="internal-model", status=404, inner_exception=error
+        )
+
+        message = client_facing_message(LLMCallException(engine_error, status=404))
+
+        assert message == "model not found"
+        assert "internal-model" not in message
 
 
 class TestRedactSecrets:

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -327,11 +327,11 @@ OPENAI_UPSTREAM_FAILURES = [
 
 
 @contextmanager
-def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dict):
+def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dict, headers: dict | None = None):
     """Mock the main-model transport the given engine uses: aiohttp for IORails, httpx for LLMRails."""
     if engine == "iorails":
         with aioresponses() as mocked:
-            mocked.post(MAIN_MODEL_URL, status=status, body=json.dumps(body), repeat=True)
+            mocked.post(MAIN_MODEL_URL, status=status, body=json.dumps(body), headers=headers or {}, repeat=True)
             yield
     else:
         httpx_mock.add_response(
@@ -339,6 +339,7 @@ def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dic
             method="POST",
             status_code=status,
             json=body,
+            headers=headers,
             is_reusable=True,
         )
         yield
@@ -396,6 +397,31 @@ class TestQACaseTC13EnvelopeParity:
         error = response.json()["error"]
         assert error["code"] == upstream_body["error"]["code"]
         assert error["param"] == upstream_body["error"]["param"]
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    def test_rate_limit_forwards_retry_after(self, httpx_mock: HTTPXMock, serve_config, engine):
+        """A 429 forwards the provider's Retry-After header and code on either engine.
+
+        IORails never read the response headers on the error path, so an SDK's backoff was
+        blind even though the provider had supplied the value.
+        """
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        body = {
+            "error": {
+                "message": "slow down",
+                "type": "rate_limit_error",
+                "code": "rate_limit_exceeded",
+                "param": None,
+            }
+        }
+
+        with _upstream_failure(engine, httpx_mock, 429, body, headers={"retry-after": "7"}):
+            response = _chat()
+
+        _assert_served_engine(engine)
+        assert response.status_code == 429
+        assert response.headers["retry-after"] == "7"
+        assert response.json()["error"]["code"] == "rate_limit_exceeded"
 
     @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
     def test_engines_render_identical_envelopes(

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -384,6 +384,25 @@ def _assert_served_engine(engine: str) -> None:
         assert not isinstance(rails, Guardrails)
 
 
+@pytest.fixture
+def chat_against_failing_upstream(httpx_mock: HTTPXMock, serve_config):
+    """Serve the main-model config on one engine and post one chat request to a failing provider.
+
+    The engine guard runs here rather than in each test: ``Guardrails`` falls back to LLMRails
+    for a config IORails cannot serve, and an unguarded IORails case would then assert against
+    the wrong engine and pass.
+    """
+
+    def _request(engine: str, status: int, body: dict, *, headers: dict | None = None, stream: bool = False):
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        with _upstream_failure(engine, httpx_mock, status, body, headers):
+            response = _chat(stream=stream)
+        _assert_served_engine(engine)
+        return response
+
+    return _request
+
+
 class TestQACaseTC13EnvelopeParity:
     """QA case NGUARD-745 TC-13: both engines render one envelope for the same upstream failure.
 
@@ -394,15 +413,11 @@ class TestQACaseTC13EnvelopeParity:
     @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
     @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
     def test_message_is_the_provider_message_alone(
-        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, upstream_body
+        self, chat_against_failing_upstream, engine, upstream_status, upstream_body
     ):
         """The client message carries no model-routing prefix and no raw upstream body."""
-        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        response = chat_against_failing_upstream(engine, upstream_status, upstream_body)
 
-        with _upstream_failure(engine, httpx_mock, upstream_status, upstream_body):
-            response = _chat()
-
-        _assert_served_engine(engine)
         assert response.status_code == upstream_status
         message = response.json()["error"]["message"]
         assert message == upstream_body["error"]["message"]
@@ -413,27 +428,22 @@ class TestQACaseTC13EnvelopeParity:
     @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
     @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
     def test_provider_code_and_param_are_preserved(
-        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, upstream_body
+        self, chat_against_failing_upstream, engine, upstream_status, upstream_body
     ):
         """The provider's own code and param reach the caller instead of being nulled."""
-        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        response = chat_against_failing_upstream(engine, upstream_status, upstream_body)
 
-        with _upstream_failure(engine, httpx_mock, upstream_status, upstream_body):
-            response = _chat()
-
-        _assert_served_engine(engine)
         error = response.json()["error"]
         assert error["code"] == upstream_body["error"]["code"]
         assert error["param"] == upstream_body["error"]["param"]
 
     @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
-    def test_rate_limit_forwards_retry_after(self, httpx_mock: HTTPXMock, serve_config, engine):
+    def test_rate_limit_forwards_retry_after(self, chat_against_failing_upstream, engine):
         """A 429 forwards the provider's Retry-After header and code on either engine.
 
         IORails never read the response headers on the error path, so an SDK's backoff was
         blind even though the provider had supplied the value.
         """
-        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
         body = {
             "error": {
                 "message": "slow down",
@@ -443,10 +453,8 @@ class TestQACaseTC13EnvelopeParity:
             }
         }
 
-        with _upstream_failure(engine, httpx_mock, 429, body, headers={"retry-after": "7"}):
-            response = _chat()
+        response = chat_against_failing_upstream(engine, 429, body, headers={"retry-after": "7"})
 
-        _assert_served_engine(engine)
         assert response.status_code == 429
         assert response.headers["retry-after"] == "7"
         assert response.json()["error"]["code"] == "rate_limit_exceeded"
@@ -462,40 +470,34 @@ class TestQACaseTC13EnvelopeParity:
         ],
     )
     def test_status_and_type_agree_beyond_the_qa_scenarios(
-        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, expected_type
+        self, chat_against_failing_upstream, engine, upstream_status, expected_type
     ):
         """Statuses outside TC-13 map to the same type and message on either engine.
 
         401 and 403 matter most: a rail model rejecting the server's own key must not read
         as the caller's credentials being bad.
         """
-        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
         body = {"error": {"message": f"upstream returned {upstream_status}", "type": expected_type}}
 
-        with _upstream_failure(engine, httpx_mock, upstream_status, body):
-            response = _chat()
+        response = chat_against_failing_upstream(engine, upstream_status, body)
 
-        _assert_served_engine(engine)
         assert response.status_code == upstream_status
         error = response.json()["error"]
         assert error["type"] == expected_type
         assert error["message"] == f"upstream returned {upstream_status}"
 
     @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
-    def test_streaming_initial_failure_is_promoted_to_an_http_status(self, httpx_mock: HTTPXMock, serve_config, engine):
+    def test_streaming_initial_failure_is_promoted_to_an_http_status(self, chat_against_failing_upstream, engine):
         """A failure before the first token becomes a real HTTP status, not a 200 SSE stream.
 
         An SSE response has no status line, so ``code`` carries it; the server reads that
         back to promote the frame. This is the path the report flags where ``code`` is the
         only status carrier.
         """
-        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
         body = {"error": {"message": "overloaded", "type": "server_error"}}
 
-        with _upstream_failure(engine, httpx_mock, 503, body):
-            response = _chat(stream=True)
+        response = chat_against_failing_upstream(engine, 503, body, stream=True)
 
-        _assert_served_engine(engine)
         assert response.status_code == 503
         error = response.json()["error"]
         assert error["message"] == "overloaded"
@@ -503,9 +505,7 @@ class TestQACaseTC13EnvelopeParity:
         assert "gpt-4o-mini" not in error["message"]
 
     @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
-    def test_engines_render_identical_envelopes(
-        self, httpx_mock: HTTPXMock, serve_config, upstream_status, upstream_body
-    ):
+    def test_engines_render_identical_envelopes(self, chat_against_failing_upstream, upstream_status, upstream_body):
         """Both engines return the same status and the same whole envelope for one upstream failure.
 
         The field-level tests above pin each engine to the provider's own values; this one
@@ -514,17 +514,13 @@ class TestQACaseTC13EnvelopeParity:
         """
         # LLMRails runs first so the IORails instance is the one left in the cache for the
         # reset fixture to shut down; clearing it afterwards would leak its aiohttp session.
-        serve_config(MAIN_MODEL_CONFIG)
-        with _upstream_failure("llmrails", httpx_mock, upstream_status, upstream_body):
-            llmrails_response = _chat()
-        _assert_served_engine("llmrails")
+        llmrails_response = chat_against_failing_upstream("llmrails", upstream_status, upstream_body)
 
+        # Forces a fresh instance, otherwise the second request reuses the first engine and
+        # the comparison below is a response against itself.
         api.llm_rails_instances.clear()
 
-        serve_config(MAIN_MODEL_CONFIG, iorails=True)
-        with _upstream_failure("iorails", httpx_mock, upstream_status, upstream_body):
-            iorails_response = _chat()
-        _assert_served_engine("iorails")
+        iorails_response = chat_against_failing_upstream("iorails", upstream_status, upstream_body)
 
         assert iorails_response.status_code == llmrails_response.status_code
         assert iorails_response.json() == llmrails_response.json()

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -355,20 +355,28 @@ OPENAI_UPSTREAM_FAILURES = [
 
 
 @contextmanager
-def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dict, headers: dict | None = None):
-    """Mock the main-model transport the given engine uses: aiohttp for IORails, httpx for LLMRails."""
+def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dict | str, headers: dict | None = None):
+    """Mock the main-model transport the given engine uses: aiohttp for IORails, httpx for LLMRails.
+
+    ``body`` is a dict for a JSON provider error, or a str for a body the provider did not
+    render as JSON at all (an empty body, or a gateway's HTML page).
+    """
+    raw_body = json.dumps(body) if isinstance(body, dict) else body
     if engine == "iorails":
         with aioresponses() as mocked:
-            mocked.post(MAIN_MODEL_URL, status=status, body=json.dumps(body), headers=headers or {}, repeat=True)
+            mocked.post(MAIN_MODEL_URL, status=status, body=raw_body, headers=headers or {}, repeat=True)
             yield
     else:
+        # A dict goes through ``json=`` so the common case keeps its content-type; a raw body
+        # has none to declare.
+        payload = {"json": body} if isinstance(body, dict) else {"content": raw_body.encode()}
         httpx_mock.add_response(
             url=MAIN_MODEL_URL,
             method="POST",
             status_code=status,
-            json=body,
             headers=headers,
             is_reusable=True,
+            **payload,
         )
         yield
 
@@ -485,6 +493,21 @@ class TestQACaseTC13EnvelopeParity:
         error = response.json()["error"]
         assert error["type"] == expected_type
         assert error["message"] == f"upstream returned {upstream_status}"
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    def test_provider_error_without_a_usable_body_hides_the_model(self, chat_against_failing_upstream, engine):
+        """A provider that returns no usable body still yields no model-routing detail.
+
+        With nothing to extract, the message falls back to the bare status. This is the path
+        where IORails previously had only its own ``HTTP <status> from model '<name>'`` text
+        to offer the caller.
+        """
+        response = chat_against_failing_upstream(engine, 502, "")
+
+        assert response.status_code == 502
+        message = response.json()["error"]["message"]
+        assert message == "HTTP 502"
+        assert "gpt-4o-mini" not in message
 
     @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
     def test_streaming_initial_failure_is_promoted_to_an_http_status(self, chat_against_failing_upstream, engine):

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -22,6 +22,7 @@
 # ``ModelEngine`` over aiohttp (``aioresponses``).
 
 import json
+from contextlib import contextmanager
 
 import pytest
 from aioresponses import aioresponses
@@ -292,6 +293,136 @@ class TestRailEngineErrors:
 
         assert response.status_code == 429
         assert response.json()["error"]["type"] == "rate_limit_error"
+
+
+# The two upstream failures from QA case P0_0.24.0_NGUARD-745_http_error_openai_sdk_E2E TC-13
+OPENAI_UPSTREAM_FAILURES = [
+    pytest.param(
+        400,
+        {
+            "error": {
+                "message": (
+                    "Invalid 'temperature': decimal above maximum value. Expected a value <= 2, but got 100.0 instead."
+                ),
+                "type": "invalid_request_error",
+                "param": "temperature",
+                "code": "decimal_above_max_value",
+            }
+        },
+        id="temperature-above-maximum",
+    ),
+    pytest.param(
+        404,
+        {
+            "error": {
+                "message": "The model `gpt-4o-does-not-exist-qa-745` does not exist or you do not have access to it.",
+                "type": "invalid_request_error",
+                "param": None,
+                "code": "model_not_found",
+            }
+        },
+        id="model-not-found",
+    ),
+]
+
+
+@contextmanager
+def _upstream_failure(engine: str, httpx_mock: HTTPXMock, status: int, body: dict):
+    """Mock the main-model transport the given engine uses: aiohttp for IORails, httpx for LLMRails."""
+    if engine == "iorails":
+        with aioresponses() as mocked:
+            mocked.post(MAIN_MODEL_URL, status=status, body=json.dumps(body), repeat=True)
+            yield
+    else:
+        httpx_mock.add_response(
+            url=MAIN_MODEL_URL,
+            method="POST",
+            status_code=status,
+            json=body,
+            is_reusable=True,
+        )
+        yield
+
+
+def _assert_served_engine(engine: str) -> None:
+    """Fail if the request ran on the other engine, which would make the envelope assertions vacuous."""
+    served = list(api.llm_rails_instances.values())
+    assert served, "no rails instance was constructed, so no upstream call was attempted"
+    rails = served[0]
+    if engine == "iorails":
+        assert isinstance(rails, Guardrails) and rails.use_iorails_engine
+    else:
+        assert not isinstance(rails, Guardrails)
+
+
+class TestQACaseTC13EnvelopeParity:
+    """QA case NGUARD-745 TC-13: both engines render one envelope for the same upstream failure.
+
+    The LLMRails leg is the passing baseline the QA case compares against; the IORails leg
+    is where all four TC-13 failures and both code/param observations were reported.
+    """
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
+    def test_message_is_the_provider_message_alone(
+        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, upstream_body
+    ):
+        """The client message carries no model-routing prefix and no raw upstream body."""
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+
+        with _upstream_failure(engine, httpx_mock, upstream_status, upstream_body):
+            response = _chat()
+
+        _assert_served_engine(engine)
+        assert response.status_code == upstream_status
+        message = response.json()["error"]["message"]
+        assert message == upstream_body["error"]["message"]
+        assert "gpt-4o-mini" not in message
+        assert "upstream.invalid" not in message
+        assert '"error"' not in message
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
+    def test_provider_code_and_param_are_preserved(
+        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, upstream_body
+    ):
+        """The provider's own code and param reach the caller instead of being nulled."""
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+
+        with _upstream_failure(engine, httpx_mock, upstream_status, upstream_body):
+            response = _chat()
+
+        _assert_served_engine(engine)
+        error = response.json()["error"]
+        assert error["code"] == upstream_body["error"]["code"]
+        assert error["param"] == upstream_body["error"]["param"]
+
+    @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
+    def test_engines_render_identical_envelopes(
+        self, httpx_mock: HTTPXMock, serve_config, upstream_status, upstream_body
+    ):
+        """Both engines return the same status and the same whole envelope for one upstream failure.
+
+        The field-level tests above pin each engine to the provider's own values; this one
+        catches drift on any field nobody enumerated, which is what the QA case's two servers
+        against one config store actually compare.
+        """
+        # LLMRails runs first so the IORails instance is the one left in the cache for the
+        # reset fixture to shut down; clearing it afterwards would leak its aiohttp session.
+        serve_config(MAIN_MODEL_CONFIG)
+        with _upstream_failure("llmrails", httpx_mock, upstream_status, upstream_body):
+            llmrails_response = _chat()
+        _assert_served_engine("llmrails")
+
+        api.llm_rails_instances.clear()
+
+        serve_config(MAIN_MODEL_CONFIG, iorails=True)
+        with _upstream_failure("iorails", httpx_mock, upstream_status, upstream_body):
+            iorails_response = _chat()
+        _assert_served_engine("iorails")
+
+        assert iorails_response.status_code == llmrails_response.status_code
+        assert iorails_response.json() == llmrails_response.json()
 
 
 class TestProtocolLevelResponses:

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -294,6 +294,34 @@ class TestRailEngineErrors:
         assert response.status_code == 429
         assert response.json()["error"]["type"] == "rate_limit_error"
 
+    def test_rail_upstream_error_forwards_provider_code_and_param(self, serve_config):
+        """A rail failure nests twice and still carries the provider's fields.
+
+        The rail reaches its model through ``llm_call``, which wraps the engine error again:
+        LLMCallException -> ModelEngineError -> LLMClientError. Unwrapping only one link
+        nulls code and param for every rail-served failure.
+        """
+        serve_config(CONTENT_SAFETY_CONFIG, iorails=True)
+        body = {
+            "error": {
+                "message": "slow down",
+                "type": "rate_limit_error",
+                "code": "rate_limit_exceeded",
+                "param": "messages",
+            }
+        }
+
+        with aioresponses() as mocked:
+            mocked.post(MAIN_MODEL_URL, status=429, body=json.dumps(body), repeat=True)
+            response = _chat()
+
+        assert response.status_code == 429
+        error = response.json()["error"]
+        assert error["message"] == "slow down"
+        assert error["code"] == "rate_limit_exceeded"
+        assert error["param"] == "messages"
+        assert "gpt-4o-mini" not in error["message"]
+
 
 # The two upstream failures from QA case P0_0.24.0_NGUARD-745_http_error_openai_sdk_E2E TC-13
 OPENAI_UPSTREAM_FAILURES = [
@@ -422,6 +450,57 @@ class TestQACaseTC13EnvelopeParity:
         assert response.status_code == 429
         assert response.headers["retry-after"] == "7"
         assert response.json()["error"]["code"] == "rate_limit_exceeded"
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    @pytest.mark.parametrize(
+        "upstream_status,expected_type",
+        [
+            (401, "authentication_error"),
+            (403, "permission_error"),
+            (500, "server_error"),
+            (503, "server_error"),
+        ],
+    )
+    def test_status_and_type_agree_beyond_the_qa_scenarios(
+        self, httpx_mock: HTTPXMock, serve_config, engine, upstream_status, expected_type
+    ):
+        """Statuses outside TC-13 map to the same type and message on either engine.
+
+        401 and 403 matter most: a rail model rejecting the server's own key must not read
+        as the caller's credentials being bad.
+        """
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        body = {"error": {"message": f"upstream returned {upstream_status}", "type": expected_type}}
+
+        with _upstream_failure(engine, httpx_mock, upstream_status, body):
+            response = _chat()
+
+        _assert_served_engine(engine)
+        assert response.status_code == upstream_status
+        error = response.json()["error"]
+        assert error["type"] == expected_type
+        assert error["message"] == f"upstream returned {upstream_status}"
+
+    @pytest.mark.parametrize("engine", ["llmrails", "iorails"])
+    def test_streaming_initial_failure_is_promoted_to_an_http_status(self, httpx_mock: HTTPXMock, serve_config, engine):
+        """A failure before the first token becomes a real HTTP status, not a 200 SSE stream.
+
+        An SSE response has no status line, so ``code`` carries it; the server reads that
+        back to promote the frame. This is the path the report flags where ``code`` is the
+        only status carrier.
+        """
+        serve_config(MAIN_MODEL_CONFIG, iorails=(engine == "iorails"))
+        body = {"error": {"message": "overloaded", "type": "server_error"}}
+
+        with _upstream_failure(engine, httpx_mock, 503, body):
+            response = _chat(stream=True)
+
+        _assert_served_engine(engine)
+        assert response.status_code == 503
+        error = response.json()["error"]
+        assert error["message"] == "overloaded"
+        assert error["code"] == 503
+        assert "gpt-4o-mini" not in error["message"]
 
     @pytest.mark.parametrize("upstream_status,upstream_body", OPENAI_UPSTREAM_FAILURES)
     def test_engines_render_identical_envelopes(


### PR DESCRIPTION
## Description

PR #1832 (NGUARD-745) made `/v1/chat/completions` return a single OpenAI-compatible error
envelope: a downstream provider failure is classified into a typed `LLMClientError`, the
provider's `code`/`param`/`Retry-After` are preserved, and the message is sanitized before it
reaches the caller. That contract was implemented on the LLMRails path only.

On IORails (`NEMO_GUARDRAILS_IORAILS_ENGINE=1`) an outbound model failure raised
`ModelEngineError`, which `as_client_error()` did not recognize, so `_client_error_details`
fell through to `str(exc)`. For the same request, the two engines returned:

```
LLMRails  {"error":{"message":"Invalid 'temperature': decimal above maximum value. Expected a
                                value <= 2, but got 100.0 instead.",
                    "type":"invalid_request_error","param":"temperature",
                    "code":"decimal_above_max_value"}}

IORails   {"error":{"message":"HTTP 400 from model 'gpt-4o-mini': {\"error\": {\"message\":
                                \"Invalid 'temperature': ...\", \"param\": \"temperature\",
                                \"code\": \"decimal_above_max_value\"}}",
                    "type":"invalid_request_error","param":null,"code":null}}
```

So an API caller received the internal model name and the verbatim upstream body, while
`code` and `param` were null even though the provider had supplied both inside the body that
was copied into the message. The HTTP status was already correct on both engines.

### Approach

`ModelEngineError` stays the raised type and now carries the typed `LLMClientError` in a new
`inner_exception` field, mirroring how `LLMCallException` already carries one. `ModelEngine`
builds that inner error with the same `raise_for_status` the LLMRails httpx client calls
(`llm/clients/base.py:232`), so classification, provider body-shape tolerance, secret
redaction, and `Retry-After` parsing are reused rather than reimplemented.

`nemoguardrails/server/exception_handlers.py` is unchanged — once `as_client_error` finds the
inner error, the message, `code`, `param`, and the `retry-after` header all fall out of the
existing code. `.status`/`.status_code` on `ModelEngineError` are untouched, so every
`except ModelEngineError` guard and `rail_guard._STATUS_BEARING_ERRORS` keep working.

`as_client_error` now walks the `inner_exception` chain instead of checking one level. A
library rail re-wraps `ModelEngineError` inside `LLMCallException` (`llm/call.py:407`), so
rail-served failures nest twice and a single-level unwrap would still null `code` and `param`
for them.

Four adjacent LLMRails-parity gaps are closed in the same change, since they share the
classification path:

- **`Retry-After` on a 429.** `_raise_for_status` never read `response.headers`, so IORails
  emitted no `retry-after` even though `api.py:250` CORS-exposes it.
- **Typed transport failures.** `_classify_transport_failure` maps aiohttp timeouts and
  connection errors to `LLMTimeoutError`/`LLMConnectionError`, mirroring `base.py:200-223`.
  The status stays `None` (still a 500); the message becomes `Request timed out: ...` rather
  than one naming the model.
- **Mid-stream SSE error frames.** `stream_call` parsed `data:` lines but never checked for a
  provider `{"error": ...}` frame, so a mid-stream failure was silently dropped and the
  stream ended as if generation had completed. Now handled as in `base.py:329-332`.
- **Rail block-reason disclosure.** `rail_guard._blocked_reason_or_reraise` built the reason
  from `str(exc)`, and that reason reaches callers through `client_reason` in the streaming
  violation payloads (`iorails.py:1538,1553,1733,1832`). It now uses `client_facing_message`;
  logs keep the full text.



## Related Issue(s)

* [NGUARD-877](https://jirasw.nvidia.com/browse/NGUARD-877)
* https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6537640


## Verification

## Test Plan

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-client-error-message
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7181 items]

...............................s........................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
....................................s..s..ss............................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
......................................s................................. [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
....s................................................................... [ 11%]
...........................s.ssss.s.s........................s.s.s..s.ss [ 12%]
..ss.................................................................... [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
.................s.......................................s.....s........ [ 19%]
..........................................................ss..s..s..s.s. [ 20%]
s...................................s................................... [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
........................................................................ [ 34%]
............s.sssss.s.s.....................sssss...s............s.s.... [ 35%]
..s.........................................................s.sss.sss..s [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
...................s.s.................................................. [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
.......................sssss............s.ss.ss.s..s..sss.s.ssssss.s.... [ 42%]
...............................s........................................ [ 43%]
...........s............................................................ [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
.........................s.s...s.s..s................................... [ 48%]
........................................................................ [ 49%]
........................................................................ [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
.....................................ssss............................... [ 54%]
............ssssssssssssss.............................................. [ 55%]
..................s.......ss.sssss...................................... [ 56%]
........................................................................ [ 57%]
...........................................................ssssss....... [ 58%]
.....................................................sss................ [ 59%]
.....................ss........................ss....................... [ 60%]
........s....................................s.ssss.ss..s.sssss......... [ 61%]
........................................................................ [ 62%]
........................................................................ [ 63%]
........................................................................ [ 64%]
........................................................................ [ 65%]
............................................s........................... [ 66%]
..................................s..................................... [ 67%]
.....................s................s................................. [ 68%]
................................................s.s.ssss................ [ 69%]
........................................................................ [ 70%]
.................................................................s...... [ 71%]
.s...................................................................... [ 72%]
........................................................................ [ 73%]
........................................................................ [ 74%]
...................s.................................................... [ 75%]
........................................................................ [ 76%]
...................................................................sssss [ 77%]
ssss.ssssssssss......................................................... [ 78%]
........................................................................ [ 79%]
....................................................s................... [ 80%]
........................................................................ [ 81%]
...................................................ss................... [ 82%]
.................................................ss..................... [ 83%]
..................................................ss.................... [ 84%]
........................................................................ [ 85%]
........................................................................ [ 86%]
........................................................................ [ 87%]
.....................................................................s.. [ 88%]
ss.sss.................................................................. [ 89%]
..............................................s......................... [ 90%]
..ssss....................................s...ss............s.s......... [ 91%]
...............s............sssss.sss................................... [ 92%]
....................................................s................... [ 93%]
.............ss......................................................... [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
........................................................................ [ 97%]
.......................................s................................ [ 98%]
........................................................................ [ 99%]
.....................................................                    [100%]

══════════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and 
inline-snapshot will not be able to fix snapshots or generate reports.

====================== 6970 passed, 211 skipped in 42.68s ======================

```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of provider HTTP, timeout, connection, validation, and streaming failures.
  - Error responses now provide clearer provider messages while protecting internal model details and response contents.
  - Preserved relevant status codes and retry information for more consistent client handling.
  - Streaming requests now surface provider-reported errors while ignoring empty error fields.
  - Nested provider errors are recognized reliably across API responses.
  - Error bodies are safely bounded, including non-JSON responses, to prevent unintended content exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->