### PR TITLE
docs(benchmark): add Locust mock quickstart

### DIFF
--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -7,42 +7,130 @@ This directory contains a Locust-based load testing framework for the NeMo Guard
 The [Locust](https://locust.io/) stress-testing tool ramps up concurrent users making API calls to the `/v1/chat/completions` endpoint of an OpenAI-compatible LLM with configurable parameters.
 This complements [ai-perf](https://github.com/ai-dynamo/aiperf), which measures steady-state performance.  Locust instead focuses on ramping up load potentially beyond what a system can handle, and measure how gracefully it degrades under higher-than-expected load.
 
-## Getting Started
+## Quickstart
 
-### Prerequisites
+Use this quickstart to load test the repository's local mock Guardrails stack.
+It requires no GPU or external model credentials.
 
-These steps have been tested with Python 3.11.11.
+### 1. Start the mock stack
 
-1. **Create a virtual environment in which to install Locust and other benchmarking tools**
+This mirrors
+[1. Run Server-side components](../README.md#1-run-server-side-components-guardrails-openai-compatible-service-with-mock-llms-for-content-safety-and-application-llms)
+and
+[2. Validate services are running correctly](../README.md#2-validate-services-are-running-correctly)
+in the benchmark README, with `locust` added. See those steps for the full
+annotated walkthrough.
 
-   ```bash
-   $ mkdir ~/env
-   $ python -m venv ~/env/benchmark_env
-   ```
+First raise the file descriptor limit. This matters more for Locust than for
+steady-state benchmarks: it caps how many concurrent users you can ramp to
+before the operating system, rather than Guardrails, becomes the bottleneck.
 
-2. **Activate environment and install dependencies in the virtual environment**
+```shell
+$ ulimit -n 65536
+```
 
-   ```bash
-   $ source ~/env/benchmark_env/bin/activate
-   (benchmark_env) $ pip install -r benchmark/requirements.txt
-   ```
+Install the dependencies. `honcho` reads the [`Procfile`](../Procfile) to bring
+up the services, and `locust` drives the load test:
 
-## Running Benchmarks
+```shell
+$ uv sync --locked --extra server
+$ uv pip install honcho locust
+```
 
-The Locust benchmarks uses YAML configuration file to configure load-testing parameters.
-To get started and load-test a model hosted at `http://localhost:8000`, use the following command.
-Set `headless: false` in your YAML config to use Locust's interactive web UI. Then open http://localhost:8089 to control the test and view real-time metrics.
+Start the Guardrails server and the mock LLMs. Wait for all three `Uvicorn
+running on ...` messages, which are typically not on consecutive lines:
 
-   ```bash
-   (benchmark_env) $ python -m benchmark.locust benchmark/locust/configs/local.yaml
-   ```
+```shell
+$ cd benchmark
+$ uv run honcho start
+13:40:33 system    | gr.1 started (pid=93634)
+13:40:33 system    | app_llm.1 started (pid=93635)
+13:40:33 system    | cs_llm.1 started (pid=93636)
+...
+13:40:41 app_llm.1 | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+...
+13:40:41 cs_llm.1  | INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
+...
+13:40:45 gr.1      | INFO:     Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
+```
+
+In a second shell, validate that all three services are answering:
+
+```shell
+$ cd benchmark
+$ scripts/validate_mocks.sh
+Starting LLM endpoint health check...
+
+--- Checking Port: 8000 ---
+Health Check PASSED: Status is 'healthy'.
+Model Check PASSED: Found 'meta/llama-3.3-70b-instruct' in model list.
+--- Port 8000: ALL CHECKS PASSED ---
+...
+--- Final Summary ---
+Port 8000 (meta/llama-3.3-70b-instruct): PASSED
+Port 8001 (nvidia/llama-3.1-nemoguard-8b-content-safety): PASSED
+Port 9000 (Rails Config): PASSED
+---------------------
+Overall Status: All endpoints are healthy!
+```
+
+The mock application model runs on port `8000`, the mock content-safety model on
+port `8001`, and the Guardrails server on port `9000`.
+
+### 2. Run a small load test
+
+Run this from the repository root, so `cd ..` first if you are still in
+`benchmark/` from the validation step. It starts one Locust user for 15
+seconds, which is suitable for confirming the setup before increasing load.
+
+```bash
+mkdir -p locust_results
+LOCUST_CONFIG_ID=content_safety_local \
+LOCUST_MODEL=meta/llama-3.3-70b-instruct \
+LOCUST_MESSAGE="Hello, what can you do?" \
+uv run locust \
+  -f benchmark/locust/locustfile.py \
+  --host http://localhost:9000 \
+  --users 1 \
+  --spawn-rate 1 \
+  --run-time 15s \
+  --headless \
+  --only-summary \
+  --html locust_results/report.html
+```
+
+To use the Locust web UI instead, omit `--headless` and `--only-summary`, then
+open `http://localhost:8089`.
+
+Increase `--users`, `--spawn-rate`, and `--run-time` only after the smoke test
+completes successfully. Stop the mock stack with `Ctrl-C` in its terminal.
+
+For repeatable or tuned runs, use the YAML-driven CLI described below instead of
+passing flags by hand.
+
+## Running Benchmarks With The CLI
+
+The `benchmark.locust` CLI wraps Locust and reads load-testing parameters from a
+YAML configuration file, so a run can be version-controlled and repeated.
+Set `headless: false` in your YAML config to use Locust's interactive web UI, then
+open http://localhost:8089 to control the test and view real-time metrics.
+
+```bash
+uv run python -m benchmark.locust benchmark/locust/configs/local.yaml
+```
+
+Point `host` at the server you mean to test before running this. A `host` on
+port `8000` targets the mock application LLM rather than Guardrails, and that
+model ignores the `config_id` the load test sends — so the run reports success
+while measuring the mock instead of the guardrails you meant to benchmark.
+
+Note also that [`configs/local.yaml`](configs/local.yaml) ramps to 1024 users
+over 120 seconds. Run the single-user smoke test above before using it.
 
 ### CLI Options
 
-The `benchmark.locust` CLI supports the following options:
-
 ```bash
-python -m benchmark.locust [OPTIONS] CONFIG_FILE
+uv run python -m benchmark.locust [OPTIONS] CONFIG_FILE
 ```
 
 **Arguments:**
@@ -54,7 +142,8 @@ python -m benchmark.locust [OPTIONS] CONFIG_FILE
 
 ## Configuration Options
 
-All configuration is done via YAML files. The following fields are supported:
+All CLI configuration is done via YAML files. Unknown fields are rejected. The
+following fields are supported:
 
 ### Required Fields
 
@@ -71,6 +160,10 @@ All configuration is done via YAML files. The following fields are supported:
 - `headless`: Run without web UI (default: `true`)
 - `output_base_dir`: Directory for test results (default: `"locust_results"`)
 
+`host` defaults to port `8000`, which in the quickstart stack is the mock
+application LLM rather than Guardrails, so set it explicitly to the server you
+intend to benchmark.
+
 ## Load Test Behavior
 
 - **Request Type**: 100% POST `/v1/chat/completions` requests
@@ -82,16 +175,25 @@ All configuration is done via YAML files. The following fields are supported:
 
 ### Headless Mode
 
-When run in headless mode, results are saved to timestamped directories:
+The quickstart command writes a single HTML report to the path given by `--html`:
 
+```text
+locust_results/
+└── report.html  # HTML report with charts
 ```
+
+The CLI instead saves results to timestamped directories under
+`output_base_dir`, so successive runs do not overwrite each other:
+
+```text
 locust_results/
 └── YYYYMMDD_HHMMSS/
-    ├── report.html          # HTML report with charts
-    ├── run_metadata.json    # Test configuration metadata
-    ├── stats.csv            # Request statistics
-    ├── stats_failures.csv   # Failure statistics
-    └── stats_history.csv    # Statistics over time
+    ├── report.html               # HTML report with charts
+    ├── run_metadata.json         # Test configuration metadata
+    ├── stats_stats.csv           # Request statistics
+    ├── stats_stats_history.csv   # Statistics over time
+    ├── stats_failures.csv        # Failure statistics
+    └── stats_exceptions.csv      # Exceptions raised during the run
 ```
 
 ### Web UI Mode
@@ -104,8 +206,19 @@ Real-time metrics are displayed in the web interface at http://localhost:8089, i
 
 ### Troubleshooting
 
-If you see validation errors:
+If the load test does not start:
+
+- Run `./scripts/validate_mocks.sh` from `benchmark/` and resolve any failed
+  service checks before starting Locust.
+- Run the Locust command from the repository root so the `locustfile.py` path
+  resolves correctly.
+- Confirm that `honcho` and `locust` are installed, per the quickstart above.
+- Start with the documented single-user smoke test before increasing load.
+
+If you see validation errors from the CLI:
+
 - Ensure all required fields (`config_id`, `model`) are present in your YAML config
 - Check that the `config_id` matches a configuration on your server
 - Verify that numeric values meet minimum requirements (e.g., `users >= 1`, `spawn_rate >= 0.1`)
 - Ensure `host` starts with `http://` or `https://`
+- Remove any unrecognized fields, which are rejected rather than ignored


### PR DESCRIPTION
## Description

Refactors `benchmark/locust/README.md` so it matches the repo's current setup.

The old "Getting Started" pointed at `benchmark/requirements.txt`, which no longer exists. This replaces it with a quickstart against the mock Guardrails stack (no GPU or credentials needed), linking to the parent benchmark README for stack setup instead of duplicating it. The YAML/CLI reference sections are kept, and the output section now covers both the quickstart's flat `report.html` and the CLI's timestamped result directories.

## Related Issue(s)

- Fixes #2305

Note: #2305 is still `status: needs triage` and unassigned — opened ahead of triage at the author's direction.

## Verification

Ran the documented quickstart end-to-end on macOS:

- `uv sync --locked --extra server` + `uv pip install honcho locust`, then `uv run honcho start` — all three services came up (8000, 8001, 9000).
- `./scripts/validate_mocks.sh` — all endpoints healthy, overall PASSED.
- The quickstart Locust command, copied verbatim from the README — completed with **2 requests, 0 failures**, exit code 0, and wrote `locust_results/report.html`.
- `uv run --locked pre-commit run --files benchmark/locust/README.md` — passed.
- YAML field defaults/minimums and the CLI's timestamped output layout checked against `locust_models.py` and `run_locust.py`. `uv run python -m benchmark.locust <config> --dry-run` parses and emits the expected command.

## Related work (no merge-order dependency)

While verifying the quickstart I found that the `benchmark.locust` CLI cannot target the Guardrails server: it preflights `{host}/health`, which the server does not serve. Filed as #2308 and fixed in #2309.

This PR is deliberately independent of that fix. It documents the CLI's configuration fields and warns that a `host` on port `8000` targets the mock application LLM rather than Guardrails, without instructing readers to point the CLI at the Guardrails port — that guidance belongs with #2309, which also corrects the shipped `configs/local.yaml`. Either PR can merge first.

The quickstart's `locust` invocation does not go through the CLI preflight and works on `develop` today, verified end-to-end.

Also corrected here: the CSV filenames in the CLI's output tree. The README claimed `stats.csv` / `stats_history.csv`, but a real run writes `stats_stats.csv`, `stats_stats_history.csv`, `stats_failures.csv`, and `stats_exceptions.csv`. That error predates this PR and was only caught by running it.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me. (#2305 linked but not yet triaged/assigned.)
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable. (N/A — docs only)
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
