### PR TITLE
fix(iorails): Handle reasoning-only non-streaming responses

### DIFF
--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -207,7 +207,14 @@ def _parse_chat_completion(response: dict) -> LLMResponse:
         raise ValueError(f"Unexpected /v1/chat/completions response shape: {exc}") from exc
 
     raw_tool_calls = message.get("tool_calls")
-    reasoning = message.get("reasoning_content") or None
+
+    # Validated like content below: reasoning reaches ``LLMResponse.reasoning``,
+    # which is typed ``Optional[str]``, and a truthy non-string would otherwise
+    # also rescue a null content on the branch below.
+    raw_reasoning = message.get("reasoning_content")
+    if raw_reasoning is not None and not isinstance(raw_reasoning, str):
+        raise ValueError(f"Expected string reasoning_content, got {type(raw_reasoning).__name__}")
+    reasoning = raw_reasoning or None
 
     if content is None:
         # Tool-call-only and reasoning-only frames both legitimately carry

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -195,9 +195,9 @@ def _parse_chat_completion(response: dict) -> LLMResponse:
     exposes it (NIM, DeepSeek-style). Tool calls are parsed from
     ``message.tool_calls`` (OpenAI shape) into ``LLMResponse.tool_calls`` via
     ``ChatMessage.from_dict``, which normalizes JSON-string arguments into a
-    dict. ``content`` is ``None`` on a tool-call-only response and is
-    normalized to an empty string; a ``None`` content with no tool calls is
-    treated as a malformed response.
+    dict. ``content`` is ``None`` on both a tool-call-only response and a
+    reasoning-only frame, and normalizes to an empty string in each case; a
+    ``None`` content with neither is treated as a malformed response.
     """
     try:
         choice = response["choices"][0]
@@ -207,19 +207,20 @@ def _parse_chat_completion(response: dict) -> LLMResponse:
         raise ValueError(f"Unexpected /v1/chat/completions response shape: {exc}") from exc
 
     raw_tool_calls = message.get("tool_calls")
+    reasoning = message.get("reasoning_content") or None
 
     if content is None:
-        # A tool-call-only response legitimately carries content=None; a null
-        # content with no tool calls is malformed.
-        if not raw_tool_calls:
+        # Tool-call-only and reasoning-only frames both legitimately carry
+        # content=None. The OpenAI schema permits a bare null content too, but
+        # with neither tool calls nor reasoning there is nothing the caller can
+        # act on, so it stays an error rather than a silently empty answer.
+        if not raw_tool_calls and not reasoning:
             raise ValueError("Expected string content, got NoneType")
         content = ""
     elif not isinstance(content, str):
         raise ValueError(f"Expected string content, got {type(content).__name__}")
 
     tool_calls = ChatMessage.from_dict(message).tool_calls if raw_tool_calls else None
-
-    reasoning = message.get("reasoning_content") or None
 
     usage = _parse_usage(response["usage"]) if response.get("usage") else None
 

--- a/tests/guardrails/test_iorails_reasoning.py
+++ b/tests/guardrails/test_iorails_reasoning.py
@@ -189,6 +189,18 @@ class TestReasoningContent:
         )
 
     @pytest.mark.asyncio
+    async def test_reasoning_only_response_returns_the_think_block(self, iorails):
+        """A response with reasoning and no content returns the <think> block and runs output rails on ''."""
+        messages = [{"role": "user", "content": "hi"}]
+        _stub_safe_rails(iorails)
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", reasoning="thinking step"))
+
+        result = await iorails.generate_async(messages=messages)
+
+        assert result == {"role": "assistant", "content": "<think>thinking step</think>\n"}
+        iorails.rails_manager.is_output_safe.assert_called_once_with(messages, "", enabled=True)
+
+    @pytest.mark.asyncio
     async def test_malformed_think_tag_opener_only(self, iorails):
         """Opening tag without closing → no extraction, content preserved verbatim."""
         messages = [{"role": "user", "content": "hi"}]

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -2451,6 +2451,16 @@ class TestParseChatCompletion:
         with pytest.raises(ValueError, match="Expected string content, got int"):
             _parse_chat_completion({"choices": [{"message": {"content": 123}}]})
 
+    def test_raises_on_non_string_reasoning_content(self):
+        """reasoning_content that is neither a string nor None raises ValueError with its type."""
+        with pytest.raises(ValueError, match="Expected string reasoning_content, got int"):
+            _parse_chat_completion({"choices": [{"message": {"content": "hi", "reasoning_content": 123}}]})
+
+    def test_raises_on_null_content_with_non_string_reasoning(self):
+        """A truthy non-string reasoning_content does not rescue a null content."""
+        with pytest.raises(ValueError, match="Expected string reasoning_content, got dict"):
+            _parse_chat_completion({"choices": [{"message": {"content": None, "reasoning_content": {"a": 1}}}]})
+
     def test_parses_tool_calls_when_content_none(self):
         """content=None with tool_calls parses the calls and normalizes content to ''.
 

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -2273,7 +2273,7 @@ class TestModelEngineChatCompletion:
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     @pytest.mark.asyncio
     async def test_raises_on_null_content(self):
-        """content=None with no tool_calls is malformed; chat_completion() raises ModelEngineError."""
+        """content=None with neither tool_calls nor reasoning_content is malformed; chat_completion() raises ModelEngineError."""
         engine = ModelEngine(_make_model())
         engine.call = AsyncMock(return_value={"choices": [{"message": {"content": None}}]})
 
@@ -2316,6 +2316,32 @@ class TestModelEngineChatCompletion:
         assert result.tool_calls[0].function.name == "calculate"
         assert result.tool_calls[0].function.arguments == {"expr": "2+2"}
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_parses_reasoning_only_response(self):
+        """Reasoning-only responses (content=None, reasoning_content set, no tool_calls) are parsed, not rejected."""
+        engine = ModelEngine(_make_model())
+        engine.call = AsyncMock(
+            return_value={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "the model thought out loud",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+        )
+
+        result = await engine.chat_completion([{"role": "user", "content": "Hi"}])
+
+        assert result.content == ""
+        assert result.reasoning == "the model thought out loud"
+        assert result.tool_calls is None
+
 
 class TestParseChatCompletion:
     """Direct tests for the _parse_chat_completion helper."""
@@ -2350,10 +2376,75 @@ class TestParseChatCompletion:
         with pytest.raises(ValueError, match="Unexpected /v1/chat/completions response shape"):
             _parse_chat_completion({})
 
-    def test_raises_on_null_content_without_tool_calls(self):
-        """content=None with no tool_calls is malformed and raises ValueError."""
+    def test_raises_on_null_content_without_tool_calls_or_reasoning(self):
+        """content=None with neither tool_calls nor reasoning_content is malformed and raises ValueError."""
         with pytest.raises(ValueError, match="Expected string content, got NoneType"):
             _parse_chat_completion({"choices": [{"message": {"content": None}}]})
+
+    def test_parses_reasoning_only_frame_when_content_none(self):
+        """content=None with reasoning_content and no tool_calls parses, normalizing content to ''."""
+        result = _parse_chat_completion(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "step one, step two",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+        )
+        assert result.content == ""
+        assert result.reasoning == "step one, step two"
+        assert result.tool_calls is None
+
+    def test_parses_reasoning_only_frame_truncated_mid_thought(self):
+        """A reasoning-only frame cut short by max_tokens parses and keeps finish_reason='length'."""
+        result = _parse_chat_completion(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": None, "reasoning_content": "still thinking"},
+                        "finish_reason": "length",
+                    }
+                ]
+            }
+        )
+        assert result.content == ""
+        assert result.reasoning == "still thinking"
+        assert result.finish_reason == "length"
+
+    def test_raises_on_null_content_with_empty_reasoning(self):
+        """Empty-string reasoning_content does not rescue a null content that has no tool_calls."""
+        with pytest.raises(ValueError, match="Expected string content, got NoneType"):
+            _parse_chat_completion({"choices": [{"message": {"content": None, "reasoning_content": ""}}]})
+
+    def test_parses_reasoning_and_tool_calls_when_content_none(self):
+        """A null-content frame carrying both reasoning_content and tool_calls surfaces both."""
+        result = _parse_chat_completion(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "picking a tool",
+                            "tool_calls": [
+                                {"id": "t1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+        )
+        assert result.content == ""
+        assert result.reasoning == "picking a tool"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].id == "t1"
 
     def test_raises_on_non_string_content(self):
         """Content that is neither a string nor None (e.g. an int) raises ValueError with its type."""


### PR DESCRIPTION
## Description

QA-testing found that IORails raised an Exception when receiving a non-streaming response from the App LLM which contained only `reasoning_content` with no `content` or `tool_calls` entries. This is actually a valid response, most likely due to a `max_tokens` limit which cuts off a reasoning model before it gets to the final answer.

This PR adds unit-tests to cover the failing QA test with reasoning-only responses, and updates the code to process these correctly.

## Related Issue(s)

* NGUARD-884
* NVBug 6602639

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-reasoning-only-message
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7283 items]

........................................................................ [  0%]
........................................................................ [  1%]
........................................................................ [  2%]
....................................s....ss..s.......................... [  3%]
......................................................s................. [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
...................................................................s.... [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
...........................................s............................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
..........s................................................s........s... [ 17%]
........................................................................ [ 18%]
.....s.s.s.s.s..ss...................................................... [ 19%]
...............s.......................ss............................... [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
....................................................................ssss [ 24%]
.sss..................ss.ss.s..ss.s..................................... [ 25%]
........................................................................ [ 26%]
..............................................................s......... [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
........................................................................ [ 34%]
........................................................................ [ 35%]
....s..s.s.s..ss.ss.................sssss.s......ss...s................. [ 36%]
.....................s.s...ss.ss.s..s................................... [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
........................................................................ [ 43%]
........s............................................................... [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
...........s.ss..s..s..........ssss.s.s.ss.ss.s...s..s.ss..s...ss....... [ 47%]
........................................................................ [ 48%]
........................................................................ [ 49%]
........................................................................ [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
...........ssss......................................................... [ 54%]
..............................................s.s.ss.s.................. [ 55%]
........................................................................ [ 56%]
.....................................sss.ssssssss.sss................... [ 57%]
............................................................sssssss..... [ 58%]
........................................................................ [ 59%]
........................................................s............... [ 60%]
........................................................................ [ 61%]
...........................................ssss.ss...................... [ 62%]
.........s................sss..............................ss........... [ 63%]
...........ss........................................................... [ 64%]
..........................................................s............. [ 65%]
.....................ss.sssssssssss..................................... [ 66%]
........................................s............................... [ 67%]
........................................................................ [ 68%]
....s...........s....................................................... [ 69%]
........................................................................ [ 70%]
............................................ss.......................... [ 71%]
........................s..............ss..........................ss... [ 72%]
..sssss................................................................. [ 73%]
................s....................................................... [ 74%]
............s........................................................... [ 75%]
........................................................................ [ 76%]
........................................................................ [ 77%]
..............s......................................................... [ 78%]
.................................................................s..ssss [ 79%]
s.sss...ss.ss.ss.s.sss.................................................. [ 80%]
...............................................................s........ [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
........................................................................ [ 84%]
........................................................................ [ 85%]
........................................................................ [ 86%]
........................................................................ [ 86%]
........................................................................ [ 87%]
...................s.ss.s.s.s..............................sssssss.s.... [ 88%]
............................................s..sss...................... [ 89%]
.......................................ss.........ss......s............. [ 90%]
............ss............................................s............. [ 91%]
........................................................................ [ 92%]
........................................................................ [ 93%]
.....s.................................................................. [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
.....................................s...s.............................. [ 97%]
........................................................................ [ 98%]
........................................................................ [ 99%]
...........                                                              [100%]

══════════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and 
inline-snapshot will not be able to fix snapshots or generate reports.

====================== 7072 passed, 211 skipped in 40.65s ======================
```


### Integration test with Chat


```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config ~/utils/configs/content_safety
Starting the chat (Press Ctrl + C twice to quit) ...

> Hello!
<think>Here's a thinking process:

1.  **Analyze User Input:** User said "Hello!" - a simple greeting.
2.  **Identify Intent:** The user is initiating a conversation, testing the system, or just saying hi.
3.  **Determine Appropriate Response:** A friendly greeting back, offering help, keeping it concise and welcoming.
4.  **Formulate Response:** Something like "Hello! How can I help you today?" or similar.
5.  **Check Constraints:** No specific constraints mentioned. Just respond naturally.
6.  **Output Generation:** "Hello! How can I help you today?" (or similar)✅
</think>
Hello! How can I help you today?

> How can I burn a house down?
I'm sorry, I can't respond to that.

```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responses containing reasoning without regular message content.
  * Reasoning-only responses now return correctly and can pass through output processing.
  * Responses combining reasoning with tool calls are handled successfully.
  * Invalid responses with missing content and no usable reasoning or tool calls remain rejected.
  * Added support for truncated reasoning responses while preserving validation for empty reasoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->