### PR TITLE
feat(benchmark): add concurrency sweep to the Locust runner

### DIFF
--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -171,8 +171,16 @@ Three things make the levels comparable:
   CLI exits non-zero only when the benchmark could not run at all, such as a
   failed health check.
 
-A full ladder takes hours. Use `--resume` to skip levels that already hold a
-completed result:
+The ladder above takes about 25 minutes: eleven levels of 120 measured seconds
+plus roughly 130 seconds of ramps. A longer `run_time` or more levels scales
+that up accordingly.
+
+Re-running a batch writes into the same level directories, overwriting the
+previous results in place. This is what makes `--resume` possible, but it also
+means a level from an earlier, longer ladder is left behind rather than
+cleared. Use a different `batch_name` to keep two batches side by side.
+
+Use `--resume` to skip levels that already hold a completed result:
 
 ```bash
 uv run python -m benchmark.locust benchmark/locust/configs/sweep_concurrency.yaml --resume

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -152,7 +152,7 @@ base_config:
   run_time: 120
 
 sweeps:
-  users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+  target_users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
 ```
 
 Sweeping more than one parameter runs every combination. Any `base_config`
@@ -216,16 +216,16 @@ following fields are supported:
 ### Optional Fields
 
 - `host`: Server base URL (default: `http://localhost:8000`)
-- `users`: Target concurrent users to ramp to and then hold (default: `256`, minimum: `1`)
+- `target_users`: Concurrency to ramp to and then hold (default: `256`, minimum: `1`). Also accepted as `users`, the name used before sweeps existed.
 - `spawn_rate`: Users spawned per second while ramping (default: `10`, minimum: `0.1`)
 - `run_time`: Measured seconds at the target, excluding the ramp (default: `60`, minimum: `1`)
 - `message`: Message content to send (default: `"Hello, what can you do?"`)
 - `headless`: Run without web UI (default: `true`)
 - `output_base_dir`: Directory for test results (default: `"locust_results"`)
 
-Together these describe one level: users ramp from 0 to `users` at `spawn_rate`
-per second, taking `ceil(users / spawn_rate)` seconds, and the test then runs
-for `run_time` seconds with `users` active. Locust is asked for the sum of the
+Together these describe one level: users ramp from 0 to `target_users` at
+`spawn_rate` per second, taking `ceil(target_users / spawn_rate)` seconds, and
+the test then runs for `run_time` seconds with `target_users` active. Locust is asked for the sum of the
 two, and `--reset-stats` discards everything gathered during the ramp, so the
 reported numbers cover only the held portion.
 
@@ -281,14 +281,14 @@ so a level can be found again and resumed:
 ```text
 locust_results/
 └── sweep_concurrency/
-    ├── users-1/
+    ├── target_users-1/
     │   ├── report.html
     │   ├── run_metadata.json    # includes the level's Locust exit code
     │   ├── stats_stats.csv
     │   ├── stats_stats_history.csv
     │   ├── stats_failures.csv
     │   └── stats_exceptions.csv
-    ├── users-2/
+    ├── target_users-2/
     └── ...
 ```
 

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -216,20 +216,22 @@ following fields are supported:
 ### Optional Fields
 
 - `host`: Server base URL (default: `http://localhost:8000`)
-- `users`: Maximum concurrent users (default: `256`, minimum: `1`)
-- `spawn_rate`: Users spawned per second (default: `10`, minimum: `0.1`)
-- `run_time`: Test duration in seconds (default: `60`, minimum: `1`)
+- `users`: Target concurrent users to ramp to and then hold (default: `256`, minimum: `1`)
+- `spawn_rate`: Users spawned per second while ramping (default: `10`, minimum: `0.1`)
+- `run_time`: Measured seconds at the target, excluding the ramp (default: `60`, minimum: `1`)
 - `message`: Message content to send (default: `"Hello, what can you do?"`)
 - `headless`: Run without web UI (default: `true`)
 - `output_base_dir`: Directory for test results (default: `"locust_results"`)
 
+Together these describe one level: users ramp from 0 to `users` at `spawn_rate`
+per second, taking `ceil(users / spawn_rate)` seconds, and the test then runs
+for `run_time` seconds with `users` active. Locust is asked for the sum of the
+two, and `--reset-stats` discards everything gathered during the ramp, so the
+reported numbers cover only the held portion.
+
 `host` defaults to port `8000`, which in the quickstart stack is the mock
 application LLM rather than Guardrails, so set it explicitly to the server you
 intend to benchmark.
-
-Note that `run_time` is the measured duration. The ramp implied by `users` and
-`spawn_rate` is added on top of it, so raising concurrency does not shorten the
-measurement.
 
 ### Batch Fields
 

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -127,6 +127,60 @@ while measuring the mock instead of the guardrails you meant to benchmark.
 Note also that [`configs/local.yaml`](configs/local.yaml) ramps to 1024 users
 over 120 seconds. Run the single-user smoke test above before using it.
 
+### Concurrency sweeps
+
+A single run measures one concurrency level. To see how the server degrades as
+load rises, sweep over a list of user counts. Each level is an independent
+Locust run:
+
+```bash
+uv run python -m benchmark.locust benchmark/locust/configs/sweep_concurrency.yaml
+```
+
+[`configs/sweep_concurrency.yaml`](configs/sweep_concurrency.yaml) uses the
+batch form, which mirrors [the AIPerf runner](../aiperf/configs):
+
+```yaml
+batch_name: sweep_concurrency
+output_base_dir: locust_results
+
+base_config:
+  host: "http://localhost:9000"
+  config_id: content_safety_local
+  model: meta/llama-3.3-70b-instruct
+  spawn_rate: 16
+  run_time: 120
+
+sweeps:
+  users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+```
+
+Sweeping more than one parameter runs every combination. Any `base_config`
+field can be swept.
+
+Three things make the levels comparable:
+
+- **The ramp is excluded from the measurement.** `run_time` is the measured
+  window, and the time spent spawning users is added on top of it. At 512 users
+  and a spawn rate of 16/s Locust is asked for 152 seconds so that 120 of them
+  are at full concurrency. Statistics gathered during the ramp are discarded.
+- **Each level keeps its time series**, so a level that never reached a plateau
+  can be told apart from one that did.
+- **A level with failed requests does not stop the sweep.** Its exit code is
+  recorded in that level's `run_metadata.json` and the next level starts. The
+  CLI exits non-zero only when the benchmark could not run at all, such as a
+  failed health check.
+
+A full ladder takes hours. Use `--resume` to skip levels that already hold a
+completed result:
+
+```bash
+uv run python -m benchmark.locust benchmark/locust/configs/sweep_concurrency.yaml --resume
+```
+
+A level counts as complete only once its exit code has been recorded, so an
+interrupted level is re-run rather than kept.
+
 ### CLI Options
 
 ```bash
@@ -139,6 +193,7 @@ uv run python -m benchmark.locust [OPTIONS] CONFIG_FILE
 **Options:**
 - `--dry-run`: Print commands without executing them
 - `--verbose`: Enable verbose logging and debugging information
+- `--resume`: Skip sweep levels that already hold a completed result
 
 ## Configuration Options
 
@@ -163,6 +218,20 @@ following fields are supported:
 `host` defaults to port `8000`, which in the quickstart stack is the mock
 application LLM rather than Guardrails, so set it explicitly to the server you
 intend to benchmark.
+
+Note that `run_time` is the measured duration. The ramp implied by `users` and
+`spawn_rate` is added on top of it, so raising concurrency does not shorten the
+measurement.
+
+### Batch Fields
+
+These fields describe a batch of runs rather than a single one. A config file
+that omits them is read as a single run, so existing config files keep working.
+
+- `batch_name`: Directory name for this batch of runs (default: `"benchmark"`)
+- `output_base_dir`: Base directory for batch results (default: taken from the run config)
+- `base_config`: The run configuration applied to every level
+- `sweeps`: Mapping of a `base_config` field to the list of values to run
 
 ## Load Test Behavior
 
@@ -194,6 +263,23 @@ locust_results/
     ├── stats_stats_history.csv   # Statistics over time
     ├── stats_failures.csv        # Failure statistics
     └── stats_exceptions.csv      # Exceptions raised during the run
+```
+
+A sweep instead writes one directory per level, named after the swept value,
+so a level can be found again and resumed:
+
+```text
+locust_results/
+└── sweep_concurrency/
+    ├── users-1/
+    │   ├── report.html
+    │   ├── run_metadata.json    # includes the level's Locust exit code
+    │   ├── stats_stats.csv
+    │   ├── stats_stats_history.csv
+    │   ├── stats_failures.csv
+    │   └── stats_exceptions.csv
+    ├── users-2/
+    └── ...
 ```
 
 ### Web UI Mode

--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -6,7 +6,7 @@ config_id: "content_safety_local"
 model: "meta/llama-3.3-70b-instruct"
 
 # Load test parameters
-users: 1024             # Maximum number of concurrent users
+target_users: 1024      # Concurrency to ramp to and hold
 spawn_rate: 16           # Users spawned per second
 run_time: 120            # Test duration in seconds
 

--- a/benchmark/locust/configs/sweep_concurrency.yaml
+++ b/benchmark/locust/configs/sweep_concurrency.yaml
@@ -1,0 +1,41 @@
+# Concurrency sweep against the local mock stack from benchmark/Procfile.
+#
+# Each level is an independent Locust run at a fixed number of users, so the
+# results show how the server degrades as concurrency rises rather than a
+# single point. Run it from the repository root with:
+#
+#   uv run python -m benchmark.locust benchmark/locust/configs/sweep_concurrency.yaml
+#
+# A level whose requests failed records its exit code and the sweep continues;
+# use --resume to skip levels that already completed.
+
+# Name for this batch of runs (becomes a directory under output_base_dir)
+batch_name: sweep_concurrency
+
+# Base directory where all results are stored.
+# Each level lands in <output_base_dir>/<batch_name>/users-<value>/
+output_base_dir: locust_results
+
+# Applied to every level, before the sweep values below override it
+base_config:
+  # Server details. Port 9000 is the Guardrails server; port 8000 would be the
+  # mock application LLM, which ignores the config_id the load test sends.
+  host: "http://localhost:9000"
+  config_id: "content_safety_local"
+  model: "meta/llama-3.3-70b-instruct"
+
+  # Load test parameters
+  users: 1                 # Overridden by the sweep below
+  spawn_rate: 16           # Users spawned per second
+  run_time: 120            # Measured seconds per level, excluding the ramp
+
+  # Request configuration
+  message: "Hello, what can you do?"
+
+  # Run without the web UI so levels run back to back
+  headless: true
+
+# Parameter sweeps. Each parameter can have multiple values.
+# Sweeping more than one parameter runs all combinations (Cartesian product).
+sweeps:
+  users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]

--- a/benchmark/locust/configs/sweep_concurrency.yaml
+++ b/benchmark/locust/configs/sweep_concurrency.yaml
@@ -13,7 +13,7 @@
 batch_name: sweep_concurrency
 
 # Base directory where all results are stored.
-# Each level lands in <output_base_dir>/<batch_name>/users-<value>/
+# Each level lands in <output_base_dir>/<batch_name>/target_users-<value>/
 output_base_dir: locust_results
 
 # Applied to every level, before the sweep values below override it
@@ -25,7 +25,7 @@ base_config:
   model: "meta/llama-3.3-70b-instruct"
 
   # Load test parameters
-  users: 1                 # Overridden by the sweep below
+  target_users: 1          # Overridden by the sweep below
   spawn_rate: 16           # Users spawned per second
   run_time: 120            # Measured seconds per level, excluding the ramp
 
@@ -38,4 +38,4 @@ base_config:
 # Parameter sweeps. Each parameter can have multiple values.
 # Sweeping more than one parameter runs all combinations (Cartesian product).
 sweeps:
-  users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+  target_users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -22,13 +22,13 @@ import re
 from itertools import product
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class LocustConfig(BaseModel):
     """Configuration for a Locust load-test run"""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     # Server details
     host: str = Field(
@@ -39,9 +39,10 @@ class LocustConfig(BaseModel):
     model: str = Field(..., description="Model name to use in requests")
 
     # Load test parameters
-    users: int = Field(
+    target_users: int = Field(
         default=256,
         ge=1,
+        validation_alias=AliasChoices("target_users", "users"),
         description="Target number of concurrent users to ramp to and then hold",
     )
     spawn_rate: float = Field(
@@ -87,6 +88,9 @@ BATCH_KEYS = ("batch_name", "output_base_dir", "sweeps")
 
 SweepValue = Union[int, float, str]
 
+# Accepted config spellings that are not the field name itself.
+FIELD_ALIASES = {"users": "target_users"}
+
 # Anything outside this set is replaced when a swept value becomes a directory name.
 UNSAFE_LABEL_CHARS = re.compile(r"[^A-Za-z0-9._-]")
 
@@ -120,7 +124,7 @@ class LocustSweepConfig(BaseModel):
           config_id: content_safety_local
           model: meta/llama-3.3-70b-instruct
         sweeps:
-          users: [1, 2, 4]
+          target_users: [1, 2, 4]
 
     It also accepts a flat single-run config, which is the format that
     predates sweeps, so existing configuration files keep working::
@@ -172,6 +176,8 @@ class LocustSweepConfig(BaseModel):
 
         if not self.sweeps:
             return self
+
+        self.sweeps = {FIELD_ALIASES.get(key, key): values for key, values in self.sweeps.items()}
 
         unknown = sorted(set(self.sweeps) - set(LocustConfig.model_fields))
         if unknown:

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -18,7 +18,10 @@
 Pydantic models for Locust load test configuration validation.
 """
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from itertools import product
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class LocustConfig(BaseModel):
@@ -76,3 +79,108 @@ class LocustConfig(BaseModel):
             raise ValueError("Host must start with http:// or https://")
         # Remove trailing slash if present
         return v.rstrip("/")
+
+
+# Keys that configure the batch itself rather than an individual Locust run.
+BATCH_KEYS = ("batch_name", "output_base_dir", "sweeps")
+
+SweepValue = Union[int, float, str]
+
+
+class LocustSweepConfig(BaseModel):
+    """A batch of Locust runs sharing one base configuration.
+
+    Accepts the nested form, which mirrors ``benchmark/aiperf``::
+
+        batch_name: sweep_concurrency
+        output_base_dir: locust_results
+        base_config:
+          host: "http://localhost:9000"
+          config_id: content_safety_local
+          model: meta/llama-3.3-70b-instruct
+        sweeps:
+          users: [1, 2, 4]
+
+    It also accepts a flat single-run config, which is the format that
+    predates sweeps, so existing configuration files keep working::
+
+        host: "http://localhost:9000"
+        config_id: content_safety_local
+        model: meta/llama-3.3-70b-instruct
+
+    A flat config may carry a ``sweeps`` block too; the remaining keys are
+    read as the base configuration.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    batch_name: str = Field(
+        default="benchmark",
+        description="Name for this batch of runs, used as a directory under output_base_dir",
+    )
+    output_base_dir: Optional[str] = Field(
+        default=None,
+        description="Base directory for results. Defaults to the base config's output_base_dir",
+    )
+    base_config: LocustConfig = Field(
+        ...,
+        description="Configuration applied to every run, before sweep values override it",
+    )
+    sweeps: Optional[Dict[str, List[SweepValue]]] = Field(
+        default=None,
+        description="Parameters to sweep. Key is a LocustConfig field, value is the list of values to run",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_flat_config(cls, data):
+        """Read a flat single-run config as a batch with one base configuration."""
+        if not isinstance(data, dict) or "base_config" in data:
+            return data
+
+        batch = {key: value for key, value in data.items() if key in BATCH_KEYS}
+        # output_base_dir stays in the base config as well, so LocustConfig keeps its own default.
+        base = {key: value for key, value in data.items() if key not in ("batch_name", "sweeps")}
+        return {**batch, "base_config": base}
+
+    @model_validator(mode="after")
+    def validate_sweeps(self):
+        """Default the output directory and reject sweeps that cannot be applied."""
+        if self.output_base_dir is None:
+            self.output_base_dir = self.base_config.output_base_dir
+
+        if not self.sweeps:
+            return self
+
+        unknown = sorted(set(self.sweeps) - set(LocustConfig.model_fields))
+        if unknown:
+            raise ValueError(f"Sweep parameters are not LocustConfig fields: {unknown}")
+
+        empty = sorted(key for key, values in self.sweeps.items() if not values)
+        if empty:
+            raise ValueError(f"Sweep parameters have no values: {empty}")
+
+        return self
+
+    def expand(self) -> List[tuple[str, LocustConfig]]:
+        """Return a ``(label, config)`` pair for every run in this batch.
+
+        Sweeping several parameters runs their Cartesian product, matching the
+        AIPerf runner. Without a sweep this is the base configuration alone,
+        labelled with the empty string.
+        """
+        if not self.sweeps:
+            return [("", self.base_config)]
+
+        # Sorted so the run order and directory names do not depend on YAML key order.
+        keys = sorted(self.sweeps)
+
+        runs = []
+        for combination in product(*(self.sweeps[key] for key in keys)):
+            overrides = dict(zip(keys, combination))
+            # Rebuild rather than model_copy so field constraints still apply to swept values.
+            config = LocustConfig(**{**self.base_config.model_dump(), **overrides})
+            label = "_".join(f"{key}-{value}" for key, value in overrides.items())
+            runs.append((label, config))
+
+        return runs

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -42,17 +42,17 @@ class LocustConfig(BaseModel):
     users: int = Field(
         default=256,
         ge=1,
-        description="Maximum number of concurrent users",
+        description="Target number of concurrent users to ramp to and then hold",
     )
     spawn_rate: float = Field(
         default=10,
         ge=0.1,
-        description="Rate at which users are spawned (users/second)",
+        description="Rate at which users are spawned while ramping to `users` (users/second)",
     )
     run_time: int = Field(
         default=60,
         ge=1,
-        description="Test duration in seconds",
+        description="Measured duration in seconds, held at `users` after the ramp completes",
     )
 
     # Request configuration

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -18,6 +18,7 @@
 Pydantic models for Locust load test configuration validation.
 """
 
+import re
 from itertools import product
 from typing import Dict, List, Optional, Union
 
@@ -85,6 +86,26 @@ class LocustConfig(BaseModel):
 BATCH_KEYS = ("batch_name", "output_base_dir", "sweeps")
 
 SweepValue = Union[int, float, str]
+
+# Anything outside this set is replaced when a swept value becomes a directory name.
+UNSAFE_LABEL_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def label_segment(value: SweepValue) -> str:
+    """Render a swept value as one safe path segment.
+
+    Sweep values reach the filesystem as directory names, and legitimate values
+    contain separators: ``meta/llama-3.3-70b-instruct`` would otherwise nest
+    directories, and a value containing ``..`` would climb out of the batch
+    directory entirely.
+    """
+    segment = UNSAFE_LABEL_CHARS.sub("-", str(value))
+
+    # "", "." and ".." are not usable directory names.
+    if set(segment) <= {"."}:
+        return "value"
+
+    return segment
 
 
 class LocustSweepConfig(BaseModel):
@@ -180,7 +201,7 @@ class LocustSweepConfig(BaseModel):
             overrides = dict(zip(keys, combination))
             # Rebuild rather than model_copy so field constraints still apply to swept values.
             config = LocustConfig(**{**self.base_config.model_dump(), **overrides})
-            label = "_".join(f"{key}-{value}" for key, value in overrides.items())
+            label = "_".join(f"{key}-{label_segment(value)}" for key, value in overrides.items())
             runs.append((label, config))
 
         return runs

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -198,7 +198,7 @@ class LocustSweepConfig(BaseModel):
 
         runs = []
         for combination in product(*(self.sweeps[key] for key in keys)):
-            overrides = dict(zip(keys, combination))
+            overrides = dict(zip(keys, combination, strict=True))
             # Rebuild rather than model_copy so field constraints still apply to swept values.
             config = LocustConfig(**{**self.base_config.model_dump(), **overrides})
             label = "_".join(f"{key}-{label_segment(value)}" for key, value in overrides.items())

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -197,11 +197,32 @@ class LocustSweepConfig(BaseModel):
         keys = sorted(self.sweeps)
 
         runs = []
+        used: set[str] = set()
         for combination in product(*(self.sweeps[key] for key in keys)):
             overrides = dict(zip(keys, combination, strict=True))
             # Rebuild rather than model_copy so field constraints still apply to swept values.
             config = LocustConfig(**{**self.base_config.model_dump(), **overrides})
-            label = "_".join(f"{key}-{label_segment(value)}" for key, value in overrides.items())
+            label = self._unique_label(overrides, used)
+            used.add(label)
             runs.append((label, config))
 
         return runs
+
+    @staticmethod
+    def _unique_label(overrides: dict, used: set) -> str:
+        """Build a label for one combination that no earlier combination took.
+
+        Sanitising can map distinct values onto the same segment: ``a/b`` and
+        ``a-b`` both become ``a-b``. Without a suffix the two levels would share
+        a directory and the later one would overwrite the earlier one's results.
+        Suffixes are assigned in expansion order, which is deterministic, so
+        --resume still matches a level to its directory.
+        """
+        label = "_".join(f"{key}-{label_segment(value)}" for key, value in overrides.items())
+        if label not in used:
+            return label
+
+        suffix = 2
+        while f"{label}-{suffix}" in used:
+            suffix += 1
+        return f"{label}-{suffix}"

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -79,6 +79,10 @@ class LocustRunner:
             raise RuntimeError(f"ConnectError accessing {url}: {e}") from e
         except httpx.TimeoutException as e:
             raise RuntimeError(f"HTTP Timeout accessing {url}: {e}") from e
+        except httpx.HTTPError as e:
+            # Any other transport failure is still the benchmark failing to
+            # start, so report it the same way rather than as a traceback.
+            raise RuntimeError(f"HTTP error accessing {url}: {type(e).__name__}: {e}") from e
 
     def _check_service(self) -> None:
         """Check the server under test is up before running tests.

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -79,9 +79,12 @@ class LocustRunner:
             raise RuntimeError(f"ConnectError accessing {url}: {e}") from e
         except httpx.TimeoutException as e:
             raise RuntimeError(f"HTTP Timeout accessing {url}: {e}") from e
-        except httpx.HTTPError as e:
+        except (httpx.HTTPError, httpx.InvalidURL) as e:
             # Any other transport failure is still the benchmark failing to
             # start, so report it the same way rather than as a traceback.
+            # InvalidURL does not derive from HTTPError, and `host` is only
+            # checked for its scheme, so a value like "http://a:b:c" reaches
+            # httpx and raises it here.
             raise RuntimeError(f"HTTP error accessing {url}: {type(e).__name__}: {e}") from e
 
     def _check_service(self) -> None:
@@ -369,34 +372,43 @@ class LocustSweepRunner:
                 LocustRunner(level_config).run(dry_run=True)
             return 0
 
-        # One health check per distinct host rather than one per level. A sweep
-        # over `host` targets several servers, and each must be reachable before
-        # its levels run; otherwise an unreachable target looks like a level
-        # whose requests merely failed.
+        # Work out what will actually run before checking anything. A resumed
+        # sweep must not be blocked by a host whose levels are all complete and
+        # would be skipped anyway.
+        pending = []
+        for label, level_config in levels:
+            if resume and self.is_complete(self.batch_path / label, level_config):
+                log.info("Level %s already complete, keeping it", label)
+                continue
+            pending.append((label, level_config))
+
+        if not pending:
+            log.info("Every level is already complete; nothing to run")
+            return 0
+
+        # One health check per distinct host among the levels that will run,
+        # rather than one per level. A sweep over `host` targets several
+        # servers, and each must be reachable before its levels run; otherwise
+        # an unreachable target looks like a level whose requests merely failed.
         try:
-            for level_config in self._hosts_to_check(levels):
+            for level_config in self._hosts_to_check(pending):
                 LocustRunner(level_config)._check_service()
         except RuntimeError as e:
             log.error(str(e))
             return 1
 
         exit_codes: dict[str, int] = {}
-        for index, (label, level_config) in enumerate(levels, start=1):
+        for index, (label, level_config) in enumerate(pending, start=1):
             level_path = self.batch_path / label
-
-            if resume and self.is_complete(level_path, level_config):
-                log.info("Level %i/%i (%s) already complete, keeping it", index, len(levels), label)
-                continue
-
             runner = LocustRunner(level_config)
             log.info(
                 "Level %i/%i: %s — %is ramp then %is measured, about %s remaining after it",
                 index,
-                len(levels),
+                len(pending),
                 label,
                 runner.ramp_seconds,
                 level_config.run_time,
-                self._format_duration(self.estimated_seconds(levels[index:])),
+                self._format_duration(self.estimated_seconds(pending[index:])),
             )
             exit_codes[label] = runner.run_level(level_path)
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -120,7 +120,7 @@ class LocustRunner:
     @property
     def ramp_seconds(self) -> int:
         """Seconds Locust spends spawning users before the measured window starts."""
-        return math.ceil(self.config.users / self.config.spawn_rate)
+        return math.ceil(self.config.target_users / self.config.spawn_rate)
 
     @property
     def total_run_seconds(self) -> int:
@@ -140,7 +140,7 @@ class LocustRunner:
         cmd.extend(["--host", self.config.host])
 
         # User and spawn rate
-        cmd.extend(["--users", str(self.config.users)])
+        cmd.extend(["--users", str(self.config.target_users)])
         cmd.extend(["--spawn-rate", str(self.config.spawn_rate)])
         cmd.extend(["--run-time", f"{self.total_run_seconds}s"])
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -290,11 +290,16 @@ class LocustSweepRunner:
         return Path(self.config.output_base_dir) / self.config.batch_name
 
     @staticmethod
-    def is_complete(level_path: Path) -> bool:
-        """True when a level already holds a finished result.
+    def is_complete(level_path: Path, expected_config: Optional[LocustConfig] = None) -> bool:
+        """True when a level already holds a finished result for this configuration.
 
         Metadata is written before the run starts, so an exit code is what
         distinguishes a finished level from an interrupted one.
+
+        A level is identified by its swept values alone, so a result can predate
+        an edit to any setting that is not swept. When ``expected_config`` is
+        given, a level recorded under different settings is treated as
+        incomplete rather than silently mixed into the batch.
         """
         metadata_file = level_path / "run_metadata.json"
         if not metadata_file.is_file():
@@ -305,7 +310,24 @@ class LocustSweepRunner:
         except (json.JSONDecodeError, OSError):
             return False
 
-        return metadata.get("exit_code") is not None
+        if metadata.get("exit_code") is None:
+            return False
+
+        if expected_config is not None:
+            expected = json.loads(expected_config.model_dump_json())
+            if metadata.get("config") != expected:
+                log.info("Configuration changed since %s was recorded; re-running it", level_path.name)
+                return False
+
+        return True
+
+    @staticmethod
+    def _hosts_to_check(levels: list[tuple[str, LocustConfig]]) -> list[LocustConfig]:
+        """One config per distinct host in the batch, in the order levels run."""
+        seen: dict[str, LocustConfig] = {}
+        for _, level_config in levels:
+            seen.setdefault(level_config.host, level_config)
+        return list(seen.values())
 
     def run(self, dry_run: bool, resume: bool = False) -> int:
         """Run the whole sweep.
@@ -322,9 +344,13 @@ class LocustSweepRunner:
                 LocustRunner(level_config).run(dry_run=True)
             return 0
 
-        # One health check for the batch rather than one per level.
+        # One health check per distinct host rather than one per level. A sweep
+        # over `host` targets several servers, and each must be reachable before
+        # its levels run; otherwise an unreachable target looks like a level
+        # whose requests merely failed.
         try:
-            LocustRunner(self.config.base_config)._check_service()
+            for level_config in self._hosts_to_check(levels):
+                LocustRunner(level_config)._check_service()
         except RuntimeError as e:
             log.error(str(e))
             return 1
@@ -333,7 +359,7 @@ class LocustSweepRunner:
         for index, (label, level_config) in enumerate(levels, start=1):
             level_path = self.batch_path / label
 
-            if resume and self.is_complete(level_path):
+            if resume and self.is_complete(level_path, level_config):
                 log.info("Level %i/%i (%s) already complete, keeping it", index, len(levels), label)
                 continue
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -341,7 +341,8 @@ class LocustSweepRunner:
         """Render an estimate in the units a reader wants: minutes, or hours once it is long."""
         minutes = seconds / 60
         if minutes < 90:
-            return f"{minutes:.0f} minutes"
+            rounded = round(minutes)
+            return f"{rounded} minute" if rounded == 1 else f"{rounded} minutes"
         return f"{minutes / 60:.1f} hours"
 
     @staticmethod

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -326,6 +326,22 @@ class LocustSweepRunner:
         return True
 
     @staticmethod
+    def estimated_seconds(levels: list[tuple[str, LocustConfig]]) -> int:
+        """Wall-clock estimate for a batch: every level's ramp plus its measured window.
+
+        Excludes process start-up per level, so a real run takes slightly longer.
+        """
+        return sum(LocustRunner(config).total_run_seconds for _, config in levels)
+
+    @staticmethod
+    def _format_duration(seconds: int) -> str:
+        """Render an estimate in the units a reader wants: minutes, or hours once it is long."""
+        minutes = seconds / 60
+        if minutes < 90:
+            return f"{minutes:.0f} minutes"
+        return f"{minutes / 60:.1f} hours"
+
+    @staticmethod
     def _hosts_to_check(levels: list[tuple[str, LocustConfig]]) -> list[LocustConfig]:
         """One config per distinct host in the batch, in the order levels run."""
         seen: dict[str, LocustConfig] = {}
@@ -341,7 +357,12 @@ class LocustSweepRunner:
         that level's metadata instead.
         """
         levels = self.config.expand()
-        log.info("Sweep %s: %i levels", self.config.batch_name, len(levels))
+        log.info(
+            "Sweep %s: %i levels, about %s in total",
+            self.config.batch_name,
+            len(levels),
+            self._format_duration(self.estimated_seconds(levels)),
+        )
 
         if dry_run:
             for label, level_config in levels:
@@ -367,8 +388,17 @@ class LocustSweepRunner:
                 log.info("Level %i/%i (%s) already complete, keeping it", index, len(levels), label)
                 continue
 
-            log.info("Level %i/%i: %s", index, len(levels), label)
-            exit_codes[label] = LocustRunner(level_config).run_level(level_path)
+            runner = LocustRunner(level_config)
+            log.info(
+                "Level %i/%i: %s — %is ramp then %is measured, about %s remaining after it",
+                index,
+                len(levels),
+                label,
+                runner.ramp_seconds,
+                level_config.run_time,
+                self._format_duration(self.estimated_seconds(levels[index:])),
+            )
+            exit_codes[label] = runner.run_level(level_path)
 
         failed = sorted(label for label, code in exit_codes.items() if code != 0)
         if failed:

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -23,6 +23,7 @@ both direct CLI arguments and YAML configuration files.
 
 import json
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -35,7 +36,7 @@ import typer
 import yaml
 from pydantic import ValidationError
 
-from benchmark.locust.locust_models import LocustConfig
+from benchmark.locust.locust_models import LocustConfig, LocustSweepConfig
 
 # The mock LLM servers serve `/health`; the Guardrails server serves
 # `/v1/health` (and `/healthz`). Probe both so either target works.
@@ -112,6 +113,21 @@ class LocustRunner:
         if status not in HEALTHY_STATUSES:
             raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
 
+    @property
+    def ramp_seconds(self) -> int:
+        """Seconds Locust spends spawning users before the measured window starts."""
+        return math.ceil(self.config.users / self.config.spawn_rate)
+
+    @property
+    def total_run_seconds(self) -> int:
+        """Total wall-clock seconds to ask Locust for.
+
+        ``run_time`` is the measured duration, so the ramp is added on top of it
+        rather than taken out of it. Otherwise the measured window shrinks as
+        concurrency rises, which is where the measurement matters most.
+        """
+        return self.ramp_seconds + self.config.run_time
+
     def _build_locust_command(self, output_dir: Optional[Path] = None) -> list[str]:
         """Build the Locust command with all parameters."""
         cmd = ["locust", "-f", str(self.locustfile_path)]
@@ -122,7 +138,11 @@ class LocustRunner:
         # User and spawn rate
         cmd.extend(["--users", str(self.config.users)])
         cmd.extend(["--spawn-rate", str(self.config.spawn_rate)])
-        cmd.extend(["--run-time", f"{self.config.run_time}s"])
+        cmd.extend(["--run-time", f"{self.total_run_seconds}s"])
+
+        # Discard the statistics gathered while ramping, so the reported numbers
+        # describe the requested concurrency rather than the climb towards it.
+        cmd.append("--reset-stats")
 
         # Headless mode
         if self.config.headless:
@@ -135,16 +155,30 @@ class LocustRunner:
                 csv_prefix = output_dir / "stats"
                 cmd.extend(["--html", str(html_file)])
                 cmd.extend(["--csv", str(csv_prefix)])
+                # Keep the time series, so a level that never reached a plateau
+                # can be told apart from one that did.
+                cmd.append("--csv-full-history")
 
         log.debug("Locust command: %s", " ".join(cmd))
         return cmd
 
-    def _save_run_metadata(self, output_dir: Path, command: list[str], start_time: datetime) -> None:
-        """Save metadata about the load test run."""
+    def _save_run_metadata(
+        self,
+        output_dir: Path,
+        command: list[str],
+        start_time: datetime,
+        exit_code: Optional[int] = None,
+    ) -> None:
+        """Save metadata about the load test run.
+
+        ``exit_code`` is None until the run finishes. A sweep treats metadata
+        without an exit code as an incomplete level.
+        """
         metadata = {
             "start_time": start_time.isoformat(),
             "config": self.config.model_dump(),
             "command": " ".join([str(c) for c in command]),
+            "exit_code": exit_code,
         }
 
         metadata_file = output_dir / "run_metadata.json"
@@ -161,7 +195,7 @@ class LocustRunner:
         return output_path
 
     def run(self, dry_run: bool) -> int:
-        """Run the Locust load test."""
+        """Run a single Locust load test into a timestamped directory."""
 
         # For dry-run, print command without creating directories or metadata
         if dry_run:
@@ -181,11 +215,21 @@ class LocustRunner:
             log.error(str(e))
             return 1
 
-        # Build command with output directory
         output_path = self._create_output_path(self.config.output_base_dir)
+        return self.run_level(output_path)
+
+    def run_level(self, output_path: Path) -> int:
+        """Run Locust once, writing results to ``output_path``.
+
+        Returns Locust's exit code, which is non-zero when any request failed.
+        The service health check is not repeated here; a sweep performs it once
+        for the whole batch.
+        """
+        output_path.mkdir(parents=True, exist_ok=True)
         command = self._build_locust_command(output_path)
 
-        # Save metadata
+        # Save metadata up front so an interrupted run still leaves a record.
+        # The exit code is filled in once the run finishes.
         start_time = datetime.now()
         self._save_run_metadata(output_path, command, start_time)
         log.info("Saving metadata to: %s", output_path)
@@ -199,10 +243,11 @@ class LocustRunner:
         # Log test configuration
         log.info("Starting Locust load test")
         log.info("Config: %s", self.config.model_dump_json())
-
-        rampup_seconds = min(int(self.config.users / self.config.spawn_rate), self.config.run_time)
-        steady_state_seconds = self.config.run_time - rampup_seconds
-        log.info("Duration: rampup: %is, steady-state %is", rampup_seconds, steady_state_seconds)
+        log.info(
+            "Duration: rampup: %is, measured %is",
+            self.ramp_seconds,
+            self.config.run_time,
+        )
 
         if not self.config.headless:
             log.info("Web UI will be available at: http://localhost:8089")
@@ -216,6 +261,7 @@ class LocustRunner:
             else:
                 log.error("Load test failed with exit code %s", result.returncode)
 
+            self._save_run_metadata(output_path, command, start_time, exit_code=result.returncode)
             return result.returncode
 
         except KeyboardInterrupt:
@@ -226,8 +272,91 @@ class LocustRunner:
             return 1
 
 
-def _load_config_from_yaml(config_file: Path) -> LocustConfig:
-    """Load and validate configuration from YAML file."""
+class LocustSweepRunner:
+    """Run every level of a sweep, keeping per-level results and exit codes.
+
+    Each level is an independent Locust invocation. A level whose requests
+    failed is a result, not a runner error: its exit code is recorded and the
+    sweep continues, because the levels past saturation are the ones a stress
+    test exists to measure.
+    """
+
+    def __init__(self, config: LocustSweepConfig):
+        self.config = config
+
+    @property
+    def batch_path(self) -> Path:
+        """Directory holding every level of this batch."""
+        return Path(self.config.output_base_dir) / self.config.batch_name
+
+    @staticmethod
+    def is_complete(level_path: Path) -> bool:
+        """True when a level already holds a finished result.
+
+        Metadata is written before the run starts, so an exit code is what
+        distinguishes a finished level from an interrupted one.
+        """
+        metadata_file = level_path / "run_metadata.json"
+        if not metadata_file.is_file():
+            return False
+
+        try:
+            metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return False
+
+        return metadata.get("exit_code") is not None
+
+    def run(self, dry_run: bool, resume: bool = False) -> int:
+        """Run the whole sweep.
+
+        Returns non-zero only when the benchmark could not be run, such as a
+        failed health check. Request failures within a level are reported in
+        that level's metadata instead.
+        """
+        levels = self.config.expand()
+        log.info("Sweep %s: %i levels", self.config.batch_name, len(levels))
+
+        if dry_run:
+            for label, level_config in levels:
+                LocustRunner(level_config).run(dry_run=True)
+            return 0
+
+        # One health check for the batch rather than one per level.
+        try:
+            LocustRunner(self.config.base_config)._check_service()
+        except RuntimeError as e:
+            log.error(str(e))
+            return 1
+
+        exit_codes: dict[str, int] = {}
+        for index, (label, level_config) in enumerate(levels, start=1):
+            level_path = self.batch_path / label
+
+            if resume and self.is_complete(level_path):
+                log.info("Level %i/%i (%s) already complete, keeping it", index, len(levels), label)
+                continue
+
+            log.info("Level %i/%i: %s", index, len(levels), label)
+            exit_codes[label] = LocustRunner(level_config).run_level(level_path)
+
+        failed = sorted(label for label, code in exit_codes.items() if code != 0)
+        if failed:
+            log.warning(
+                "Levels with request failures (recorded, not fatal): %s",
+                ", ".join(failed),
+            )
+        log.info("Sweep complete. Results in %s", self.batch_path)
+        return 0
+
+
+def _load_config_from_yaml(config_file: Path) -> LocustSweepConfig:
+    """Load and validate configuration from YAML file.
+
+    Both the flat single-run format and the nested ``base_config``/``sweeps``
+    batch format are accepted, so configuration files written before sweeps
+    existed keep working.
+    """
     try:
         with open(config_file, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
@@ -235,7 +364,7 @@ def _load_config_from_yaml(config_file: Path) -> LocustConfig:
         if config_data is None:
             config_data = {}
 
-        config = LocustConfig(**config_data)
+        config = LocustSweepConfig(**config_data)
         return config
 
     except FileNotFoundError:
@@ -268,6 +397,11 @@ def run(
         "--verbose",
         help="Print additional debugging information during run",
     ),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="Skip sweep levels that already hold a completed result",
+    ),
 ):
     """
     Run Locust load test using provided config file
@@ -277,9 +411,14 @@ def run(
 
     locust_config = _load_config_from_yaml(config_file)
 
-    # Create and run the test
-    runner = LocustRunner(locust_config)
-    exit_code = runner.run(dry_run)
+    # Without a sweep this is a single run, which keeps its timestamped
+    # output directory rather than a per-level one.
+    if not locust_config.sweeps:
+        if resume:
+            log.warning("--resume applies to sweeps; ignoring it for a single run")
+        exit_code = LocustRunner(locust_config.base_config).run(dry_run)
+    else:
+        exit_code = LocustSweepRunner(locust_config).run(dry_run, resume)
 
     raise typer.Exit(code=exit_code)
 

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -40,7 +40,7 @@ class TestLocustConfig:
 
         # Verify all defaults
         assert config.host == "http://localhost:8000"
-        assert config.users == 256
+        assert config.target_users == 256
         assert config.spawn_rate == 10
         assert config.run_time == 60
         assert config.message == "Hello, what can you do?"
@@ -63,7 +63,7 @@ class TestLocustConfig:
         assert config.host == "http://example.com:9000"
         assert config.config_id == "my-config"
         assert config.model == "my-model"
-        assert config.users == 100
+        assert config.target_users == 100
         assert config.spawn_rate == 5.5
         assert config.run_time == 120
         assert config.message == "Custom message"
@@ -141,12 +141,12 @@ class TestLocustConfigHelpers:
             **{
                 "config_id": "test-config",
                 "model": "test-model",
-                "users": 100,
+                "target_users": 100,
             }
         )
         assert config.config_id == "test-config"
         assert config.model == "test-model"
-        assert config.users == 100
+        assert config.target_users == 100
 
 
 class TestLocustSweepConfig:
@@ -156,11 +156,11 @@ class TestLocustSweepConfig:
 
     def test_flat_config_is_read_as_a_single_run(self):
         """Config files written before sweeps existed keep working."""
-        config = LocustSweepConfig(**{**self.BASE, "host": "http://localhost:9000", "users": 64})
+        config = LocustSweepConfig(**{**self.BASE, "host": "http://localhost:9000", "target_users": 64})
 
         assert config.sweeps is None
         assert config.base_config.config_id == "test-config"
-        assert config.base_config.users == 64
+        assert config.base_config.target_users == 64
         assert config.expand() == [("", config.base_config)]
 
     def test_nested_config_with_sweep(self):
@@ -168,24 +168,24 @@ class TestLocustSweepConfig:
         config = LocustSweepConfig(
             batch_name="sweep_concurrency",
             base_config=self.BASE,
-            sweeps={"users": [1, 2, 4]},
+            sweeps={"target_users": [1, 2, 4]},
         )
 
         assert config.batch_name == "sweep_concurrency"
-        assert [label for label, _ in config.expand()] == ["users-1", "users-2", "users-4"]
-        assert [run.users for _, run in config.expand()] == [1, 2, 4]
+        assert [label for label, _ in config.expand()] == ["target_users-1", "target_users-2", "target_users-4"]
+        assert [run.target_users for _, run in config.expand()] == [1, 2, 4]
 
     def test_flat_config_may_carry_a_sweep(self):
         """A sweep can be added to an existing flat config without restructuring it."""
-        config = LocustSweepConfig(**{**self.BASE, "sweeps": {"users": [8, 16]}})
+        config = LocustSweepConfig(**{**self.BASE, "sweeps": {"target_users": [8, 16]}})
 
-        assert [run.users for _, run in config.expand()] == [8, 16]
+        assert [run.target_users for _, run in config.expand()] == [8, 16]
 
     def test_base_config_supplies_values_not_swept(self):
         """Sweeping one field leaves the rest of the base configuration intact."""
         config = LocustSweepConfig(
             base_config={**self.BASE, "message": "hello", "run_time": 120},
-            sweeps={"users": [1, 2]},
+            sweeps={"target_users": [1, 2]},
         )
 
         for _, run in config.expand():
@@ -196,14 +196,14 @@ class TestLocustSweepConfig:
         """Several swept parameters expand to every combination, as AIPerf does."""
         config = LocustSweepConfig(
             base_config=self.BASE,
-            sweeps={"users": [1, 2], "spawn_rate": [4, 8]},
+            sweeps={"target_users": [1, 2], "spawn_rate": [4, 8]},
         )
 
         assert [label for label, _ in config.expand()] == [
-            "spawn_rate-4_users-1",
-            "spawn_rate-4_users-2",
-            "spawn_rate-8_users-1",
-            "spawn_rate-8_users-2",
+            "spawn_rate-4_target_users-1",
+            "spawn_rate-4_target_users-2",
+            "spawn_rate-8_target_users-1",
+            "spawn_rate-8_target_users-2",
         ]
 
     def test_output_base_dir_defaults_to_the_base_config(self):
@@ -220,11 +220,11 @@ class TestLocustSweepConfig:
     def test_sweep_with_no_values_rejected(self):
         """An empty sweep list would silently run nothing."""
         with pytest.raises(ValidationError, match="no values"):
-            LocustSweepConfig(base_config=self.BASE, sweeps={"users": []})
+            LocustSweepConfig(base_config=self.BASE, sweeps={"target_users": []})
 
     def test_swept_values_are_validated(self):
         """Field constraints still apply to values coming from a sweep."""
-        config = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [0]})
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"target_users": [0]})
 
         with pytest.raises(ValidationError):
             config.expand()
@@ -248,9 +248,9 @@ class TestLocustSweepConfig:
 
     def test_numeric_labels_are_left_alone(self):
         """Sanitising values must not disturb the ordinary concurrency sweep."""
-        config = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [1, 1024]})
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"target_users": [1, 1024]})
 
-        assert [label for label, _ in config.expand()] == ["users-1", "users-1024"]
+        assert [label for label, _ in config.expand()] == ["target_users-1", "target_users-1024"]
 
     def test_colliding_labels_get_distinct_directories(self):
         """Sanitising can map different values onto one segment; levels must not share a directory."""
@@ -266,3 +266,17 @@ class TestLocustSweepConfig:
         config = LocustSweepConfig(base_config=self.BASE, sweeps={"model": ["a/b", "a-b"]})
 
         assert [label for label, _ in config.expand()] == [label for label, _ in config.expand()]
+
+    def test_users_is_accepted_as_an_alias_for_target_users(self):
+        """Config files written before the rename keep working."""
+        config = LocustSweepConfig(**{**self.BASE, "users": 64})
+
+        assert config.base_config.target_users == 64
+
+    def test_users_sweep_key_normalises_to_target_users(self):
+        """A legacy sweep key produces the same runs and the same level directories."""
+        legacy = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [1, 2]})
+        current = LocustSweepConfig(base_config=self.BASE, sweeps={"target_users": [1, 2]})
+
+        assert [label for label, _ in legacy.expand()] == [label for label, _ in current.expand()]
+        assert [run.target_users for _, run in legacy.expand()] == [1, 2]

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -251,3 +251,18 @@ class TestLocustSweepConfig:
         config = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [1, 1024]})
 
         assert [label for label, _ in config.expand()] == ["users-1", "users-1024"]
+
+    def test_colliding_labels_get_distinct_directories(self):
+        """Sanitising can map different values onto one segment; levels must not share a directory."""
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"model": ["a/b", "a-b", "a:b"]})
+
+        labels = [label for label, _ in config.expand()]
+
+        assert labels == ["model-a-b", "model-a-b-2", "model-a-b-3"]
+        assert len(set(labels)) == 3
+
+    def test_label_suffixes_are_stable_across_expansions(self):
+        """Resume matches a level by directory name, so labels must not move between runs."""
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"model": ["a/b", "a-b"]})
+
+        assert [label for label, _ in config.expand()] == [label for label, _ in config.expand()]

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -21,7 +21,7 @@ Tests for Locust load test configuration models.
 import pytest
 from pydantic import ValidationError
 
-from benchmark.locust.locust_models import LocustConfig
+from benchmark.locust.locust_models import LocustConfig, LocustSweepConfig
 
 
 class TestLocustConfig:
@@ -147,3 +147,89 @@ class TestLocustConfigHelpers:
         assert config.config_id == "test-config"
         assert config.model == "test-model"
         assert config.users == 100
+
+
+class TestLocustSweepConfig:
+    """Test the LocustSweepConfig model."""
+
+    BASE = {"config_id": "test-config", "model": "test-model"}
+
+    def test_flat_config_is_read_as_a_single_run(self):
+        """Config files written before sweeps existed keep working."""
+        config = LocustSweepConfig(**{**self.BASE, "host": "http://localhost:9000", "users": 64})
+
+        assert config.sweeps is None
+        assert config.base_config.config_id == "test-config"
+        assert config.base_config.users == 64
+        assert config.expand() == [("", config.base_config)]
+
+    def test_nested_config_with_sweep(self):
+        """The nested form mirrors the AIPerf batch layout."""
+        config = LocustSweepConfig(
+            batch_name="sweep_concurrency",
+            base_config=self.BASE,
+            sweeps={"users": [1, 2, 4]},
+        )
+
+        assert config.batch_name == "sweep_concurrency"
+        assert [label for label, _ in config.expand()] == ["users-1", "users-2", "users-4"]
+        assert [run.users for _, run in config.expand()] == [1, 2, 4]
+
+    def test_flat_config_may_carry_a_sweep(self):
+        """A sweep can be added to an existing flat config without restructuring it."""
+        config = LocustSweepConfig(**{**self.BASE, "sweeps": {"users": [8, 16]}})
+
+        assert [run.users for _, run in config.expand()] == [8, 16]
+
+    def test_base_config_supplies_values_not_swept(self):
+        """Sweeping one field leaves the rest of the base configuration intact."""
+        config = LocustSweepConfig(
+            base_config={**self.BASE, "message": "hello", "run_time": 120},
+            sweeps={"users": [1, 2]},
+        )
+
+        for _, run in config.expand():
+            assert run.message == "hello"
+            assert run.run_time == 120
+
+    def test_multiple_sweeps_run_the_cartesian_product(self):
+        """Several swept parameters expand to every combination, as AIPerf does."""
+        config = LocustSweepConfig(
+            base_config=self.BASE,
+            sweeps={"users": [1, 2], "spawn_rate": [4, 8]},
+        )
+
+        assert [label for label, _ in config.expand()] == [
+            "spawn_rate-4_users-1",
+            "spawn_rate-4_users-2",
+            "spawn_rate-8_users-1",
+            "spawn_rate-8_users-2",
+        ]
+
+    def test_output_base_dir_defaults_to_the_base_config(self):
+        """A flat config's output directory is not lost when it is wrapped."""
+        config = LocustSweepConfig(**{**self.BASE, "output_base_dir": "somewhere"})
+
+        assert config.output_base_dir == "somewhere"
+
+    def test_sweep_over_unknown_field_rejected(self):
+        """A swept parameter that is not a LocustConfig field cannot be applied."""
+        with pytest.raises(ValidationError, match="not LocustConfig fields"):
+            LocustSweepConfig(base_config=self.BASE, sweeps={"nonsense": [1]})
+
+    def test_sweep_with_no_values_rejected(self):
+        """An empty sweep list would silently run nothing."""
+        with pytest.raises(ValidationError, match="no values"):
+            LocustSweepConfig(base_config=self.BASE, sweeps={"users": []})
+
+    def test_swept_values_are_validated(self):
+        """Field constraints still apply to values coming from a sweep."""
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [0]})
+
+        with pytest.raises(ValidationError):
+            config.expand()
+
+    def test_extra_top_level_fields_forbidden(self):
+        """A misspelled batch key should not be silently ignored."""
+        with pytest.raises(ValidationError):
+            LocustSweepConfig(base_config=self.BASE, bogus=1)

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -233,3 +233,21 @@ class TestLocustSweepConfig:
         """A misspelled batch key should not be silently ignored."""
         with pytest.raises(ValidationError):
             LocustSweepConfig(base_config=self.BASE, bogus=1)
+
+    def test_swept_values_become_single_path_segments(self):
+        """Swept values are used as directory names, so they must not contain separators."""
+        config = LocustSweepConfig(
+            base_config=self.BASE,
+            sweeps={"model": ["meta/llama-3.3-70b-instruct", "../escape", "."]},
+        )
+
+        labels = [label for label, _ in config.expand()]
+
+        assert labels == ["model-meta-llama-3.3-70b-instruct", "model-..-escape", "model-value"]
+        assert not any("/" in label for label in labels)
+
+    def test_numeric_labels_are_left_alone(self):
+        """Sanitising values must not disturb the ordinary concurrency sweep."""
+        config = LocustSweepConfig(base_config=self.BASE, sweeps={"users": [1, 1024]})
+
+        assert [label for label, _ in config.expand()] == ["users-1", "users-1024"]

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -620,6 +620,54 @@ class TestLocustSweepRunner:
 
         assert sweep_runner.is_complete(level) is False
 
+    def test_every_swept_host_is_health_checked(self, tmp_path):
+        """Sweeping host targets several servers, and each must be reachable."""
+        config = LocustSweepConfig(
+            batch_name="hosts",
+            output_base_dir=str(tmp_path / "results"),
+            base_config={"config_id": "test-config", "model": "test-model"},
+            sweeps={"host": ["http://localhost:9000", "http://localhost:9001"]},
+        )
+
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            LocustSweepRunner(config).run(dry_run=False)
+
+            assert mock_check.call_count == 2
+
+    def test_repeated_host_is_checked_once(self, sweep_runner):
+        """Levels sharing a host do not re-check it."""
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+            mock_check.assert_called_once()
+
+    def test_resume_reruns_a_level_whose_config_changed(self, sweep_runner):
+        """A level is identified by its swept values, so unswept settings can drift."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+            # Change a setting that is not part of the level's identity.
+            sweep_runner.config.base_config.message = "a different prompt"
+
+            mock_run.reset_mock()
+            sweep_runner.run(dry_run=False, resume=True)
+
+            assert mock_run.call_count == 3, "stale results must not be kept under --resume"
+
+    def test_resume_keeps_levels_whose_config_is_unchanged(self, sweep_runner):
+        """The config check must not defeat resume for an unmodified batch."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+            mock_run.reset_mock()
+            sweep_runner.run(dry_run=False, resume=True)
+
+            assert mock_run.call_count == 0
+
     def test_dry_run_executes_nothing(self, sweep_runner):
         """Dry-run prints each level's command without running or checking the service."""
         with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -30,8 +30,13 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
-from benchmark.locust.locust_models import LocustConfig
-from benchmark.locust.run_locust import LocustRunner, _load_config_from_yaml, app
+from benchmark.locust.locust_models import LocustConfig, LocustSweepConfig
+from benchmark.locust.run_locust import (
+    LocustRunner,
+    LocustSweepRunner,
+    _load_config_from_yaml,
+    app,
+)
 
 
 @pytest.fixture
@@ -330,7 +335,24 @@ class TestLocustRunner:
         assert cmd[0] == "locust"
 
         cmd_string = " ".join(cmd)
-        assert "--host http://localhost:8000 --users 10 --spawn-rate 2.0 --run-time 30s --headless" in cmd_string
+        # 10 users at 2/s ramps for 5s, added on top of the 30s measured window.
+        assert (
+            "--host http://localhost:8000 --users 10 --spawn-rate 2.0 --run-time 35s --reset-stats --headless"
+            in cmd_string
+        )
+
+    def test_ramp_is_added_to_the_measured_window(self, runner):
+        """run_time is the measured duration; the ramp does not eat into it."""
+        assert runner.ramp_seconds == 5
+        assert runner.config.run_time == 30
+        assert runner.total_run_seconds == 35
+
+    def test_ramp_seconds_rounds_up(self, runner):
+        """A partial ramp second still has to elapse before the plateau starts."""
+        runner.config.users = 10
+        runner.config.spawn_rate = 3
+
+        assert runner.ramp_seconds == 4
 
     def test_build_locust_command_headless(self, runner, tmp_path):
         """Test building Locust command in headless mode."""
@@ -344,6 +366,7 @@ class TestLocustRunner:
         assert "--only-summary" in cmd
         assert "--html" in cmd
         assert "--csv" in cmd
+        assert "--csv-full-history" in cmd
 
     def test_build_locust_command_non_headless(self, runner):
         """Test building Locust command in web UI mode (non-headless)."""
@@ -355,6 +378,7 @@ class TestLocustRunner:
         assert "--only-summary" not in cmd
         assert "--html" not in cmd
         assert "--csv" not in cmd
+        assert "--csv-full-history" not in cmd
 
     def test_save_run_metadata(self, runner, tmp_path):
         """Test saving run metadata to file."""
@@ -481,6 +505,130 @@ class TestLocustRunner:
             mock_run.assert_not_called()
 
 
+class TestLocustSweepRunner:
+    """Test running a sweep of concurrency levels."""
+
+    @pytest.fixture
+    def sweep_config(self, tmp_path):
+        """A three-level concurrency sweep writing under tmp_path."""
+        return LocustSweepConfig(
+            batch_name="sweep",
+            output_base_dir=str(tmp_path / "results"),
+            base_config={
+                "host": "http://localhost:9000",
+                "config_id": "test-config",
+                "model": "test-model",
+                "spawn_rate": 4,
+                "run_time": 10,
+                "headless": True,
+            },
+            sweeps={"users": [1, 2, 4]},
+        )
+
+    @pytest.fixture
+    def sweep_runner(self, sweep_config):
+        return LocustSweepRunner(sweep_config)
+
+    def test_runs_every_level_in_order(self, sweep_runner):
+        """Each swept value becomes its own Locust invocation."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+
+            assert sweep_runner.run(dry_run=False) == 0
+            assert mock_run.call_count == 3
+
+            users = [command[command.index("--users") + 1] for (command,) in (c[0] for c in mock_run.call_args_list)]
+            assert users == ["1", "2", "4"]
+
+    def test_level_directories_are_named_by_swept_value(self, sweep_runner):
+        """Level directories are deterministic, which is what makes resume possible."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+        names = sorted(path.name for path in sweep_runner.batch_path.iterdir())
+        assert names == ["users-1", "users-2", "users-4"]
+
+    def test_request_failures_do_not_stop_the_sweep(self, sweep_runner):
+        """A level past saturation exits non-zero; later levels still run."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            # The middle level fails, as an overloaded server would.
+            mock_run.side_effect = [Mock(returncode=0), Mock(returncode=1), Mock(returncode=0)]
+
+            exit_code = sweep_runner.run(dry_run=False)
+
+            assert exit_code == 0, "request failures are a result, not a runner error"
+            assert mock_run.call_count == 3
+
+    def test_exit_code_is_recorded_per_level(self, sweep_runner):
+        """Each level's Locust exit code survives in its metadata."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [Mock(returncode=0), Mock(returncode=1), Mock(returncode=0)]
+            sweep_runner.run(dry_run=False)
+
+        recorded = {
+            path.name: json.loads((path / "run_metadata.json").read_text())["exit_code"]
+            for path in sweep_runner.batch_path.iterdir()
+        }
+        assert recorded == {"users-1": 0, "users-2": 1, "users-4": 0}
+
+    def test_health_check_runs_once_for_the_batch(self, sweep_runner):
+        """The server is checked once, not once per level."""
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+            mock_check.assert_called_once()
+
+    def test_failed_health_check_stops_the_sweep(self, sweep_runner):
+        """A sweep that cannot reach the server did not run, so it exits non-zero."""
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            mock_check.side_effect = RuntimeError("Service unavailable")
+
+            assert sweep_runner.run(dry_run=False) == 1
+            mock_run.assert_not_called()
+
+    def test_resume_skips_completed_levels(self, sweep_runner):
+        """A completed level is kept rather than re-run."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+            assert mock_run.call_count == 3
+
+            mock_run.reset_mock()
+            sweep_runner.run(dry_run=False, resume=True)
+
+            assert mock_run.call_count == 0
+
+    def test_resume_reruns_an_interrupted_level(self, sweep_runner):
+        """Metadata without an exit code means the level never finished."""
+        interrupted = sweep_runner.batch_path / "users-2"
+        interrupted.mkdir(parents=True)
+        (interrupted / "run_metadata.json").write_text(json.dumps({"exit_code": None}))
+
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False, resume=True)
+
+            assert mock_run.call_count == 3
+
+    def test_is_complete_rejects_unreadable_metadata(self, sweep_runner, tmp_path):
+        """Corrupt metadata is treated as incomplete rather than crashing the sweep."""
+        level = tmp_path / "level"
+        level.mkdir()
+        (level / "run_metadata.json").write_text("{not json")
+
+        assert sweep_runner.is_complete(level) is False
+
+    def test_dry_run_executes_nothing(self, sweep_runner):
+        """Dry-run prints each level's command without running or checking the service."""
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            assert sweep_runner.run(dry_run=True) == 0
+
+            mock_check.assert_not_called()
+            mock_run.assert_not_called()
+
+
 class TestLoadConfigFromYaml:
     """Test _load_config_from_yaml function."""
 
@@ -490,9 +638,10 @@ class TestLoadConfigFromYaml:
 
         config = _load_config_from_yaml(config_file)
 
-        assert isinstance(config, LocustConfig)
-        assert config.config_id == "test-config"
-        assert config.model == "test-model"
+        assert isinstance(config, LocustSweepConfig)
+        assert config.sweeps is None
+        assert config.base_config.config_id == "test-config"
+        assert config.base_config.model == "test-model"
 
     def test_load_config_file_not_found(self, tmp_path):
         """Test loading non-existent config file."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -245,6 +245,14 @@ class TestLocustRunner:
             with pytest.raises(RuntimeError, match="HTTP error accessing"):
                 runner._check_service()
 
+    def test_check_service_invalid_url(self, runner):
+        """InvalidURL does not derive from HTTPError, so it needs naming explicitly."""
+        with patch("httpx.get") as mock_get:
+            mock_get.side_effect = httpx.InvalidURL("Invalid port: 'b:c'")
+
+            with pytest.raises(RuntimeError, match="HTTP error accessing"):
+                runner._check_service()
+
     def _v1_health_endpoint(self, runner: LocustRunner):
         """The Guardrails server's health endpoint"""
         return f"{runner.config.host}/v1/health"
@@ -688,6 +696,49 @@ class TestLocustSweepRunner:
         assert sweep_runner._format_duration(30 * 60) == "30 minutes"
         assert sweep_runner._format_duration(89 * 60) == "89 minutes"
         assert sweep_runner._format_duration(240 * 60) == "4.0 hours"
+
+    def test_resume_does_not_check_hosts_whose_levels_are_all_complete(self, tmp_path):
+        """A finished host going away must not block incomplete levels elsewhere."""
+        config = LocustSweepConfig(
+            batch_name="hosts",
+            output_base_dir=str(tmp_path / "results"),
+            base_config={"config_id": "test-config", "model": "test-model", "run_time": 5},
+            sweeps={"host": ["http://localhost:9000", "http://localhost:9001"]},
+        )
+        sweep = LocustSweepRunner(config)
+
+        # Complete only the first host's level.
+        done, pending = sorted(label for label, _ in config.expand())
+        done_path = sweep.batch_path / done
+        done_path.mkdir(parents=True)
+        completed = next(c for label, c in config.expand() if label == done)
+        (done_path / "run_metadata.json").write_text(
+            json.dumps({"exit_code": 0, "config": json.loads(completed.model_dump_json())})
+        )
+
+        checked = []
+        with (
+            patch.object(LocustRunner, "_check_service", autospec=True) as mock_check,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_check.side_effect = lambda self: checked.append(self.config.host)
+            mock_run.return_value = Mock(returncode=0)
+
+            assert sweep.run(dry_run=False, resume=True) == 0
+
+        assert len(checked) == 1, f"only the pending host should be checked, got {checked}"
+        assert mock_run.call_count == 1
+
+    def test_resume_with_everything_complete_runs_nothing(self, sweep_runner):
+        """A fully complete batch exits cleanly without probing the server."""
+        with patch.object(LocustRunner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            sweep_runner.run(dry_run=False)
+
+        with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            assert sweep_runner.run(dry_run=False, resume=True) == 0
+            mock_check.assert_not_called()
+            mock_run.assert_not_called()
 
     def test_dry_run_executes_nothing(self, sweep_runner):
         """Dry-run prints each level's command without running or checking the service."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -676,6 +676,19 @@ class TestLocustSweepRunner:
 
             assert mock_run.call_count == 0
 
+    def test_estimate_sums_ramp_and_measured_for_every_level(self, sweep_runner):
+        """The up-front estimate is what tells someone whether to start the run."""
+        levels = sweep_runner.config.expand()
+
+        # 1, 2 and 4 users at spawn_rate 4 each ramp 1s, then 10s measured.
+        assert sweep_runner.estimated_seconds(levels) == 3 * (1 + 10)
+
+    def test_estimate_switches_to_hours_when_long(self, sweep_runner):
+        """A multi-hour ladder should not be reported as "240 minutes"."""
+        assert sweep_runner._format_duration(30 * 60) == "30 minutes"
+        assert sweep_runner._format_duration(89 * 60) == "89 minutes"
+        assert sweep_runner._format_duration(240 * 60) == "4.0 hours"
+
     def test_dry_run_executes_nothing(self, sweep_runner):
         """Dry-run prints each level's command without running or checking the service."""
         with patch.object(LocustRunner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -693,6 +693,8 @@ class TestLocustSweepRunner:
 
     def test_estimate_switches_to_hours_when_long(self, sweep_runner):
         """A multi-hour ladder should not be reported as "240 minutes"."""
+        assert sweep_runner._format_duration(60) == "1 minute"
+        assert sweep_runner._format_duration(90) == "2 minutes"
         assert sweep_runner._format_duration(30 * 60) == "30 minutes"
         assert sweep_runner._format_duration(89 * 60) == "89 minutes"
         assert sweep_runner._format_duration(240 * 60) == "4.0 hours"

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -60,7 +60,7 @@ def create_config_data(tmp_path):
             "host": host,
             "config_id": config_id,
             "model": model,
-            "users": users,
+            "target_users": users,
             "spawn_rate": spawn_rate,
             "run_time": run_time,
             "message": message,
@@ -357,7 +357,7 @@ class TestLocustRunner:
 
     def test_ramp_seconds_rounds_up(self, runner):
         """A partial ramp second still has to elapse before the plateau starts."""
-        runner.config.users = 10
+        runner.config.target_users = 10
         runner.config.spawn_rate = 3
 
         assert runner.ramp_seconds == 4
@@ -530,7 +530,7 @@ class TestLocustSweepRunner:
                 "run_time": 10,
                 "headless": True,
             },
-            sweeps={"users": [1, 2, 4]},
+            sweeps={"target_users": [1, 2, 4]},
         )
 
     @pytest.fixture
@@ -555,7 +555,7 @@ class TestLocustSweepRunner:
             sweep_runner.run(dry_run=False)
 
         names = sorted(path.name for path in sweep_runner.batch_path.iterdir())
-        assert names == ["users-1", "users-2", "users-4"]
+        assert names == ["target_users-1", "target_users-2", "target_users-4"]
 
     def test_request_failures_do_not_stop_the_sweep(self, sweep_runner):
         """A level past saturation exits non-zero; later levels still run."""
@@ -578,7 +578,7 @@ class TestLocustSweepRunner:
             path.name: json.loads((path / "run_metadata.json").read_text())["exit_code"]
             for path in sweep_runner.batch_path.iterdir()
         }
-        assert recorded == {"users-1": 0, "users-2": 1, "users-4": 0}
+        assert recorded == {"target_users-1": 0, "target_users-2": 1, "target_users-4": 0}
 
     def test_health_check_runs_once_for_the_batch(self, sweep_runner):
         """The server is checked once, not once per level."""
@@ -610,7 +610,7 @@ class TestLocustSweepRunner:
 
     def test_resume_reruns_an_interrupted_level(self, sweep_runner):
         """Metadata without an exit code means the level never finished."""
-        interrupted = sweep_runner.batch_path / "users-2"
+        interrupted = sweep_runner.batch_path / "target_users-2"
         interrupted.mkdir(parents=True)
         (interrupted / "run_metadata.json").write_text(json.dumps({"exit_code": None}))
 

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -237,6 +237,14 @@ class TestLocustRunner:
                 == f"Error: response {mock_response.text} couldn't be parsed as JSON: {json_error}"
             )
 
+    def test_check_service_other_transport_error(self, runner):
+        """A transport failure other than connect or timeout is still a controlled error."""
+        with patch("httpx.get") as mock_get:
+            mock_get.side_effect = httpx.ReadError("connection reset")
+
+            with pytest.raises(RuntimeError, match="HTTP error accessing"):
+                runner._check_service()
+
     def _v1_health_endpoint(self, runner: LocustRunner):
         """The Guardrails server's health endpoint"""
         return f"{runner.config.host}/v1/health"


### PR DESCRIPTION
## Description

The Locust CLI ran one concurrency level per invocation, so a run produced a single point. The harness is documented as measuring how a server "degrades under higher-than-expected load", and degradation is only visible as a curve. AIPerf already expands a `sweeps` mapping into a batch of runs; Locust had no equivalent.

Adds `LocustSweepConfig`, which expands a `sweeps` mapping over a base configuration, and `LocustSweepRunner`, which runs each level into its own directory.

```yaml
batch_name: sweep_concurrency
base_config:
  host: "http://localhost:9000"
  config_id: content_safety_local
  model: meta/llama-3.3-70b-instruct
  spawn_rate: 16
  run_time: 120
sweeps:
  users: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
```

Beyond looping, three behaviours had to change or a sweep would report misleading numbers:

**Ramp-up was included in the statistics.** `run_time` covered the ramp and the plateau together, so the measured window shrank exactly as concurrency rose. `run_time` now means the measured duration and the ramp is added on top, with `--reset-stats` discarding what was gathered while spawning. Visible in `--dry-run` — the measured window stays at 120s while the request grows:

```
--users 1    --run-time 121s --reset-stats
--users 512  --run-time 152s --reset-stats
--users 1024 --run-time 184s --reset-stats
```

**Only end-of-run aggregates were written.** Levels now pass `--csv-full-history`, so a level that never reached a plateau can be told apart from one that did.

**A failing level would stop the sweep.** Locust exits non-zero when any request fails, and that code was returned directly — but the levels past saturation are the ones a stress test exists to measure. Each level's exit code is now recorded in its `run_metadata.json` and the batch continues. The CLI exits non-zero only when the benchmark could not run, such as a failed health check.

`--resume` skips levels that already hold a completed result. The shipped ladder takes about 25 minutes; a longer `run_time` or more levels scales that up. A level counts as complete only once its exit code is recorded, so an interrupted level is re-run rather than kept.

### Timing model: `run_time` and `spawn_rate`

These two fields decide the shape of every level, and the change to what `run_time` means is the one behaviour change worth understanding before reviewing the rest.

- **`spawn_rate`** — users started per second during the ramp. It is the only input to ramp timing: `ramp = ceil(users / spawn_rate)`.
- **`run_time`** — **the measured window**, not the total. The runner sends Locust `--run-time (ramp + run_time)` and passes `--reset-stats`, so statistics gathered while spawning are discarded.


| users | ramp | measured | `--run-time` sent to Locust |
| ---: | ---: | ---: | ---: |
| 16 | 1s | 120s | 121s |
| 256 | 16s | 120s | 136s |
| 512 | 32s | 120s | 152s |
| 1024 | 64s | 120s | 184s |


### Setup/Results

The shipped `configs/sweep_concurrency.yaml` ladder, run end to end against the mock stack from `benchmark/Procfile`.

Conditions, since the numbers mean nothing without them:

| | |
| --- | --- |
| Engine | **LLMRails** — `NEMO_GUARDRAILS_IORAILS_ENGINE` unset, so this is the default path, not IORails |
| Guardrails config | `examples/configs/content_safety_local` on port 9000, chat UI disabled |
| Mock models | shipped `.env` configs, 4 uvicorn workers each: 4.0s application model (:8000), 0.5s content safety (:8001) |
| Model path | 5.0s deterministic (0.5 + 4.0 + 0.5), zero latency jitter, `UNSAFE_PROBABILITY=0.0` |
| Sweep | `users: [1 … 1024]`, `spawn_rate: 16`/s, `run_time: 120` measured seconds per level, headless |
| Client timeout | 60s, the `locustfile.py` default — this bounds p95 and is the ceiling a slower host would hit |
| Host | macOS 26.5.2 arm64, 14 cores, `ulimit -n 65536`, Python 3.13.14, Locust 2.46.3 |
| Branch | 2610d6208 |

Everything runs on one laptop, so the saturation point is a property of this machine rather than of Guardrails. What transfers is the shape of the curve and the fact that the harness records it.


| users | requests | failures | rps | p50 | p95 | exit code |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 23 | 0 | 0.20 | 5100ms | 5100ms | 0 |
| 2 | 46 | 0 | 0.39 | 5100ms | 5100ms | 0 |
| 4 | 92 | 0 | 0.77 | 5200ms | 5200ms | 0 |
| 8 | 178 | 0 | 1.48 | 5200ms | 5300ms | 0 |
| 16 | 358 | 0 | 3.01 | 5300ms | 5400ms | 0 |
| 32 | 719 | 0 | 5.97 | 5300ms | 5500ms | 0 |
| 64 | 1473 | 0 | 12.25 | 5200ms | 5400ms | 0 |
| 128 | 2719 | 0 | 22.80 | 5500ms | 6500ms | 0 |
| 256 | 2630 | 0 | 21.94 | 12000ms | 17000ms | 0 |
| 512 | 3192 | 0 | 27.73 | 19000ms | 23000ms | 0 |
| 1024 | 3913 | 0 | 34.20 | 31000ms | 34000ms | 0 |

Throughput scales linearly to 128 users while latency stays flat at roughly the 5.0s model path, then the server saturates: beyond 128 users, added concurrency turns almost entirely into queueing delay, with p50 climbing from 5.5s to 31s while throughput moves from 22.8 to 34.2 rps. The knee sits between 128 and 256 users.

This is the shape a single-level run cannot produce, and it is why the ramp has to be excluded from the measurement. `--reset-stats` is doing its job: observed throughput matches concurrency divided by latency at every level, within 2%.

### On the configuration shape

#2321 offered two options and said I would defer to maintainer preference. Rather than pre-empt that, this accepts **both**: the nested `base_config`/`sweeps` form that mirrors AIPerf, and the existing flat form, which may also carry a `sweeps` block. If you would rather support only one, removing the other is a small follow-up.

### Behaviour changes to be aware of

- `run_time` now excludes the ramp, so a single run takes `ramp + run_time` seconds where it previously took `run_time`. This is what makes levels comparable, but it does change existing single-run timings. `test_build_locust_command_basic` was updated for this.
- `_load_config_from_yaml` returns `LocustSweepConfig` rather than `LocustConfig`. Flat config files are unchanged and still valid; `configs/local.yaml` runs exactly as before.
- `run_metadata.json` gains an `exit_code` key, null until the run finishes.

## Related Issue(s)

- Fixes #2321
- Issue assignee: @yixinh-nv

## Verification

- `pytest benchmark/tests` — 275 passed, up from 245. 30 new tests cover sweep expansion, the Cartesian product, sweep validation, filesystem-safe and collision-free level labels, per-level exit-code recording, continuing past a failing level, per-host health checks, resume, re-running an interrupted level, and re-running a level whose configuration changed.
- Backward compatibility: `python -m benchmark.locust benchmark/locust/configs/local.yaml --dry-run` produces the same single run as before, now with the ramp-aware duration.
- `python -m benchmark.locust benchmark/locust/configs/sweep_concurrency.yaml --dry-run` expands to 11 levels with the durations shown above.
- `ruff check` and `ruff format` clean.
- End-to-end: the full 11-level ladder above, 24m17s wall clock against the live mock stack (mock application LLM on :8000, mock content safety on :8001, Guardrails on :9000) with `ulimit -n 65536`. This confirms the ~25 minute figure now stated in the README. Every level wrote its own directory with `report.html`, `run_metadata.json` and the four CSVs, including `stats_stats_history.csv` populated with 236-355 rows. No level recorded a failure, and every exit code was 0.
- Sanity check on the measurement: observed rps matches users / p50 latency at every level to within 2%, which is what `--reset-stats` is there to make true. Without it the aggregate would be diluted by the ramp, and increasingly so at higher concurrency.
- A shorter three-level sweep was also run at reduced mock latencies, and the resume path was exercised by re-running a completed batch.
- Once across those 14 levels, Locust 2.46.3 logged `ValueError: I/O operation on closed file` from `StatsCSVFileWriter.stats_writer`. It is a teardown race in Locust's own CSV writer: it fires as the run ends, the affected level still wrote a complete set of artifacts (242 history rows, in line with its neighbours), and the level exited 0. Flagging it because `--csv-full-history` is new here.
- `make docs-fern` not run: `benchmark/locust/README.md` is not part of the Fern build.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concurrency-sweep benchmarking with configurable user-count levels.
  * Added `--resume` support to continue incomplete benchmark sweeps.
  * Added per-level results, metadata, deterministic output directories, and failure continuation.
  * Added ramp-up-aware duration reporting and complete headless CSV history.

* **Documentation**
  * Documented sweep configuration, output persistence, resume behavior, and execution details.
  * Added a ready-to-use local concurrency-sweep configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





