### PR TITLE
fix!(server): harden Chat Completions request validation

### DIFF
--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.mdx
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.mdx
@@ -55,7 +55,6 @@ The response follows the standard OpenAI `ChatCompletion` format, with an additi
   ],
   "guardrails": {
     "config_id": "content_safety",
-    "state": null,
     "llm_output": null,
     "output_data": null,
     "log": null
@@ -65,10 +64,15 @@ The response follows the standard OpenAI `ChatCompletion` format, with an additi
 
 The `guardrails` response object may include additional fields depending on your request options:
 
-- **`state`** — State object for continuing the conversation. Return this in subsequent requests to resume.
 - **`llm_output`** — Additional LLM output data (when `guardrails.options.llm_output` is `true`).
 - **`output_data`** — Values for requested context variables (when `guardrails.options.output_vars` is set).
 - **`log`** — Logging information (when `guardrails.options.log` is configured).
+
+<Note>
+
+The HTTP endpoint does not accept caller-supplied runtime state. To continue a conversation, send the full message history or use a `thread_id`. Trusted in-process Python callers using Colang 1.x can pass state directly to `LLMRails.generate_async()`.
+
+</Note>
 
 ## Using the OpenAI Python SDK
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -807,7 +807,7 @@ class LLMRails(BaseGuardrails):
                     events.append({"type": "ContextUpdate", "data": msg["content"]})
                 elif msg["role"] == "event":
                     events.append(msg["event"])
-                elif msg["role"] == "system":
+                elif msg["role"] in ("developer", "system"):
                     # Handle system messages - convert them to SystemMessage events
                     events.append({"type": "SystemMessage", "content": msg["content"]})
                 elif msg["role"] == "tool":
@@ -864,7 +864,7 @@ class LLMRails(BaseGuardrails):
                     events.append({"type": "ContextUpdate", "data": msg["content"]})
                 elif msg["role"] == "event":
                     events.append(msg["event"])
-                elif msg["role"] == "system":
+                elif msg["role"] in ("developer", "system"):
                     # Handle system messages - convert them to SystemMessage events
                     events.append({"type": "SystemMessage", "content": msg["content"]})
                 elif msg["role"] == "tool":

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -110,36 +110,6 @@ class GuardrailsApp(FastAPI):
 registered_loggers: List[Callable] = []
 
 
-def _raise_invalid_state(detail: str) -> None:
-    raise HTTPException(status_code=422, detail=detail)
-
-
-def _validate_public_state_shape(state: Optional[dict]) -> None:
-    """Validate request state shape before loading rails config.
-
-    At the public HTTP boundary, the only accepted non-empty dict state shape is
-    Colang 1.0 transcript state: {"events": [...]}. Colang 2.0 has no safe
-    public dict state shape.
-    """
-    if state is None or state == {}:
-        return
-
-    if state.get("version") == "2.x" or "state" in state:
-        _raise_invalid_state(
-            "Caller-supplied state is not accepted for Colang 2.0 over HTTP. "
-            "Full Colang 2.0 flow-state continuation over HTTP is not currently supported."
-        )
-
-    if "events" not in state:
-        _raise_invalid_state(
-            "Invalid state format: state must contain an 'events' key. "
-            "Use an empty dict {} to start a new conversation."
-        )
-
-    if not isinstance(state["events"], list):
-        _raise_invalid_state("Invalid state format: 'events' must be a list.")
-
-
 api_description = """Guardrails Server API."""
 
 # The headers for each request
@@ -648,8 +618,6 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
                 detail="No guardrails config_id provided and server has no default configuration",
             )
 
-    _validate_public_state_shape(body.guardrails.state)
-
     try:
         llm_rails = await _get_rails(config_ids, model_name=body.model)
 
@@ -659,16 +627,6 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             status_code=400,
             detail=f"Could not load the requested guardrails configuration: {config_ids}",
         )
-
-    # Version-aware state validation, now that the config is loaded.
-    # 1.0 accepts the pre-validated {"events": [...]} transcript. 2.0 has no
-    # valid public dict state shape.
-    if body.guardrails.state is not None and body.guardrails.state != {}:
-        if llm_rails.config.colang_version != "1.0":
-            raise HTTPException(
-                status_code=422,
-                detail="Stateful continuation over HTTP is not supported for Colang 2.0.",
-            )
 
     if body.guardrails.thread_id and llm_rails.config.colang_version != "1.0":
         raise HTTPException(
@@ -741,7 +699,6 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
         stream_iterator = llm_rails.stream_async(
             messages=messages,
             options=generation_options,
-            state=body.guardrails.state,
         )
 
         try:
@@ -778,7 +735,6 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
         res = await llm_rails.generate_async(
             messages=messages,
             options=generation_options,
-            state=body.guardrails.state,
         )
 
         # Extract bot message for thread storage if needed

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -40,7 +40,6 @@ class GuardrailsDataOutput(BaseModel):
         default=None,
         description="The guardrails configuration ID associated with this response.",
     )
-    state: Optional[dict] = Field(default=None, description="State object for continuing the conversation.")
     llm_output: Optional[dict] = Field(default=None, description="Additional LLM output data.")
     output_data: Optional[dict] = Field(default=None, description="Additional output data.")
     log: Optional[dict] = Field(default=None, description="Generation log data.")
@@ -331,10 +330,13 @@ class GuardrailsDataInput(BaseModel):
         default_factory=GenerationOptions,
         description="Additional generation options.",
     )
-    state: Optional[dict] = Field(
-        default=None,
-        description="State object to continue the interaction.",
-    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_caller_supplied_state(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("state") is not None:
+            raise ValueError("Caller-supplied state is not accepted over HTTP.")
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -19,7 +19,16 @@ import os
 from typing import Annotated, Any, List, Literal, Optional, Union
 
 from openai.types.chat.chat_completion import ChatCompletion
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from nemoguardrails.rails.llm.options import GenerationOptions, RailType
 
@@ -43,14 +52,169 @@ class GuardrailsChatCompletion(ChatCompletion):
     guardrails: Optional[GuardrailsDataOutput] = Field(default=None, description="Guardrails specific output data.")
 
 
-class _OpenAIChatMessageSchema(BaseModel):
-    model_config = ConfigDict(extra="allow")
+class _OpenAIChatMessageBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
-    role: str
+
+class _OpenAIChatMessageRoleSchema(BaseModel):
+    role: Literal["developer", "system", "user", "assistant", "tool", "function", "context"]
+
+
+class _OpenAIPromptCacheBreakpointSchema(_OpenAIChatMessageBase):
+    mode: Literal["explicit"]
+
+
+class _OpenAIImageURLSchema(_OpenAIChatMessageBase):
+    url: str
+    detail: Optional[Literal["auto", "low", "high"]] = None
+
+
+class _OpenAITextContentPartSchema(_OpenAIChatMessageBase):
+    text: str
+    type: Literal["text"]
+    prompt_cache_breakpoint: Optional[_OpenAIPromptCacheBreakpointSchema] = None
+
+
+class _OpenAIImageContentPartSchema(_OpenAIChatMessageBase):
+    image_url: _OpenAIImageURLSchema
+    type: Literal["image_url"]
+    prompt_cache_breakpoint: Optional[_OpenAIPromptCacheBreakpointSchema] = None
+
+
+class _OpenAIFileSchema(_OpenAIChatMessageBase):
+    file_data: Optional[str] = None
+    file_id: Optional[str] = None
+    filename: Optional[str] = None
+
+
+class _OpenAIFileContentPartSchema(_OpenAIChatMessageBase):
+    file: _OpenAIFileSchema
+    type: Literal["file"]
+    prompt_cache_breakpoint: Optional[_OpenAIPromptCacheBreakpointSchema] = None
+
+
+class _OpenAIRefusalContentPartSchema(_OpenAIChatMessageBase):
+    refusal: str
+    type: Literal["refusal"]
+
+
+_OpenAITextContentSchema = Union[str, List[_OpenAITextContentPartSchema]]
+_OpenAIUserContentPartSchema = Union[
+    _OpenAITextContentPartSchema,
+    _OpenAIImageContentPartSchema,
+    _OpenAIFileContentPartSchema,
+]
+
+
+class _OpenAIDeveloperMessageSchema(_OpenAIChatMessageBase):
+    content: _OpenAITextContentSchema
+    role: Literal["developer"]
+    name: Optional[str] = None
+
+
+class _OpenAISystemMessageSchema(_OpenAIChatMessageBase):
+    content: _OpenAITextContentSchema
+    role: Literal["system"]
+    name: Optional[str] = None
+
+
+class _OpenAIUserMessageSchema(_OpenAIChatMessageBase):
+    content: Union[str, List[_OpenAIUserContentPartSchema]]
+    role: Literal["user"]
+    name: Optional[str] = None
+
+
+class _OpenAIFunctionCallSchema(_OpenAIChatMessageBase):
+    arguments: str
+    name: str
+
+
+class _OpenAIFunctionToolCallSchema(_OpenAIChatMessageBase):
+    id: str
+    function: _OpenAIFunctionCallSchema
+    type: Literal["function"]
+
+
+class _OpenAICustomToolSchema(_OpenAIChatMessageBase):
+    input: str
+    name: str
+
+
+class _OpenAICustomToolCallSchema(_OpenAIChatMessageBase):
+    id: str
+    custom: _OpenAICustomToolSchema
+    type: Literal["custom"]
+
+
+_OpenAIToolCallSchema = Union[_OpenAIFunctionToolCallSchema, _OpenAICustomToolCallSchema]
+
+
+class _OpenAIAssistantMessageSchema(_OpenAIChatMessageBase):
+    role: Literal["assistant"]
+    content: Optional[Union[str, List[Union[_OpenAITextContentPartSchema, _OpenAIRefusalContentPartSchema]]]] = None
+    function_call: Optional[_OpenAIFunctionCallSchema] = None
+    name: Optional[str] = None
+    tool_calls: Optional[List[_OpenAIToolCallSchema]] = None
+    refusal: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_content_or_call(cls, value: Any) -> Any:
+        if (
+            isinstance(value, dict)
+            and value.get("content") is None
+            and value.get("function_call") is None
+            and not value.get("tool_calls")
+            and value.get("refusal") is None
+        ):
+            raise ValidationError.from_exception_data(
+                cls.__name__,
+                [{"type": "missing", "loc": ("content",), "input": value}],
+            )
+        return value
+
+
+class _OpenAIToolMessageSchema(_OpenAIChatMessageBase):
+    content: _OpenAITextContentSchema
+    role: Literal["tool"]
+    tool_call_id: str
+
+
+class _OpenAIFunctionMessageSchema(_OpenAIChatMessageBase):
+    content: Optional[str]
+    name: str
+    role: Literal["function"]
+
+
+class _GuardrailsContextMessageSchema(_OpenAIChatMessageBase):
+    content: dict[str, Any]
+    role: Literal["context"]
+
+
+_OpenAIChatMessageInput = Union[
+    _OpenAIDeveloperMessageSchema,
+    _OpenAISystemMessageSchema,
+    _OpenAIUserMessageSchema,
+    _OpenAIAssistantMessageSchema,
+    _OpenAIToolMessageSchema,
+    _OpenAIFunctionMessageSchema,
+    _GuardrailsContextMessageSchema,
+]
+
+_OPENAI_CHAT_MESSAGE_SCHEMAS: dict[str, type[BaseModel]] = {
+    "developer": _OpenAIDeveloperMessageSchema,
+    "system": _OpenAISystemMessageSchema,
+    "user": _OpenAIUserMessageSchema,
+    "assistant": _OpenAIAssistantMessageSchema,
+    "tool": _OpenAIToolMessageSchema,
+    "function": _OpenAIFunctionMessageSchema,
+    "context": _GuardrailsContextMessageSchema,
+}
 
 
 def _validate_openai_chat_message(message: Any) -> Any:
-    _OpenAIChatMessageSchema.model_validate(message)
+    role = _OpenAIChatMessageRoleSchema.model_validate(message).role
+    _OPENAI_CHAT_MESSAGE_SCHEMAS[role].model_validate(message)
     return message
 
 
@@ -58,13 +222,22 @@ OpenAIChatMessage = Annotated[
     dict[str, Any],
     BeforeValidator(
         _validate_openai_chat_message,
-        json_schema_input_type=_OpenAIChatMessageSchema,
+        json_schema_input_type=_OpenAIChatMessageInput,
     ),
 ]
 
 
 class OpenAIChatCompletionRequest(BaseModel):
     """Standard OpenAI chat completion request parameters."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_unsupported_audio(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            modalities = data.get("modalities")
+            if "audio" in data or (isinstance(modalities, list) and "audio" in modalities):
+                raise ValueError("Audio input and output are not supported.")
+        return data
 
     messages: Optional[List[OpenAIChatMessage]] = Field(
         default=None,

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -135,26 +135,12 @@ class _OpenAIFunctionToolCallSchema(_OpenAIChatMessageBase):
     type: Literal["function"]
 
 
-class _OpenAICustomToolSchema(_OpenAIChatMessageBase):
-    input: str
-    name: str
-
-
-class _OpenAICustomToolCallSchema(_OpenAIChatMessageBase):
-    id: str
-    custom: _OpenAICustomToolSchema
-    type: Literal["custom"]
-
-
-_OpenAIToolCallSchema = Union[_OpenAIFunctionToolCallSchema, _OpenAICustomToolCallSchema]
-
-
 class _OpenAIAssistantMessageSchema(_OpenAIChatMessageBase):
     role: Literal["assistant"]
     content: Optional[Union[str, List[Union[_OpenAITextContentPartSchema, _OpenAIRefusalContentPartSchema]]]] = None
     function_call: Optional[_OpenAIFunctionCallSchema] = None
     name: Optional[str] = None
-    tool_calls: Optional[List[_OpenAIToolCallSchema]] = None
+    tool_calls: Optional[List[_OpenAIFunctionToolCallSchema]] = None
     refusal: Optional[str] = None
 
     @model_validator(mode="before")
@@ -232,10 +218,32 @@ class OpenAIChatCompletionRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def reject_unsupported_custom_tools(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            tools = data.get("tools")
+            if isinstance(tools, list) and any(
+                isinstance(tool, dict) and tool.get("type") == "custom" for tool in tools
+            ):
+                raise ValueError("Custom tools are not supported.")
+
+            tool_choice = data.get("tool_choice")
+            if isinstance(tool_choice, dict):
+                allowed_tools = tool_choice.get("tools")
+                if tool_choice.get("type") == "custom" or (
+                    isinstance(allowed_tools, list)
+                    and any(isinstance(tool, dict) and tool.get("type") == "custom" for tool in allowed_tools)
+                ):
+                    raise ValueError("Custom tools are not supported.")
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def reject_unsupported_audio(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            modalities = data.get("modalities")
-            if "audio" in data or (isinstance(modalities, list) and "audio" in modalities):
+            if "modalities" in data and not isinstance(data["modalities"], list):
+                raise ValueError("The 'modalities' parameter must be a list.")
+            modalities = data.get("modalities", [])
+            if "audio" in data or "audio" in modalities:
                 raise ValueError("Audio input and output are not supported.")
         return data
 

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -370,7 +370,6 @@ def generation_response_to_chat_completion(
             llm_output=response.llm_output,
             output_data=response.output_data,
             log=log_dict,
-            state=response.state,
         ),
     )
 

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -539,6 +539,7 @@ def test_chat_completion_rejects_unsupported_audio_messages(message):
     "audio_options",
     [
         {"modalities": ["text", "audio"]},
+        {"modalities": "audio"},
         {"audio": {"voice": "alloy", "format": "wav"}},
     ],
 )
@@ -553,6 +554,59 @@ def test_chat_completion_rejects_unsupported_audio_options(audio_options):
                 **audio_options,
             },
         )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    get_rails.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "custom_tool_input",
+    [
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_custom",
+                            "type": "custom",
+                            "custom": {"name": "code_exec", "input": "print('hello')"},
+                        }
+                    ],
+                }
+            ]
+        },
+        {
+            "tools": [
+                {
+                    "type": "custom",
+                    "custom": {"name": "code_exec", "description": "Execute code"},
+                }
+            ]
+        },
+        {"tool_choice": {"type": "custom", "custom": {"name": "code_exec"}}},
+        {
+            "tool_choice": {
+                "type": "allowed_tools",
+                "mode": "auto",
+                "tools": [{"type": "custom", "name": "code_exec"}],
+            }
+        },
+    ],
+    ids=["assistant-message", "tool-definition", "tool-choice", "allowed-tools"],
+)
+def test_chat_completion_rejects_unsupported_custom_tools(custom_tool_input):
+    request = {
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "guardrails": {"config_id": "test_config"},
+        **custom_tool_input,
+    }
+
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post("/v1/chat/completions", json=request)
 
     assert response.status_code == 422
     assert response.json()["error"]["type"] == "invalid_request_error"
@@ -601,8 +655,8 @@ def test_request_body_accepts_guardrails_context_message():
             "tool_calls": [
                 {
                     "id": "call_abc",
-                    "type": "custom",
-                    "custom": {"name": "code_exec", "input": "print('hello')"},
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Boston"}'},
                 }
             ],
         },

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -409,6 +409,223 @@ def test_chat_completion_rejects_message_without_role():
     get_rails.assert_not_awaited()
 
 
+def test_chat_completion_rejects_internal_event_message():
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [
+                    {
+                        "role": "event",
+                        "event": {
+                            "type": "StartInternalSystemAction",
+                            "action_name": "unsafe_action",
+                            "action_params": {"value": "untrusted"},
+                            "action_result_key": "result",
+                            "action_uid": "action-1",
+                        },
+                    }
+                ],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["param"] == "messages.0.role"
+    get_rails.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"role": "user"},
+        {"role": "developer"},
+        {"role": "system"},
+        {"role": "assistant"},
+        {"role": "tool", "tool_call_id": "call_abc"},
+        {"role": "function", "name": "get_weather"},
+        {"role": "context"},
+    ],
+)
+def test_chat_completion_rejects_message_without_content(message):
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [message],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["param"] == "messages.0.content"
+    get_rails.assert_not_awaited()
+
+
+def test_chat_completion_rejects_null_user_content():
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": None}],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["param"].startswith("messages.0.content")
+    get_rails.assert_not_awaited()
+
+
+def test_chat_completion_rejects_unexpected_message_fields():
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Hello",
+                        "event": {"type": "StartInternalSystemAction"},
+                    }
+                ],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["param"] == "messages.0.event"
+    get_rails.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this recording."},
+                {"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
+            ],
+        },
+        {"role": "assistant", "content": "Previous response", "audio": {"id": "audio_abc"}},
+    ],
+)
+def test_chat_completion_rejects_unsupported_audio_messages(message):
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-audio",
+                "messages": [message],
+                "guardrails": {"config_id": "test_config"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    get_rails.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "audio_options",
+    [
+        {"modalities": ["text", "audio"]},
+        {"audio": {"voice": "alloy", "format": "wav"}},
+    ],
+)
+def test_chat_completion_rejects_unsupported_audio_options(audio_options):
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-audio",
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "guardrails": {"config_id": "test_config"},
+                **audio_options,
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    get_rails.assert_not_awaited()
+
+
+def test_request_body_accepts_guardrails_context_message():
+    data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "context", "content": {"user_name": "John"}}],
+        "guardrails": {"config_id": "test_config"},
+    }
+
+    request_body = GuardrailsChatCompletionRequest.model_validate(data)
+
+    assert request_body.messages == data["messages"]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {
+            "role": "developer",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Follow these instructions.",
+                    "prompt_cache_breakpoint": {"mode": "explicit"},
+                }
+            ],
+            "name": "policy",
+        },
+        {"role": "system", "content": [{"type": "text", "text": "Be concise."}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe these inputs."},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                {"type": "file", "file": {"file_id": "file_abc"}},
+            ],
+        },
+        {"role": "assistant", "content": [{"type": "refusal", "refusal": "I cannot help."}]},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "custom",
+                    "custom": {"name": "code_exec", "input": "print('hello')"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": [{"type": "text", "text": "Tool result"}],
+            "tool_call_id": "call_abc",
+        },
+        {"role": "function", "content": None, "name": "get_weather"},
+    ],
+)
+def test_request_body_accepts_openai_chat_message(message):
+    data = {
+        "model": "gpt-4o",
+        "messages": [message],
+        "guardrails": {"config_id": "test_config"},
+    }
+
+    request_body = GuardrailsChatCompletionRequest.model_validate(data)
+
+    assert request_body.messages == data["messages"]
+
+
 def test_request_body_tools_and_tool_choice():
     """Test GuardrailsChatCompletionRequest accepts OpenAI tools parameters."""
     data = {

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
@@ -341,8 +342,7 @@ def test_thread_id_without_datastore_returns_400(monkeypatch):
     }
 
 
-def test_request_body_state():
-    """Test GuardrailsChatCompletionRequest state handling."""
+def test_request_body_rejects_state():
     data = {
         "model": "gpt-4o",
         "messages": [{"role": "user", "content": "Hello"}],
@@ -351,8 +351,8 @@ def test_request_body_state():
             "state": {"key": "value"},
         },
     }
-    request_body = GuardrailsChatCompletionRequest.model_validate(data)
-    assert request_body.guardrails.state == {"key": "value"}
+    with pytest.raises(ValidationError, match="Caller-supplied state is not accepted over HTTP"):
+        GuardrailsChatCompletionRequest.model_validate(data)
 
 
 def test_request_body_context():
@@ -750,7 +750,7 @@ def test_chat_completion_passes_tools_to_llm_params():
 
     captured_options = {}
 
-    async def mock_generate_async(*, messages, options, state):
+    async def mock_generate_async(*, messages, options):
         captured_options["options"] = options
         return GenerationResponse(response=[{"role": "assistant", "content": "ok"}])
 
@@ -786,7 +786,7 @@ def test_chat_completion_accepts_stop_parameter(stop):
 
     captured_options = {}
 
-    async def mock_generate_async(*, messages, options, state):
+    async def mock_generate_async(*, messages, options):
         captured_options["options"] = options
         return GenerationResponse(response=[{"role": "assistant", "content": "ok"}])
 
@@ -894,7 +894,7 @@ def test_chat_completion_returns_tool_calls():
         }
     ]
 
-    async def mock_generate_async(*, messages, options, state):
+    async def mock_generate_async(*, messages, options):
         return GenerationResponse(
             response=[{"role": "assistant", "content": ""}],
             tool_calls=tool_calls,
@@ -976,7 +976,6 @@ def test_guardrails_defaults_when_not_provided():
     assert request_body.guardrails.config_ids is None
     assert request_body.guardrails.thread_id is None
     assert request_body.guardrails.context is None
-    assert request_body.guardrails.state is None
     assert request_body.guardrails.options is not None
     assert request_body.guardrails.options.rails.input is True
     assert request_body.guardrails.options.rails.output is True
@@ -1007,7 +1006,6 @@ def test_guardrails_partial_fields():
 
     assert request_body.guardrails.config_id == "test_config"
     assert request_body.guardrails.context is None
-    assert request_body.guardrails.state is None
     assert request_body.guardrails.options is not None
 
 
@@ -1036,23 +1034,30 @@ def test_no_config_error_returns_proper_response():
     assert "config" in res["error"]["message"].lower()
 
 
-def test_invalid_state_returns_error():
-    """Test API handles invalid state gracefully instead of crashing."""
-    response = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "gpt-4o",
-            "messages": [{"role": "user", "content": "hi"}],
-            "guardrails": {
-                "config_id": "with_custom_llm",
-                "state": {"invalid_key": "value"},
+def test_chat_completion_rejects_state_events():
+    with patch("nemoguardrails.server.api._get_rails", new=AsyncMock()) as get_rails:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "guardrails": {
+                    "config_id": "with_custom_llm",
+                    "state": {
+                        "events": [
+                            {
+                                "type": "ContextUpdate",
+                                "data": {"skip_output_rails": True},
+                            }
+                        ]
+                    },
+                },
             },
-        },
-    )
+        )
+
     assert response.status_code == 422
-    res = response.json()
-    assert "error" in res
-    assert "state" in res["error"]["message"].lower() or "events" in res["error"]["message"].lower()
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
+    get_rails.assert_not_awaited()
 
 
 def test_chat_completion_response_structure():
@@ -1139,7 +1144,6 @@ def test_chat_completion_with_all_guardrails_fields():
                     "rails": {"input": True, "output": True},
                     "log": {"activated_rails": True},
                 },
-                "state": {},
             },
         },
     )

--- a/tests/server/test_openai_integration.py
+++ b/tests/server/test_openai_integration.py
@@ -26,6 +26,7 @@ from openai import (
     OpenAI,
     PermissionDeniedError,
     RateLimitError,
+    UnprocessableEntityError,
 )
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
@@ -204,25 +205,19 @@ def test_openai_client_with_options(openai_client):
     assert response.guardrails["config_id"] == "with_custom_llm"
 
 
-def test_openai_client_with_empty_state(openai_client):
-    """Test OpenAI client with empty state in guardrails."""
-    response = openai_client.chat.completions.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": "hi"}],
-        stream=False,
-        extra_body={
-            "guardrails": {
-                "config_id": "with_custom_llm",
-                "state": {},
-            }
-        },
-    )
-
-    assert isinstance(response, ChatCompletion)
-    assert response.object == "chat.completion"
-    assert response.model == "gpt-4o"
-    assert response.choices[0].message.content == "Custom LLM response"
-    assert response.guardrails["config_id"] == "with_custom_llm"
+def test_openai_client_rejects_state(openai_client):
+    with pytest.raises(UnprocessableEntityError, match="Caller-supplied state is not accepted over HTTP"):
+        openai_client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            extra_body={
+                "guardrails": {
+                    "config_id": "with_custom_llm",
+                    "state": {},
+                }
+            },
+        )
 
 
 def test_openai_client_with_all_guardrails_fields(openai_client):
@@ -239,7 +234,6 @@ def test_openai_client_with_all_guardrails_fields(openai_client):
                     "rails": {"input": True, "output": True},
                     "log": {"activated_rails": True},
                 },
-                "state": {},
             }
         },
     )

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -158,7 +158,7 @@ def test_generation_response_to_chat_completion():
     assert result.guardrails.llm_output == {"llm_output": "This is an LLM output"}
     assert result.guardrails.output_data == {"output_data": "This is output data"}
     assert result.guardrails.log is not None
-    assert result.guardrails.state == {"state": "This is a state"}
+    assert "state" not in result.guardrails.model_dump()
 
 
 def test_generation_response_to_chat_completion_with_empty_content():

--- a/tests/server/test_server_calls_with_state.py
+++ b/tests/server/test_server_calls_with_state.py
@@ -23,6 +23,7 @@ from nemoguardrails.server import api
 from nemoguardrails.server.datastore.memory_store import MemoryStore
 
 client = TestClient(api.app)
+_UNSET = object()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -47,8 +48,8 @@ def setup_test_env():
         os.environ.pop("MAIN_MODEL_BASE_URL", None)
 
 
-def _chat_payload(config_id, state, stream=False):
-    return {
+def _chat_payload(config_id, state=_UNSET, stream=False):
+    payload = {
         "model": "gpt-4o",
         "stream": stream,
         "messages": [
@@ -59,42 +60,51 @@ def _chat_payload(config_id, state, stream=False):
         ],
         "guardrails": {
             "config_id": config_id,
-            "state": state,
         },
     }
+    if state is not _UNSET:
+        payload["guardrails"]["state"] = state
+    return payload
 
 
-def _test_call(config_id):
+def test_1_x_without_state_runs_without_returning_state():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server")
     response = client.post(
         "/v1/chat/completions",
-        json=_chat_payload(config_id, {}),
+        json=_chat_payload("config_1"),
     )
     assert response.status_code == 200
     res = response.json()
-    print(res)
     assert len(res["choices"][0]["message"]) == 2
     assert res["choices"][0]["message"]["content"] == "Hello!"
-    assert res["guardrails"]["state"]
+    assert "state" not in res["guardrails"]
 
+
+def test_1_x_events_state_rejected_at_server():
+    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server")
     response = client.post(
         "/v1/chat/completions",
-        json=_chat_payload(config_id, res["guardrails"]["state"]),
+        json=_chat_payload(
+            "config_1",
+            {
+                "events": [
+                    {
+                        "type": "ContextUpdate",
+                        "data": {"skip_output_rails": True},
+                    }
+                ]
+            },
+        ),
     )
-    assert response.status_code == 200
-    res = response.json()
-    assert res["choices"][0]["message"]["content"] == "Hello again!"
+    assert response.status_code == 422
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
 
 
-def test_1():
-    api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server")
-    _test_call("config_1")
-
-
-def test_2_x_empty_state_runs_without_returning_state():
+def test_2_x_without_state_runs_without_returning_state():
     api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
     response = client.post(
         "/v1/chat/completions",
-        json=_chat_payload("config_2", {}),
+        json=_chat_payload("config_2"),
     )
 
     assert response.status_code == 200
@@ -104,18 +114,13 @@ def test_2_x_empty_state_runs_without_returning_state():
 
 
 def test_2_x_raw_state_rejected_at_server():
-    """Colang 2.0 stateful continuation over HTTP is no longer supported.
-
-    The serialized 2.0 State carried trusted control-plane fields, so the server
-    rejects any 2.0-shaped state with a 422 instead of forwarding it to the core.
-    """
     api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
     response = client.post(
         "/v1/chat/completions",
         json=_chat_payload("config_2", {"version": "2.x", "state": "{}"}),
     )
     assert response.status_code == 422
-    assert "Colang 2.0" in response.json()["error"]["message"]
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
 
 
 def test_2_x_raw_state_rejected_at_server_streaming():
@@ -126,10 +131,10 @@ def test_2_x_raw_state_rejected_at_server_streaming():
     )
 
     assert response.status_code == 422
-    assert "Colang 2.0" in response.json()["error"]["message"]
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
 
 
-def test_2_x_events_state_rejected_after_config_load():
+def test_2_x_events_state_rejected_at_server():
     api.app.rails_config_path = os.path.join(os.path.dirname(__file__), "..", "test_configs", "simple_server_2_x")
     response = client.post(
         "/v1/chat/completions",
@@ -137,7 +142,7 @@ def test_2_x_events_state_rejected_after_config_load():
     )
 
     assert response.status_code == 422
-    assert "Colang 2.0" in response.json()["error"]["message"]
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
 
 
 def test_2_x_thread_id_rejected_after_config_load():
@@ -171,7 +176,7 @@ def test_invalid_state_shape_rejected_before_model_init():
     )
 
     assert response.status_code == 422
-    assert "events" in response.json()["error"]["message"]
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]
 
 
 def test_invalid_events_state_type_rejected_before_model_init():
@@ -184,4 +189,4 @@ def test_invalid_events_state_type_rejected_before_model_init():
     )
 
     assert response.status_code == 422
-    assert response.json()["error"]["message"] == "Invalid state format: 'events' must be a list."
+    assert "Caller-supplied state is not accepted over HTTP" in response.json()["error"]["message"]

--- a/tests/test_system_message_conversion.py
+++ b/tests/test_system_message_conversion.py
@@ -20,7 +20,8 @@ from tests.utils import FakeLLMModel
 
 
 @pytest.mark.asyncio
-async def test_system_message_conversion_v1():
+@pytest.mark.parametrize("role", ["developer", "system"])
+async def test_system_message_conversion_v1(role):
     """Test that system messages are correctly converted to SystemMessage events in Colang 1.0."""
 
     config = RailsConfig.parse_object(
@@ -40,7 +41,7 @@ async def test_system_message_conversion_v1():
     llm_rails = LLMRails(config=config, llm=llm)
 
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": role, "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello!"},
     ]
 
@@ -52,7 +53,8 @@ async def test_system_message_conversion_v1():
 
 
 @pytest.mark.asyncio
-async def test_system_message_conversion_v2x():
+@pytest.mark.parametrize("role", ["developer", "system"])
+async def test_system_message_conversion_v2x(role):
     """Test that system messages are correctly converted to SystemMessage events in Colang 2.x."""
 
     config = RailsConfig.parse_object(
@@ -72,7 +74,7 @@ async def test_system_message_conversion_v2x():
     llm_rails = LLMRails(config=config, llm=llm)
 
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": role, "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello!"},
     ]
 


### PR DESCRIPTION
## Description

Validate role-specific public Chat Completions messages at the HTTP boundary. Internal event messages and unexpected message fields are rejected before configuration loading or action dispatch; supported OpenAI roles remain accepted, the `developer` role is handled as a system instruction, and unsupported audio requests fail explicitly.

## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: OpenAI Codex).

## Checklist

- [x] I've read the contributing guidelines.
- [x] The title follows the project commit convention.
- [x] Tests cover the reported event message and supported public roles.
- [x] No generated changelog files were edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both `developer` and `system` messages in Colang system-message conversion.
  * Expanded OpenAI-compatible chat message support, including multimodal content, tool calls, refusals, context messages, and function messages.

* **Bug Fixes**
  * Invalid chat requests are now rejected with clear validation errors, including unsupported audio options, missing content, and unexpected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->