### PR TITLE
fix(server): keep OpenAIChatMessage validator importable across the supported pydantic range

### DIFF
--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -203,12 +203,28 @@ def _validate_openai_chat_message(message: Any) -> Any:
     return message
 
 
+def _build_chat_message_validator() -> BeforeValidator:
+    """Build the chat-message before-validator across supported pydantic versions.
+
+    ``json_schema_input_type`` (which keeps the generated JSON schema describing
+    the rich per-role message union instead of a plain object) is only accepted
+    by ``BeforeValidator`` from pydantic 2.9 onwards, while this project supports
+    ``pydantic>=2.5``. On older versions fall back to a plain validator so the
+    module keeps importing; JSON schema generation then describes ``messages``
+    as generic objects.
+    """
+    try:
+        return BeforeValidator(
+            _validate_openai_chat_message,
+            json_schema_input_type=_OpenAIChatMessageInput,
+        )
+    except TypeError:
+        return BeforeValidator(_validate_openai_chat_message)
+
+
 OpenAIChatMessage = Annotated[
     dict[str, Any],
-    BeforeValidator(
-        _validate_openai_chat_message,
-        json_schema_input_type=_OpenAIChatMessageInput,
-    ),
+    _build_chat_message_validator(),
 ]
 
 

--- a/tests/server/test_openai_schemas_compat.py
+++ b/tests/server/test_openai_schemas_compat.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility tests for the OpenAI server schemas across the supported pydantic range.
+
+``OpenAIChatMessage`` used ``BeforeValidator(..., json_schema_input_type=...)``,
+an argument that only pydantic 2.9+ accepts, while the project declares
+``pydantic>=2.5``. These tests pin down the behavior required by issue #2292:
+the module must import and validate identically on every supported version,
+and the richer JSON schema input type is preserved where pydantic supports it.
+"""
+
+from typing import List
+
+import pydantic
+import pytest
+from pydantic import BeforeValidator, ValidationError
+
+from nemoguardrails.server.schemas.openai import OpenAIChatMessage
+
+
+def _supports_json_schema_input_type() -> bool:
+    try:
+        BeforeValidator(lambda value: value, json_schema_input_type=int)
+    except TypeError:
+        return False
+    return True
+
+
+def _make_request_model() -> type[pydantic.BaseModel]:
+    class RequestModel(pydantic.BaseModel):
+        messages: List[OpenAIChatMessage]
+
+    return RequestModel
+
+
+def test_accepts_valid_user_message():
+    model = _make_request_model()
+    parsed = model.model_validate({"messages": [{"role": "user", "content": "hi"}]})
+    assert parsed.messages[0] == {"role": "user", "content": "hi"}
+
+
+def test_rejects_unknown_role():
+    model = _make_request_model()
+    with pytest.raises(ValidationError):
+        model.model_validate({"messages": [{"role": "wizard", "content": "hi"}]})
+
+
+def test_json_schema_generation_succeeds():
+    # JSON schema generation must work on every supported pydantic version.
+    schema = _make_request_model().model_json_schema()
+    assert "messages" in schema["properties"]
+
+
+@pytest.mark.skipif(
+    not _supports_json_schema_input_type(),
+    reason="pydantic < 2.9 does not support json_schema_input_type",
+)
+def test_json_schema_uses_rich_input_type_when_supported():
+    schema = _make_request_model().model_json_schema()
+    items = schema["properties"]["messages"]["items"]
+    # The union input type is rendered either as a direct reference or as an
+    # anyOf over the per-role message schemas defined in $defs.
+    if "$ref" in items:
+        assert items["$ref"].startswith("#/$defs/")
+    else:
+        assert "anyOf" in items
+        assert all(branch["$ref"].startswith("#/$defs/") for branch in items["anyOf"])


### PR DESCRIPTION
## Summary

Fixes #2292.

`OpenAIChatMessage` passed `json_schema_input_type` to `BeforeValidator`, but that argument is only accepted from pydantic 2.9 onwards, while the project declares `pydantic>=2.5,<3.0`. Importing `nemoguardrails.server.schemas.openai` on pydantic 2.5–2.8 therefore raised:

```
TypeError: BeforeValidator.__init__() got an unexpected keyword argument 'json_schema_input_type'
```

This change builds the validator through a small helper that applies the argument when the installed pydantic supports it and falls back to a plain `BeforeValidator` otherwise:

```python
def _build_chat_message_validator() -> BeforeValidator:
    try:
        return BeforeValidator(
            _validate_openai_chat_message,
            json_schema_input_type=_OpenAIChatMessageInput,
        )
    except TypeError:
        return BeforeValidator(_validate_openai_chat_message)
```

On pydantic < 2.9 the generated JSON schema describes `messages` as generic objects instead of the per-role union; runtime validation behavior (string `role` required, per-role payload validation) is identical.

I kept the declared dependency range as-is rather than bumping the minimum to 2.9, per the issue's "either remove/replace the argument or raise the minimum" — happy to switch to a floor bump + lockfile regeneration if maintainers prefer that route.

## Verification

- Reproduced the original `TypeError` empirically on pydantic 2.5.1, 2.6.4, 2.7.4 and 2.8.2 before the change; confirmed 2.9.2 accepts the argument.
- New tests in `tests/server/test_openai_schemas_compat.py`:
  - valid user message round-trips through validation,
  - unknown role is rejected,
  - JSON schema generation succeeds on every supported version,
  - the rich per-role input type is asserted when pydantic supports it (auto-skipped below 2.9).
- Ran the new tests against pydantic **2.8.2** (fallback path: 3 passed, rich-schema test skipped) and **2.13.4** (rich path: 4 passed).
- `ruff check` and `ruff format --check` clean with the repo-pinned ruff 0.14.6.

## AI Disclosure

Per [AI_POLICY.md](https://github.com/NVIDIA-NeMo/Guardrails/blob/main/AI_POLICY.md): this pull request was written with AI assistance (ox-alpha coding agent operating on behalf of the submitting human) and reviewed and edited by a human, who verified the changes locally across the pydantic versions listed above. No AI co-author is recorded; the commit is DCO signed by the submitter.
