### PR TITLE
fix(server): Return reasoning in /v1/chat/completion responses

### DIFF
--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -196,12 +196,16 @@ Admission control through an `AsyncWorkQueue` (and a separate semaphore for stre
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
 | Reasoning trace handling (`<think>` tags or reasoning field) | ✓ | ✓ | |
-| `reasoning_content` in a structured response | ✓ | ✗ | Requires `GenerationResponse` |
+| `reasoning_content` in a structured response | ✓ | ✓ | Requires `GenerationResponse` |
+| `reasoning_content` over HTTP | ✓ | ✓ | Non-streaming only |
 
 Both engines preserve model reasoning traces, whether the model returns them in a dedicated reasoning field or inline within `<think>` tags, and both keep reasoning out of the prompt history sent back to the model.
 
-`LLMRails` can expose reasoning in the structured response through `reasoning_content`.
-Because `IORails` returns a message dictionary rather than a `GenerationResponse`, the structured `reasoning_content` field is an `LLMRails` capability.
+Both engines expose reasoning through `GenerationResponse.reasoning_content` when `generate_async` is called with `options`, and inline it into the message content as a `<think>` prefix when it is called without them.
+
+Neither engine returns reasoning that output rails have blocked or rewritten.
+Reasoning does not pass through output rails, so once a rail changes the response the trace no longer describes what the caller receives -- and after a redaction rail it would still contain the text the rail removed.
+In both cases the reasoning is dropped and only the rail-approved content is returned.
 
 ### Multimodal
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -147,18 +147,21 @@ Tool calls are returned in the OpenAI-style `tool_calls` field of the response m
 | `generate` / `generate_async` | ✓ | ✓ | |
 | `stream_async` | ✓ | ✓ | |
 | Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
-| `check` / `check_async` (rails-only validation) | ✓ | ✗ | LLMRails only |
-| `GenerationOptions` | ✓ | ◐ | IORails uses `llm_params` and rail toggles; no `log` or `output_data` |
-| `GenerationResponse` (structured response object) | ✓ | ✗ | IORails returns an OpenAI-style message dict |
+| `check` / `check_async` (rails-only validation) | ✓ | ✓ | |
+| `GenerationOptions` | ✓ | ◐ | IORails supports `llm_params`, rail toggles, and `log.activated_rails` / `log.llm_calls`; no `output_vars` or `output_data` |
+| `GenerationResponse` (structured response object) | ✓ | ✓ | Returned by both when `options` are supplied |
 | `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
 
 Both engines expose `generate`, `generate_async`, and `stream_async`.
-`LLMRails` can return a rich `GenerationResponse` and processes the full `GenerationOptions` object, including rail toggles, `llm_params`, logging options, and `output_data`.
-It also exposes the event-based API (`generate_events` and `process_events`), the rails-only validation methods (`check` and `check_async`), and `explain()` for debugging.
+Both engines return the same two shapes: a `GenerationResponse` when `generate_async` is called with `options`, and an OpenAI-style message dictionary with `role`, `content`, and optional `tool_calls` when it is called without them.
+Both also provide the rails-only validation methods, `check` and `check_async`.
 
-`IORails` returns an OpenAI-style message dictionary with `role`, `content`, and optional `tool_calls`, rather than a `GenerationResponse`.
-It accepts `GenerationOptions` but uses only `llm_params` and rail toggles.
-The event-based API, `check` and `check_async`, and `explain()` are not available; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
+`LLMRails` processes the full `GenerationOptions` object, including rail toggles, `llm_params`, logging options, `output_vars`, and `output_data`.
+It also exposes the event-based API (`generate_events` and `process_events`) and `explain()` for debugging.
+
+`IORails` accepts `GenerationOptions` but supports a subset: `llm_params`, rail toggles, and the `log.activated_rails` / `log.llm_calls` logging options.
+Requesting `output_vars` raises `ValueError`, and `log.internal_events` or `log.colang_history` raise `NotImplementedError`, because both are Colang-runtime concerns.
+The event-based API and `explain()` are not available; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
 
 ### Streaming
 

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.mdx
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.mdx
@@ -70,6 +70,44 @@ The `guardrails` response object may include additional fields depending on your
 - **`output_data`** — Values for requested context variables (when `guardrails.options.output_vars` is set).
 - **`log`** — Logging information (when `guardrails.options.log` is configured).
 
+## Reasoning Models
+
+When the configured model is a reasoning model, the reasoning it produces before its answer is returned in `reasoning_content` on the response message, alongside the answer in `content`.
+This matches the field NIM, vLLM, and DeepSeek-style endpoints already return, so putting guardrails in front of a reasoning model does not change the response shape your client parses.
+
+```json
+{
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The capital of France is Paris.",
+        "reasoning_content": "The user is asking for a capital city. France's capital is Paris."
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+```
+
+The answer in `content` is always clean.
+Reasoning is never merged into it, whether the model returned reasoning in a dedicated field or inline within `<think>` tags, so clients that only read `content` need no changes.
+
+The `reasoning_content` field is omitted entirely, rather than returned as `null`, in three cases:
+
+- The model is not a reasoning model, or returned no reasoning for this request.
+- An output rail blocked the response. The reasoning describes the answer the rail rejected, so it is not returned with the refusal.
+- An output rail rewrote the response, for example a rail that masks personally identifiable information. The reasoning describes the answer the model generated rather than the redacted one, and would otherwise still contain the text the rail removed.
+
+<Note>
+Reasoning is not evaluated by output rails.
+It is dropped whenever a rail changes the response, so only rail-approved content reaches the caller.
+</Note>
+
+Streaming responses do not currently carry reasoning.
+When `stream` is `true`, the server emits content deltas only.
+
 ## Using the OpenAI Python SDK
 
 Since the server is OpenAI-compatible, you can use the [OpenAI Python SDK](https://github.com/openai/openai-python) to interact with it.

--- a/fern/openapi.yml
+++ b/fern/openapi.yml
@@ -82,6 +82,7 @@ paths:
                         message:
                           role: assistant
                           content: Paris is the capital of France.
+                          reasoning_content: The user asked for the capital of France, which is Paris.
                         finish_reason: stop
                     guardrails:
                       config_id: content_safety
@@ -469,13 +470,27 @@ components:
             $ref: "#/components/schemas/ChatCompletionChoice"
         guardrails:
           $ref: "#/components/schemas/GuardrailsResponseData"
+    ChatCompletionResponseMessage:
+      allOf:
+        - $ref: "#/components/schemas/ChatMessage"
+        - type: object
+          properties:
+            reasoning_content:
+              type: string
+              description: >-
+                Reasoning the model produced before its answer, present only for reasoning
+                models. Omitted when the model returns no reasoning, and omitted when an
+                output rail blocked or rewrote the response, because the reasoning describes
+                the answer the model generated rather than the one being returned. Response
+                only; sending this field on a request has no effect.
+              example: The user asked for the capital of France, which is Paris.
     ChatCompletionChoice:
       type: object
       properties:
         index:
           type: integer
         message:
-          $ref: "#/components/schemas/ChatMessage"
+          $ref: "#/components/schemas/ChatCompletionResponseMessage"
         finish_reason:
           type: string
           nullable: true

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -539,6 +539,18 @@ def extract_bot_thinking_from_events(events: list):
             return event.get("content")
 
 
+def extract_generated_bot_message_from_events(events: list):
+    """The message the model generated, before output rails saw it.
+
+    Emitted alongside ``BotThinking`` by the generation action, so the first of each pairs
+    up: they describe the same model call. A blocked turn generates a second pair for the
+    refusal, which is why this stops at the first match rather than the last.
+    """
+    for event in events:
+        if event.get("type") == "BotMessage":
+            return event.get("text")
+
+
 def get_and_clear_response_metadata_contextvar() -> Optional[dict]:
     """Get the current response metadata and clear it from the context.
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -1086,6 +1086,10 @@ class IORails(BaseGuardrails):
             if rewritten is not None:
                 log.info("[%s] Output rails rewrote the response", req_id)
                 response_text = rewritten
+                # The reasoning describes the answer the model produced, not the rewritten
+                # one, and on a redaction rail it still contains what the rail just removed.
+                # A block drops it the same way, by returning through _finalize_refusal.
+                reasoning_content = None
 
         if has_generation_options:
             log_obj = _build_generation_log(records, options, time.monotonic() - t_start)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -45,6 +45,7 @@ from typing_extensions import Self
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
 from nemoguardrails.actions.llm.utils import (
     extract_bot_thinking_from_events,
+    extract_generated_bot_message_from_events,
     extract_tool_calls_from_events,
     get_and_clear_response_metadata_contextvar,
     get_colang_history,
@@ -1205,6 +1206,13 @@ class LLMRails(BaseGuardrails):
         tool_calls = extract_tool_calls_from_events(new_events)
         llm_metadata = get_and_clear_response_metadata_contextvar()
         reasoning_content = extract_bot_thinking_from_events(new_events)
+        # Reasoning describes the answer the model produced, and it never passes through
+        # output rails. Once a rail has blocked or rewritten the response, the content being
+        # returned is no longer that answer -- and on a redaction rail the trace still holds
+        # what the rail just removed -- so the trace must not ship with it.
+        if reasoning_content and extract_generated_bot_message_from_events(new_events) != new_message["content"]:
+            reasoning_content = None
+
         # If we have generation options, we prepare a GenerationResponse instance.
         if gen_options:
             # If a prompt was used, we only need to return the content of the message.

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -233,16 +233,21 @@ def resolve_tool_calls(bot_message: dict, response_tool_calls: Optional[list] = 
 def build_chat_completion_message(
     bot_message: dict,
     tool_calls: Optional[List[dict]] = None,
+    reasoning_content: Optional[str] = None,
 ) -> ChatCompletionMessage:
     """Build an OpenAI ChatCompletionMessage from an internal bot message dict."""
     content = bot_message.get("content")
     if content == "" and tool_calls:
         content = None
 
+    # Only pass the key when there is reasoning to report.
+    extra: Dict[str, Any] = {"reasoning_content": reasoning_content} if reasoning_content else {}
+
     if not tool_calls:
         return ChatCompletionMessage(
             role="assistant",
             content=content,
+            **extra,
         )
 
     openai_tool_calls = normalize_tool_calls_openai(tool_calls)
@@ -251,6 +256,7 @@ def build_chat_completion_message(
         role="assistant",
         content=content,
         tool_calls=cast(Any, openai_tool_calls),
+        **extra,
     )
 
 
@@ -360,7 +366,7 @@ def generation_response_to_chat_completion(
         choices=[
             Choice(
                 index=0,
-                message=build_chat_completion_message(bot_message, tool_calls),
+                message=build_chat_completion_message(bot_message, tool_calls, response.reasoning_content),
                 finish_reason=finish_reason,
                 logprobs=None,
             )

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -240,7 +240,9 @@ def build_chat_completion_message(
     if content == "" and tool_calls:
         content = None
 
-    # Only pass the key when there is reasoning to report.
+    # Passing reasoning_content=None would add a real None entry to the message's extras,
+    # which changes message equality and puts the key on the wire for callers that do not
+    # exclude nulls. Omitting the key is not the same as sending it empty.
     extra: Dict[str, Any] = {"reasoning_content": reasoning_content} if reasoning_content else {}
 
     if not tool_calls:

--- a/tests/guardrails/test_iorails_generation_response.py
+++ b/tests/guardrails/test_iorails_generation_response.py
@@ -31,6 +31,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 
+from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails, _response_content_for_capture
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -418,3 +419,49 @@ class TestResponseContentForCapture:
     def test_capture_content(self, result, expected):
         """Assistant content is pulled from structured list/str responses and from the bare-dict path; non-str/absent content yields None."""
         assert _response_content_for_capture(result) == expected
+
+
+class TestReasoningDroppedWhenOutputRailsChangeTheAnswer:
+    """Reasoning ships only when the returned content is still the model's own answer.
+
+    Reasoning bypasses output rails by design, so once a rail blocks or rewrites the
+    response the trace no longer describes what the caller receives -- and on a redaction
+    rail it still contains the very text the rail removed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rewritten_response_drops_reasoning(self, iorails):
+        """An output rail that rewrites the answer clears reasoning_content."""
+        _stub_safe_rails(iorails)
+        iorails.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(RailOutcome.transform([(TransformTarget.BOT_MESSAGE, "Call me at [PHONE]")]))
+        )
+        _stub_model(iorails, LLMResponse(content="Call me at 555-0100", reasoning="the number is 555-0100"))
+
+        result = await iorails.generate_async(messages=_USER, options=GenerationOptions())
+
+        assert result.response == [{"role": "assistant", "content": "Call me at [PHONE]"}]
+        assert result.reasoning_content is None
+
+    @pytest.mark.asyncio
+    async def test_blocked_response_drops_reasoning(self, iorails):
+        """An output rail that blocks returns the refusal with no reasoning attached."""
+        _stub_safe_rails(iorails)
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult.block(reason="unsafe"))
+        _stub_model(iorails, LLMResponse(content="unsafe answer", reasoning="the unsafe thinking"))
+
+        result = await iorails.generate_async(messages=_USER, options=GenerationOptions())
+
+        assert result.response == [{"role": "assistant", "content": REFUSAL_MESSAGE}]
+        assert result.reasoning_content is None
+
+    @pytest.mark.asyncio
+    async def test_untouched_response_keeps_reasoning(self, iorails):
+        """Output rails that run and leave the answer alone keep reasoning_content."""
+        _stub_safe_rails(iorails)
+        _stub_model(iorails, LLMResponse(content="Hello", reasoning="thinking step"))
+
+        result = await iorails.generate_async(messages=_USER, options=GenerationOptions())
+
+        assert result.response == [{"role": "assistant", "content": "Hello"}]
+        assert result.reasoning_content == "thinking step"

--- a/tests/server/test_reasoning_content_e2e.py
+++ b/tests/server/test_reasoning_content_e2e.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A reasoning model's reasoning must survive the trip through the HTTP server, on either engine.
+
+One mocked model reply carrying both content and reasoning is driven through the real ASGI
+app twice, once per engine, and every assertion is on the JSON the client receives. The
+engines reach the same wire shape by unrelated routes -- LLMRails via ``BotThinking`` events,
+IORails via ``LLMResponse.reasoning`` -- so the equivalence cases pin agreement that nothing
+else in the codebase enforces.
+
+The mock sits at each engine's model boundary rather than at the transport, because the two
+engines do not share an HTTP client: LLMRails calls through ``httpx`` and IORails through
+``aiohttp``, so no single transport-level mock covers both.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
+from fastapi.testclient import TestClient
+
+from nemoguardrails import Guardrails, RailsConfig
+from nemoguardrails.rails import LLMRails
+from nemoguardrails.server import api
+from nemoguardrails.types import LLMResponse
+from tests.guardrails.async_helpers import mock_rail_model
+from tests.utils import FakeLLMModel
+
+# A single main model and no rails: the narrowest config both engines accept, so any
+# difference in the response is attributable to reasoning handling alone.
+SINGLE_MODEL_CONFIG = """
+models:
+  - type: main
+    engine: openai
+    model: test-model
+"""
+
+CONTENT = "Hello! I'm doing well, thanks."
+REASONING = "The user greeted me, so a short warm reply is enough."
+
+# The same reply expressed the two ways a reasoning model can deliver it: a provider-native
+# reasoning field, and inline <think> tags the engines must strip out of the content.
+NATIVE_REASONING = LLMResponse(content=CONTENT, reasoning=REASONING)
+INLINE_THINK_TAGS = LLMResponse(content=f"<think>{REASONING}</think>{CONTENT}")
+NO_REASONING = LLMResponse(content=CONTENT)
+
+ENGINES = ["llmrails", "iorails"]
+
+
+def _build_rails(engine: str, llm_response: LLMResponse):
+    """Build one engine wired to a model that always returns *llm_response*."""
+    config = RailsConfig.from_content(yaml_content=SINGLE_MODEL_CONFIG)
+    if engine == "llmrails":
+        return LLMRails(config, llm=FakeLLMModel(llm_responses=[llm_response]))
+
+    # IORails rejects an `llm` argument outright (`IORails.unsupported_reason`), so the double
+    # goes on the engine registry instead. `require_iorails` keeps a silent fallback to
+    # LLMRails from turning the IORails half of these tests into a second LLMRails run.
+    guardrails = Guardrails(config, use_iorails=True, require_iorails=True)
+    mock_rail_model(guardrails.rails_engine.engine_registry, AsyncMock(return_value=llm_response))
+    return guardrails
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    """Clear the per-config rails caches and force multi-config mode around each test."""
+    original_single_config_mode = api.app.single_config_mode
+    api.app.single_config_mode = False
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    yield
+    api.llm_rails_instances.clear()
+    api.llm_rails_events_history_cache.clear()
+    api.app.single_config_mode = original_single_config_mode
+
+
+@pytest.fixture(autouse=True)
+def provider_api_keys(monkeypatch):
+    """Satisfy config-time credential lookup without reaching a provider."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+
+
+@pytest.fixture
+def assistant_message(monkeypatch):
+    """Return a callable that POSTs one chat completion on the named engine and yields choices[0].message."""
+    started = []
+
+    def _post(engine: str, llm_response: LLMResponse) -> dict:
+        rails = _build_rails(engine, llm_response)
+        started.append(rails)
+        monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
+        client = TestClient(api.app, raise_server_exceptions=False)
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "stream": False,
+                "messages": [{"role": "user", "content": "Hello! How are you"}],
+                "guardrails": {"config_id": "reasoning"},
+            },
+        )
+        assert response.status_code == 200, response.text
+        return response.json()["choices"][0]["message"]
+
+    yield _post
+
+    # IORails starts a worker queue on first generate; stop it so no asyncio tasks outlive the test.
+    for rails in started:
+        if isinstance(rails, Guardrails):
+            asyncio.run(rails.shutdown())
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_native_reasoning_reaches_the_client(engine, assistant_message):
+    """A provider-native reasoning field is delivered as message.reasoning_content."""
+    message = assistant_message(engine, NATIVE_REASONING)
+    assert message.get("reasoning_content") == REASONING
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_inline_think_tags_reach_the_client(engine, assistant_message):
+    """Reasoning arriving as inline <think> tags is delivered as message.reasoning_content."""
+    message = assistant_message(engine, INLINE_THINK_TAGS)
+    assert message.get("reasoning_content") == REASONING
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("llm_response", [NATIVE_REASONING, INLINE_THINK_TAGS], ids=["native", "inline"])
+def test_reasoning_is_not_merged_into_content(engine, llm_response, assistant_message):
+    """The answer is returned clean: reasoning rides in its own field, never inside content."""
+    message = assistant_message(engine, llm_response)
+    assert message["content"] == CONTENT
+    assert "<think>" not in message["content"]
+    assert REASONING not in message["content"]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_no_reasoning_omits_the_field(engine, assistant_message):
+    """A model that returns no reasoning produces no reasoning_content key at all."""
+    message = assistant_message(engine, NO_REASONING)
+    assert "reasoning_content" not in message
+
+
+@pytest.mark.parametrize(
+    "llm_response",
+    [NATIVE_REASONING, INLINE_THINK_TAGS, NO_REASONING],
+    ids=["native", "inline", "none"],
+)
+def test_engines_return_identical_messages(llm_response, assistant_message):
+    """Both engines put the same model reply on the wire, so neither can drift from the other."""
+    assert assistant_message("llmrails", llm_response) == assistant_message("iorails", llm_response)

--- a/tests/server/test_reasoning_content_e2e.py
+++ b/tests/server/test_reasoning_content_e2e.py
@@ -26,13 +26,13 @@ engines do not share an HTTP client: LLMRails calls through ``httpx`` and IORail
 ``aiohttp``, so no single transport-level mock covers both.
 """
 
-import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+import pytest_asyncio
 
 pytest.importorskip("openai", reason="openai is required for server tests")
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
 from nemoguardrails import Guardrails, RailsConfig
 from nemoguardrails.rails import LLMRails
@@ -96,72 +96,84 @@ def provider_api_keys(monkeypatch):
     monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
 
 
-@pytest.fixture
-def assistant_message(monkeypatch):
-    """Return a callable that POSTs one chat completion on the named engine and yields choices[0].message."""
+@pytest_asyncio.fixture
+async def assistant_message():
+    """Return a coroutine that POSTs one chat completion on the named engine and yields choices[0].message.
+
+    The app is driven in-process on the running event loop rather than through ``TestClient``,
+    which would run it in a portal loop of its own. IORails starts a worker queue and provider
+    sessions on first generate, and those must be stopped from the loop that created them --
+    a portal loop is already closed by teardown, so stopping from there raises
+    ``RuntimeError: Event loop is closed``.
+    """
     started = []
 
-    def _post(engine: str, llm_response: LLMResponse) -> dict:
+    async def _post(engine: str, llm_response: LLMResponse) -> dict:
         rails = _build_rails(engine, llm_response)
         started.append(rails)
-        monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
-        client = TestClient(api.app, raise_server_exceptions=False)
-        response = client.post(
-            "/v1/chat/completions",
-            json={
-                "model": "test-model",
-                "stream": False,
-                "messages": [{"role": "user", "content": "Hello! How are you"}],
-                "guardrails": {"config_id": "reasoning"},
-            },
-        )
+        with patch.object(api, "_get_rails", AsyncMock(return_value=rails)):
+            transport = ASGITransport(app=api.app, raise_app_exceptions=False)
+            async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+                response = await client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test-model",
+                        "stream": False,
+                        "messages": [{"role": "user", "content": "Hello! How are you"}],
+                        "guardrails": {"config_id": "reasoning"},
+                    },
+                )
         assert response.status_code == 200, response.text
         return response.json()["choices"][0]["message"]
 
     yield _post
 
-    # IORails starts a worker queue on first generate; stop it so no asyncio tasks outlive the test.
     for rails in started:
         if isinstance(rails, Guardrails):
-            asyncio.run(rails.shutdown())
+            await rails.shutdown()
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("engine", ENGINES)
-def test_native_reasoning_reaches_the_client(engine, assistant_message):
+async def test_native_reasoning_reaches_the_client(engine, assistant_message):
     """A provider-native reasoning field is delivered as message.reasoning_content."""
-    message = assistant_message(engine, NATIVE_REASONING)
+    message = await assistant_message(engine, NATIVE_REASONING)
     assert message.get("reasoning_content") == REASONING
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("engine", ENGINES)
-def test_inline_think_tags_reach_the_client(engine, assistant_message):
+async def test_inline_think_tags_reach_the_client(engine, assistant_message):
     """Reasoning arriving as inline <think> tags is delivered as message.reasoning_content."""
-    message = assistant_message(engine, INLINE_THINK_TAGS)
+    message = await assistant_message(engine, INLINE_THINK_TAGS)
     assert message.get("reasoning_content") == REASONING
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("llm_response", [NATIVE_REASONING, INLINE_THINK_TAGS], ids=["native", "inline"])
-def test_reasoning_is_not_merged_into_content(engine, llm_response, assistant_message):
+async def test_reasoning_is_not_merged_into_content(engine, llm_response, assistant_message):
     """The answer is returned clean: reasoning rides in its own field, never inside content."""
-    message = assistant_message(engine, llm_response)
+    message = await assistant_message(engine, llm_response)
     assert message["content"] == CONTENT
     assert "<think>" not in message["content"]
     assert REASONING not in message["content"]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("engine", ENGINES)
-def test_no_reasoning_omits_the_field(engine, assistant_message):
+async def test_no_reasoning_omits_the_field(engine, assistant_message):
     """A model that returns no reasoning produces no reasoning_content key at all."""
-    message = assistant_message(engine, NO_REASONING)
+    message = await assistant_message(engine, NO_REASONING)
     assert "reasoning_content" not in message
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "llm_response",
     [NATIVE_REASONING, INLINE_THINK_TAGS, NO_REASONING],
     ids=["native", "inline", "none"],
 )
-def test_engines_return_identical_messages(llm_response, assistant_message):
+async def test_engines_return_identical_messages(llm_response, assistant_message):
     """Both engines put the same model reply on the wire, so neither can drift from the other."""
-    assert assistant_message("llmrails", llm_response) == assistant_message("iorails", llm_response)
+    assert await assistant_message("llmrails", llm_response) == await assistant_message("iorails", llm_response)

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -256,6 +256,88 @@ def test_bot_message_to_chat_completion():
     assert result.guardrails.config_id == "cfg"
 
 
+# Reasoning a model emits for a greeting; long enough that an accidental
+# substring match against the answer would not pass.
+REASONING = "The user greeted me, so a short warm reply is enough."
+
+
+def test_generation_response_carries_reasoning_content():
+    """Reasoning on the GenerationResponse reaches choices[0].message.reasoning_content."""
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": "Hello! I'm doing well, thanks."}],
+        reasoning_content=REASONING,
+    )
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    message = result.choices[0].message
+    assert getattr(message, "reasoning_content", None) == REASONING
+
+
+def test_generation_response_reasoning_leaves_content_clean():
+    """Reasoning is delivered in its own field and never merged back into content."""
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": "Hello! I'm doing well, thanks."}],
+        reasoning_content=REASONING,
+    )
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    content = result.choices[0].message.content
+    assert content == "Hello! I'm doing well, thanks."
+    assert "<think>" not in content
+    assert REASONING not in content
+
+
+def test_generation_response_without_reasoning_omits_the_field():
+    """A non-reasoning model produces no reasoning_content key at all, rather than a null one."""
+    response = GenerationResponse(response=[{"role": "assistant", "content": "Hello"}])
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    assert "reasoning_content" not in result.choices[0].message.model_dump()
+
+
+def test_generation_response_empty_reasoning_omits_the_field():
+    """An empty reasoning string is normalized away instead of serializing as ""."""
+    response = GenerationResponse(response=[{"role": "assistant", "content": "Hello"}], reasoning_content="")
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    assert "reasoning_content" not in result.choices[0].message.model_dump()
+
+
+def test_generation_response_reasoning_survives_serialization():
+    """The extra field survives the response_model round-trip FastAPI applies before sending."""
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": "Hello"}],
+        reasoning_content=REASONING,
+    )
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    served = GuardrailsChatCompletion.model_validate(result.model_dump()).model_dump(exclude_none=True)
+    assert served["choices"][0]["message"]["reasoning_content"] == REASONING
+
+
+def test_generation_response_carries_reasoning_alongside_tool_calls():
+    """Reasoning and tool calls are delivered together rather than one displacing the other."""
+    tool_calls = [
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": {"city": "Boston"}},
+        }
+    ]
+    response = GenerationResponse(
+        response=[{"role": "assistant", "content": ""}],
+        tool_calls=tool_calls,
+        reasoning_content=REASONING,
+    )
+    result = generation_response_to_chat_completion(response=response, model="test_model")
+    message = result.choices[0].message
+    assert getattr(message, "reasoning_content", None) == REASONING
+    assert message.tool_calls[0].function.name == "get_weather"
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_bot_message_to_chat_completion_omits_reasoning():
+    """The bare-dict path carries reasoning inline in content, so it emits no reasoning_content key."""
+    bot_message = {"role": "assistant", "content": f"<think>{REASONING}</think>\nHello"}
+    result = bot_message_to_chat_completion(bot_message, model="gpt-4o")
+    assert "reasoning_content" not in result.choices[0].message.model_dump()
+
+
 # ===== Tests for create_error_chat_completion =====
 
 

--- a/tests/test_bot_thinking_events.py
+++ b/tests/test_bot_thinking_events.py
@@ -217,6 +217,7 @@ async def test_bot_thinking_none_when_no_reasoning():
 
 @pytest.mark.asyncio
 async def test_bot_thinking_usable_in_output_rail_logic():
+    """An output rail can branch on $bot_thinking; blocking on it keeps the trace off the response."""
     test_reasoning_trace = "This contains sensitive information"
 
     with patch(REASONING_TRACE_MOCK_PATH) as mock_get_reasoning:
@@ -247,9 +248,11 @@ async def test_bot_thinking_usable_in_output_rail_logic():
         )
 
         assert isinstance(result.response, list)
-        assert result.reasoning_content == test_reasoning_trace
+        # The rail fired, which is what proves $bot_thinking was readable inside rail logic.
         assert result.response[0]["content"] == "I'm sorry, I can't respond to that."
         assert test_reasoning_trace not in result.response[0]["content"]
+        # Reasoning the rail blocked on must not come back in the field either.
+        assert result.reasoning_content is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1613,3 +1613,54 @@ def test_load_library_sorts_files_for_deterministic_overrides(tmp_path, monkeypa
     rails = LLMRails(config, llm=FakeLLMModel(responses=["unused"]))
 
     assert rails.config.bot_messages["test det msg"] == ["from_a"]
+
+
+# Output rails that block, that rewrite, and that leave the answer alone. Reasoning ships
+# only in the last case: once a rail changes the response the trace no longer describes what
+# the caller receives, and on a redaction rail it still names what the rail removed.
+_OUTPUT_RAIL_CONFIG = "models: []\npassthrough: true\nrails:\n  output:\n    flows:\n      - myrail\n"
+
+_BLOCKING_RAIL = 'define flow myrail\n  if "SECRET" in $bot_message\n    bot refuse to respond\n    stop\n'
+_REWRITING_RAIL = 'define flow myrail\n  $bot_message = "Call me at [PHONE]"\n'
+_INERT_RAIL = "define flow myrail\n  $unused = 1\n"
+
+
+async def _generate_with_output_rail(colang_content: str, reasoning_trace: str, answer: str):
+    """Run one turn whose model emits *reasoning_trace*, through a config carrying one output rail."""
+    with patch(REASONING_TRACE_MOCK_PATH) as mock_get_reasoning:
+        mock_get_reasoning.return_value = reasoning_trace
+
+        config = RailsConfig.from_content(colang_content=colang_content, yaml_content=_OUTPUT_RAIL_CONFIG)
+        llm_rails = LLMRails(config=config, llm=FakeLLMModel(responses=[answer]))
+
+        return await llm_rails.generate_async(
+            messages=[{"role": "user", "content": "hi"}],
+            options=GenerationOptions(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_async_blocked_response_drops_reasoning():
+    """An output rail that blocks returns the refusal with no reasoning attached."""
+    result = await _generate_with_output_rail(_BLOCKING_RAIL, "the SECRET is 42", "SECRET answer")
+
+    assert result.response[0]["content"] == "I'm sorry, I can't respond to that."
+    assert result.reasoning_content is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_rewritten_response_drops_reasoning():
+    """An output rail that rewrites the answer clears reasoning_content."""
+    result = await _generate_with_output_rail(_REWRITING_RAIL, "the number is 555-0100", "Call me at 555-0100")
+
+    assert result.response[0]["content"] == "Call me at [PHONE]"
+    assert result.reasoning_content is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_untouched_response_keeps_reasoning():
+    """Output rails that run and leave the answer alone keep reasoning_content."""
+    result = await _generate_with_output_rail(_INERT_RAIL, "a harmless trace", "The answer is 42")
+
+    assert result.response[0]["content"] == "The answer is 42"
+    assert result.reasoning_content == "a harmless trace"


### PR DESCRIPTION
## Description

This PR adds`reasoning_content` to the `build_chat_completion_message` used to create  ChatCompletionsMessage. This is the response data type for /v1/chat/completions. Prior to this change, neither LLMRails nor IORails would pass reasoning content as a separate field in the struct. 

## Related Issue(s)

* https://jirasw.nvidia.com/browse/NGUARD-881
* https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6538672

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
```


### Integration test with Server (Before this PR)

#### LLMRails

**Server**
```
$ MAIN_MODEL_ENGINE=nim \
MAIN_MODEL_BASE_URL=https://integrate.api.nvidia.com/v1 \
  uv run nemoguardrails server --config ~/utils/configs \
 --default-config-id content_safety
```

**Client**
```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
          "stream": false,
          "max_completion_tokens": 55

  }' | jq

{
  "id": "chatcmpl-bebab371-f0bf-4fec-b4c9-382d4a280ea9",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! I'm doing well, thank you for asking! While I don't have feelings or a personal state, I'm fully operational and ready to help. I can dive into all sorts of topics—answer questions, brainstorm ideas, help with writing or coding, chat about hobbies or current events, or just keep you company. I'm designed to pick up on context and keep things detailed and engaging, so feel free to lead the conversation wherever you'd like!\n\nHow are you doing today? Is there something specific on your mind, or were you just checking in?",
        "role": "assistant"
      }
    }
  ],
  "created": 1787174716,
  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
  "object": "chat.completion",
  "guardrails": {
    "config_id": "nemoguards"
  }
}

```

#### IORails (before the PR)

**Server**
```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 \
MAIN_MODEL_ENGINE=nim \
MAIN_MODEL_BASE_URL=https://integrate.api.nvidia.com/v1 \
 uv run nemoguardrails server --config ~/utils/configs --default-config-id content_safety
```

**Client**
```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
          "stream": false,
          "max_completion_tokens": 55

  }' | jq

{
  "id": "chatcmpl-d8428f1d-a81a-47da-a011-a8e39a3160bd",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! I'm doing well, thank you for asking. How can I help you today?",
        "role": "assistant"
      }
    }
  ],
  "created": 1787174872,
  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
  "object": "chat.completion",
  "guardrails": {
    "config_id": "nemoguards"
  }
}
```


#### LLMRails (after the PR)

**Client** (Server is the same as above). Notice the reasoning content is now returned by the nvidia/nemotron-3.5-lightning-30b-a3b model as well as the content field.

```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
          "stream": false,
          "max_completion_tokens": 55

  }' | jq


{
  "id": "chatcmpl-2271136a-9ee5-4996-a872-ca61952eb9e9",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! I'm doing well, thank you for asking! As an AI, I don't have feelings or a physical state, but I'm fully operational, fully trained, and ready to dive into whatever you'd like to explore. I can chat about anything from the latest scientific discoveries and historical events to creative writing, coding puzzles, travel tips, or just friendly banter. \n\nHow are you doing today? Is there something specific on your mind, or were you just looking to start a conversation? I'm all ears—and I love a good deep-dive into any topic you're curious about!",
        "role": "assistant",
        "reasoning_content": "Here's a thinking process:\n\n1.  **Analyze User Input:** User said \"Hello! How are you\"\n2.  **Identify Intent:** Greeting + inquiry about well-being\n3.  **Determine Response Tone/Style:** Talkative, provides specific details, human-like, but as an AI I should be appropriate\n4.  **Formulate Response:** \n   - Acknowledge greeting\n   - Respond to \"How are you\" in an AI-appropriate way (I don't have feelings, but I can say I'm functioning well/ready to help)\n   - Keep it engaging, maybe ask how I can help\n   - Match the \"talkative and provides lots of specific details\" trait from the system prompt, but naturally\n5.  **Draft Response:** \n   \"Hello! I'm doing well, thank you for asking! As an AI, I don't have feelings, but I'm fully operational and ready to help with any questions or tasks you have. I can chat about a wide range of topics, from science and history to creative writing or coding. How are you doing today? Is there something specific you'd like to talk about or work on?\"\n6.  **Check Against Constraints:** \n   - Truthfully says if I don't know? N/A here\n   - Talkative/provides details? Yes, touches on capabilities\n   - Human-like text? Yes\n   - Greeting responded to? Yes\n   All good. Output matches.✅\n"
      }
    }
  ],
  "created": 1787190610,
  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
  "object": "chat.completion",
  "guardrails": {
    "config_id": "content_safety"
  }
}

```

#### IORails (after the PR)

**Client** (Server is the same as above). Notice the reasoning content is now returned by the nvidia/nemotron-3.5-lightning-30b-a3b model as well as the content field.

```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello! How are you"
            }
          ],
          "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
          "stream": false,
          "max_completion_tokens": 55

  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1361  100  1058  100   303    353    101  0:00:03  0:00:02  0:00:01   455
{
  "id": "chatcmpl-e7109f41-4f46-4c55-b537-8ccf1cba4344",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! I'm doing well, thank you for asking. How can I help you today?",
        "role": "assistant",
        "reasoning_content": "Here's a thinking process:\n\n1.  **Analyze User Input:** User said \"Hello! How are you\"\n2.  **Identify Intent:** Greeting, conversational opener\n3.  **Determine Appropriate Response:** Standard polite greeting, respond to \"How are you\", optionally ask back\n4.  **Formulate Response:** \n   - Acknowledge greeting\n   - State \"I'm doing well\" or similar (as an AI)\n   - Return the question\n   - Keep it friendly and concise\n5.  **Check Constraints:** No specific constraints given. Just a normal chat interaction.\n6.  **Generate Output:** \"Hello! I'm doing well, thank you for asking. How can I help you today?\" or similar. I'll keep it natural and open-ended.✅\n"
      }
    }
  ],
  "created": 1787190755,
  "model": "nvidia/nemotron-3.5-lightning-30b-a3b",
  "object": "chat.completion",
  "guardrails": {
    "config_id": "content_safety"
  }
}
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat completion responses now support optional structured `reasoning_content` for assistant messages, including responses with tool calls.
  * Reasoning remains separate from the assistant’s answer text and is omitted when unavailable.
  * Support is available across both supported rails engines and non-streaming HTTP responses.

* **Bug Fixes**
  * Reasoning is no longer exposed when output controls block, rewrite, or redact the final response.

* **Documentation**
  * Added guidance and examples covering reasoning responses, availability, filtering, and current streaming limitations.

* **Tests**
  * Expanded coverage for API serialization, engine behavior, tool calls, and output-control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->