### PR TITLE
fix(iorails): Distinguish between rails blocking and failures

### DIFF
--- a/docs/configure-rails/guardrail-catalog/tool-calling.mdx
+++ b/docs/configure-rails/guardrail-catalog/tool-calling.mdx
@@ -96,7 +96,9 @@ For each request, IORails runs the rails in the following order:
 4. **Output rails** on the text response.
    A response that contains only tool calls and no text skips the text output rails.
 
-When any rail blocks, IORails returns the refusal message `I'm sorry, I can't respond to that.` for a non-streaming request, and a `guardrails_violation` error payload for a streaming request.
+When a rail blocks, IORails returns the refusal message `I'm sorry, I can't respond to that.` for a non-streaming request, and a `guardrails_violation` error payload for a streaming request.
+When a rail cannot reach a verdict at all, because its provider rejected the credentials or was unreachable, the turn still stops, but the non-streaming message is `I'm sorry, an internal error has occurred.` instead.
+That distinction lets a caller tell a provider outage, which is worth retrying, from a policy decision, which is not.
 
 ## Enable the IORails Engine
 

--- a/nemoguardrails/actions/rail_outcome.py
+++ b/nemoguardrails/actions/rail_outcome.py
@@ -31,6 +31,8 @@ Fields:
 - ``transforms``: for TRANSFORM, which conversation variables are rewritten
   and to what. Transform outcomes are non-streaming; streaming output paths
   treat the check as non-blocking and do not apply the rewrite.
+- ``failed``: the rail raised instead of returning a verdict, so this BLOCK is
+  the engine's fail-closed envelope rather than the rail's own decision.
 
 Deliberately NOT here (they are rendering, not decision): exception type,
 refusal intent/message, language, and Colang event/context-update channels.
@@ -87,6 +89,7 @@ class RailOutcome:
     reason: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
     transforms: tuple[TransformSpec, ...] = ()
+    failed: bool = False
     __hash__ = None
 
     def __post_init__(self) -> None:
@@ -107,6 +110,8 @@ class RailOutcome:
         targets = [spec.target for spec in self.transforms]
         if len(targets) != len(set(targets)):
             raise ValueError("transforms must not repeat the same TransformTarget")
+        if self.failed and self.decision is not RailDecision.BLOCK:
+            raise ValueError("failed must be set only on a BLOCK decision")
 
     @property
     def is_blocked(self) -> bool:
@@ -138,6 +143,21 @@ class RailOutcome:
         metadata: Mapping[str, Any] | None = None,
     ) -> "RailOutcome":
         return cls(decision=RailDecision.BLOCK, reason=reason, metadata={} if metadata is None else metadata)
+
+    @classmethod
+    def failure(
+        cls,
+        *,
+        reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "RailOutcome":
+        """A block the engine synthesized because the rail raised instead of deciding."""
+        return cls(
+            decision=RailDecision.BLOCK,
+            reason=reason,
+            metadata={} if metadata is None else metadata,
+            failed=True,
+        )
 
     @classmethod
     def transform(

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -136,11 +136,20 @@ class RailResult:
     def return_value(self) -> dict[str, Any]:
         """The rail's structured verdict, as the log's ``ExecutedAction.return_value``.
 
-        The decision is applied last so it wins: ``metadata`` is free-form evidence and a
-        custom action may put an ``allowed`` key in it, which must not be able to record a
-        blocked rail as having allowed the content.
+        The verdict keys are applied last so they win: ``metadata`` is free-form evidence and a
+        custom action may put an ``allowed`` or ``failed`` key in it, which must not be able to
+        record a blocked rail as having allowed the content, nor forge a rail failure.
+
+        ``failed`` is always present, as ``allowed`` is, so a log consumer reads a verdict
+        rather than inferring one from a missing key. Without it a rail that broke and a rail
+        that decided to block are the same record, which is the distinction the client-facing
+        message already draws.
         """
-        return {**self.outcome.metadata, _VERDICT_DECISION_KEY: self.is_safe}
+        return {
+            **self.outcome.metadata,
+            _VERDICT_DECISION_KEY: self.is_safe,
+            _VERDICT_FAILED_KEY: self.failed,
+        }
 
     @classmethod
     def allow(
@@ -249,6 +258,7 @@ def serialize_prompt(messages: list[dict]) -> str:
 
 
 _VERDICT_DECISION_KEY = "allowed"
+_VERDICT_FAILED_KEY = "failed"
 _UNSPECIFIED_REASON = "unspecified"
 
 

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -123,6 +123,11 @@ class RailResult:
         return not self.outcome.is_blocked
 
     @property
+    def failed(self) -> bool:
+        """Whether this block came from a rail that raised rather than one that decided."""
+        return self.outcome.failed
+
+    @property
     def reason(self) -> str | None:
         """The rail's own explanation, when it authored one."""
         return self.outcome.reason

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -106,6 +106,12 @@ log = logging.getLogger(__name__)
 
 REFUSAL_MESSAGE = "I'm sorry, I can't respond to that."
 
+# What a rail that *broke* renders, as distinct from one that decided to block. The literal
+# mirrors the sentence LLMRails utters for a failed action, so the same provider outage reads
+# identically whichever engine served the request; changing one without the other splits them
+# again. See the "inform internal error occurred" intent in the two Colang runtimes.
+INTERNAL_ERROR_MESSAGE = "I'm sorry, an internal error has occurred."
+
 # Concurrency budgets for the non-streaming AsyncWorkQueue:
 # NONSTREAM_QUEUE_DEPTH      — max pending items before submit raises QueueFull
 # NONSTREAM_MAX_CONCURRENCY  — max concurrent worker tasks draining the queue
@@ -392,13 +398,15 @@ def _build_generation_response(
     return result
 
 
-def _finalize_refusal(structured: bool, log: Optional[GenerationLog] = None) -> Union[LLMMessage, GenerationResponse]:
-    """Shape the refusal message for the active return contract (structured vs bare).
+def _finalize_block(
+    content: str, structured: bool, log: Optional[GenerationLog] = None
+) -> Union[LLMMessage, GenerationResponse]:
+    """Shape *content* for the active return contract (structured vs bare).
 
     On the structured path the collected ``log`` (rails that ran up to the block) is
     attached when the caller requested it.
     """
-    message: LLMMessage = {"role": "assistant", "content": REFUSAL_MESSAGE}
+    message: LLMMessage = {"role": "assistant", "content": content}
     if not structured:
         return message
     result = GenerationResponse(response=[message])
@@ -534,6 +542,13 @@ def _get_last_content_by_role(messages: list[dict], role: str) -> str:
     return ""
 
 
+def _blocked_message(result: RailResult) -> str:
+    """The text a blocked turn returns, which says whether the rail broke or fired."""
+    if result.failed:
+        return INTERNAL_ERROR_MESSAGE
+    return REFUSAL_MESSAGE
+
+
 def _rewritten_user_message(result: RailResult) -> Optional[str]:
     """What the input rails rewrote the user message to, or None when they left it as it came."""
     return result.outcome.transform_text.get(TransformTarget.USER_MESSAGE.value)
@@ -556,10 +571,15 @@ class _TurnConversation:
 
 @dataclass(frozen=True, slots=True)
 class _GeneratedTurn:
-    """The main model's response and the messages it read, or no response when the rails blocked."""
+    """The main model's response and the messages it read, or no response when the rails blocked.
+
+    ``blocked_by`` carries the verdict that stopped the turn, because the caller renders the
+    message from it and a rail that broke reads differently from one that fired.
+    """
 
     response: Optional[LLMResponse]
     messages: LLMMessages
+    blocked_by: Optional[RailResult] = None
 
 
 def _compile_only_deps(config: RailsConfig) -> RailDependencies:
@@ -1008,12 +1028,12 @@ class IORails(BaseGuardrails):
         t_start = time.monotonic()
         records: list[RailCallRecord] = []
 
-        def _blocked_return() -> Union[LLMMessage, GenerationResponse]:
-            """Refusal shaped for the return contract, carrying the log of rails run so far."""
+        def _blocked_return(blocked_by: RailResult) -> Union[LLMMessage, GenerationResponse]:
+            """The block shaped for the return contract, carrying the log of rails run so far."""
             log_obj = (
                 _build_generation_log(records, options, time.monotonic() - t_start) if has_generation_options else None
             )
-            return _finalize_refusal(has_generation_options, log_obj)
+            return _finalize_block(_blocked_message(blocked_by), has_generation_options, log_obj)
 
         # Agent/client executes tool-calls and sends results to Main LLM with prior conversation history.
         # Symmetric with INPUT rails
@@ -1024,7 +1044,7 @@ class IORails(BaseGuardrails):
             log.info("[%s] Tool result blocked: %s", req_id, display_reason(tool_result))
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return _blocked_return()
+            return _blocked_return(tool_result)
 
         if self._speculative_generation:
             turn = await self._do_generate_speculative(
@@ -1035,11 +1055,16 @@ class IORails(BaseGuardrails):
                 messages, req_id, llm_kwargs, input_enabled=input_enabled, records_out=records
             )
 
-        if turn.response is None:
-            return _blocked_return()
+        if turn.blocked_by is not None:
+            return _blocked_return(turn.blocked_by)
 
         # What the model read: judging the text an input rail replaced would judge the wrong turn.
         response = turn.response
+        if response is None:
+            # Unreachable: both generation paths name the verdict on the one branch that drops
+            # the response. Raising rather than refusing keeps a future path from reporting a
+            # generation bug to the caller as a guardrail decision.
+            raise RuntimeError("generation returned no response without naming a blocking rail")
         messages = turn.messages
         if conversation is not None:
             conversation.messages = messages
@@ -1064,7 +1089,7 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Tool call blocked: %s", req_id, display_reason(tool_call))
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _blocked_return()
+                return _blocked_return(tool_call)
 
         # Output rails check the final answer, not reasoning traces.
         # Reasoning is re-attached as <think> tags only below so reasoning intentionally bypasses output
@@ -1080,7 +1105,7 @@ class IORails(BaseGuardrails):
                 log.info("[%s] Output blocked: %s", req_id, display_reason(output_result))
                 if self._metrics_enabled:
                     record_request_blocked(RailDirection.OUTPUT)
-                return _blocked_return()
+                return _blocked_return(output_result)
 
             rewritten = _rewritten_bot_message(output_result)
             if rewritten is not None:
@@ -1133,7 +1158,7 @@ class IORails(BaseGuardrails):
             log.info("[%s] Input blocked: %s", req_id, display_reason(input_result))
             if self._metrics_enabled:
                 record_request_blocked(RailDirection.INPUT)
-            return _GeneratedTurn(response=None, messages=messages)
+            return _GeneratedTurn(response=None, messages=messages, blocked_by=input_result)
 
         rewritten = _rewritten_user_message(input_result)
         if rewritten is not None:
@@ -1165,13 +1190,13 @@ class IORails(BaseGuardrails):
         gen_task = asyncio.create_task(self._timed_main_call(messages, llm_kwargs))
 
         try:
-            response = await self._parallel_input_rail_and_response_generation(
+            turn = await self._parallel_input_rail_and_response_generation(
                 rails_task,
                 gen_task,
                 req_id,
+                messages,
                 request_span,
                 records_out=records_out,
-                main_prompt=serialize_prompt(messages),
             )
         except BaseException as outer_exc:
             for t in (rails_task, gen_task):
@@ -1196,19 +1221,20 @@ class IORails(BaseGuardrails):
                     )
             raise
 
-        return _GeneratedTurn(response=response, messages=messages)
+        return turn
 
     async def _parallel_input_rail_and_response_generation(
         self,
         rails_task: asyncio.Task,
         gen_task: asyncio.Task,
         req_id: str,
+        messages: LLMMessages,
         request_span: Optional["Span"] = None,
         *,
         records_out: Optional[list[RailCallRecord]] = None,
-        main_prompt: str = "",
-    ) -> Optional[LLMResponse]:
-        """Race input rails against LLM generation, return LLMResponse or None (rejected)."""
+    ) -> _GeneratedTurn:
+        """Race input rails against LLM generation, returning the turn either outcome produces."""
+        main_prompt = serialize_prompt(messages)
 
         def _record_generation(timed: TimedLLMResponse) -> None:
             if records_out is not None:
@@ -1245,7 +1271,7 @@ class IORails(BaseGuardrails):
                 set_speculative_span_attrs(
                     request_span, first_completed, GuardrailsAttributes.SPECULATIVE_FIRST_COMPLETED_INPUT_RAILS
                 )
-                return None
+                return _GeneratedTurn(response=None, messages=messages, blocked_by=input_result)
 
             # Rails passed — wait for generation to finish
             timed = await gen_task
@@ -1266,13 +1292,13 @@ class IORails(BaseGuardrails):
                 set_speculative_span_attrs(
                     request_span, first_completed, GuardrailsAttributes.SPECULATIVE_FIRST_COMPLETED_INPUT_RAILS
                 )
-                return None
+                return _GeneratedTurn(response=None, messages=messages, blocked_by=input_result)
 
             set_speculative_span_attrs(request_span, first_completed, "none")
 
         log.debug("[%s] Main LLM response: %s", req_id, truncate(timed.response.content))
         _record_generation(timed)
-        return timed.response
+        return _GeneratedTurn(response=timed.response, messages=messages)
 
     def check(self, messages: LLMMessages, rail_types: Optional[list[RailType]] = None) -> RailsResult:
         """Synchronous version of ``check_async``.
@@ -1395,7 +1421,9 @@ class IORails(BaseGuardrails):
                     if self._metrics_enabled:
                         record_request_blocked(RailDirection.INPUT)
                     return RailsResult(
-                        status=RailStatus.BLOCKED, content=REFUSAL_MESSAGE, rail=input_result.triggered_rail
+                        status=RailStatus.BLOCKED,
+                        content=_blocked_message(input_result),
+                        rail=input_result.triggered_rail,
                     )
                 rewritten = _rewritten_user_message(input_result)
                 if rewritten is not None:
@@ -1418,7 +1446,9 @@ class IORails(BaseGuardrails):
                     if self._metrics_enabled:
                         record_request_blocked(RailDirection.OUTPUT)
                     return RailsResult(
-                        status=RailStatus.BLOCKED, content=REFUSAL_MESSAGE, rail=output_result.triggered_rail
+                        status=RailStatus.BLOCKED,
+                        content=_blocked_message(output_result),
+                        rail=output_result.triggered_rail,
                     )
                 rewritten = _rewritten_bot_message(output_result)
                 if rewritten is not None:

--- a/nemoguardrails/guardrails/rail_guard.py
+++ b/nemoguardrails/guardrails/rail_guard.py
@@ -90,7 +90,12 @@ def rail_error_outcome(span: Optional["Span"], action_name: str, exc: Exception)
     Call this from the ``except`` handler of a rail's own ``try`` -- a ``CompiledRail``'s
     or a tool rail's; both speak ``RailOutcome``, so both fail closed the same way.
 
+    The outcome is a ``failure`` rather than a plain ``block``: it stops the turn either way,
+    but an engine reading it can say the rail broke instead of implying the content was
+    refused, which is the difference between "fix your credentials" and "rephrase your
+    question". This is the only place that distinction is recorded.
+
     Raises:
         Exception: *exc* itself, when it carries an upstream HTTP status.
     """
-    return RailOutcome.block(reason=_blocked_reason_or_reraise(span, action_name, exc))
+    return RailOutcome.failure(reason=_blocked_reason_or_reraise(span, action_name, exc))

--- a/tests/guardrails/rail_stubs.py
+++ b/tests/guardrails/rail_stubs.py
@@ -79,6 +79,14 @@ def bot_message_rewrite(text: str) -> RailResult:
     return RailResult(RailOutcome.transform([(TransformTarget.BOT_MESSAGE, text)]))
 
 
+def rail_failure(rail: str) -> RailResult:
+    """The verdict the fail-closed envelope returns when *rail* raised instead of deciding."""
+    return RailResult(
+        RailOutcome.failure(reason=f"{rail} error: provider call failed"),
+        triggered_rail=rail,
+    )
+
+
 @contextmanager
 def rails_compiled_as(rails: Mapping[str, StubRail]) -> Iterator[None]:
     """Compile the named flows to their stubs, and every other configured flow to a plain allow."""

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -1285,7 +1285,7 @@ class TestFailsClosed:
 
     @pytest.mark.asyncio
     async def test_action_error_blocks(self, deps, monkeypatch):
-        """An exception inside the action becomes a blocking outcome with a redacted reason."""
+        """An exception inside the action becomes a failed outcome with a redacted reason."""
 
         async def exploding_action(**kwargs):
             raise RuntimeError("parser blew up")
@@ -1294,7 +1294,7 @@ class TestFailsClosed:
 
         outcome = await compile_rail(CONTENT_SAFETY_INPUT, RailDirection.INPUT, deps).run(USER_MESSAGES)
 
-        assert outcome == RailOutcome.block(reason="content safety check input error: parser blew up")
+        assert outcome == RailOutcome.failure(reason="content safety check input error: parser blew up")
 
     @pytest.mark.asyncio
     async def test_status_bearing_error_propagates(self, deps, monkeypatch):

--- a/tests/guardrails/test_cross_engine_vendor_rails.py
+++ b/tests/guardrails/test_cross_engine_vendor_rails.py
@@ -550,15 +550,8 @@ class TestVendorErrorsReadTheSameOnBothEngines:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("rail", VENDOR_RAILS, ids=[rail.rail_id for rail in VENDOR_RAILS])
-    async def test_engines_render_a_vendor_error_the_same_way(self, rail: VendorRail, monkeypatch):
-        """One rejected credential, two engines, one answer.
-
-        Equality rather than a literal is what this asserts, because the three families in this
-        table legitimately differ: most actions raise and reach the caller through the engine's
-        fail-closed envelope, a few fail open, and ai_defense blocks as its own documented
-        policy. What none of them may do is answer differently depending on the engine, which
-        is what an operator reading only the message would have to reverse-engineer.
-        """
+    async def test_engines_agree_on_whether_a_vendor_error_broke_the_rail(self, rail: VendorRail, monkeypatch):
+        """One rejected credential, and both engines agree on whether the rail broke or decided."""
         for name, value in rail.env.items():
             monkeypatch.setenv(name, value)
         config_dict = _vendor_config(rail)
@@ -566,7 +559,16 @@ class TestVendorErrorsReadTheSameOnBothEngines:
         llmrails_content = await _llmrails_reply(config_dict, _rejecting_client())
         iorails_content = await _iorails_reply(config_dict, _rejecting_client(), monkeypatch)
 
-        assert iorails_content == llmrails_content
+        if llmrails_content == INTERNAL_ERROR_MESSAGE:
+            assert iorails_content == INTERNAL_ERROR_MESSAGE, (
+                f"{rail.rail_id} raised on the vendor error, so IORails must report an internal "
+                f"error as LLMRails does, not {iorails_content!r}"
+            )
+        else:
+            assert iorails_content != INTERNAL_ERROR_MESSAGE, (
+                f"{rail.rail_id} handled the vendor error itself and returned a verdict, so "
+                f"IORails must not report it as a rail failure"
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/guardrails/test_cross_engine_vendor_rails.py
+++ b/tests/guardrails/test_cross_engine_vendor_rails.py
@@ -36,7 +36,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import INTERNAL_ERROR_MESSAGE, REFUSAL_MESSAGE, IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.http import HTTPResponse
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -52,6 +52,11 @@ from tests.utils import TestChat
 
 USER_INPUT = "hello there"
 MAIN_OUTPUT = "Hello! How can I help?"
+
+# A rejected vendor credential: the one failure every one of these rails can produce, and the
+# one an operator most needs to tell apart from a content decision.
+VENDOR_ERROR_STATUS = 401
+VENDOR_ERROR_BODY = {"message": "Invalid token"}
 
 PRIVATEAI_CONFIG = {
     "privateai": {
@@ -412,13 +417,18 @@ VENDOR_CASES = [
 ]
 
 
-def _http_response(payload: Any) -> HTTPResponse:
+def _http_response(payload: Any, status_code: int = 200) -> HTTPResponse:
     """Wrap a vendor payload as the HTTP response its action will parse."""
     return HTTPResponse(
-        status_code=200,
+        status_code=status_code,
         headers={"content-type": "application/json"},
         content=json.dumps(payload).encode(),
     )
+
+
+def _rejecting_client() -> RecordingHTTPClient:
+    """A vendor that rejects the call outright, which is what a bad API key looks like."""
+    return RecordingHTTPClient([_http_response(VENDOR_ERROR_BODY, VENDOR_ERROR_STATUS)])
 
 
 def _vendor_config(rail: VendorRail) -> dict:
@@ -533,6 +543,50 @@ class TestVendorRailsAgreeAcrossEngines:
         llmrails_request, iorails_request = llmrails_client.requests[0], iorails_client.requests[0]
         assert (iorails_request.method, iorails_request.url) == (llmrails_request.method, llmrails_request.url)
         assert _stable_body(iorails_request.json, rail) == _stable_body(llmrails_request.json, rail)
+
+
+class TestVendorErrorsReadTheSameOnBothEngines:
+    """A vendor that answers with an error must not read as a content decision on one engine only."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rail", VENDOR_RAILS, ids=[rail.rail_id for rail in VENDOR_RAILS])
+    async def test_engines_render_a_vendor_error_the_same_way(self, rail: VendorRail, monkeypatch):
+        """One rejected credential, two engines, one answer.
+
+        Equality rather than a literal is what this asserts, because the three families in this
+        table legitimately differ: most actions raise and reach the caller through the engine's
+        fail-closed envelope, a few fail open, and ai_defense blocks as its own documented
+        policy. What none of them may do is answer differently depending on the engine, which
+        is what an operator reading only the message would have to reverse-engineer.
+        """
+        for name, value in rail.env.items():
+            monkeypatch.setenv(name, value)
+        config_dict = _vendor_config(rail)
+
+        llmrails_content = await _llmrails_reply(config_dict, _rejecting_client())
+        iorails_content = await _iorails_reply(config_dict, _rejecting_client(), monkeypatch)
+
+        assert iorails_content == llmrails_content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "rail",
+        [rail for rail in VENDOR_RAILS if rail.rail_id.startswith("f5_")],
+        ids=lambda rail: rail.rail_id,
+    )
+    async def test_a_rejected_f5_credential_is_not_the_refusal(self, rail: VendorRail, monkeypatch):
+        """The reported case, pinned to a literal so equality above cannot agree on the wrong text.
+
+        nvbug 6620440: an F5 401 reached the caller as the refusal a genuine F5 trip produces,
+        so a provider outage was indistinguishable from a safety decision.
+        """
+        for name, value in rail.env.items():
+            monkeypatch.setenv(name, value)
+        config_dict = _vendor_config(rail)
+        iorails_content = await _iorails_reply(config_dict, _rejecting_client(), monkeypatch)
+
+        assert iorails_content == INTERNAL_ERROR_MESSAGE
+        assert iorails_content != REFUSAL_MESSAGE
 
 
 class TestVendorRailsAreReachable:

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -19,6 +19,7 @@ from typing import Any, ClassVar
 
 import pytest
 
+from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
@@ -100,17 +101,29 @@ class TestRailResult:
         """The structured verdict is the decision plus the outcome's metadata, not a stored copy."""
         result = RailResult.block(metadata={"policy_violations": ["S1: Violence"]})
 
-        assert result.return_value == {"allowed": False, "policy_violations": ["S1: Violence"]}
+        assert result.return_value == {"allowed": False, "failed": False, "policy_violations": ["S1: Violence"]}
 
     def test_return_value_of_a_bare_allow_states_only_the_decision(self):
         """A rail with no metadata still yields a verdict the GenerationLog can record."""
-        assert RailResult.allow().return_value == {"allowed": True}
+        assert RailResult.allow().return_value == {"allowed": True, "failed": False}
+
+    def test_return_value_reports_a_rail_that_broke(self):
+        """The log separates a rail that failed from one that decided, as the message does."""
+        failed = RailResult(RailOutcome.failure(reason="content safety check input error: parser blew up"))
+
+        assert failed.return_value == {"allowed": False, "failed": True}
 
     def test_metadata_cannot_overwrite_the_decision(self):
         """A custom action putting ``allowed`` in metadata cannot log a block as an allow."""
         result = RailResult.block(metadata={"allowed": True, "policy_violations": ["S1: Violence"]})
 
-        assert result.return_value == {"allowed": False, "policy_violations": ["S1: Violence"]}
+        assert result.return_value == {"allowed": False, "failed": False, "policy_violations": ["S1: Violence"]}
+
+    def test_metadata_cannot_forge_a_rail_failure(self):
+        """A rail that decided to block cannot log itself as having broken."""
+        result = RailResult.block(metadata={"failed": True})
+
+        assert result.return_value == {"allowed": False, "failed": False}
 
     def test_metadata_participates_in_equality(self):
         """Two blocks differing only in evidence are no longer equal.

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -29,6 +29,7 @@ from nemoguardrails.guardrails.iorails import (
     INTERNAL_ERROR_MESSAGE,
     REFUSAL_MESSAGE,
     IORails,
+    _GeneratedTurn,
     _rewritten_bot_message,
     _rewritten_user_message,
 )
@@ -467,6 +468,21 @@ class TestGenerateAsync:
         await iorails.generate_async(messages=messages, options={"llm_params": llm_params})
 
         iorails.engine_registry.model_call.assert_called_once_with("main", messages, **llm_params)
+
+    @pytest.mark.asyncio
+    async def test_a_turn_with_neither_a_response_nor_a_verdict_raises(self, iorails):
+        """A generation bug must surface as an error, not as a plausible-looking guardrail block.
+
+        Both generation paths name the blocking verdict on the one branch that drops the
+        response, so this state is unreachable today; the guard is what keeps a future path
+        from reporting a missing response to the caller as a refusal.
+        """
+        messages = [{"role": "user", "content": "hi"}]
+        iorails._speculative_generation = False
+        iorails._do_generate_sequential = AsyncMock(return_value=_GeneratedTurn(response=None, messages=messages))
+
+        with pytest.raises(RuntimeError, match="without naming a blocking rail"):
+            await iorails.generate_async(messages=messages)
 
     @pytest.mark.asyncio
     async def test_generate_async_propagates_exception(self, iorails):

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -26,6 +26,7 @@ from aiohttp.test_utils import TestServer
 from nemoguardrails import Guardrails
 from nemoguardrails.guardrails.guardrails_types import RailDirection, RailResult
 from nemoguardrails.guardrails.iorails import (
+    INTERNAL_ERROR_MESSAGE,
     REFUSAL_MESSAGE,
     IORails,
     _rewritten_bot_message,
@@ -35,7 +36,7 @@ from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse
 from nemoguardrails.types import LLMResponse, LLMResponseChunk, ToolCall, ToolCallFunction
-from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
+from tests.guardrails.rail_stubs import bot_message_rewrite, rail_failure, user_message_rewrite
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
 
@@ -382,6 +383,76 @@ class TestGenerateAsync:
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         record_blocked.assert_called_once_with(RailDirection.OUTPUT)
+
+    @pytest.mark.asyncio
+    async def test_failed_input_rail_returns_the_internal_error(self, iorails):
+        """A rail that raised renders the internal error, not the refusal a real block gets."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=rail_failure("f5 guardrails scan input"))
+        iorails.engine_registry.model_call = AsyncMock()
+        iorails.rails_manager.is_output_safe = AsyncMock()
+
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
+        iorails.engine_registry.model_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_input_rail_returns_the_internal_error_with_generation_options(self, iorails):
+        """The structured return shape carries the same sentence as the bare one."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=rail_failure("f5 guardrails scan input"))
+        iorails.engine_registry.model_call = AsyncMock()
+        iorails.rails_manager.is_output_safe = AsyncMock()
+
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}], options=GenerationOptions())
+
+        assert isinstance(result, GenerationResponse)
+        assert result.response == [{"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}]
+
+    @pytest.mark.asyncio
+    async def test_failed_output_rail_returns_the_internal_error(self, iorails):
+        """An output rail that raised is reported the same way an input one is."""
+        messages = [{"role": "user", "content": "hi"}]
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="an answer"))
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=rail_failure("f5 guardrails scan output"))
+
+        result = await iorails.generate_async(messages=messages)
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_failed_tool_result_rail_returns_the_internal_error(self, iorails):
+        """A tool-result rail that raised short-circuits before generation with the internal error."""
+        iorails.rails_manager.are_tool_results_safe = AsyncMock(return_value=rail_failure("tool result validation"))
+        iorails.rails_manager.is_input_safe = AsyncMock()
+        iorails.engine_registry.model_call = AsyncMock()
+
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "hi"}])
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
+        iorails.engine_registry.model_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_tool_call_rail_returns_the_internal_error(self, iorails):
+        """A tool-call rail that raised discards the model's tool calls with the internal error."""
+        tool_calls = [
+            ToolCall(
+                id="call_1",
+                type="function",
+                function=ToolCallFunction(name="get_weather", arguments={"city": "Paris"}),
+            )
+        ]
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="", tool_calls=tool_calls))
+        iorails.rails_manager.are_tool_calls_safe = AsyncMock(return_value=rail_failure("tool call validation"))
+        iorails.rails_manager.is_output_safe = AsyncMock()
+
+        result = await iorails.generate_async(messages=[{"role": "user", "content": "weather?"}])
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
+        iorails.rails_manager.is_output_safe.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dict_options_forwarded(self, iorails):
@@ -1000,6 +1071,10 @@ class TestRefusalMessage:
         assert isinstance(REFUSAL_MESSAGE, str)
         assert len(REFUSAL_MESSAGE) > 0
 
+    def test_the_internal_error_is_not_the_refusal(self):
+        """Aliasing the two would silently undo the distinction the whole fix rests on."""
+        assert INTERNAL_ERROR_MESSAGE != REFUSAL_MESSAGE
+
 
 class TestIORailsConfigToCallURL:
     """End-to-end: from a RailsConfig with a user-supplied base_url to the URL the engine POSTs.
@@ -1256,6 +1331,25 @@ class TestGeneratedTurn:
         assert turn.response is None
         assert turn.messages is REWRITE_MESSAGES
         iorails.engine_registry.model_call.assert_not_called()
+
+    async def test_a_blocked_turn_carries_the_verdict_that_blocked_it(self, iorails):
+        """The caller renders the message from this verdict, so a failed rail must survive the hop."""
+        verdict = rail_failure("f5 guardrails scan input")
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=verdict)
+        iorails.engine_registry.model_call = AsyncMock()
+
+        turn = await iorails._do_generate_sequential(REWRITE_MESSAGES, "req-1", {})
+
+        assert turn.blocked_by is verdict
+
+    async def test_an_unblocked_turn_names_no_blocking_verdict(self, iorails):
+        """Nothing blocked, so there is no verdict for the caller to render a message from."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
+        iorails.engine_registry.model_call = AsyncMock(return_value=LLMResponse(content="sure"))
+
+        turn = await iorails._do_generate_sequential(REWRITE_MESSAGES, "req-1", {})
+
+        assert turn.blocked_by is None
 
 
 @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_check.py
+++ b/tests/guardrails/test_iorails_check.py
@@ -30,6 +30,7 @@ import pytest_asyncio
 from nemoguardrails.exceptions import RailTypeNotConfiguredError
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import (
+    INTERNAL_ERROR_MESSAGE,
     REFUSAL_MESSAGE,
     IORails,
     _determine_rails_from_messages,
@@ -37,7 +38,7 @@ from nemoguardrails.guardrails.iorails import (
 )
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailStatus, RailType
-from tests.guardrails.rail_stubs import bot_message_rewrite, user_message_rewrite
+from tests.guardrails.rail_stubs import bot_message_rewrite, rail_failure, user_message_rewrite
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG, TOPIC_SAFETY_CONFIG
 
 SAFE = RailResult.allow()
@@ -467,6 +468,45 @@ class TestCheckAsyncBlockedResult:
         assert result.rail is None
 
 
+class TestCheckAsyncFailedRail:
+    """A rail that failed is reported as an internal error, not as a content refusal."""
+
+    @pytest.mark.asyncio
+    async def test_input_rail_failure_returns_the_internal_error_message(self, iorails):
+        """A failed input rail blocks with the sentence LLMRails uses for a failed action."""
+        _mock_rails(iorails, input_result=rail_failure("f5 guardrails scan input"))
+
+        result = await iorails.check_async([{"role": "user", "content": "hello"}])
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == INTERNAL_ERROR_MESSAGE
+        assert result.rail == "f5 guardrails scan input"
+
+    @pytest.mark.asyncio
+    async def test_output_rail_failure_returns_the_internal_error_message(self, iorails):
+        """A failed output rail renders the same internal error the input side does."""
+        _mock_rails(iorails, output_result=rail_failure("f5 guardrails scan output"))
+
+        result = await iorails.check_async([{"role": "assistant", "content": "hi there"}])
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == INTERNAL_ERROR_MESSAGE
+        assert result.rail == "f5 guardrails scan output"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_rail_is_distinguishable_from_a_rail_that_fired(self, iorails):
+        """The two blocks differ in content, which is the whole point of the marker."""
+        _mock_rails(iorails, input_result=rail_failure("f5 guardrails scan input"))
+        failed = await iorails.check_async([{"role": "user", "content": "hello"}])
+
+        _mock_rails(iorails, input_result=_unsafe("f5 guardrails scan input"))
+        decided = await iorails.check_async([{"role": "user", "content": "hello"}])
+
+        assert failed.status == decided.status
+        assert failed.rail == decided.rail
+        assert failed.content != decided.content
+
+
 class TestCheckSync:
     """Synchronous check() spins up an ephemeral engine via asyncio.run."""
 
@@ -490,6 +530,16 @@ class TestCheckSync:
 
         assert result.status == RailStatus.BLOCKED
         assert result.rail == "content safety check input"
+
+    def test_check_renders_the_internal_error_for_a_failed_rail(self, iorails_sync):
+        """The sync wrapper carries the failed-rail rendering, not just the async path."""
+        _mock_rails(iorails_sync, input_result=rail_failure("f5 guardrails scan input"))
+
+        with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails_sync):
+            result = iorails_sync.check([{"role": "user", "content": "hello"}])
+
+        assert result.status == RailStatus.BLOCKED
+        assert result.content == INTERNAL_ERROR_MESSAGE
 
     def test_check_with_explicit_rails_skips_output(self, iorails_sync):
         """Sync check() honors rail_types, skipping the output rail."""

--- a/tests/guardrails/test_iorails_generation_log.py
+++ b/tests/guardrails/test_iorails_generation_log.py
@@ -34,6 +34,7 @@ from nemoguardrails.guardrails.iorails import IORails, _activated_rail
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.types import LLMResponse, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
+from tests.guardrails.rail_stubs import rail_failure
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
 
 _USER = [{"role": "user", "content": "hi"}]
@@ -152,6 +153,49 @@ class TestActivatedRails:
         assert rail.type == "input"
         assert rail.executed_actions[0].action_name == "content_safety_check_input"
         assert rail.executed_actions[0].return_value == verdict
+
+    @pytest.mark.asyncio
+    async def test_a_failed_rail_is_logged_as_failed(self, iorails):
+        """A rail that broke reaches the log marked as such, not as a verdict on the content.
+
+        The verdict is derived from a real failed ``RailResult`` rather than written as a
+        literal: what is under test is what ``RailResult.return_value`` puts on the record,
+        not that the log builder copies a dict it was handed.
+        """
+        failed = rail_failure(_CS_INPUT_FLOW)
+        _stub_pipeline(
+            iorails,
+            input_records=[_input_record(is_safe=False, return_value=failed.return_value)],
+            input_safe=False,
+        )
+
+        result = await iorails.generate_async(messages=_USER, options={"log": {"activated_rails": True}})
+
+        assert result.log is not None
+        rail = next(r for r in result.log.activated_rails if r.name == _CS_INPUT_FLOW)
+        assert rail.stop is True
+        assert rail.executed_actions[0].return_value == {"allowed": False, "failed": True}
+
+    @pytest.mark.asyncio
+    async def test_a_decided_block_is_logged_as_not_failed(self, iorails):
+        """The contrast case: an operator reading the log can tell the two apart."""
+        blocked = RailResult.block(reason="unsafe", metadata={"policy_violations": ["Violence"]})
+        _stub_pipeline(
+            iorails,
+            input_records=[_input_record(is_safe=False, return_value=blocked.return_value)],
+            input_safe=False,
+        )
+
+        result = await iorails.generate_async(messages=_USER, options={"log": {"activated_rails": True}})
+
+        assert result.log is not None
+        rail = next(r for r in result.log.activated_rails if r.name == _CS_INPUT_FLOW)
+        assert rail.stop is True
+        assert rail.executed_actions[0].return_value == {
+            "allowed": False,
+            "failed": False,
+            "policy_violations": ["Violence"],
+        }
 
     @pytest.mark.asyncio
     async def test_stop_set_on_blocking_rail(self, iorails):

--- a/tests/guardrails/test_iorails_generation_log_capture.py
+++ b/tests/guardrails/test_iorails_generation_log_capture.py
@@ -109,7 +109,7 @@ class TestRailRecordCapture:
         assert record.llm_model_name == _CS_MODEL
         assert record.llm_provider_name == "nim"
         assert record.request_id == "req-cs-input"
-        assert record.return_value == {"allowed": True, "policy_violations": []}
+        assert record.return_value == {"allowed": True, "failed": False, "policy_violations": []}
 
     @pytest.mark.asyncio
     async def test_failed_model_call_still_records_the_attempt(self, iorails):
@@ -128,6 +128,8 @@ class TestRailRecordCapture:
         assert record.llm_model_name == _CS_MODEL
         assert record.llm_provider_name == "nim"
         assert record.duration is not None
+        # The log says the rail broke, not that it judged the content unsafe.
+        assert record.return_value == {"allowed": False, "failed": True}
 
 
 class TestGenerationLogEndToEnd:
@@ -155,7 +157,7 @@ class TestGenerationLogEndToEnd:
 
         cs_rail = next(rail for rail in result.log.activated_rails if rail.name == _CS_INPUT)
         assert cs_rail.type == "input"
-        assert cs_rail.executed_actions[0].return_value == {"allowed": True, "policy_violations": []}
+        assert cs_rail.executed_actions[0].return_value == {"allowed": True, "failed": False, "policy_violations": []}
         # The provider's response id is threaded through as request_id.
         cs_call = cs_rail.executed_actions[0].llm_calls[0]
         assert cs_call.request_id == "req-cs"

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -31,7 +31,7 @@ from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, RailResult, get_request_id
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import INTERNAL_ERROR_MESSAGE, REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailStatus
 from nemoguardrails.tracing import constants as tracing_constants
@@ -516,7 +516,8 @@ class TestSpanHierarchy:
                 engine.chat_completion = AsyncMock(return_value=LLMResponse(content=SAFE_INPUT_JSON))
 
         result = await iorails_tracing.generate_async(messages=[{"role": "user", "content": "hi"}])
-        assert result["content"] == REFUSAL_MESSAGE
+        # The rail broke rather than fired, so the caller is told so; the span still carries the error.
+        assert result["content"] == INTERNAL_ERROR_MESSAGE
 
         spans = exporter.get_finished_spans()
         action_spans = [s for s in spans if s.name == "guardrails.action"]

--- a/tests/guardrails/test_rail_guard.py
+++ b/tests/guardrails/test_rail_guard.py
@@ -77,6 +77,19 @@ class TestFailsClosed:
         assert outcome.is_blocked
         assert outcome.reason == "content safety check input error: parser blew up"
 
+    def test_unexpected_exception_is_marked_as_a_rail_failure(self):
+        """The block is marked failed, so an engine can tell it from a rail that decided to block."""
+        outcome = rail_error_outcome(None, ACTION_NAME, RuntimeError("parser blew up"))
+
+        assert outcome.failed is True
+
+    @status_bearing_types
+    def test_status_bearing_exception_without_a_status_is_marked_as_a_rail_failure(self, make_exc):
+        """A connection-level failure fails closed, and is marked failed like any other rail error."""
+        outcome = rail_error_outcome(None, ACTION_NAME, make_exc(None))
+
+        assert outcome.failed is True
+
     @status_bearing_types
     def test_status_bearing_exception_without_a_status_blocks(self, make_exc):
         """A connection-level failure carries status=None, so it fails closed rather than propagating."""
@@ -158,10 +171,10 @@ class TestReturnShape:
     """Every rail, compiled or tool, gets the same blocking RailOutcome."""
 
     def test_entry_point_returns_a_rail_outcome(self):
-        """``rail_error_outcome`` yields a blocking RailOutcome with no metadata or transforms."""
+        """``rail_error_outcome`` yields a failed RailOutcome with no metadata or transforms."""
         returned = rail_error_outcome(None, ACTION_NAME, RuntimeError("parser blew up"))
 
-        assert returned == RailOutcome.block(reason="content safety check input error: parser blew up")
+        assert returned == RailOutcome.failure(reason="content safety check input error: parser blew up")
 
 
 class TestLogsAreRedacted:
@@ -305,7 +318,13 @@ class TestToolRailsShareTheEnvelope:
         """A malformed payload fails closed, named after the rail and with credentials removed."""
         result = DummyToolRail(ValueError("bad header sk-abc123secret")).check()
 
-        assert result == RailOutcome.block(reason="tool call validation error: bad header sk-***")
+        assert result == RailOutcome.failure(reason="tool call validation error: bad header sk-***")
+
+    def test_exception_is_marked_as_a_rail_failure(self):
+        """A tool rail's fail-closed block carries the same failed marker a compiled rail's does."""
+        result = DummyToolRail(ValueError("bad payload")).check()
+
+        assert result.failed is True
 
     def test_status_bearing_exception_is_reraised(self):
         """A tool rail is held to the same propagation policy, though no shipped one can raise this."""

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -519,7 +519,7 @@ class TestSequentialMultiRail:
         mock_jailbreak_nim(httpx_mock, jailbreak=True, score=0.95)
         result = await nemoguards_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
-        assert result.return_value == {"allowed": False}
+        assert result.return_value == {"allowed": False, "failed": False}
 
 
 # --- Topic safety via is_input_safe ---
@@ -543,7 +543,7 @@ class TestTopicSafetyIsInputSafe:
         )
         result = await topic_safety_rails_manager.is_input_safe(MESSAGES)
         assert not result.is_safe
-        assert result.return_value == {"allowed": False}
+        assert result.return_value == {"allowed": False, "failed": False}
 
     @pytest.mark.asyncio
     async def test_model_error(self, topic_safety_rails_manager):
@@ -1170,7 +1170,7 @@ class TestOutcomeToResult:
         result = _rail_result(outcome)
 
         assert result.is_safe is is_safe
-        assert result.return_value == {"allowed": is_safe}
+        assert result.return_value == {"allowed": is_safe, "failed": False}
 
     def test_a_transform_becomes_a_safe_verdict_carrying_its_rewrite(self):
         """A rewrite does not block, and the text it produced survives on the outcome."""
@@ -1762,7 +1762,7 @@ class TestLibraryActionContract:
         with _mocked_reply(UNSAFE_INPUT_JSON):
             result = await content_safety_rails_manager.is_input_safe(MESSAGES)
 
-        assert result.return_value == {"allowed": False, "policy_violations": ["S1: Violence"]}
+        assert result.return_value == {"allowed": False, "failed": False, "policy_violations": ["S1: Violence"]}
 
     @pytest.mark.asyncio
     async def test_topic_safety_reports_its_decision_under_allowed(self, topic_safety_rails_manager):
@@ -1771,7 +1771,7 @@ class TestLibraryActionContract:
             result = await topic_safety_rails_manager.is_input_safe(MESSAGES)
 
         assert result.is_safe is False
-        assert result.return_value == {"allowed": False}
+        assert result.return_value == {"allowed": False, "failed": False}
 
     @pytest.mark.asyncio
     async def test_an_unconfigured_max_tokens_uses_the_library_default(self):

--- a/tests/guardrails/test_speculative_generation.py
+++ b/tests/guardrails/test_speculative_generation.py
@@ -28,13 +28,13 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import RailResult
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import INTERNAL_ERROR_MESSAGE, REFUSAL_MESSAGE, IORails
 from nemoguardrails.manifests import RailDirection as SurfaceDirection
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationResponse
 from nemoguardrails.types import LLMResponse, UsageInfo
 from tests.guardrails.async_helpers import started_iorails
-from tests.guardrails.rail_stubs import declared_rewriter, rails_compiled_as
+from tests.guardrails.rail_stubs import declared_rewriter, rail_failure, rails_compiled_as
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG, NEMOGUARDS_SPECULATIVE_CONFIG
 
 MESSAGES = [{"role": "user", "content": "hi"}]
@@ -182,6 +182,49 @@ class TestSpeculativeGeneration:
 
         assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
         iorails.rails_manager.is_output_safe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rails_first_failure_returns_the_internal_error(self, iorails):
+        """A rail that raised is rendered as an internal error on the rails-first branch too."""
+
+        async def failing_rails(messages, *, enabled=True):
+            return rail_failure("f5 guardrails scan input")
+
+        async def generation_still_in_flight(model_type, messages):
+            # Never resolves, so the rails task is the only one that can complete first.
+            # The block path cancels this, which is what ends the wait.
+            await asyncio.Event().wait()
+
+        iorails.rails_manager.is_input_safe = failing_rails
+        iorails.engine_registry.model_call = generation_still_in_flight
+        iorails.rails_manager.is_output_safe = AsyncMock()
+
+        result = await iorails.generate_async(messages=MESSAGES)
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
+
+    @pytest.mark.asyncio
+    async def test_gen_first_failure_returns_the_internal_error(self, iorails):
+        """The generation-first branch renders the failure the same way, from the same verdict."""
+        generation_done = asyncio.Event()
+
+        async def rails_failing_after_generation(messages, *, enabled=True):
+            # Created first and so scheduled first, this suspends here until generation has
+            # returned, which is what puts the race the other way round without a clock.
+            await generation_done.wait()
+            return rail_failure("f5 guardrails scan input")
+
+        async def generation_finishing_first(model_type, messages):
+            generation_done.set()
+            return LLMResponse(content="Should be discarded")
+
+        iorails.rails_manager.is_input_safe = rails_failing_after_generation
+        iorails.engine_registry.model_call = generation_finishing_first
+        iorails.rails_manager.is_output_safe = AsyncMock()
+
+        result = await iorails.generate_async(messages=MESSAGES)
+
+        assert result == {"role": "assistant", "content": INTERNAL_ERROR_MESSAGE}
 
     @pytest.mark.asyncio
     async def test_llm_error_cancels_rails(self, iorails):

--- a/tests/recorded/rails/library/test_iorails_parity.py
+++ b/tests/recorded/rails/library/test_iorails_parity.py
@@ -263,10 +263,10 @@ async def test_f5_guardrails_output_blocks_violating_assistant_message(f5_api_ke
 
 
 async def test_f5_guardrails_input_fails_closed_on_401(f5_api_key, monkeypatch, caplog):
-    """A recorded 401 blocks on both engines, but IORails renders the plain refusal."""
-    # LLMRails renders "I'm sorry, an internal error has occurred." here, distinguishing a rail
-    # that failed from a rail that fired. IORails renders one refusal for both, so a caller
-    # cannot tell a provider outage from a genuine block by reading the message.
+    """A recorded 401 blocks on both engines, and both render the internal-error sentence."""
+    # The rail failed rather than fired, and the message says so on either engine. Reserving
+    # the refusal for a rail that actually decided is what lets a caller tell a provider
+    # outage from a genuine block, and so whether the request is worth retrying.
     monkeypatch.setenv("F5_GUARDRAILS_API_KEY", "invalid-recorded-replay")
 
     # Cleared first: records leak between tests in a module, and a stale error from an earlier
@@ -281,8 +281,8 @@ async def test_f5_guardrails_input_fails_closed_on_401(f5_api_key, monkeypatch, 
 
     assert result.status is RailStatus.BLOCKED
     assert result.rail == "f5 guardrails scan input"
-    assert result.content == REFUSAL
-    assert result.content != INTERNAL_ERROR
+    assert result.content == INTERNAL_ERROR
+    assert result.content != REFUSAL
     # The rail must have failed on the *recorded* 401. This test cannot use rail_ran_cleanly,
     # because it expects a rail error -- so without naming the error, an unreplayed cassette
     # would fail the rail for a different reason and satisfy every assertion above. Matched on

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -239,7 +239,7 @@ class TestContentSafetyParserIntegration:
             "content safety check input $model=test_model", RailDirection.INPUT, dependencies
         ).run([{"role": "user", "content": "Some content"}])
 
-        assert outcome == RailOutcome.block(
+        assert outcome == RailOutcome.failure(
             reason="content safety check input error: Failed to parse content safety model response"
         )
 

--- a/tests/test_generation_options.py
+++ b/tests/test_generation_options.py
@@ -88,6 +88,7 @@ def _expected_serialized_outcome(outcome):
         "reason": outcome.reason,
         "metadata": dict(outcome.metadata),
         "transforms": [{"target": spec.target.value, "text": spec.text} for spec in outcome.transforms],
+        "failed": outcome.failed,
     }
 
 

--- a/tests/test_rail_outcome.py
+++ b/tests/test_rail_outcome.py
@@ -68,6 +68,40 @@ def test_block_is_blocked_with_reason_and_metadata():
     assert outcome.transforms == ()
 
 
+def test_failure_is_a_block_marked_failed():
+    """``failure`` is a BLOCK that also records the rail never reached a verdict."""
+    outcome = RailOutcome.failure(reason="content safety check input error: parser blew up")
+
+    assert outcome.decision is RailDecision.BLOCK
+    assert outcome.is_blocked is True
+    assert outcome.failed is True
+    assert outcome.reason == "content safety check input error: parser blew up"
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        pytest.param(RailOutcome.allow(), id="allow"),
+        pytest.param(RailOutcome.block(reason="unsafe"), id="block"),
+        pytest.param(RailOutcome.transform([(TransformTarget.USER_MESSAGE, "masked")]), id="transform"),
+    ],
+)
+def test_a_rails_own_verdict_is_never_marked_failed(outcome):
+    """The three decision factories leave ``failed`` unset, so the flag cannot forge a rail failure."""
+    assert outcome.failed is False
+
+
+def test_failed_requires_a_block_decision():
+    """Only a BLOCK may be marked failed: the fail-closed envelope has no other decision to make."""
+    with pytest.raises(ValueError, match="failed must be set only on a BLOCK decision"):
+        RailOutcome(decision=RailDecision.ALLOW, failed=True)
+
+
+def test_failed_distinguishes_two_otherwise_equal_blocks():
+    """A failed block and a decided block with the same reason do not compare equal."""
+    assert RailOutcome.failure(reason="unsafe") != RailOutcome.block(reason="unsafe")
+
+
 def test_transform_targets_variables():
     outcome = RailOutcome.transform(
         [


### PR DESCRIPTION
## Description

An F5 Guardrails HTTP 401 fail-closed on IORails, but the caller saw `I'm sorry, I can't respond to that.`, identical to a successfully executed rail blocking.
By comparison, LLMRails returns `I'm sorry, an internal error has occurred.` rather than `I'm sorry, I can't respond to that.` for the same recorded 401.
A caller could not tell a provider outage from a safety decision, and so could not know the request was worth retrying after fixing the key.

The defect was not F5-specific. The `rail_guard` mapped every non-status-bearing exception to `RailOutcome.block()`, which is structurally identical to what a rail returns when it *decides* to block, and IORails then hardcoded `REFUSAL_MESSAGE` for both.
Every HTTP-backed library rail raises a status-less `ValueError`/`RuntimeError` on a vendor non-200 (activefence, privateai, f5, gliner, policyai, clavata, hf_classifier, autoalign, …), so the whole family was affected.

The two engines diverged because they represent a failed rail differently.
LLMRails separates whether a rail ran successfully from its result, [`ActionDispatcher.execute_action`](https://github.com/NVIDIA-NeMo/Guardrails/blob/e961f810ca266e3738c4815df8712a35a71dc7fa/nemoguardrails/actions/action_dispatcher.py#L318) returns a tuple of the result and whether it passed or failed. For example the Colang runtime substitutes the internal error message when the `(None, "failed")` tuple is returned from ActionDispatcher. A failed rail never produces a `RailOutcome` at all, because the "failed" string distinguishes between a failure and successful block or allow.
Prior to this PR, IORails treated a rail failure as a blocking outcome. Conflating the two means clients can't decide whether to back off and retry (rail failure case) or not (rail block case).

After this PR, `RailOutcome` gains a `failed` flag, set only by `rail_guard.rail_error_outcome`, and IORails renders the internal-error sentence from it on both the `check` and `generate` paths.
Because `CompiledRail.execute` and `ToolRailAction._guarded` both funnel through that one function, every rail is covered by a single-line change there.

Propagation is unchanged: an exception carrying an upstream HTTP status still re-raises on both engines, so `test_content_safety_input_provider_error_raises` is untouched.
Streaming is unchanged too — its `guardrails_violation` payload already carried `"<rail> error: …"` via `client_reason`, so it was never the ambiguous surface.

## Related Issue(s)

* NGUARD-886

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test
env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/fix/iorails-f5-rail-error
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7359 items]

........................................................................ [  0%]
........................................................................ [  1%]
........................................................................ [  2%]
......................................................s...s..ss......... [  3%]
......................................................................s. [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
...........................................s............................ [  9%]
........................................................................ [ 10%]
......................................................s................. [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
.............s...........s..s........................................... [ 20%]
............sss.s.s...ss................................................ [ 21%]
...............................s........................................ [ 22%]
........................................................................ [ 23%]
.....................ss.sssss......................ss.ssssss............ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
.........ss.ss.s.ss.s.........................ss.s.s..s.s..........ss... [ 32%]
.......s......................................sss.ssss.s................ [ 33%]
........................................................................ [ 34%]
........................................................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
........................................................................ [ 43%]
..........................................ss...............s............ [ 44%]
........................................................................ [ 45%]
........................................................................ [ 45%]
........................................................................ [ 46%]
.......................................................s.s.ss.s......... [ 47%]
.............s.s.ss.sss.ss.sssss..s.s..s..s............................. [ 48%]
..................................s..................................... [ 49%]
........................................................................ [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
........................................................................ [ 55%]
............................................................sssss....... [ 56%]
........................................................................ [ 57%]
........................................................................ [ 58%]
...ss................................................................... [ 59%]
...................................ss..................................s [ 60%]
s....................................................................... [ 61%]
.....................................s.................................. [ 62%]
....................s................................................... [ 63%]
.......................ss.ssss.......................................sss [ 64%]
...........................ss.......................ss.................. [ 65%]
........................................................................ [ 66%]
........................................................................ [ 67%]
.........................................................ss.sss.ssssssss [ 68%]
................s........s.............................................. [ 69%]
.........................................s..........................s... [ 70%]
....................s................................................... [ 71%]
...........sss.......................................................... [ 72%]
....ssssssssssssss...................................................... [ 73%]
.........sssssss...................................s.................... [ 74%]
........................................................................ [ 75%]
........s.....................s......................................... [ 76%]
................s............................................ss.sss..... [ 77%]
........................................................................ [ 78%]
........................................................................ [ 79%]
....................................s................................... [ 80%]
............................sss.ssssss..sssssss.ss.s.................... [ 81%]
........................................................................ [ 82%]
........................................................................ [ 83%]
........................................................................ [ 84%]
........................................................................ [ 85%]
....ss.ss..s............................................................ [ 86%]
.............................sss.s...................................... [ 87%]
...........s.s.......................ss....................ssssssss..... [ 88%]
........................................................................ [ 89%]
...............................................................ss....... [ 90%]
........................................................................ [ 90%]
......................s................................................. [ 91%]
..........................................................s............. [ 92%]
........................................................................ [ 93%]
........................................................................ [ 94%]
...............................................................s........ [ 95%]
.......................................................s................ [ 96%]
........................................................................ [ 97%]
.........s.............................................................. [ 98%]
....................................s................................... [ 99%]
...............                                                          [100%]

══════════════════════════════════════════════════════════════════════ inline-snapshot ═══════════════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will only return x and 
inline-snapshot will not be able to fix snapshots or generate reports.


====================== 7148 passed, 211 skipped in 41.24s ======================

```


### Integration test (TODO)


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider credential and connectivity failures now return a distinct internal-error message instead of appearing as ordinary refusals.
  * Failed input, output, tool, and structured-generation checks consistently preserve their blocked status and triggering rail details.
  * Streaming provider failures continue to stop the active turn safely.
* **Documentation**
  * Updated rail behavior documentation to clarify the difference between policy refusals and provider failures.
* **Tests**
  * Added coverage across synchronous, asynchronous, speculative, vendor, and telemetry workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->