### PR TITLE
fix(regex): reject catastrophic regex patterns at config load and cap scan length

### DIFF
--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -22,6 +22,14 @@ from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 
 log = logging.getLogger(__name__)
 
+# Upper bound on the text scanned per pattern-detection call. Patterns are
+# vetted against a safe subset at config load time (see
+# nemoguardrails.library.regex.safety), but ambiguous-alternation shapes
+# that static analysis cannot prove safe remain; capping the scan keeps
+# their worst case bounded instead of unbounded (#2203). Matches beyond
+# the cap are not detected and a warning is logged.
+MAX_REGEX_SCAN_CHARS = 200_000
+
 
 class RegexDetectionResult(TypedDict):
     is_match: bool
@@ -81,6 +89,17 @@ async def detect_regex_pattern(
     if not text:
         log.debug("Empty text provided, skipping regex check.")
         return _regex_outcome(source, RegexDetectionResult(is_match=False, text=text, detections=[]))
+
+    if len(text) > MAX_REGEX_SCAN_CHARS:
+        log.warning(
+            "Regex detection text for source %r is %d characters, exceeding the %d character scan cap; "
+            "only the first %d characters are scanned.",
+            source,
+            len(text),
+            MAX_REGEX_SCAN_CHARS,
+            MAX_REGEX_SCAN_CHARS,
+        )
+        text = text[:MAX_REGEX_SCAN_CHARS]
 
     # Match against pre-compiled patterns and collect all matches.
     matched: List[str] = []

--- a/nemoguardrails/library/regex/rail_config.py
+++ b/nemoguardrails/library/regex/rail_config.py
@@ -16,6 +16,10 @@
 import re
 from typing import List, Optional
 
+from nemoguardrails.library.regex.safety import (
+    UnsafeRegexPatternError,
+    ensure_pattern_is_safe,
+)
 from nemoguardrails.manifests.config_schema import (
     Field,
     PrivateAttr,
@@ -42,7 +46,12 @@ class RegexDetectionOptions(RailConfigBaseModel):
 
     @model_validator(mode="after")
     def compile_patterns(self) -> "RegexDetectionOptions":
-        """Pre-compile regex patterns at config load time."""
+        """Pre-compile regex patterns at config load time.
+
+        Beyond syntax validation, each pattern is checked against the
+        documented safe subset so that a configured pattern cannot exhibit
+        catastrophic backtracking at request time (ReDoS, #2203).
+        """
         flags = re.IGNORECASE if self.case_insensitive else 0
         compiled = []
         for i, pattern in enumerate(self.patterns):
@@ -50,6 +59,10 @@ class RegexDetectionOptions(RailConfigBaseModel):
                 compiled.append(re.compile(pattern, flags))
             except re.error as e:
                 raise ValueError(f"Invalid regex pattern at index {i} ({pattern!r}): {e}") from e
+            try:
+                ensure_pattern_is_safe(pattern, flags)
+            except UnsafeRegexPatternError as e:
+                raise ValueError(f"Unsafe regex pattern at index {i} ({pattern!r}): {e}") from e
         object.__setattr__(self, "_compiled_patterns", compiled)
         return self
 

--- a/nemoguardrails/library/regex/safety.py
+++ b/nemoguardrails/library/regex/safety.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static safety analysis for configured regex patterns (#2203).
+
+Python's ``re`` engine backtracks, so a pattern that applies an unbounded
+quantifier inside the body of another unbounded quantifier (``(a+)+``,
+``(?:\\w+\\s*)*``, ...) can exhibit catastrophic backtracking on crafted
+input and pin a worker thread even though the pattern is syntactically
+valid. Configuration-load-time syntax checking does not catch this.
+
+``ensure_pattern_is_safe`` implements a conservative, documented safe
+subset: reject any pattern where an unbounded repetition (``*``, ``+``,
+``{n,}``, lazy variants included) transitively contains another unbounded
+repetition through grouping, alternation, lookarounds, or bounded
+repetitions. Patterns in this subset run in linear-ish time on the
+standard engine.
+
+Known limitation (documented, accepted): ambiguous alternations without
+nested quantifiers (``(a|aa)*b``) are not detected by this analysis; the
+input-length cap applied by :mod:`nemoguardrails.library.regex.actions`
+is the backstop for residual cases.
+"""
+
+import logging
+
+try:
+    from re import _constants as _sre_constants
+    from re import _parser as _sre_parser
+except ImportError:  # pragma: no cover - Python < 3.11
+    import sre_constants as _sre_constants
+    import sre_parse as _sre_parser
+
+
+log = logging.getLogger(__name__)
+
+
+MAXREPEAT = _sre_constants.MAXREPEAT
+_REPEAT_OPS = (_sre_constants.MAX_REPEAT, _sre_constants.MIN_REPEAT)
+_MAX_ANALYSIS_DEPTH = 64
+
+
+class UnsafeRegexPatternError(ValueError):
+    """Raised when a configured pattern is rejected as unsafe."""
+
+
+def _child_sequences(op, av):
+    """Yield the nested sequences of a parsed node, if any."""
+    if op == _sre_constants.SUBPATTERN:
+        return (av[3],)
+    if op == _sre_constants.BRANCH:
+        return tuple(av[1])
+    if op in (_sre_constants.ASSERT, _sre_constants.ASSERT_NOT):
+        return (av[1],)
+    if getattr(_sre_constants, "ATOMIC_GROUP", None) is not None and op == _sre_constants.ATOMIC_GROUP:
+        return (av,)
+    return ()
+
+
+def _has_unbounded_descendant(seq, depth):
+    """True if any descendant of ``seq`` applies an unbounded repetition."""
+    if depth > _MAX_ANALYSIS_DEPTH:
+        # re itself bounds pattern size/complexity; treat pathological
+        # parse trees conservatively rather than recursing forever.
+        return True
+    for op, av in seq:
+        if op in _REPEAT_OPS:
+            maximum = av[1]
+            if maximum == MAXREPEAT:
+                return True
+            if _has_unbounded_descendant(av[2], depth + 1):
+                return True
+            continue
+        found = False
+        for child in _child_sequences(op, av):
+            if _has_unbounded_descendant(child, depth + 1):
+                found = True
+                break
+        if found:
+            return True
+    return False
+
+
+def _contains_unsafe_nesting(seq, depth):
+    """True if an unbounded repetition contains another one below it."""
+    if depth > _MAX_ANALYSIS_DEPTH:
+        return True
+    for op, av in seq:
+        if op in _REPEAT_OPS:
+            _, maximum, body = av
+            if maximum == MAXREPEAT and _has_unbounded_descendant(body, depth + 1):
+                return True
+            if _contains_unsafe_nesting(body, depth + 1):
+                return True
+            continue
+        found = False
+        for child in _child_sequences(op, av):
+            if _contains_unsafe_nesting(child, depth + 1):
+                found = True
+                break
+        if found:
+            return True
+    return False
+
+
+def ensure_pattern_is_safe(pattern: str, flags: int = 0) -> None:
+    """Reject patterns that can exhibit catastrophic backtracking.
+
+    Called after a successful ``re.compile`` so syntax errors have already
+    been reported by the compiler; parse failures here are ignored because
+    they can only be syntax problems.
+    """
+    try:
+        parsed = _sre_parser.parse(pattern, flags)
+    except Exception:  # noqa: BLE001 - unreachable after re.compile succeeded
+        log.debug("Pattern %r could not be re-parsed for safety analysis.", pattern)
+        return
+    if _contains_unsafe_nesting(parsed, 0):
+        raise UnsafeRegexPatternError(
+            "pattern nests an unbounded quantifier inside another "
+            "unbounded quantifier (catastrophic backtracking risk); "
+            "rewrite it so repetitions do not enclose other "
+            "variable-length repetitions"
+        )

--- a/tests/test_regex_rail_safety.py
+++ b/tests/test_regex_rail_safety.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from nemoguardrails.library.regex.actions import (
+    MAX_REGEX_SCAN_CHARS,
+    detect_regex_pattern,
+)
+from nemoguardrails.library.regex.rail_config import RegexDetectionOptions
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"(a+)+",
+        r"(a*)*",
+        r"(a+)+$",
+        r"(?:\w+\s*)*$",
+        r"(a|a+)*b",
+        r"(?:a*b+)*c",
+        r"((a+)b)+",
+        r"x|(a+)*y",
+        r"(a+){2,}b",
+    ],
+)
+def test_unsafe_nested_quantifier_rejected_at_config_load(pattern):
+    """Patterns that nest unbounded quantifiers must fail config load."""
+    with pytest.raises(ValidationError, match="Unsafe regex pattern"):
+        RegexDetectionOptions(patterns=[pattern])
+
+
+@pytest.mark.unit
+def test_invalid_pattern_error_unchanged():
+    """Syntax errors keep their existing message and take precedence."""
+    with pytest.raises(ValidationError, match="Invalid regex pattern"):
+        RegexDetectionOptions(patterns=["(a+"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"\d{3}-\d{2}-\d{4}",
+        r"(?:cat|dog)s?",
+        r"a*b*c*",
+        r"[abc]+",
+        r"\b\w+\b",
+        r"(?:ab)*c",
+        r"^abc$",
+        r"x(?:y|z)?w",
+        r"(a{0,2}){0,2}",
+        r"(a{2})+",
+        r"(?<=pre)post",
+        r".*?",
+        r"(19|20)\d{2}",
+    ],
+)
+def test_safe_patterns_accepted(pattern):
+    """Ordinary patterns, bounded nesting, and lookarounds stay allowed."""
+    options = RegexDetectionOptions(patterns=[pattern])
+    assert len(options.compiled_patterns) == 1
+
+
+@pytest.mark.unit
+def test_case_insensitive_flag_still_applied():
+    """The safe-subset check must not disturb case_insensitive behavior."""
+    options = RegexDetectionOptions(
+        patterns=[r"ssn:\s+\d+"],
+        case_insensitive=True,
+    )
+    (compiled,) = options.compiled_patterns
+    assert compiled.search("SSN:   123-45-6789") is not None
+
+
+def _config_with_patterns(*patterns: str):
+    from nemoguardrails import RailsConfig
+
+    # Escape backslashes for YAML double-quoted scalars.
+    lines = "\n".join(f'                      - "{p.replace(chr(92), chr(92) * 2)}"' for p in patterns)
+    return RailsConfig.from_content(
+        yaml_content=f"""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+{lines}
+        """,
+    )
+
+
+@pytest.mark.unit
+def test_detect_regex_pattern_still_matches_after_vetting():
+    """End-to-end action behavior on a vetted pattern is unchanged."""
+    config = _config_with_patterns(r"\d{3}-\d{2}-\d{4}")
+    result = asyncio.run(detect_regex_pattern(source="input", text="My SSN is 123-45-6789", config=config))
+    assert result.metadata["is_match"] is True
+    assert result.metadata["detections"] == [r"\d{3}-\d{2}-\d{4}"]
+
+
+@pytest.mark.unit
+def test_scan_cap_limits_text_and_logs(monkeypatch, caplog):
+    """Oversized texts are truncated to the cap with a warning; matches
+    beyond the cap are not reported (documented trade-off)."""
+    monkeypatch.setattr("nemoguardrails.library.regex.actions.MAX_REGEX_SCAN_CHARS", 40)
+    config = _config_with_patterns(r"SECRET-\d+")
+
+    inside = "A" * 30 + " SECRET-1"
+    outside = "A" * 45 + " SECRET-9"
+
+    with caplog.at_level(logging.WARNING):
+        hit = asyncio.run(detect_regex_pattern(source="input", text=inside, config=config))
+        miss = asyncio.run(detect_regex_pattern(source="input", text=outside, config=config))
+
+    assert hit.metadata["is_match"] is True
+    assert miss.metadata["is_match"] is False
+    assert any("scan cap" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_default_scan_cap_constant_is_bounded():
+    """The shipped default keeps worst-case work bounded (#2203)."""
+    assert 0 < MAX_REGEX_SCAN_CHARS <= 1_000_000


### PR DESCRIPTION
## Summary

Fixes #2203.

Regex detection rail patterns were only syntax-checked at config load and then evaluated with Python's backtracking `re` engine against request-sized text. A configured pattern with a catastrophic-backtracking shape (e.g. `(a+)+`) combined with crafted input could pin a worker — a ReDoS on a security control.

This PR adds two coordinated bounds at the single choke point that serves the input, output, **and** retrieval matching paths (`detect_regex_pattern`):

### 1. Config-load rejection of unsafe shapes (`nemoguardrails/library/regex/safety.py`)

After the existing syntax check, each pattern is parsed with `re._parser` (with an `sre_parse` fallback for Python 3.10) and validated against a documented safe subset:

> An unbounded quantifier (`*`, `+`, `{n,}`, lazy variants included) must not transitively contain another unbounded quantifier through grouping, alternation, lookarounds, or bounded repetitions.

Such nestings are precisely the classic exponential-backtracking shapes: `(a+)+`, `(?:\w+\s*)*$`, `((a+)b)+`, `(?:a*b+)*c`, … are rejected at load; ordinary patterns, sibling unbounded quantifiers (`a*b*c*`), bounded nesting (`(a{0,2}){0,2}`), alternations without nesting, and lookarounds all remain allowed. Rejection reuses the existing per-index `ValueError` style so operator-facing behavior stays consistent:

```
Unsafe regex pattern at index 0 ('(a+)'): pattern nests an unbounded quantifier inside another unbounded quantifier ...
```

**Documented limitation**: ambiguous alternations *without* nested quantifiers (e.g. `(a|aa)*b`) cannot be proven safe statically and stay allowed by the subset — which is what the second bound is for.

### 2. Bounded scan length (`actions.py`)

`MAX_REGEX_SCAN_CHARS = 200_000`: longer texts are scanned as their prefix, with a warning naming the source. This keeps worst-case work bounded for the residual shapes static analysis accepts.

### Unchanged behavior

- `case_insensitive` flag handling
- invalid-pattern error messages (`Invalid regex pattern at index ...`)
- match semantics for every pattern in the accepted subset

## Verification

- New `tests/test_regex_rail_safety.py` (27 tests):
  - 9 parametrized unsafe shapes → config-load `ValidationError` with `Unsafe regex pattern`
  - 13 parametrized safe shapes (incl. bounded nesting, lookarounds, IGNORECASE) → accepted
  - invalid-pattern message unchanged; end-to-end action match on a vetted SSN-style pattern unchanged
  - scan cap: oversized text truncated to the monkeypatched cap with warning logged; match inside the prefix reported, match beyond the cap not reported (documented trade-off)
- `pytest tests/test_regex_detection.py tests/test_regex_rail_safety.py tests/manifests tests/test_config_loading.py` → **130 passed**
- `ruff check` clean on all changed files under the pre-commit-pinned ruff v0.16.0 rule set (the 8 remaining findings in those files exist identically on `develop` and are untouched by this PR)

## AI Disclosure

Per [AI_POLICY.md](https://github.com/NVIDIA-NeMo/Guardrails/blob/main/AI_POLICY.md): written with AI assistance (ox-alpha coding agent operating on behalf of the submitting human) and reviewed and edited by a human, who verified the changes locally across the test suites listed above. DCO signed by the submitter.
