### PR TITLE
fix(benchmark): let the Locust CLI target the Guardrails server

### DIFF
--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -1,8 +1,8 @@
 # Example Locust load test configuration for NeMo Guardrails
 
 # Server details
-host: "http://localhost:8000"
-config_id: "my-guardrails-config"
+host: "http://localhost:9000"
+config_id: "content_safety_local"
 model: "meta/llama-3.3-70b-instruct"
 
 # Load test parameters

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -37,6 +37,13 @@ from pydantic import ValidationError
 
 from benchmark.locust.locust_models import LocustConfig
 
+# The mock LLM servers serve `/health`; the Guardrails server serves
+# `/v1/health` (and `/healthz`). Probe both so either target works.
+HEALTH_PATHS = ("/health", "/v1/health")
+
+# `/health` reports "healthy"; the Guardrails health endpoint reports "pass".
+HEALTHY_STATUSES = frozenset({"healthy", "pass"})
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
@@ -60,29 +67,50 @@ class LocustRunner:
         self.config = config
         self.locustfile_path = Path(__file__).parent / "locustfile.py"
 
-    def _check_service(self) -> None:
-        """Check if the NeMo Guardrails server is up before running tests."""
-        url = f"{self.config.host}/health"
+    def _get(self, url: str) -> httpx.Response:
+        """Issue a preflight GET, translating transport failures into RuntimeError."""
         log.debug("Checking service is up at %s", url)
 
         try:
             # Try a simple request to verify the server is accessible
-            response = httpx.get(url, timeout=5)
+            return httpx.get(url, timeout=5)
         except httpx.ConnectError as e:
-            raise RuntimeError(f"ConnectError accessing {url}: {e}")
+            raise RuntimeError(f"ConnectError accessing {url}: {e}") from e
         except httpx.TimeoutException as e:
-            raise RuntimeError(f"HTTP Timeout accessing {url}: {e}")
+            raise RuntimeError(f"HTTP Timeout accessing {url}: {e}") from e
 
+    def _check_service(self) -> None:
+        """Check the server under test is up before running tests.
+
+        The mock LLM servers serve `/health` and the Guardrails server serves
+        `/v1/health`, so try each path and use the first one the host answers.
+        """
+        for path in HEALTH_PATHS:
+            url = f"{self.config.host}{path}"
+            response = self._get(url)
+
+            if response.status_code == httpx.codes.NOT_FOUND:
+                log.debug("No %s endpoint at %s", path, self.config.host)
+                continue
+
+            self._check_health_response(url, response)
+            log.info("Successfully connected to server at %s", self.config.host)
+            return
+
+        raise RuntimeError(f"No health endpoint found at {self.config.host}: tried {', '.join(HEALTH_PATHS)}")
+
+    def _check_health_response(self, url: str, response: httpx.Response) -> None:
+        """Raise unless the health response reports a healthy service."""
         if response.is_error:
             raise RuntimeError(f"Error {response.status_code} connecting to {url}: {response.text}")
 
         try:
-            if response.json().get("status") != "healthy":
-                raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
+            status = response.json().get("status")
         except json.decoder.JSONDecodeError as e:
-            raise RuntimeError(f"Error: response {response.text} couldn't be parsed as JSON: {e}")
+            raise RuntimeError(f"Error: response {response.text} couldn't be parsed as JSON: {e}") from e
 
-        log.info("Successfully connected to server at %s", self.config.host)
+        if status not in HEALTHY_STATUSES:
+            raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
 
     def _build_locust_command(self, output_dir: Optional[Path] = None) -> list[str]:
         """Build the Locust command with all parameters."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -169,12 +169,16 @@ class TestLocustRunner:
             )
 
     def test_check_service_error_response(self, runner):
-        """Test _check_service with non-200 response code"""
+        """Test _check_service with non-200 response code
+
+        Uses 503 rather than 404: a 404 means the host serves no `/health` and
+        falls through to the `/v1/health` probe, covered separately below.
+        """
         with patch("httpx.get") as mock_get:
             mock_response = Mock()
             mock_response.is_error = True
-            mock_response.status_code = 404
-            mock_response.text = '{"detail":"Not Found"}'
+            mock_response.status_code = 503
+            mock_response.text = '{"detail":"Service Unavailable"}'
             mock_response.json.return_value = json.loads(mock_response.text)
             mock_get.return_value = mock_response
 
@@ -227,6 +231,98 @@ class TestLocustRunner:
                 exc_info.value.args[0]
                 == f"Error: response {mock_response.text} couldn't be parsed as JSON: {json_error}"
             )
+
+    def _v1_health_endpoint(self, runner: LocustRunner):
+        """The Guardrails server's health endpoint"""
+        return f"{runner.config.host}/v1/health"
+
+    def _health_404_response(self):
+        """A response from a host that serves no /health endpoint"""
+        response = Mock()
+        response.is_error = True
+        response.status_code = 404
+        response.text = '{"error":{"message":"Not Found"}}'
+        return response
+
+    def test_check_service_falls_back_to_v1_health(self, runner):
+        """The Guardrails server serves /v1/health rather than /health"""
+        with patch("httpx.get") as mock_get:
+            v1_response = Mock()
+            v1_response.is_error = False
+            v1_response.status_code = 200
+            v1_response.json.return_value = {"status": "pass"}
+            mock_get.side_effect = [self._health_404_response(), v1_response]
+
+            # Should not raise
+            runner._check_service()
+
+            assert [call.args[0] for call in mock_get.call_args_list] == [
+                self._service_health_endpoint(runner),
+                self._v1_health_endpoint(runner),
+            ]
+
+    def test_check_service_no_health_endpoint(self, runner):
+        """A host serving neither health path is an error"""
+        with patch("httpx.get") as mock_get:
+            mock_get.side_effect = [self._health_404_response(), self._health_404_response()]
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            assert exc_info.value.args[0] == (
+                f"No health endpoint found at {runner.config.host}: tried /health, /v1/health"
+            )
+
+    def test_check_service_fallback_error_response(self, runner):
+        """A non-404 error from the fallback health path is reported"""
+        with patch("httpx.get") as mock_get:
+            v1_response = Mock()
+            v1_response.is_error = True
+            v1_response.status_code = 503
+            v1_response.text = '{"detail":"Service Unavailable"}'
+            mock_get.side_effect = [self._health_404_response(), v1_response]
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            assert (
+                exc_info.value.args[0]
+                == f"Error 503 connecting to {self._v1_health_endpoint(runner)}: {v1_response.text}"
+            )
+
+    def test_check_service_fallback_unhealthy(self, runner):
+        """An unhealthy status from the fallback health path is reported"""
+        with patch("httpx.get") as mock_get:
+            v1_response = Mock()
+            v1_response.is_error = False
+            v1_response.status_code = 200
+            v1_response.text = '{"status":"fail"}'
+            v1_response.json.return_value = {"status": "fail"}
+            mock_get.side_effect = [self._health_404_response(), v1_response]
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            assert (
+                exc_info.value.args[0]
+                == f"Service at {self._v1_health_endpoint(runner)} is unhealthy: {v1_response.text}"
+            )
+
+    def test_check_service_fallback_invalid_json(self, runner):
+        """An unparseable fallback health response is an error"""
+        with patch("httpx.get") as mock_get:
+            v1_response = Mock()
+            v1_response.is_error = False
+            v1_response.status_code = 200
+            v1_response.text = "not json"
+            json_error = JSONDecodeError("Expecting value", "not json", 0)
+            v1_response.json.side_effect = json_error
+            mock_get.side_effect = [self._health_404_response(), v1_response]
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            assert exc_info.value.args[0] == f"Error: response not json couldn't be parsed as JSON: {json_error}"
 
     def test_build_locust_command_basic(self, runner):
         """Test building basic Locust command."""


### PR DESCRIPTION
## Description

Lets the `benchmark.locust` CLI load test the Guardrails server, which it previously could not do at all.

`LocustRunner._check_service()` preflighted `{host}/health` and aborted on any error response. The Guardrails server serves `/v1/health` and `/healthz` rather than `/health`, so pointing the CLI at it always failed with a 404. Only the mock LLM servers passed the check, and those are the wrong target — `locustfile.py` sends a `guardrails.config_id` payload that only the Guardrails server interprets, so such a run silently measures the mock instead of Guardrails.

The preflight now probes each known health path in turn and uses the first the host answers:

```python
HEALTH_PATHS = ("/health", "/v1/health")
HEALTHY_STATUSES = frozenset({"healthy", "pass"})
```

`/health` covers the mock LLM servers, `/v1/health` covers Guardrails, and both reported status values are accepted. A host answering neither is an error naming the paths tried.

## Also included

`benchmark/locust/configs/local.yaml` shipped with `host: http://localhost:8000` and `config_id: my-guardrails-config`. Port 8000 is the mock application LLM, which accepts any `config_id` and returns 200 — so running the shipped example produced a green load test that measured the mock and never exercised Guardrails. It now points at `http://localhost:9000` with `content_safety_local`, which this fix makes reachable.

Documentation for the quickstart lives in #2307; that PR is independent and can merge in either order.

## Related Issue(s)

- Fixes #2308

## Verification

Confirmed against the mock benchmark stack (`uv run honcho start`) on macOS / Python 3.13.13.

Which paths each server actually serves:

```
9000 /v1/health : {"status":"pass"} [200]
9000 /healthz   : {"status":"pass"} [200]
9000 /health    : [404]
8000 /health    : {"status":"healthy",...} [200]
8000 /v1/health : [404]
```

Before — the CLI aborts before Locust starts:

```
ERROR: Error 404 connecting to http://localhost:9000/health: {"error":{"message":"Not Found",...}}
```

After — preflight succeeds and the run completes:

```
INFO: Successfully connected to server at http://localhost:9000
INFO: Load test completed successfully
```

- `make test TEST=benchmark/tests/test_run_locust.py` — 33 passed.
- `uv run --locked pre-commit run --files benchmark/locust/run_locust.py benchmark/tests/test_run_locust.py` — passed.
- Not run: full `make test` — change is scoped to the benchmark CLI's preflight.

## Test changes worth a look

Five tests added for the fallback path: `/v1/health` success, neither path present, a non-404 error from the fallback, an unhealthy status, and an unparseable response.

One existing test changed behavior-visibly: `test_check_service_error_response` used a 404 to exercise the generic "non-200 response" path. Since a 404 now means "try the next path", that test moved to 503 so it still covers the generic error path.

## Review history

The first version of this fix probed `/v1/rails/configs` instead, on the mistaken assumption that the Guardrails server had no health endpoint. @tgasser-nv pointed out `/v1/health` and `/healthz` in #2307, which made the fix both simpler and correct. That also retired the config-listing validation discussed in the earlier review threads — that code no longer exists.

## Observation (not addressed here)

At shutdown, Locust's own CSV stats writer greenlet raises `ValueError: I/O operation on closed file` after the run reports success and writes its output. It reproduces independently of this change and looks like a Locust teardown race rather than something in this repo.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable. (README wording is in #2307.)
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
