### PR TITLE
fix(iorails): Logger defaults to non-verbose

### DIFF
--- a/docs/observability/logging/index.mdx
+++ b/docs/observability/logging/index.mdx
@@ -39,6 +39,21 @@ This outputs detailed information about:
 - Action executions
 - Flow transitions
 
+### Verbose mode on `Guardrails` and `LLMRails`
+
+The two entry points interpret `verbose=True` differently.
+
+| Entry point | Effect of `verbose=True` |
+|-------------|--------------------------|
+| `LLMRails(config, verbose=True)` | Adds a verbose console handler at `INFO` to the root logger and logs LLM prompts and completions. |
+| `Guardrails(config, verbose=True)` | Calls `configure_logging(logging.DEBUG)`, attaching a stderr handler to the `nemoguardrails.guardrails` logger and setting it to `DEBUG`. |
+
+When `Guardrails` falls back to `LLMRails` — because an `llm` was passed, or the config contains flows IORails does not support — both apply, because `verbose` is forwarded to the `LLMRails` instance it creates.
+
+Note that `configure_logging` also stops the `nemoguardrails.guardrails` logger propagating to the root logger; see [OpenTelemetry logs](/observability/tracing/opentelemetry-logs) for what that means for handlers you attach yourself.
+
+A default `Guardrails(config)` construction configures no logging at all, leaving handlers, levels, and formatting to your application.
+
 ## Explain Method
 
 Get a quick summary of the last generation using the `explain()` method:

--- a/docs/observability/tracing/opentelemetry-logs.mdx
+++ b/docs/observability/tracing/opentelemetry-logs.mdx
@@ -150,7 +150,7 @@ Log records emitted outside any guardrails request, such as startup, engine regi
 - Performance
   : At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
 - Interaction with `propagate=False`
-  : If your application calls `nemoguardrails.guardrails.configure_logging()` on a freshly initialized logger, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. The flag is only set on the first call, when no handlers exist yet. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
+  : `nemoguardrails.guardrails.configure_logging()` sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. It runs when your application calls it directly, and when you construct `Guardrails(..., verbose=True)`. The flag is only set on the first call, when no handlers exist yet. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`. A default `Guardrails(...)` construction does not configure logging, so its records propagate normally.
 
 ## Related Resources
 

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -69,17 +69,15 @@ class Guardrails(BaseGuardrails):
         ``ValueError`` instead — use this when IORails-only features such as
         OpenTelemetry metrics are required.
 
-        ``verbose=True`` additionally routes this package's logs to stderr through
-        ``configure_logging``. Without it the package logs nothing on its own and
-        leaves handlers, levels and formatting to the calling application.
+        ``verbose=True`` also routes this package's logs to stderr through ``configure_logging``;
+        without it, handlers, levels and formatting are left to the calling application.
         """
 
         self.config = config
         self.verbose = verbose
 
-        # configure_logging attaches a handler and stops the package logger propagating.
-        # Calling it unconditionally would detach nemoguardrails.guardrails from
-        # the handlers the calling application installed on the root logger
+        # configure_logging attaches a handler and stops the package logger propagating, detaching
+        # nemoguardrails.guardrails from the handlers the application installed on the root logger.
         if verbose:
             configure_logging(logging.DEBUG)
 

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -68,15 +68,20 @@ class Guardrails(BaseGuardrails):
         LLMRails and logs a warning. Set ``require_iorails=True`` to raise a
         ``ValueError`` instead — use this when IORails-only features such as
         OpenTelemetry metrics are required.
+
+        ``verbose=True`` additionally routes this package's logs to stderr through
+        ``configure_logging``. Without it the package logs nothing on its own and
+        leaves handlers, levels and formatting to the calling application.
         """
 
         self.config = config
         self.verbose = verbose
 
+        # configure_logging attaches a handler and stops the package logger propagating.
+        # Calling it unconditionally would detach nemoguardrails.guardrails from
+        # the handlers the calling application installed on the root logger
         if verbose:
             configure_logging(logging.DEBUG)
-        else:
-            configure_logging(logging.INFO)
 
         if use_iorails:
             fallback_reason = IORails.unsupported_reason(config, llm)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -104,11 +104,8 @@ def mock_llm():
 
 @pytest.fixture
 def pristine_package_logger():
-    """Hand back an unconfigured ``nemoguardrails.guardrails`` logger, restoring it afterward.
-
-    Any earlier test that built a Guardrails leaves the logger already configured, and a test
-    starting from that state cannot tell a fixed constructor from a broken one.
-    """
+    """Hand back an unconfigured ``nemoguardrails.guardrails`` logger, restoring it afterward."""
+    # A test inheriting the configured state cannot tell a fixed constructor from a broken one.
     logger = logging.getLogger("nemoguardrails.guardrails")
     saved_handlers = list(logger.handlers)
     saved_propagate = logger.propagate
@@ -374,9 +371,7 @@ class TestGuardrailsInit:
 class TestConstructionLoggingSideEffects:
     """Constructing Guardrails must not take over the ``nemoguardrails.guardrails`` logger.
 
-    Configuring the package logger detaches it from whatever handlers the embedding application
-    installed, so its records stop reaching root: an app's log shipper and pytest's caplog both
-    go silent on this subtree, with no error to say so.
+    Doing so detaches it from the application's root handlers, silencing that subtree with no error.
     """
 
     @patch.object(IORails, "__init__", return_value=None)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -20,6 +20,7 @@ class correctly delegates method calls with properly formatted parameters.
 """
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -99,6 +100,28 @@ def mock_llm():
     """Create a mock LLM for testing."""
     llm = MagicMock()
     return llm
+
+
+@pytest.fixture
+def pristine_package_logger():
+    """Hand back an unconfigured ``nemoguardrails.guardrails`` logger, restoring it afterward.
+
+    Any earlier test that built a Guardrails leaves the logger already configured, and a test
+    starting from that state cannot tell a fixed constructor from a broken one.
+    """
+    logger = logging.getLogger("nemoguardrails.guardrails")
+    saved_handlers = list(logger.handlers)
+    saved_propagate = logger.propagate
+    saved_level = logger.level
+    logger.handlers.clear()
+    logger.propagate = True
+    logger.setLevel(logging.NOTSET)
+    try:
+        yield logger
+    finally:
+        logger.handlers[:] = saved_handlers
+        logger.propagate = saved_propagate
+        logger.setLevel(saved_level)
 
 
 class TestGuardrailsRouting:
@@ -346,6 +369,54 @@ class TestGuardrailsInit:
         guardrails = Guardrails(config=_content_safety_rails_config, use_iorails=True)
         assert isinstance(guardrails.rails_engine, IORails)
         mock_iorails_init.assert_called_once_with(_content_safety_rails_config)
+
+
+class TestConstructionLoggingSideEffects:
+    """Constructing Guardrails must not take over the ``nemoguardrails.guardrails`` logger.
+
+    Configuring the package logger detaches it from whatever handlers the embedding application
+    installed, so its records stop reaching root: an app's log shipper and pytest's caplog both
+    go silent on this subtree, with no error to say so.
+    """
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_default_construction_leaves_the_package_logger_propagating(
+        self, _mock_iorails_init, _content_safety_rails_config, pristine_package_logger
+    ):
+        """A default construction leaves package records reaching ancestor handlers."""
+        Guardrails(config=_content_safety_rails_config, use_iorails=True)
+
+        assert pristine_package_logger.propagate is True
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_default_construction_adds_no_handler_of_its_own(
+        self, _mock_iorails_init, _content_safety_rails_config, pristine_package_logger
+    ):
+        """A default construction attaches no handler, leaving output routing to the application."""
+        Guardrails(config=_content_safety_rails_config, use_iorails=True)
+
+        assert pristine_package_logger.handlers == []
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_records_logged_after_a_default_construction_stay_visible(
+        self, _mock_iorails_init, _content_safety_rails_config, pristine_package_logger, caplog
+    ):
+        """A package record emitted after a construction still reaches caplog, which listens at root."""
+        with caplog.at_level(logging.WARNING):
+            Guardrails(config=_content_safety_rails_config, use_iorails=True)
+            logging.getLogger("nemoguardrails.guardrails.iorails").warning("visible after construction")
+
+        assert "visible after construction" in caplog.text
+
+    @patch.object(IORails, "__init__", return_value=None)
+    def test_verbose_construction_still_configures_the_package_logger(
+        self, _mock_iorails_init, _content_safety_rails_config, pristine_package_logger
+    ):
+        """verbose=True still opts in to the package's own handler and debug level."""
+        Guardrails(config=_content_safety_rails_config, use_iorails=True, verbose=True)
+
+        assert pristine_package_logger.handlers
+        assert pristine_package_logger.level == logging.DEBUG
 
 
 class TestIORailsUnsupportedReason:

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -327,7 +327,7 @@ class TestGuardrailsInit:
         assert guardrails.rails_engine == mock_llmrails_instance
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
-    def test_init_with_llm(self, mock_llmrails_class, _nemoguards_rails_config, mock_llm):
+    def test_init_with_llm(self, mock_llmrails_class, _nemoguards_rails_config, mock_llm, pristine_package_logger):
         """Test initialization with a custom LLM."""
         mock_llmrails_instance = MagicMock()
         mock_llmrails_class.return_value = mock_llmrails_instance
@@ -1848,7 +1848,9 @@ class TestGuardrailsPickle:
         assert mock_llmrails_init.call_count == 2
 
     @patch.object(IORails, "__init__", return_value=None)
-    def test_getstate_preserves_verbose_true(self, mock_iorails_init, _nemoguards_rails_config):
+    def test_getstate_preserves_verbose_true(
+        self, mock_iorails_init, _nemoguards_rails_config, pristine_package_logger
+    ):
         """__getstate__ captures verbose=True so a verbose Guardrails round-trips
         with logging configuration intact."""
         guardrails = Guardrails(config=_nemoguards_rails_config, verbose=True)
@@ -1864,7 +1866,9 @@ class TestGuardrailsPickle:
         assert guardrails.verbose is True
 
     @patch.object(IORails, "__init__", return_value=None)
-    def test_pickle_round_trip_preserves_verbose(self, mock_iorails_init, _nemoguards_rails_config):
+    def test_pickle_round_trip_preserves_verbose(
+        self, mock_iorails_init, _nemoguards_rails_config, pristine_package_logger
+    ):
         """Full round-trip: a Guardrails constructed with verbose=True must come
         back from __getstate__/__setstate__ with verbose=True. Regression for the
         bug where verbose was hardcoded to False on restore, silently obscuring

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -103,37 +103,19 @@ def vcr_cassette_dir(request: pytest.FixtureRequest) -> str:
 
 @pytest.fixture
 def rail_ran_cleanly(caplog: pytest.LogCaptureFixture):
-    """Fail the test if any rail errored, which is what an unreplayed cassette looks like.
-
-    Without this a blocked-case assertion is vacuous: a cassette that fails to replay raises
-    inside the action, the fail-closed envelope turns that into a block naming the same rail
-    with the same refusal text, and status, rail and content all still match. The rail logs at
-    ERROR when it fails and does not when it reaches a verdict, so that is the difference.
-    """
-    # rail_guard reports a failed rail under nemoguardrails.guardrails, so this fixture is only as
-    # good as caplog's view of that logger, and a logger configured to stop propagating is detached
-    # from the root logger caplog listens on. Opening the door here rather than asserting it is
-    # already open: a Guardrails built with verbose=True anywhere earlier in this worker closes it
-    # process-wide, which says nothing about the rail this test runs.
+    """Fail the test if any rail errored, which is what an unreplayed cassette looks like."""
+    # caplog listens at root, so rail_guard's records only arrive while this logger propagates.
+    # Set it rather than trust it: a verbose=True construction earlier closes it process-wide.
     package_logger = logging.getLogger("nemoguardrails.guardrails")
     was_propagating = package_logger.propagate
     package_logger.propagate = True
     try:
         with caplog.at_level(logging.ERROR):
             yield
-            # Set above and checked here because pytest attaches its handler only to loggers already
-            # non-propagating when the phase opened: one closed *mid-test* is captured nowhere, and
-            # the records below read empty however the rail behaved.
-            assert package_logger.propagate, (
-                "something configured the nemoguardrails.guardrails logger mid-test, detaching it "
-                "from the root logger caplog listens on, so the check below reads empty"
-            )
-        # get_records("call") rather than .records: during teardown the latter reports the
-        # teardown phase, which is empty, and the check would pass no matter what the rail did.
-        # Restricted to this package's loggers because the question is whether a *rail* failed,
-        # which rail_guard reports. Anything at ERROR would also catch aiohttp's unclosed-session
-        # message, which the asyncio exception handler emits from __del__ whenever the collector
-        # happens to run -- so an unrelated leak elsewhere in the suite would fail this test.
+            # Closed mid-test it is captured nowhere, leaving the errors below empty either way.
+            assert package_logger.propagate, "the nemoguardrails.guardrails logger stopped propagating mid-test"
+        # get_records("call"): .records would report the empty teardown phase here. Package loggers
+        # only, so aiohttp's unclosed-session ERROR from an unrelated leak cannot fail the test.
         errors = [
             record.getMessage()
             for record in caplog.get_records("call")

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -110,19 +110,24 @@ def rail_ran_cleanly(caplog: pytest.LogCaptureFixture):
     with the same refusal text, and status, rail and content all still match. The rail logs at
     ERROR when it fails and does not when it reaches a verdict, so that is the difference.
     """
-    with caplog.at_level(logging.ERROR):
-        yield
-        # rail_guard reports a failed rail under nemoguardrails.guardrails, so this fixture is only
-        # as good as caplog's view of that logger. Configuring it detaches it from root, where caplog
-        # listens; pytest re-attaches its handler only to loggers already non-propagating when the
-        # phase opened, so a logger configured *mid-test* is captured nowhere and the records below
-        # read empty however the rail behaved. Asserting nothing configured it at all is the
-        # conservative form of that check: it cannot distinguish the mid-test case, which is silently
-        # wrong, from the before-the-test case, which happens to work.
-        assert logging.getLogger("nemoguardrails.guardrails").propagate, (
-            "something configured the nemoguardrails.guardrails logger, which detaches it from the "
-            "root logger caplog listens on; when that happens mid-test the check below reads empty"
-        )
+    # rail_guard reports a failed rail under nemoguardrails.guardrails, so this fixture is only as
+    # good as caplog's view of that logger, and a logger configured to stop propagating is detached
+    # from the root logger caplog listens on. Opening the door here rather than asserting it is
+    # already open: a Guardrails built with verbose=True anywhere earlier in this worker closes it
+    # process-wide, which says nothing about the rail this test runs.
+    package_logger = logging.getLogger("nemoguardrails.guardrails")
+    was_propagating = package_logger.propagate
+    package_logger.propagate = True
+    try:
+        with caplog.at_level(logging.ERROR):
+            yield
+            # Set above and checked here because pytest attaches its handler only to loggers already
+            # non-propagating when the phase opened: one closed *mid-test* is captured nowhere, and
+            # the records below read empty however the rail behaved.
+            assert package_logger.propagate, (
+                "something configured the nemoguardrails.guardrails logger mid-test, detaching it "
+                "from the root logger caplog listens on, so the check below reads empty"
+            )
         # get_records("call") rather than .records: during teardown the latter reports the
         # teardown phase, which is empty, and the check would pass no matter what the rail did.
         # Restricted to this package's loggers because the question is whether a *rail* failed,
@@ -135,6 +140,8 @@ def rail_ran_cleanly(caplog: pytest.LogCaptureFixture):
             if record.levelno >= logging.ERROR and record.name.startswith("nemoguardrails")
         ]
         assert not errors, f"a rail errored, so the cassette did not replay: {errors}"
+    finally:
+        package_logger.propagate = was_propagating
 
 
 async def check_iorails(config, messages: list[dict], rail_types: tuple[RailType, ...]):

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -112,6 +112,17 @@ def rail_ran_cleanly(caplog: pytest.LogCaptureFixture):
     """
     with caplog.at_level(logging.ERROR):
         yield
+        # rail_guard reports a failed rail under nemoguardrails.guardrails, so this fixture is only
+        # as good as caplog's view of that logger. Configuring it detaches it from root, where caplog
+        # listens; pytest re-attaches its handler only to loggers already non-propagating when the
+        # phase opened, so a logger configured *mid-test* is captured nowhere and the records below
+        # read empty however the rail behaved. Asserting nothing configured it at all is the
+        # conservative form of that check: it cannot distinguish the mid-test case, which is silently
+        # wrong, from the before-the-test case, which happens to work.
+        assert logging.getLogger("nemoguardrails.guardrails").propagate, (
+            "something configured the nemoguardrails.guardrails logger, which detaches it from the "
+            "root logger caplog listens on; when that happens mid-test the check below reads empty"
+        )
         # get_records("call") rather than .records: during teardown the latter reports the
         # teardown phase, which is empty, and the check would pass no matter what the rail did.
         # Restricted to this package's loggers because the question is whether a *rail* failed,


### PR DESCRIPTION
## Description

Constructing Guardrails(...) reconfigured process-global logging as a side effect, even with the default verbose=False.
Guardrails.__init__ called configure_logging() unconditionally, which attaches a stderr handler to the nemoguardrails.guardrails logger and sets propagate = False on it.

Two consequences follow from that flag.

For applications embedding the SDK, every record under nemoguardrails.guardrails.* stops reaching the root logger the moment a Guardrails is constructed.
Whatever the application installed there — a JSON formatter, a log shipper, an OTEL logging bridge — silently stops receiving this subtree, with no error and no opt-out.
configure_logging() also walks any handlers already on that logger and calls setLevel/setFormatter on them, so it reformats handlers it does not own.

For the test suite, the same flag breaks caplog in an order-dependent way.
pytest attaches its capture handler to the root logger, plus any logger already non-propagating when the test phase opens; _pytest/logging.py notes it "will miss loggers that become non-propagating after the __enter__".
So a test that constructs its first Guardrails inside its own body lands in a gap: the records reach neither root nor a directly-attached handler, and caplog.text reads empty while the text still appears on stderr.
A test that runs after some earlier test already flipped the flag works fine, because pytest then attaches directly.


## Related Issue(s)

* https://jirasw.nvidia.com/browse/NGUARD-869
* [NVBug 6469002](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6469002)

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-test-logger
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7182 items]

.........................s.............................................. [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
......................................................................ss [  4%]
..ss.................................................................... [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
.............................................................s.......... [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
................................s....................................... [ 12%]
........................................................................ [ 13%]
....................................................................ss.s [ 14%]
sss..s............................ss.ss.s.ss..s......................... [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
......................................s...................s..s.......... [ 28%]
........................................................................ [ 29%]
...s..s..s....s...s.s.s................................................. [ 30%]
....s................................................................... [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
...............................................................sssss.sss [ 34%]
.................ssssss...s.s...s.........................sss.sssss..... [ 35%]
........................................................................ [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
....................sssss.......sssssssssssssssss.s.......s............. [ 43%]
........................................................................ [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
.............................................................sss.ss..... [ 48%]
........................................................................ [ 49%]
........................................................................ [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
..................................ss.................................... [ 55%]
...........................................ss........................... [ 56%]
....ss..................................s.s............................. [ 57%]
...............................................s........................ [ 58%]
........................................................................ [ 59%]
................................................................sss.sss. [ 60%]
..............s........................................s................ [ 61%]
.....................sss.........................ss..................... [ 62%]
ss...................................................................... [ 63%]
........................................................................ [ 64%]
..................................................................s.ssss [ 65%]
ssssssss.......................................................s........ [ 66%]
.......................................................................s [ 67%]
......................................s................................. [ 68%]
........................................................................ [ 69%]
......................................s....................s............ [ 70%]
..................................................s..s.....ss.sss....... [ 71%]
........................................................................ [ 72%]
s............................................s.......................... [ 73%]
.............................................ssssssssssss.ss............ [ 74%]
............s........................................................... [ 75%]
..................sssss.ss.............................................. [ 76%]
........................................................................ [ 77%]
........................................................................ [ 78%]
........................................................................ [ 79%]
.......s.ss.ssssss.ssssssssss........................................... [ 80%]
........................................................................ [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
.................................................................ssssss. [ 84%]
............................................................ssss........ [ 85%]
..............ss...........ss...................ssssssss................ [ 86%]
........................................................................ [ 87%]
....................................ss.................................. [ 88%]
...................................s......s.ss.s........................ [ 89%]
........................................................................ [ 90%]
........................................................................ [ 91%]
........................................................................ [ 92%]
s....................................................................... [ 93%]
........................................................................ [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
.........................................................s.............. [ 97%]
........................................................................ [ 98%]
........................................................................ [ 99%]
............s.........................................                   [100%]

══════════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and 
inline-snapshot will not be able to fix snapshots or generate reports.


====================== 6971 passed, 211 skipped in 49.04s ======================
```


### Integration test with Chat (non-verbose)

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config ~/utils/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...

> Hello!
<think>Here's a thinking process:

1.  **Analyze User Input:** The user said "Hello!" - a simple greeting.
2.  **Identify Intent:** Greeting, starting a conversation.
3.  **Determine Response:** Friendly, polite, welcoming response. Should acknowledge the greeting and offer assistance.
4.  **Formulate Response:**
   - "Hello! How can I help you today?"
   - Keep it simple and open-ended.
5.  **Final Check:** Matches expected behavior for a greeting. No complex reasoning needed. Output matches.✅
</think>
Hello! How can I help you today?

> How can I blow up a car?
I'm sorry, I can't respond to that.
```

### Integration test with Chat (verbose with debug logging)

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config ~/utils/configs/nemoguards --verbose

Entered verbose mode.
NOTE: use the `--verbose-no-llm` option to exclude the LLM prompts and completions from the log.

Starting the chat (Press Ctrl + C twice to quit) ...
2026-08-18 23:05:32 INFO: Registered model engine: type=main, model=nvidia/nemotron-3.5-lightning-30b-a3b, base_url=https://integrate.api.nvidia.com
2026-08-18 23:05:32 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvi
dia.com
2026-08-18 23:05:32 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidi
a.com
2026-08-18 23:05:32 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_co
ntrol', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_para
llel=False, output_parallel=False

> Hello!
2026-08-18 23:05:35 INFO: [0d55cfe3dbc2ca86] generate_async called
2026-08-18 23:05:35 DEBUG: [0d55cfe3dbc2ca86] generate_async messages=[{'role': 'user', 'content': 'Hello!'}]
2026-08-18 23:05:35 INFO: [0d55cfe3dbc2ca86] Running tool result rails
2026-08-18 23:05:35 INFO: [0d55cfe3dbc2ca86] Running input rails

LLM Prompt (10a2e..) - content_safety_check_input $model=content_safety
<removed lines>
2026-08-18 23:05:35 INFO: [0d55cfe3dbc2ca86] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safet
y'
2026-08-18 23:05:35 DEBUG: [0d55cfe3dbc2ca86] HTTP request body: {'model': 'nvidia/llama-3.1-nemoguard-8b-content-safety', 'messages': [{'role': 'user', 'cont
ent': 'Task: Check if there is unsafe content in the user or agent messages in the below conversation in ac...
2026-08-18 23:05:35 DEBUG: [0d55cfe3dbc2ca86] HTTP response status=200 time=392.1ms body: {'id': 'chat-d9e7cf539d784e0bafa64cfb1e41b50e', 'object': 'chat.comp
letion', 'created': 1787112335, 'model': 'nvidia/llama-3.1-nemoguard-8b-content-safety', 'choices': [{'index': 0, 'message': {'role'...

LLM Completion (10a2e..)
<removed lines>
2026-08-18 23:05:35 INFO: [0d55cfe3dbc2ca86] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control
'
2026-08-18 23:05:35 DEBUG: [0d55cfe3dbc2ca86] HTTP request body: {'model': 'nvidia/llama-3.1-nemoguard-8b-topic-control', 'messages': [{'role': 'system', 'con
tent': 'You are to act as a customer service agent, providing users with factual information in accordance ...
2026-08-18 23:05:35 DEBUG: [0d55cfe3dbc2ca86] HTTP response status=200 time=307.7ms body: {'id': 'chat-a3df323140b84154b4d3f232a3b31dfb', 'object': 'chat.comp
letion', 'created': 1787112335, 'model': 'nvidia/llama-3.1-nemoguard-8b-topic-control', 'choices': [{'index': 0, 'message': {'role':...

LLM Completion (f6131..)
<removed lines>

2026-08-18 23:05:36 DEBUG: [0d55cfe3dbc2ca86] Input flow jailbreak detection model result RailResult(outcome=RailOutcome(decision=<RailDecision.ALLOW: 'allow'
>, reason=None, metadata={}, transforms=()), triggered_rail=None, records=(RailCallRecord(flow='jailbreak detection model', rail_type='input', is_safe=True, m
ade_call=True, action_name='jailbreak_detection_model', return_value={'allowed': True}, task='jailbreak_detection_model', request_id=None, usage=UsageInfo(inp
ut_tokens=0, output_tokens=0, total_tokens=0, reasoning_tokens=None, cached_tokens=None), llm_model_name='unknown', llm_provider_name='unknown', prompt=None,
completion=None, started_at=1787112335.858143, finished_at=1787112336.141231, duration=0.28304100036621094),))
2026-08-18 23:05:36 INFO: [0d55cfe3dbc2ca86] Calling main LLM
2026-08-18 23:05:36 DEBUG: [0d55cfe3dbc2ca86] Model engine 'main' messages: [{'role': 'user', 'content': 'Hello!'}]
2026-08-18 23:05:36 INFO: [0d55cfe3dbc2ca86] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-lightning-30b-a3b'
2026-08-18 23:05:36 DEBUG: [0d55cfe3dbc2ca86] HTTP request body: {'model': 'nvidia/nemotron-3.5-lightning-30b-a3b', 'messages': [{'role': 'user', 'content': '
Hello!'}]}
2026-08-18 23:05:39 DEBUG: [0d55cfe3dbc2ca86] HTTP response status=200 time=3675.5ms body: {'id': 'chatcmpl-9a8f0cf0-76df-42ea-ad0a-a14b6f9dd8d9', 'choices':
[{'index': 0, 'message': {'content': 'Hello! How can I help you today?', 'role': 'assistant', 'reasoning_content': 'Here\'s a thinkin...
2026-08-18 23:05:39 DEBUG: [0d55cfe3dbc2ca86] Model engine 'main' response: LLMResponse(content='Hello! How can I help you today?', reasoning='Here\'s a think
ing process:\n\n1.  **Analyze User Input:** The user said "Hello!" which is a simple greeting.\n2.  **Identify Intent:...
2026-08-18 23:05:39 DEBUG: [0d55cfe3dbc2ca86] Raw LLM response: Hello! How can I help you today?
2026-08-18 23:05:39 INFO: [0d55cfe3dbc2ca86] Running output rails 
.....

```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default `Guardrails` initialization now preserves application logging settings and propagation.
  * Logging handlers and subsequent records remain available to host applications by default.
  * Verbose mode continues to enable debug logging and configure a dedicated handler.

* **Documentation**
  * Clarified when logging configuration occurs and how propagation behaves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->