### PR TITLE
fix(server): Inline think-tags when reasoning content present

### DIFF
--- a/nemoguardrails/llm/call.py
+++ b/nemoguardrails/llm/call.py
@@ -454,6 +454,13 @@ def _extract_and_remove_think_tags(response: LLMResponse) -> Optional[str]:
     return None
 
 
+def _prepend_think_tags(content: str, reasoning_content: Optional[str]) -> str:
+    """Re-attach `reasoning_content` to `content` as a leading <think> block, the inverse of `_extract_and_remove_think_tags`."""
+    if not reasoning_content:
+        return content
+    return f"<think>{reasoning_content}</think>\n{content}"
+
+
 def _store_tool_calls(response: LLMResponse) -> None:
     if response.tool_calls:
         tool_calls_var.set([tc.to_dict() for tc in response.tool_calls])

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -635,7 +635,9 @@ def _inline_reasoning_as_think_tags(res: GenerationResponse) -> GenerationRespon
         # IORails only strips inline tags when the provider gave no structured reasoning
         # (`response.reasoning or _extract_and_remove_think_tags(...)`), so a provider that
         # sends both leaves a block already in the content; prepending would duplicate it.
-        if content.startswith("<think>"):
+        # TODO: this pattern is copied from `_extract_and_remove_think_tags` in
+        # nemoguardrails/llm/call.py; factor the two onto one shared matcher.
+        if re.search(r"<think>(.*?)</think>", content, re.DOTALL):
             continue
         message["content"] = _prepend_think_tags(content, res.reasoning_content)
         inlined = True

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -34,7 +34,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.responses import JSONResponse, RedirectResponse, StreamingResponse
 
-from nemoguardrails import LLMRails, RailsConfig, utils
+from nemoguardrails import Guardrails, LLMRails, RailsConfig, utils
 from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidStateError,
@@ -44,6 +44,7 @@ from nemoguardrails.exceptions import (
 )
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError
+from nemoguardrails.llm.call import _prepend_think_tags
 from nemoguardrails.llm.clients._errors import build_error_payload, normalize_error_status
 from nemoguardrails.llm.models.initializer import ModelInitializationError
 from nemoguardrails.rails.llm.config import Model
@@ -616,6 +617,29 @@ def process_chunk(chunk: Any) -> Union[Any, ChunkError]:
     return chunk
 
 
+def _inline_reasoning_as_think_tags(res: GenerationResponse) -> GenerationResponse:
+    """Move `reasoning_content` into the assistant message as a <think> prefix and clear the field."""
+    if not res.reasoning_content:
+        return res
+    if not isinstance(res.response, list):
+        return res
+
+    inlined = False
+    for message in res.response:
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            message["content"] = _prepend_think_tags(content, res.reasoning_content)
+            inlined = True
+
+    # A tool-call-only message has `content=None`, so there is nowhere to put the
+    # trace; keep the field rather than dropping the reasoning on the floor.
+    if inlined:
+        res.reasoning_content = None
+    return res
+
+
 @app.post(
     "/v1/chat/completions",
     response_model=GuardrailsChatCompletion,
@@ -780,6 +804,10 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             options=generation_options,
             state=body.guardrails.state,
         )
+
+        # IORails-only: prefix `content` with `reasoning_content` and think-tags
+        if isinstance(llm_rails, Guardrails) and isinstance(res, GenerationResponse):
+            res = _inline_reasoning_as_think_tags(res)
 
         # Extract bot message for thread storage if needed
         bot_message = extract_bot_message_from_response(res)

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -42,6 +42,7 @@ from nemoguardrails.exceptions import (
     RailTypeNotConfiguredError,
     StreamingNotSupportedError,
 )
+from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.guardrails.model_engine import ModelEngineError
 from nemoguardrails.http.errors import HTTPClientError
 from nemoguardrails.llm.call import _prepend_think_tags
@@ -629,9 +630,15 @@ def _inline_reasoning_as_think_tags(res: GenerationResponse) -> GenerationRespon
         if message.get("role") != "assistant":
             continue
         content = message.get("content")
-        if isinstance(content, str):
-            message["content"] = _prepend_think_tags(content, res.reasoning_content)
-            inlined = True
+        if not isinstance(content, str):
+            continue
+        # IORails only strips inline tags when the provider gave no structured reasoning
+        # (`response.reasoning or _extract_and_remove_think_tags(...)`), so a provider that
+        # sends both leaves a block already in the content; prepending would duplicate it.
+        if "<think>" in content:
+            continue
+        message["content"] = _prepend_think_tags(content, res.reasoning_content)
+        inlined = True
 
     # A tool-call-only message has `content=None`, so there is nowhere to put the
     # trace; keep the field rather than dropping the reasoning on the floor.
@@ -805,8 +812,14 @@ async def chat_completion(body: GuardrailsChatCompletionRequest, request: Reques
             state=body.guardrails.state,
         )
 
-        # IORails-only: prefix `content` with `reasoning_content` and think-tags
-        if isinstance(llm_rails, Guardrails) and isinstance(res, GenerationResponse):
+        # IORails-only: prefix `content` with `reasoning_content` and think-tags.
+        # A Guardrails wrapper can fall back to an LLMRails engine, which already
+        # inlines reasoning itself, so the engine check is what scopes this.
+        if (
+            isinstance(llm_rails, Guardrails)
+            and isinstance(llm_rails.rails_engine, IORails)
+            and isinstance(res, GenerationResponse)
+        ):
             res = _inline_reasoning_as_think_tags(res)
 
         # Extract bot message for thread storage if needed

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -635,7 +635,7 @@ def _inline_reasoning_as_think_tags(res: GenerationResponse) -> GenerationRespon
         # IORails only strips inline tags when the provider gave no structured reasoning
         # (`response.reasoning or _extract_and_remove_think_tags(...)`), so a provider that
         # sends both leaves a block already in the content; prepending would duplicate it.
-        if "<think>" in content:
+        if content.startswith("<think>"):
             continue
         message["content"] = _prepend_think_tags(content, res.reasoning_content)
         inlined = True

--- a/tests/llm/test_call_reasoning.py
+++ b/tests/llm/test_call_reasoning.py
@@ -16,7 +16,12 @@
 import pytest
 
 from nemoguardrails.context import reasoning_trace_var
-from nemoguardrails.llm.call import _store_reasoning_traces, llm_call
+from nemoguardrails.llm.call import (
+    _extract_and_remove_think_tags,
+    _prepend_think_tags,
+    _store_reasoning_traces,
+    llm_call,
+)
 from nemoguardrails.types import LLMResponse
 from tests.utils import FakeLLMModel
 
@@ -285,3 +290,60 @@ Step 3: Formulate the answer"""
         assert stored_trace is None
 
         reasoning_trace_var.set(None)
+
+
+class TestPrependThinkTagsUnit:
+    def test_prepends_reasoning_as_a_leading_think_block(self):
+        """Reasoning is wrapped in <think> tags and joined to the content by a single newline."""
+        assert _prepend_think_tags("Paris.", "Step 1") == "<think>Step 1</think>\nParis."
+
+    def test_returns_content_unchanged_when_reasoning_is_none(self):
+        """Content is passed straight through when there is no reasoning to attach."""
+        assert _prepend_think_tags("Paris.", None) == "Paris."
+
+    def test_returns_content_unchanged_when_reasoning_is_empty(self):
+        """An empty reasoning string attaches nothing rather than an empty <think> block."""
+        assert _prepend_think_tags("Paris.", "") == "Paris."
+
+    def test_prepends_to_empty_content(self):
+        """A tool-call turn with empty content still yields a well-formed <think> block."""
+        assert _prepend_think_tags("", "Step 1") == "<think>Step 1</think>\n"
+
+
+class TestThinkTagRoundTripUnit:
+    @pytest.mark.parametrize(
+        "content, reasoning",
+        [
+            ("Paris.", "The user asked for a capital city."),
+            ("Paris.", "Step 1\nStep 2"),
+            ("Line one\nLine two", "why"),
+        ],
+        ids=["single_line", "multiline_reasoning", "multiline_content"],
+    )
+    def test_prepend_then_extract_restores_both_parts(self, content, reasoning):
+        """Extracting from a prepended string returns the original content and reasoning unchanged."""
+        response = LLMResponse(content=_prepend_think_tags(content, reasoning))
+
+        extracted_reasoning = _extract_and_remove_think_tags(response)
+
+        assert extracted_reasoning == reasoning
+        assert response.content == content
+
+    def test_extract_then_prepend_restores_the_inline_string(self):
+        """Splitting an inline <think> string and re-attaching it reproduces the original string."""
+        original = "<think>because</think>\nParis."
+        response = LLMResponse(content=original)
+
+        extracted_reasoning = _extract_and_remove_think_tags(response)
+
+        assert _prepend_think_tags(response.content, extracted_reasoning) == original
+
+    def test_extract_then_prepend_is_a_no_op_without_think_tags(self):
+        """Content that carries no reasoning survives a full split-and-reattach cycle untouched."""
+        original = "Paris."
+        response = LLMResponse(content=original)
+
+        extracted_reasoning = _extract_and_remove_think_tags(response)
+
+        assert extracted_reasoning is None
+        assert _prepend_think_tags(response.content, extracted_reasoning) == original

--- a/tests/server/test_iorails_engine_compat.py
+++ b/tests/server/test_iorails_engine_compat.py
@@ -29,8 +29,44 @@ from fastapi.testclient import TestClient
 
 from nemoguardrails import Guardrails, RailsConfig
 from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.server import api
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG
+
+REASONING_TRACE = "The user asked for a capital city."
+LLM_ANSWER = "Paris."
+THINK_PREFIXED_ANSWER = f"<think>{REASONING_TRACE}</think>\n{LLM_ANSWER}"
+
+
+class _StubLLMRails:
+    """Stand-in for a real LLMRails: not a Guardrails instance, and keeps reasoning in the structured field.
+
+    The shipped configs use the `nim` engine, so constructing a real LLMRails would need
+    provider credentials; only the engine dispatch matters here.
+    """
+
+    def __init__(self, config, verbose=False):
+        self.config = config
+        self.events_history_cache = {}
+
+    async def generate_async(self, messages=None, options=None, state=None, **kwargs):
+        return GenerationResponse(
+            response=[{"role": "assistant", "content": LLM_ANSWER}],
+            reasoning_content=REASONING_TRACE,
+        )
+
+
+def _post_chat_completion():
+    """POST a single-turn request to /v1/chat/completions against the content_safety config."""
+    client = TestClient(api.app, raise_server_exceptions=False)
+    return client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the capital of France?"}],
+            "guardrails": {"config_id": "content_safety"},
+        },
+    )
 
 
 @pytest.fixture
@@ -107,3 +143,116 @@ def test_chat_completion_returns_200_under_iorails_alias(iorails_alias, monkeypa
     assert res["object"] == "chat.completion"
     assert res["choices"][0]["message"]["role"] == "assistant"
     assert res["choices"][0]["message"]["content"] == "hello from iorails"
+
+
+@pytest.fixture
+def llmrails_engine(monkeypatch, iorails_compatible_config):
+    """Serve the same config through a non-Guardrails engine: the contrast case for `iorails_alias`."""
+    monkeypatch.setattr(api, "LLMRails", _StubLLMRails)
+    monkeypatch.setattr(api.RailsConfig, "from_path", staticmethod(lambda full_path: iorails_compatible_config))
+    yield
+
+
+def test_chat_completion_inlines_reasoning_as_think_tags_under_iorails_alias(iorails_alias, monkeypatch):
+    """Reasoning split into `reasoning_content` by IORails reaches the client as a <think> prefix on the content."""
+
+    async def _fake_start(self):
+        self._running = True
+
+    async def _fake_generate_async(self, messages, **kwargs):
+        return GenerationResponse(
+            response=[{"role": "assistant", "content": LLM_ANSWER}],
+            reasoning_content=REASONING_TRACE,
+        )
+
+    monkeypatch.setattr(IORails, "start", _fake_start)
+    monkeypatch.setattr(IORails, "generate_async", _fake_generate_async)
+
+    response = _post_chat_completion()
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == THINK_PREFIXED_ANSWER
+
+
+def test_chat_completion_leaves_reasoning_alone_on_the_llmrails_engine(llmrails_engine):
+    """A non-Guardrails engine keeps the message content clean, so the fold stays scoped to IORails."""
+    response = _post_chat_completion()
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == LLM_ANSWER
+
+
+def test_inline_reasoning_clears_the_field_once_folded_into_content():
+    """`reasoning_content` is cleared after its trace is folded into the assistant message."""
+    res = GenerationResponse(
+        response=[{"role": "assistant", "content": LLM_ANSWER}],
+        reasoning_content=REASONING_TRACE,
+    )
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == THINK_PREFIXED_ANSWER
+    assert folded.reasoning_content is None
+
+
+def test_inline_reasoning_keeps_the_trace_when_a_tool_call_has_no_content():
+    """A tool-call-only message has no content to prefix, so the reasoning stays in its field rather than being dropped."""
+    res = GenerationResponse(
+        response=[{"role": "assistant", "content": None, "tool_calls": [{"id": "call_1"}]}],
+        reasoning_content=REASONING_TRACE,
+    )
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] is None
+    assert folded.reasoning_content == REASONING_TRACE
+
+
+def test_inline_reasoning_leaves_content_alone_when_there_is_no_trace():
+    """A response without reasoning passes through with its content untouched."""
+    res = GenerationResponse(response=[{"role": "assistant", "content": LLM_ANSWER}])
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == LLM_ANSWER
+    assert folded.reasoning_content is None
+
+
+def test_inline_reasoning_keeps_the_trace_when_the_response_is_a_bare_string():
+    """A string-shaped `response` has no message dict to fold into, so the trace is kept."""
+    res = GenerationResponse(response=LLM_ANSWER, reasoning_content=REASONING_TRACE)
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response == LLM_ANSWER
+    assert folded.reasoning_content == REASONING_TRACE
+
+
+def test_inline_reasoning_keeps_the_trace_when_no_message_is_from_the_assistant():
+    """Only assistant messages carry reasoning, so a response without one keeps the trace in its field."""
+    res = GenerationResponse(
+        response=[{"role": "user", "content": "What is the capital of France?"}],
+        reasoning_content=REASONING_TRACE,
+    )
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == "What is the capital of France?"
+    assert folded.reasoning_content == REASONING_TRACE
+
+
+def test_inline_reasoning_folds_only_into_the_assistant_message():
+    """With several messages present, the <think> prefix lands on the assistant turn alone."""
+    res = GenerationResponse(
+        response=[
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": LLM_ANSWER},
+        ],
+        reasoning_content=REASONING_TRACE,
+    )
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == "What is the capital of France?"
+    assert folded.response[1]["content"] == THINK_PREFIXED_ANSWER
+    assert folded.reasoning_content is None

--- a/tests/server/test_iorails_engine_compat.py
+++ b/tests/server/test_iorails_engine_compat.py
@@ -24,10 +24,13 @@ IORails-compatible content-safety config, so the test does not depend on the glo
 import-time env var.
 """
 
+import asyncio
+
 import pytest
 from fastapi.testclient import TestClient
 
 from nemoguardrails import Guardrails, RailsConfig
+from nemoguardrails.guardrails import guardrails as guardrails_module
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.server import api
@@ -39,13 +42,15 @@ THINK_PREFIXED_ANSWER = f"<think>{REASONING_TRACE}</think>\n{LLM_ANSWER}"
 
 
 class _StubLLMRails:
-    """Stand-in for a real LLMRails: not a Guardrails instance, and keeps reasoning in the structured field.
+    """Stand-in for a real LLMRails: not an IORails instance, and keeps reasoning in the structured field.
 
     The shipped configs use the `nim` engine, so constructing a real LLMRails would need
-    provider credentials; only the engine dispatch matters here.
+    provider credentials; only the engine dispatch matters here. The signature accepts both
+    the server's `LLMRails(config=..., verbose=...)` call and `Guardrails`' positional
+    `LLMRails(config, llm, verbose)` fallback.
     """
 
-    def __init__(self, config, verbose=False):
+    def __init__(self, config, llm=None, verbose=False):
         self.config = config
         self.events_history_cache = {}
 
@@ -256,3 +261,49 @@ def test_inline_reasoning_folds_only_into_the_assistant_message():
     assert folded.response[0]["content"] == "What is the capital of France?"
     assert folded.response[1]["content"] == THINK_PREFIXED_ANSWER
     assert folded.reasoning_content is None
+
+
+@pytest.fixture
+def guardrails_over_llmrails(monkeypatch, iorails_compatible_config):
+    """Alias LLMRails->Guardrails but force the wrapper onto its LLMRails fallback engine.
+
+    `Guardrails` falls back to LLMRails whenever `IORails.unsupported_reason` returns a reason,
+    so the server can hold a `Guardrails` that is not IORails-backed.
+    """
+    monkeypatch.setattr(api, "LLMRails", Guardrails)
+    monkeypatch.setattr(api.RailsConfig, "from_path", staticmethod(lambda full_path: iorails_compatible_config))
+    monkeypatch.setattr(IORails, "unsupported_reason", classmethod(lambda cls, config, llm=None: "forced fallback"))
+    monkeypatch.setattr(guardrails_module, "LLMRails", _StubLLMRails)
+    yield
+
+
+def test_chat_completion_leaves_reasoning_alone_when_guardrails_wraps_llmrails(guardrails_over_llmrails):
+    """A Guardrails wrapper on its LLMRails fallback engine keeps clean content: the fold is IORails-only."""
+    response = _post_chat_completion()
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == LLM_ANSWER
+
+
+def test_guardrails_over_llmrails_is_not_iorails_backed(guardrails_over_llmrails):
+    """The fallback fixture really produces a non-IORails engine, so the contrast test above is meaningful."""
+
+    async def _resolve():
+        return await api._get_rails(["content_safety"])
+
+    rails = asyncio.run(_resolve())
+
+    assert isinstance(rails, Guardrails)
+    assert not isinstance(rails.rails_engine, IORails)
+
+
+def test_inline_reasoning_does_not_duplicate_an_existing_think_block():
+    """Content that already carries an inline <think> block is left alone rather than given a second one."""
+    inline = f"<think>inline trace</think>\n{LLM_ANSWER}"
+    res = GenerationResponse(response=[{"role": "assistant", "content": inline}], reasoning_content=REASONING_TRACE)
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == inline
+    assert folded.response[0]["content"].count("<think>") == 1
+    assert folded.reasoning_content == REASONING_TRACE

--- a/tests/server/test_iorails_engine_compat.py
+++ b/tests/server/test_iorails_engine_compat.py
@@ -307,3 +307,17 @@ def test_inline_reasoning_does_not_duplicate_an_existing_think_block():
     assert folded.response[0]["content"] == inline
     assert folded.response[0]["content"].count("<think>") == 1
     assert folded.reasoning_content == REASONING_TRACE
+
+
+def test_inline_reasoning_folds_when_think_is_mentioned_mid_content():
+    """Content that merely mentions <think> outside a leading block still receives its reasoning prefix."""
+    quoted = f"{LLM_ANSWER} Reasoning models wrap traces in <think> tags."
+    res = GenerationResponse(
+        response=[{"role": "assistant", "content": quoted}],
+        reasoning_content=REASONING_TRACE,
+    )
+
+    folded = api._inline_reasoning_as_think_tags(res)
+
+    assert folded.response[0]["content"] == f"<think>{REASONING_TRACE}</think>\n{quoted}"
+    assert folded.reasoning_content is None


### PR DESCRIPTION
## Description

When IORails added support for GenerationOptions / GenerationResponse structured output in #2178, the `reasoning_content` response from the main LLM was returned in the corresponding [GenerationResponse.reasoning_content](https://github.com/NVIDIA-NeMo/Guardrails/blob/32f9ff9efb393101157b913cafb835d51af4b72a/nemoguardrails/rails/llm/options.py#L394) field. Prior to this, `reasoning_content` fro the main LLM inference was prefixed using think-tags, for example:

```
<think>Reasoning here</think>Content here
```

QA test cases expect the think-tag inlined reasoning to be present from the `nemoguardrails server` application. In #2178 the GenerationResponse had reasoning_content in the correct field, but the server neither added it to the context using think-tags nor exposed it on the `reasoning_content` field of GenerationResponse.

To fix the issue and return correct reasoning_content in the dedicated field, see #2315 .

This PR point-fixes the IORails path by prefixing reasoning _content with think-tags in the regular `content` field

## Related Issue(s)

* JIRA NGUARD-881
* NVBug 6469002

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-server-reasoning-thinktags
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7259 items]

........................................................................ [  0%]
........................................................................ [  1%]
........................................................................ [  2%]
.........................................ss.....ss...................... [  3%]
........................................................................ [  4%]
.........s.............................................................. [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
..s..................................................................... [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
................................s....................................... [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
...........................ss.ss.ss.s....................ss.sssss.s..... [ 22%]
.................................s................s.s................... [ 23%]
.............................s.s.s.s.s..s..s............................ [ 24%]
.......s................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
........................................................................ [ 34%]
........................................................................ [ 35%]
.................................................................sssssss [ 36%]
s...........ssssss..ss.....s.................ss.ssssss.................. [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
............................s........................................... [ 43%]
........................................................................ [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
........................................................................ [ 48%]
..................................ss.ss.s.............ss.sss.s.s.s..ssss [ 49%]
ssssss.................................................................. [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
.......................................ss............................... [ 55%]
.............................................s.ssss..................... [ 56%]
................................................................ss...... [ 57%]
.......s....................s........................................... [ 58%]
.............................................................ss......... [ 59%]
...................................................ssss.ss.............. [ 60%]
.............................ss......................sss................ [ 61%]
..s.......ss............................ss.............................. [ 62%]
........................................................................ [ 63%]
..........ss..sssssss.sss.s............................................. [ 64%]
........................................................................ [ 65%]
........................................................................ [ 66%]
........................................................................ [ 67%]
........................................................................ [ 68%]
.........s.................................................s............ [ 69%]
.......................................s..............................s. [ 70%]
ssss.............................................................sssssss [ 71%]
sssssss..............................................................sss [ 72%]
ssss...s................................................................ [ 73%]
.................................s...s......................s........... [ 74%]
........................................................................ [ 75%]
........................................................................ [ 76%]
........................................................................ [ 77%]
.......................................................sssssssss.sssssss [ 78%]
sss..................................................................... [ 79%]
........................................................................ [ 80%]
................................................................s....... [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
..........................sss.ss........................................ [ 84%]
...............................................s.s.s.s..s............... [ 85%]
..................................s.sss.............................ss.s [ 86%]
s.ssssss.........ss............................................s........ [ 87%]
........................................................................ [ 88%]
........................................................................ [ 89%]
.................................s.s.................................... [ 90%]
........................................................................ [ 91%]
........................................................................ [ 92%]
........................................................................ [ 93%]
.......s................................................................ [ 94%]
............s........................................................... [ 95%]
........................................................................ [ 96%]
........................................................................ [ 97%]
.............s....s..................................................... [ 98%]
........................................................................ [ 99%]
............s..............................................              [100%]

══════════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and 
inline-snapshot will not be able to fix snapshots or generate reports.


====================== 7048 passed, 211 skipped in 47.33s ======================

```

## Integration tests

### Direct-check with Main LLM

```
invoke_url='https://integrate.api.nvidia.com/v1/chat/completions'

payload=$(cat <<'JSON'
{
  "model": "nvidia/nemotron-3-nano-30b-a3b",
  "messages": [{"role":"user","content":"Hello!"}],
  "temperature": 1,
  "top_p": 0.95,
  "max_tokens": 16384,
  "reasoning_budget": 16384,
  "chat_template_kwargs": {"enable_thinking":true},
  "stream": false
}
JSON
)

curl -sS -N \
  --request POST \
  --url "$invoke_url" \
  --header "Authorization: Bearer $NVIDIA_API_KEY" \
  --header "Accept: application/json" \
  --header "Content-Type: application/json" \
  --data "$payload" | jq
{
  "id": "chatcmpl-4e8eb7e0-b6ce-42fb-a747-0b07e84b1be1",
  "choices": [
    {
      "index": 0,
      "message": {
        "content": "Hello! 😊 How can I assist you today? Feel free to ask me anything—I'm here to help!",
        "role": "assistant",
        "reasoning_content": "Okay, the user just said \"Hello!\" That's pretty straightforward. I should respond politely and warmly. Let me think about how to approach this.\n\nFirst, I need to acknowledge their greeting. Maybe say something like \"Hello!\" back to keep it friendly. Then, since they're starting a conversation, I should offer help to keep it open-ended. \n\nHmm, what's the best way to phrase it? \"Hello! How can I assist you today?\" That sounds good. It's welcoming and invites them to explain what they need help with. \n\nI should make sure my response is simple and not too formal. Keep it natural. Maybe add an emoji to keep it friendly? Like a smiley face. But I need to check if the platform allows emojis. Since the user didn't specify any restrictions, a simple 😊 should be fine.\n\nWait, the user might be testing if I'm responsive or just greeting me. So keeping it open is important. They might have a question or need help with something specific. \n\nAlso, considering the conversation history, this is the first message, so there's no context to refer back to. Just a simple, friendly reply. \n\nI think \"Hello! 😊 How can I assist you today?\" covers it. It's concise, friendly, and invites them to ask anything. That should work.\n"
      },
      "finish_reason": "stop",
      "logprobs": null
    }
  ],
  "created": 1787241523,
  "model": "nvidia/nemotron-3-nano-30b-a3b",
  "service_tier": null,
  "system_fingerprint": null,
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 18,
    "completion_tokens": 312,
    "total_tokens": 330
  }
}

```

### Integration test with Server

**Server**
```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 \
MAIN_MODEL_ENGINE=nim \
MAIN_MODEL_BASE_URL=https://integrate.api.nvidia.com/v1 \
 uv run nemoguardrails server --config ~/utils/configs --default-config-id content_safety
```

**Client**
```
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello!"
            }
          ],
          "model": "nvidia/nemotron-3-nano-30b-a3b",
          "stream": false,
          "max_completion_tokens": 55

  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   679  100   395  100   284    126     90  0:00:03  0:00:03 --:--:--   217
{
  "id": "chatcmpl-91715335-53ac-428c-aa19-bd1056966e6b",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "<think>We need to respond. There's no special instruction. Just greeting.\n</think>\nHello! How can I help you today?",
        "role": "assistant"
      }
    }
  ],
  "created": 1787241625,
  "model": "nvidia/nemotron-3-nano-30b-a3b",
  "object": "chat.completion",
  "guardrails": {
    "config_id": "content_safety"
  }
}
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Non-streaming responses from supported I/O integrations now include available reasoning in a leading `<think>...</think>` block.
  - Reasoning content is preserved when responses contain non-text content or cannot be safely updated.

- **Bug Fixes**
  - Prevented duplicate `<think>` blocks when reasoning is already embedded.
  - Improved consistency when converting between structured reasoning and inline think-tag content.
  - Responses without reasoning remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->