### PR TITLE
docs(benchmark): correct Mock LLM configuration keys

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -190,14 +190,22 @@ The Mock LLM has the following OpenAI-compatible endpoints:
 Mock LLMs are configured using the `.env` file format. These files are passed to the Mock LLM using the `--config-file` argument.
 The Mock LLMs return either a `SAFE_TEXT` or `UNSAFE_TEXT` response to `/v1/completions` or `/v1/chat/completions` inference requests.
 The probability of the `UNSAFE_TEXT` being returned if given by `UNSAFE_PROBABILITY`.
-The latency of each response is also controllable.
-Non-streaming responses use the end-to-end `E2E_LATENCY_*` settings.
-Streaming responses instead use `TTFT_*` for the first chunk and `CHUNK_LATENCY_*` for every chunk after it.
-Each of these three groups is sampled the same way, where `*` is the group prefix:
+When streaming, the Mock LLM splits that response on whitespace and returns each element as a chunk, so the chunk count is the number of whitespace-separated words in `SAFE_TEXT` or `UNSAFE_TEXT`.
 
-* Latency is first sampled from a normal distribution with mean `*_MEAN_SECONDS` and standard deviation `*_STD_SECONDS`.
-* If the sampled value is less than `*_MIN_SECONDS`, it is set to `*_MIN_SECONDS`.
-* If the sampled value is greater than `*_MAX_SECONDS`, it is set to `*_MAX_SECONDS`.
+The latency of each inference request is sampled from a truncated normal distribution. There are three latencies:
+
+* `E2E_LATENCY`: end-to-end latency of a non-streaming response.
+* `TTFT`: [time to first token](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#time-to-first-token-ttft), the latency before the first chunk of a streaming response.
+* `CHUNK_LATENCY`: [inter-token latency](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#inter-token-latency-itl), the latency before each subsequent chunk of a streaming response.
+
+Each has the following parameters, where `*` is one of the latency names above:
+
+* `*_MEAN_SECONDS`: Normal distribution mean (or average) in seconds.
+* `*_STD_SECONDS`: Normal distribution standard deviation in seconds.
+* `*_MIN_SECONDS`: Minimum latency in seconds. Latencies must be non-negative (i.e. >= 0).
+* `*_MAX_SECONDS`: Maximum latency in seconds.
+
+A sampled value below `*_MIN_SECONDS` is set to `*_MIN_SECONDS`, and a value above `*_MAX_SECONDS` is set to `*_MAX_SECONDS`.
 
 The full list of configuration fields is shown below:
 
@@ -205,15 +213,6 @@ The full list of configuration fields is shown below:
 * `UNSAFE_PROBABILITY`: Probability of an unsafe response. This must be in the range [0, 1].
 * `UNSAFE_TEXT`: String returned as an unsafe response.
 * `SAFE_TEXT`: String returned as a safe response.
-* `E2E_LATENCY_MIN_SECONDS`: Minimum end-to-end latency in seconds.
-* `E2E_LATENCY_MAX_SECONDS`: Maximum end-to-end latency in seconds.
-* `E2E_LATENCY_MEAN_SECONDS`: Normal distribution mean from which to sample end-to-end latency.
-* `E2E_LATENCY_STD_SECONDS`: Normal distribution standard deviation from which to sample end-to-end latency.
-* `TTFT_MIN_SECONDS`: Minimum [time to first token](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#time-to-first-token-ttft) in seconds. Streaming responses only.
-* `TTFT_MAX_SECONDS`: Maximum time to first token in seconds. Streaming responses only.
-* `TTFT_MEAN_SECONDS`: Normal distribution mean from which to sample time to first token. Streaming responses only.
-* `TTFT_STD_SECONDS`: Normal distribution standard deviation from which to sample time to first token. Streaming responses only.
-* `CHUNK_LATENCY_MIN_SECONDS`: Minimum [inter-token latency](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#inter-token-latency-itl) in seconds. Streaming responses only.
-* `CHUNK_LATENCY_MAX_SECONDS`: Maximum inter-token latency in seconds. Streaming responses only.
-* `CHUNK_LATENCY_MEAN_SECONDS`: Normal distribution mean from which to sample inter-token latency. Streaming responses only.
-* `CHUNK_LATENCY_STD_SECONDS`: Normal distribution standard deviation from which to sample inter-token latency. Streaming responses only.
+* `E2E_LATENCY_MEAN_SECONDS`, `E2E_LATENCY_STD_SECONDS`, `E2E_LATENCY_MIN_SECONDS`, `E2E_LATENCY_MAX_SECONDS`
+* `TTFT_MEAN_SECONDS`, `TTFT_STD_SECONDS`, `TTFT_MIN_SECONDS`, `TTFT_MAX_SECONDS`
+* `CHUNK_LATENCY_MEAN_SECONDS`, `CHUNK_LATENCY_STD_SECONDS`, `CHUNK_LATENCY_MIN_SECONDS`, `CHUNK_LATENCY_MAX_SECONDS`

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -190,11 +190,14 @@ The Mock LLM has the following OpenAI-compatible endpoints:
 Mock LLMs are configured using the `.env` file format. These files are passed to the Mock LLM using the `--config-file` argument.
 The Mock LLMs return either a `SAFE_TEXT` or `UNSAFE_TEXT` response to `/v1/completions` or `/v1/chat/completions` inference requests.
 The probability of the `UNSAFE_TEXT` being returned if given by `UNSAFE_PROBABILITY`.
-The latency of each response is also controllable, and works as follows:
+The latency of each response is also controllable.
+Non-streaming responses use the end-to-end `E2E_LATENCY_*` settings.
+Streaming responses instead use `TTFT_*` for the first chunk and `CHUNK_LATENCY_*` for every chunk after it.
+Each of these three groups is sampled the same way, where `*` is the group prefix:
 
-* Latency is first sampled from a normal distribution with mean `LATENCY_MEAN_SECONDS` and standard deviation `LATENCY_STD_SECONDS`.
-* If the sampled value is less than `LATENCY_MIN_SECONDS`, it is set to `LATENCY_MIN_SECONDS`.
-* If the sampled value is greater than `LATENCY_MAX_SECONDS`, it is set to `LATENCY_MAX_SECONDS`.
+* Latency is first sampled from a normal distribution with mean `*_MEAN_SECONDS` and standard deviation `*_STD_SECONDS`.
+* If the sampled value is less than `*_MIN_SECONDS`, it is set to `*_MIN_SECONDS`.
+* If the sampled value is greater than `*_MAX_SECONDS`, it is set to `*_MAX_SECONDS`.
 
 The full list of configuration fields is shown below:
 
@@ -202,7 +205,15 @@ The full list of configuration fields is shown below:
 * `UNSAFE_PROBABILITY`: Probability of an unsafe response. This must be in the range [0, 1].
 * `UNSAFE_TEXT`: String returned as an unsafe response.
 * `SAFE_TEXT`: String returned as a safe response.
-* `LATENCY_MIN_SECONDS`: Minimum latency in seconds.
-* `LATENCY_MAX_SECONDS`: Maximum latency in seconds.
-* `LATENCY_MEAN_SECONDS`: Normal distribution mean from which to sample latency.
-* `LATENCY_STD_SECONDS`: Normal distribution standard deviation from which to sample latency.
+* `E2E_LATENCY_MIN_SECONDS`: Minimum end-to-end latency in seconds.
+* `E2E_LATENCY_MAX_SECONDS`: Maximum end-to-end latency in seconds.
+* `E2E_LATENCY_MEAN_SECONDS`: Normal distribution mean from which to sample end-to-end latency.
+* `E2E_LATENCY_STD_SECONDS`: Normal distribution standard deviation from which to sample end-to-end latency.
+* `TTFT_MIN_SECONDS`: Minimum [time to first token](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#time-to-first-token-ttft) in seconds. Streaming responses only.
+* `TTFT_MAX_SECONDS`: Maximum time to first token in seconds. Streaming responses only.
+* `TTFT_MEAN_SECONDS`: Normal distribution mean from which to sample time to first token. Streaming responses only.
+* `TTFT_STD_SECONDS`: Normal distribution standard deviation from which to sample time to first token. Streaming responses only.
+* `CHUNK_LATENCY_MIN_SECONDS`: Minimum [inter-token latency](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#inter-token-latency-itl) in seconds. Streaming responses only.
+* `CHUNK_LATENCY_MAX_SECONDS`: Maximum inter-token latency in seconds. Streaming responses only.
+* `CHUNK_LATENCY_MEAN_SECONDS`: Normal distribution mean from which to sample inter-token latency. Streaming responses only.
+* `CHUNK_LATENCY_STD_SECONDS`: Normal distribution standard deviation from which to sample inter-token latency. Streaming responses only.


### PR DESCRIPTION
## Description

The "Mock LLM Configuration" section of `benchmark/README.md` documented four latency keys that `ModelSettings` does not read, and omitted eight that it does.

Those fields were renamed to `E2E_LATENCY_*` in #1564, which also added the `TTFT_*` and `CHUNK_LATENCY_*` groups for streaming. The section was edited after that rename in #1905, but only its prose changed — the key names stayed stale.

This matters more than ordinary doc drift because the mistake is silent. `run_server.py` hands the config file to uvicorn as `env_file=`, so the keys land in `os.environ` before `ModelSettings` is constructed. pydantic-settings rejects unknown *dotenv keys* but ignores unknown *environment variables*, so `extra="forbid"` never fires on this path. A config copied from the documentation therefore ran on field defaults, and nothing reported it:

| config file | request latency | configured intent |
| --- | --- | --- |
| README key names | 0.55s | 3.0s |
| `E2E_LATENCY_*` names | 3.03s | 3.0s |

The 0.55s is the `e2e_latency_mean_seconds` default of 0.5. `/health`, `/v1/models`, and `scripts/validate_mocks.sh` all pass in that state.

This PR corrects the four key names to `E2E_LATENCY_*` and documents the eight streaming keys, linking the NIM TTFT and ITL metric definitions already referenced from `config.py`. It is documentation only.

The silent-ignore behaviour itself is a separate defect and is not addressed here; I plan to raise it as its own issue so the fix can be scoped by maintainers.

The two shipped configs under `benchmark/mock_llm_server/configs/` already used the correct names and are unchanged.

## Related Issue(s)

- Fixes #2319
- Issue assignee: @yixinh-nv

## Verification

- `pytest benchmark/tests` — 244 passed.
- Reproduced the underlying behaviour by serving a config file with the previously documented key names and one with the real field names, then timing `/v1/chat/completions` against each. That produced the table above and confirmed the documented names have no effect.
- Cross-checked every key in the revised list against `ModelSettings.model_fields`: all 16 fields are now documented and no documented key is absent from the model.
- `make docs-fern` not run: `benchmark/README.md` is not part of the Fern build.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified mock LLM latency behavior for non-streaming and streaming responses.
  - Documented separate measurements for end-to-end latency, time to first token, and per-chunk latency.
  - Updated configuration names to distinguish each latency category.
  - Explained minimum, maximum, average, and standard-deviation settings, including normal-distribution sampling and value clamping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->