### PR TITLE
docs(iorails): Add GenerationOptions and GenerationResponse sections

### DIFF
--- a/docs/observability/logging/index.mdx
+++ b/docs/observability/logging/index.mdx
@@ -16,10 +16,10 @@ The NeMo Guardrails library provides multiple ways to inspect and debug guardrai
 
 | Method | Use Case | Engines |
 |--------|----------|---------|
-| **Verbose Mode** | Real-time console logging during development | `LLMRails`, `IORails` |
-| **Explain Method** | Quick summary of the last generation | `LLMRails` |
-| **Generation Options (log)** | Detailed structured logs returned with responses | `LLMRails`, `IORails` (no Colang fields) |
-| **Output Variables** | Return specific context variables | `LLMRails` |
+| `verbose=True` | Real-time console logging during development | `LLMRails`, `IORails` |
+| `explain()` | Quick summary of the last generation | `LLMRails` |
+| `options.log` | Detailed structured logs returned with responses, including large language model (LLM) calls | `LLMRails`, `IORails` (no Colang fields) |
+| `output_vars` | Return specific context variables | `LLMRails` |
 
 ## Verbose Mode
 
@@ -112,7 +112,7 @@ response = rails.generate(
 
 `internal_events` and `colang_history` describe Colang runtime state.
 `IORails` does not run the Colang runtime, so it raises `NotImplementedError` when you set either option to `True` instead of returning an empty value.
-For the `IORails` log structure, see [Generation Options: Log Options on IORails](/run-guardrailed-inference/using-python-apis/generation-options#log-options-on-iorails).
+For the `IORails` log structure, refer to [Generation Options: Log Options on IORails](/run-guardrailed-inference/using-python-apis/generation-options#log-options-on-iorails).
 
 ### Response Structure
 
@@ -191,7 +191,9 @@ print(f"Output rails: {stats.output_rails_duration}s")
 
 Output variables are an `LLMRails` capability, because they read the Colang context.
 `IORails` raises `ValueError` when you pass `output_vars`.
-To find which rail blocked a request on `IORails`, read `log.activated_rails` and look for the entry with `stop` set to `True`, or use [`check()` and `check_async()`](/run-guardrailed-inference/using-python-apis/check-messages), which report the blocking rail directly.
+To find which rail stopped a request on `IORails`, read `log.activated_rails` and look for the entry with `stop` set to `True`.
+The action's `return_value["failed"]` value distinguishes a rail failure from a policy block.
+You can also use [`check()` and `check_async()`](/run-guardrailed-inference/using-python-apis/check-messages), which report the rail that stopped processing.
 
 </Note>
 

--- a/docs/observability/logging/index.mdx
+++ b/docs/observability/logging/index.mdx
@@ -14,12 +14,12 @@ This guide covers the various methods for logging, debugging, and understanding 
 
 The NeMo Guardrails library provides multiple ways to inspect and debug guardrails generation:
 
-| Method | Use Case |
-|--------|----------|
-| **Verbose Mode** | Real-time console logging during development |
-| **Explain Method** | Quick summary of the last generation |
-| **Generation Options (log)** | Detailed structured logs returned with responses |
-| **Output Variables** | Return specific context variables |
+| Method | Use Case | Engines |
+|--------|----------|---------|
+| **Verbose Mode** | Real-time console logging during development | `LLMRails`, `IORails` |
+| **Explain Method** | Quick summary of the last generation | `LLMRails` |
+| **Generation Options (log)** | Detailed structured logs returned with responses | `LLMRails`, `IORails` (no Colang fields) |
+| **Output Variables** | Return specific context variables | `LLMRails` |
 
 ## Verbose Mode
 
@@ -55,6 +55,14 @@ Note that `configure_logging` also stops the `nemoguardrails.guardrails` logger 
 A default `Guardrails(config)` construction configures no logging at all, leaving handlers, levels, and formatting to your application.
 
 ## Explain Method
+
+<Note>
+
+`explain()` is an `LLMRails` method.
+It raises `NotImplementedError` when `IORails` is the active engine, because `ExplainInfo` is built from Colang events.
+On `IORails`, use the `log` generation option described below.
+
+</Note>
 
 Get a quick summary of the last generation using the `explain()` method:
 
@@ -95,12 +103,16 @@ response = rails.generate(
 
 ### Log Option Reference
 
-| Option | Description |
-|--------|-------------|
-| `activated_rails` | Detailed information about rails activated during generation |
-| `llm_calls` | Information about all LLM calls (prompt, completion, tokens, timing) |
-| `internal_events` | Array of internal generated events |
-| `colang_history` | Conversation history in Colang format |
+| Option | Description | LLMRails | IORails |
+|--------|-------------|:---:|:---:|
+| `activated_rails` | Detailed information about rails activated during generation | ✓ | ✓ |
+| `llm_calls` | Information about all LLM calls (prompt, completion, tokens, timing) | ✓ | ✓ |
+| `internal_events` | Array of internal generated events | ✓ | ✗ |
+| `colang_history` | Conversation history in Colang format | ✓ | ✗ |
+
+`internal_events` and `colang_history` describe Colang runtime state.
+`IORails` does not run the Colang runtime, so it raises `NotImplementedError` when you set either option to `True` instead of returning an empty value.
+For the `IORails` log structure, see [Generation Options: Log Options on IORails](/run-guardrailed-inference/using-python-apis/generation-options#log-options-on-iorails).
 
 ### Response Structure
 
@@ -174,6 +186,14 @@ print(f"Output rails: {stats.output_rails_duration}s")
 ```
 
 ## Output Variables
+
+<Note>
+
+Output variables are an `LLMRails` capability, because they read the Colang context.
+`IORails` raises `ValueError` when you pass `output_vars`.
+To find which rail blocked a request on `IORails`, read `log.activated_rails` and look for the entry with `stop` set to `True`, or use [`check()` and `check_async()`](/run-guardrailed-inference/using-python-apis/check-messages), which report the blocking rail directly.
+
+</Note>
 
 Return specific context variables using the `output_vars` option:
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -151,7 +151,8 @@ Tool calls are returned in the OpenAI-style `tool_calls` field of the response m
 | `GenerationOptions` | ✓ | ◐ | IORails supports rail toggles, `llm_params`, and the `log` options that do not need Colang; `output_vars` and `state` raise |
 | `GenerationResponse` (structured response object) | ✓ | ✓ | Returned by both engines when `options` is passed |
 | `GenerationLog` `internal_events` / `colang_history` | ✓ | ✗ | Colang runtime only; IORails raises `NotImplementedError` |
-| `output_data` / `output_vars` | ✓ | ✗ | Colang context only; IORails raises `ValueError` |
+| `output_vars` | ✓ | ✗ | Colang context only; IORails raises `ValueError` |
+| `output_data` | ✓ | ✗ | IORails leaves it `None`; reading it does not raise |
 | Per-rail selection by name in `GenerationOptions` | ✗ | ✓ | IORails runs only the named rails; LLMRails treats a non-empty list as "enabled" |
 | `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -174,7 +174,7 @@ The event-based API and `explain()` are not available on `IORails`; on the `Guar
 | Output-rail streaming | ✓ | ✓ | |
 | Streaming metadata (`include_metadata=True`) | ✓ | ✓ | Both emit `provider_metadata` per chunk and `usage` on the terminal frame |
 | `include_metadata` with output-rail streaming | ✓ | ✗ | IORails raises `ValueError`; its buffer strategy requires plain string chunks |
-| `GenerationOptions` through the stream | ◐ | ◐ | Both accept `llm_params` and rail toggles; neither returns a `GenerationResponse` from `stream_async` |
+| `GenerationOptions` through the stream | ◐ | ◐ | Both apply `llm_params` and rail toggles; neither yields a `GenerationResponse` from `stream_async`, so `log` and `output_vars` are unreachable |
 | Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
 
 Both engines stream responses through `stream_async` and support streaming output rails.
@@ -183,7 +183,10 @@ Both accept `include_metadata=True` to receive dictionary-framed chunks such as 
 For the frame shapes, see [Streaming Metadata](/run-guardrailed-inference/using-python-apis/streaming#streaming-metadata).
 
 `IORails` rejects `include_metadata=True` when output-rail streaming is enabled, because its buffer strategy operates on plain string chunks.
-Neither engine returns a `GenerationResponse` from `stream_async`; structured responses are a non-streaming feature.
+
+Neither engine returns a `GenerationResponse` from `stream_async`; structured responses are a non-streaming feature, and passing `options` does not change the chunk shape.
+`IORails` also validates `options` only on the non-streaming path, so the Colang-coupled options that raise in `generate_async` are silently ignored in `stream_async`.
+For details, see [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
 
 Parallel streaming output rails, where the output rail validates streamed chunks using the streaming buffer, is an `LLMRails` feature.
 `IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -147,30 +147,43 @@ Tool calls are returned in the OpenAI-style `tool_calls` field of the response m
 | `generate` / `generate_async` | ✓ | ✓ | |
 | `stream_async` | ✓ | ✓ | |
 | Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
-| `check` / `check_async` (rails-only validation) | ✓ | ✗ | LLMRails only |
-| `GenerationOptions` | ✓ | ◐ | IORails uses `llm_params` and rail toggles; no `log` or `output_data` |
-| `GenerationResponse` (structured response object) | ✓ | ✗ | IORails returns an OpenAI-style message dict |
+| `check` / `check_async` (rails-only validation) | ✓ | ✓ | |
+| `GenerationOptions` | ✓ | ◐ | IORails supports rail toggles, `llm_params`, and the `log` options that do not need Colang; `output_vars` and `state` raise |
+| `GenerationResponse` (structured response object) | ✓ | ✓ | Returned by both engines when `options` is passed |
+| `GenerationLog` `internal_events` / `colang_history` | ✓ | ✗ | Colang runtime only; IORails raises `NotImplementedError` |
+| `output_data` / `output_vars` | ✓ | ✗ | Colang context only; IORails raises `ValueError` |
+| Per-rail selection by name in `GenerationOptions` | ✗ | ✓ | IORails runs only the named rails; LLMRails treats a non-empty list as "enabled" |
 | `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
 
-Both engines expose `generate`, `generate_async`, and `stream_async`.
-`LLMRails` can return a rich `GenerationResponse` and processes the full `GenerationOptions` object, including rail toggles, `llm_params`, logging options, and `output_data`.
-It also exposes the event-based API (`generate_events` and `process_events`), the rails-only validation methods (`check` and `check_async`), and `explain()` for debugging.
+Both engines expose `generate`, `generate_async`, `stream_async`, and the rails-only validation methods `check` and `check_async`.
+Both return an OpenAI-style message dictionary when you call `generate` without `options`, and a structured `GenerationResponse` when you pass `options`.
+`LLMRails` additionally exposes the event-based API (`generate_events` and `process_events`) and `explain()` for debugging.
 
-`IORails` returns an OpenAI-style message dictionary with `role`, `content`, and optional `tool_calls`, rather than a `GenerationResponse`.
-It accepts `GenerationOptions` but uses only `llm_params` and rail toggles.
-The event-based API, `check` and `check_async`, and `explain()` are not available; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
+`IORails` builds its `GenerationResponse` without a Colang runtime, so the fields that depend on Colang behave differently.
+It fully supports `response`, `tool_calls`, `reasoning_content`, and `llm_metadata`, and it synthesizes `log.activated_rails`, `log.llm_calls`, and `log.stats` from the record each rail leaves behind.
+The Colang-only options raise rather than returning empty data: `log.internal_events` and `log.colang_history` raise `NotImplementedError`, and `output_vars` and `state` raise `ValueError`.
+`IORails` also supports selecting individual rails by name through the rail toggles, which `LLMRails` does not.
+For the field-by-field comparison, see [Generation Options: IORails and LLMRails Differences](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
+
+The event-based API and `explain()` are not available on `IORails`; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
 
 ### Streaming
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
 | Output-rail streaming | ✓ | ✓ | |
-| Streaming usage and metadata | ✓ | ✓ | IORails: `include_metadata=True` |
+| Streaming metadata (`include_metadata=True`) | ✓ | ✓ | Both emit `provider_metadata` per chunk and `usage` on the terminal frame |
+| `include_metadata` with output-rail streaming | ✓ | ✗ | IORails raises `ValueError`; its buffer strategy requires plain string chunks |
+| `GenerationOptions` through the stream | ◐ | ◐ | Both accept `llm_params` and rail toggles; neither returns a `GenerationResponse` from `stream_async` |
 | Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
 
 Both engines stream responses through `stream_async` and support streaming output rails.
-Both can include streaming metadata; on `IORails`, pass `include_metadata=True` to receive dictionary-framed chunks such as `{"text": ...}` instead of plain strings.
-`IORails` does not add a separate `metadata` field to each streamed text chunk.
+Both accept `include_metadata=True` to receive dictionary-framed chunks such as `{"text": ...}` instead of plain strings, and both use the same metadata contract: `provider_metadata` on each chunk that carries it, and token `usage` folded into the single terminal frame.
+`IORails` requests usage on the terminal chunk by default through `stream_options`, which you can override with `llm_params`.
+For the frame shapes, see [Streaming Metadata](/run-guardrailed-inference/using-python-apis/streaming#streaming-metadata).
+
+`IORails` rejects `include_metadata=True` when output-rail streaming is enabled, because its buffer strategy operates on plain string chunks.
+Neither engine returns a `GenerationResponse` from `stream_async`; structured responses are a non-streaming feature.
 
 Parallel streaming output rails, where the output rail validates streamed chunks using the streaming buffer, is an `LLMRails` feature.
 `IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.
@@ -196,12 +209,13 @@ Admission control through an `AsyncWorkQueue` (and a separate semaphore for stre
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
 | Reasoning trace handling (`<think>` tags or reasoning field) | ✓ | ✓ | |
-| `reasoning_content` in a structured response | ✓ | ✗ | Requires `GenerationResponse` |
+| `reasoning_content` in a structured response | ✓ | ✓ | Requires passing `options` so the call returns a `GenerationResponse` |
 
 Both engines preserve model reasoning traces, whether the model returns them in a dedicated reasoning field or inline within `<think>` tags, and both keep reasoning out of the prompt history sent back to the model.
 
-`LLMRails` can expose reasoning in the structured response through `reasoning_content`.
-Because `IORails` returns a message dictionary rather than a `GenerationResponse`, the structured `reasoning_content` field is an `LLMRails` capability.
+Both engines expose reasoning in the structured response through `reasoning_content` when you pass `options` to `generate` or `generate_async`.
+On `IORails`, the structured path keeps the assistant content clean, while the bare message dictionary returned without `options` carries the reasoning inline as a `<think>` prefix.
+Reasoning bypasses the output rails on both engines, so output rails check the final answer rather than the reasoning trace.
 
 ### Multimodal
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -148,46 +148,52 @@ Tool calls are returned in the OpenAI-style `tool_calls` field of the response m
 | `stream_async` | ✓ | ✓ | |
 | Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
 | `check` / `check_async` (rails-only validation) | ✓ | ✓ | |
-| `GenerationOptions` | ✓ | ◐ | IORails supports rail toggles, `llm_params`, and the `log` options that do not need Colang; `output_vars` and `state` raise |
+| `GenerationOptions` | ✓ | ◐ | IORails supports rail toggles, `llm_params`, and the `log` options that do not need Colang. `output_vars` raises. The separate `state` keyword argument also raises. |
 | `GenerationResponse` (structured response object) | ✓ | ✓ | Returned by both engines when `options` is passed |
-| `GenerationLog` `internal_events` / `colang_history` | ✓ | ✗ | Colang runtime only; IORails raises `NotImplementedError` |
-| `output_vars` | ✓ | ✗ | Colang context only; IORails raises `ValueError` |
-| `output_data` | ✓ | ✗ | IORails leaves it `None`; reading it does not raise |
-| Per-rail selection by name in `GenerationOptions` | ✗ | ✓ | IORails runs only the named rails; LLMRails treats a non-empty list as "enabled" |
+| `GenerationLog` `internal_events` / `colang_history` | ✓ | ✗ | Colang runtime only. IORails raises `NotImplementedError`. |
+| `output_vars` | ✓ | ✗ | Colang context only. IORails raises `ValueError`. |
+| `output_data` | ✓ | ✗ | IORails leaves it `None`, but reading it does not raise. |
+| Per-rail selection by name in `GenerationOptions` | ✗ | ✓ | IORails runs only the named rails. LLMRails treats a non-empty list as "enabled". |
 | `explain()` / `ExplainInfo` | ✓ | ✗ | LLMRails only |
 
 Both engines expose `generate`, `generate_async`, `stream_async`, and the rails-only validation methods `check` and `check_async`.
-Both return an OpenAI-style message dictionary when you call `generate` without `options`, and a structured `GenerationResponse` when you pass `options`.
+For message-based calls, both return an OpenAI-style message dictionary when you call `generate` without `options` and a structured `GenerationResponse` when you pass `options`.
+Prompt-based `LLMRails` calls return strings instead.
 `LLMRails` additionally exposes the event-based API (`generate_events` and `process_events`) and `explain()` for debugging.
 
 `IORails` builds its `GenerationResponse` without a Colang runtime, so the fields that depend on Colang behave differently.
 It fully supports `response`, `tool_calls`, `reasoning_content`, and `llm_metadata`, and it synthesizes `log.activated_rails`, `log.llm_calls`, and `log.stats` from the record each rail leaves behind.
 The Colang-only options raise rather than returning empty data: `log.internal_events` and `log.colang_history` raise `NotImplementedError`, and `output_vars` and `state` raise `ValueError`.
 `IORails` also supports selecting individual rails by name through the rail toggles, which `LLMRails` does not.
-For the field-by-field comparison, see [Generation Options: IORails and LLMRails Differences](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
+For the field-by-field comparison, refer to [Generation Options: IORails and LLMRails Differences](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
 
-The event-based API and `explain()` are not available on `IORails`; on the `Guardrails` facade these raise `NotImplementedError` when `IORails` is the active engine.
+The event-based API and `explain()` are not available on `IORails`.
+On the `Guardrails` facade, these raise `NotImplementedError` when `IORails` is the active engine.
 
 ### Streaming
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
 | Output-rail streaming | ✓ | ✓ | |
-| Streaming metadata (`include_metadata=True`) | ✓ | ✓ | Both emit `provider_metadata` per chunk and `usage` on the terminal frame |
-| `include_metadata` with output-rail streaming | ✓ | ✗ | IORails raises `ValueError`; its buffer strategy requires plain string chunks |
-| `GenerationOptions` through the stream | ◐ | ◐ | Both apply `llm_params` and rail toggles; neither yields a `GenerationResponse` from `stream_async`, so `log` and `output_vars` are unreachable |
+| Streaming metadata (`include_metadata=True`) | ✓ | ✓ | Both emit `provider_metadata` and normalized `usage` when the provider supplies them |
+| `include_metadata` with output-rail streaming | ◐ | ✗ | LLMRails accepts the option, but its output-rail buffer yields plain strings and drops stream metadata. IORails raises `ValueError`. |
+| `GenerationOptions` through the stream | ◐ | ◐ | Both apply `llm_params` and rail toggles. Neither yields a `GenerationResponse`, so `log` and `output_vars` are unreachable. |
 | Parallel streaming output rails | ✓ | ✗ | LLMRails streaming-buffer feature |
 
 Both engines stream responses through `stream_async` and support streaming output rails.
-Both accept `include_metadata=True` to receive dictionary-framed chunks such as `{"text": ...}` instead of plain strings, and both use the same metadata contract: `provider_metadata` on each chunk that carries it, and token `usage` folded into the single terminal frame.
+Both accept `include_metadata=True` to receive dictionary-framed chunks such as `{"text": ...}` instead of plain strings.
+Both surface `provider_metadata` and normalized token `usage` on the frame that receives the data.
+If the provider sends usage in a chunk without text, `IORails` folds it into the terminal frame, while `LLMRails` emits a separate empty frame before the terminal frame.
 `IORails` requests usage on the terminal chunk by default through `stream_options`, which you can override with `llm_params`.
-For the frame shapes, see [Streaming Metadata](/run-guardrailed-inference/using-python-apis/streaming#streaming-metadata).
+For the frame shapes, refer to [Streaming Metadata](/run-guardrailed-inference/using-python-apis/streaming#streaming-metadata).
 
 `IORails` rejects `include_metadata=True` when output-rail streaming is enabled, because its buffer strategy operates on plain string chunks.
+`LLMRails` accepts the combination, but its output-rail buffer yields plain strings and drops `provider_metadata` and `usage`.
 
-Neither engine returns a `GenerationResponse` from `stream_async`; structured responses are a non-streaming feature, and passing `options` does not change the chunk shape.
+Neither engine returns a `GenerationResponse` from `stream_async`.
+Structured responses are a non-streaming feature, and passing `options` does not change the chunk shape.
 `IORails` also validates `options` only on the non-streaming path, so the Colang-coupled options that raise in `generate_async` are silently ignored in `stream_async`.
-For details, see [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
+For details, refer to [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
 
 Parallel streaming output rails, where the output rail validates streamed chunks using the streaming buffer, is an `LLMRails` feature.
 `IORails` runs output rails over the streamed response but does not use the parallel streaming-buffer path, and speculative generation falls back to sequential execution while streaming.

--- a/docs/run-rails/using-python-apis/core-classes.mdx
+++ b/docs/run-rails/using-python-apis/core-classes.mdx
@@ -312,6 +312,12 @@ response = rails.generate(
 )
 ```
 
+Passing `options` changes the return type.
+Without `options`, `generate()` returns an OpenAI-style message dictionary that you index with `response["content"]`.
+With `options`, it returns a `GenerationResponse` object whose message list you read with `response.response[0]["content"]`.
+
+The `IORails` engine also returns a `GenerationResponse` when you pass `options`, but the fields that depend on the Colang runtime are unavailable: `output_vars` and `state` raise `ValueError`, and the `log.internal_events` and `log.colang_history` options raise `NotImplementedError`.
+
 For detailed options, refer to [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options).
 
 ---
@@ -446,10 +452,11 @@ define flow
         options={"log": {"activated_rails": True}}
     )
 
-    print(f"Response: {response['content']}")
+    # `options` was passed, so `response` is a GenerationResponse
+    print(f"Response: {response.response[0]['content']}")
 
     # Print what happened
-    if hasattr(response, 'log'):
+    if response.log:
         response.log.print_summary()
 
 asyncio.run(main())

--- a/docs/run-rails/using-python-apis/core-classes.mdx
+++ b/docs/run-rails/using-python-apis/core-classes.mdx
@@ -312,11 +312,14 @@ response = rails.generate(
 )
 ```
 
-Passing `options` changes the return type.
+For the message-based call shown above, passing `options` changes the return type.
 Without `options`, `generate()` returns an OpenAI-style message dictionary that you index with `response["content"]`.
 With `options`, it returns a `GenerationResponse` object whose message list you read with `response.response[0]["content"]`.
+For a prompt-based `LLMRails` call, the optionless return and `GenerationResponse.response` are strings instead.
 
-The `IORails` engine also returns a `GenerationResponse` when you pass `options`, but the fields that depend on the Colang runtime are unavailable: `output_vars` and `state` raise `ValueError`, and the `log.internal_events` and `log.colang_history` options raise `NotImplementedError`.
+The `IORails` engine also returns a `GenerationResponse` when you pass `options`, but fields that depend on the Colang runtime remain unavailable.
+`output_vars` and `state` raise `ValueError`.
+The `log.internal_events` and `log.colang_history` options raise `NotImplementedError`.
 
 For detailed options, refer to [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options).
 

--- a/docs/run-rails/using-python-apis/generation-options.mdx
+++ b/docs/run-rails/using-python-apis/generation-options.mdx
@@ -413,40 +413,60 @@ rails.generate(messages=[{"role": "user", "content": "Hello"}])
 
 ### GenerationOptions Support
 
-| Option | LLMRails | IORails | Notes |
-|---|:---:|:---:|---|
-| `rails.input`, `rails.output` | ✓ | ✓ | `IORails` also honors a list of rail names and runs only those rails; `LLMRails` treats any non-empty list as "enabled" |
-| `rails.tool_input`, `rails.tool_output` | ✓ | ✓ | `IORails` also honors a list of rail names |
-| `rails.dialog`, `rails.retrieval` | ✓ | n/a | `IORails` runs no dialog or retrieval rails and ignores both toggles |
-| `llm_params` | ✓ | ✓ | Applied to the main model call only |
-| `log.activated_rails`, `log.llm_calls` | ✓ | ✓ | Requesting either also populates `log.stats` |
-| `log.internal_events`, `log.colang_history` | ✓ | ✗ | `IORails` raises `NotImplementedError` |
-| `output_vars` | ✓ | ✗ | `IORails` raises `ValueError` |
-| `llm_output` | ◐ | ◐ | Accepted by both; the resulting `llm_output` field is `None` on both |
+This table covers `generate()` and `generate_async()`.
+`stream_async()` accepts `options` too, but reads only a subset of it and never yields a `GenerationResponse`; see [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
 
-Legend: ✓ supported · ✗ not supported · ◐ accepted but not populated · n/a not applicable to the engine.
+Legend: ✓ supported · ✗ not supported (raises) · ◐ accepted but not populated · n/a not applicable to the engine.
+
+| Field | Type | LLMRails | IORails | Notes |
+|---|---|:---:|:---:|---|
+| `rails.input` | `bool \| list[str]` | ✓ | ✓ | `IORails` runs only the named rails when given a list. `LLMRails` tests truthiness only, so any non-empty list means "all enabled". |
+| `rails.output` | `bool \| list[str]` | ✓ | ✓ | Same list-selection difference as `rails.input`. |
+| `rails.tool_input` | `bool \| list[str]` | ✓ | ✓ | Gates the tool-result rails. Same list-selection difference. |
+| `rails.tool_output` | `bool \| list[str]` | ✓ | ✓ | Gates the tool-call rails. Same list-selection difference. |
+| `rails.dialog` | `bool` | ✓ | n/a | `IORails` runs no dialog rails and ignores the toggle. On `LLMRails`, `dialog: False` suppresses the main LLM call and echoes the supplied message back. |
+| `rails.retrieval` | `bool \| list[str]` | ✓ | n/a | `IORails` runs no retrieval rails and ignores the toggle. |
+| `llm_params` | `dict \| None` | ✓ | ✓ | Applied to the main model call only, never to the rail models. On `IORails` this is also how you pass tool definitions, and it is accepted by `stream_async()`. |
+| `llm_output` | `bool` | ◐ | ◐ | Accepted by both; the resulting `llm_output` field is `None` on both. |
+| `output_vars` | `bool \| list[str] \| None` | ✓ | ✗ | `IORails` raises `ValueError`: it has no Colang context to read. |
+| `log` | `GenerationLogOptions` | ✓ | ◐ | See [GenerationLogOptions Support](#generationlogoptions-support). |
 
 `IORails` raises on the options it cannot honor instead of silently returning empty data, so a request never looks like it succeeded with no findings when the option was never applied.
 
+`state` is a `generate()` keyword argument rather than a `GenerationOptions` field.
+`enforce` is commented out in the source and is not a live field on either engine.
+
+### GenerationLogOptions Support
+
+| Field | Type | LLMRails | IORails | Notes |
+|---|---|:---:|:---:|---|
+| `activated_rails` | `bool` | ✓ | ✓ | `IORails` synthesizes one entry per rail, each with a single `ExecutedAction`; `decisions` is always empty. |
+| `llm_calls` | `bool` | ✓ | ✓ | Token usage, durations, timestamps, request IDs, and model and provider names are populated on both engines. |
+| `internal_events` | `bool` | ✓ | ✗ | `IORails` raises `NotImplementedError`: no Colang runtime. |
+| `colang_history` | `bool` | ✓ | ✗ | `IORails` raises `NotImplementedError`: no Colang runtime. |
+
+`GenerationLog.stats` is not a `GenerationLogOptions` field.
+Both engines populate it whenever you request either `activated_rails` or `llm_calls`.
+
+For the `IORails` log structure and how it differs from the Colang-derived log, see [Log Options on IORails](#log-options-on-iorails).
+
 ### GenerationResponse Field Support
 
-| Field | LLMRails | IORails | Notes |
-|---|:---:|:---:|---|
-| `response` | ✓ | ✓ | `IORails` always returns a one-element message list, never a bare string |
-| `tool_calls` | ✓ | ✓ | Both use the canonical dictionary-argument shape, not the OpenAI JSON-string wire shape |
-| `reasoning_content` | ✓ | ✓ | Taken from the provider reasoning field, or extracted from `<think>` tags |
-| `log` | ✓ | ◐ | `activated_rails`, `llm_calls`, and `stats` only; see [Log Options on IORails](#log-options-on-iorails) |
-| `llm_metadata` | ✓ | ◐ | `IORails` reports the main model call; `LLMRails` reports the most recent model call, which is usually the last output rail |
-| `llm_output` | ◐ | ◐ | `None` on both engines |
-| `output_data` | ✓ | ✗ | Always `None` on `IORails` |
-| `state` | ✓ | ✗ | Always `None` on `IORails` |
+The fields returned when `options` is passed to `generate()` or `generate_async()`.
+`stream_async()` never yields or returns a `GenerationResponse` on either engine.
 
-On the structured path, `IORails` keeps reasoning out of the message content and returns it in `reasoning_content`.
-Without `options`, the bare message dictionary carries reasoning inline as a `<think>` prefix, which is the shape earlier versions returned.
+| Field | Type | LLMRails | IORails | Notes |
+|---|---|:---:|:---:|---|
+| `response` | `str \| list[dict]` | ✓ | ✓ | `IORails` always returns a one-element `[assistant_msg]` list. `LLMRails` returns a plain string when called with `prompt=` instead of `messages=`. |
+| `tool_calls` | `list \| None` | ✓ | ✓ | Both use the canonical `ToolCall.to_dict()` shape with dictionary arguments. The bare-message and streaming paths keep the OpenAI wire shape with `function.arguments` as a JSON string. |
+| `reasoning_content` | `str \| None` | ✓ | ✓ | Provider `reasoning` field, or content extracted from `<think>` tags. On this path `IORails` keeps the message content clean; the bare dictionary returned without `options` inlines reasoning as a `<think>` prefix. No streamed equivalent on either engine. |
+| `log` | `GenerationLog \| None` | ✓ | ◐ | `IORails` populates `activated_rails`, `llm_calls`, and `stats` only. See [Log Options on IORails](#log-options-on-iorails). |
+| `llm_metadata` | `dict \| None` | ✓ | ◐ | Provider metadata blob verbatim, such as `response_headers`. `IORails` reports the main model call; `LLMRails` reports the most recent call, usually the last output rail. No `usage` sub-key on either engine: token usage lives in `log`. `None` when the provider returns no metadata. |
+| `llm_output` | `dict \| None` | ◐ | ◐ | Always `None` on both engines, because `LLMCallInfo.raw_response` is never assigned. |
+| `output_data` | `dict \| None` | ✓ | ✗ | Always `None` on `IORails`; passing `output_vars` raises `ValueError`. |
+| `state` | `dict \| None` | ✓ | ✗ | Always `None` on `IORails`; passing `state` raises `ValueError`. |
 
-`llm_metadata` holds the provider metadata blob verbatim, such as `response_headers`.
-It has no `usage` key on either engine: token usage lives in `log.llm_calls` and `log.stats`.
-It is `None` when the provider returns no metadata.
+Reasoning bypasses the output rails on both engines, so output rails check the final answer rather than the reasoning trace.
 
 ### Blocked Requests
 

--- a/docs/run-rails/using-python-apis/generation-options.mdx
+++ b/docs/run-rails/using-python-apis/generation-options.mdx
@@ -356,7 +356,8 @@ rails.generate(messages=messages, options={
 
 <Note>
 
-`GenerationResponse.llm_output` is currently `None` on both engines, because the raw provider response that populates it is not recorded on the LLM call.
+`GenerationResponse.llm_output` is currently `None` on both engines.
+It is populated from `LLMCallInfo.raw_response`, which no code path assigns.
 `IORails` accepts `llm_output: True` and ignores it.
 To inspect provider-specific response data, use `llm_metadata` or the `log.llm_calls` entries instead.
 

--- a/docs/run-rails/using-python-apis/generation-options.mdx
+++ b/docs/run-rails/using-python-apis/generation-options.mdx
@@ -4,7 +4,7 @@
 title: "Generation Options Reference"
 sidebar-title: "Generation Options"
 description: "Configure logging, LLM parameters, and rail selection for generation."
-keywords: ["GenerationOptions", "rails options", "LLM parameters", "generation logging", "output_vars"]
+keywords: ["GenerationOptions", "GenerationResponse", "rails options", "LLM parameters", "generation logging", "output_vars", "IORails"]
 content:
   type: "reference"
 ---
@@ -27,21 +27,79 @@ Generation options are also available through [Chat Completions: Control Generat
 
 </Note>
 
+## Engine Support
+
+Both the `LLMRails` and `IORails` engines accept generation options, and both return a structured `GenerationResponse` object when you pass `options`.
+Because `IORails` does not run the Colang runtime, the options that read or write Colang state are unavailable on it, and a few `GenerationResponse` fields are built differently.
+Each section below documents the shared behavior first and then the `IORails` difference.
+For the complete field-by-field comparison, see [IORails and LLMRails Differences](#iorails-and-llmrails-differences).
+
+<Warning>
+
+Passing `options` to `generate()` or `generate_async()` on `IORails`, or on a `Guardrails` facade that selected `IORails`, returns a `GenerationResponse` object instead of an OpenAI-style message dictionary.
+Earlier versions honored the `llm_params` and rail toggles inside `options` but always returned a message dictionary.
+Update code that reads `result["content"]` to read `result.response[0]["content"]`.
+
+</Warning>
+
+```python
+# No options: an OpenAI-style message dictionary.
+message = rails.generate(messages=messages)
+print(message["content"])
+
+# With options: a GenerationResponse.
+result = rails.generate(messages=messages, options={"log": {"llm_calls": True}})
+print(result.response[0]["content"])
+print(result.reasoning_content)
+```
+
+<Note>
+
+An empty `options={}` behaves differently on the two engines.
+`IORails` treats it as an all-defaults `GenerationOptions` and returns a `GenerationResponse`.
+`LLMRails` raises `TypeError`, because an empty dictionary is falsy and does not match its dictionary branch.
+Pass `options=GenerationOptions()` when you want the structured return with default settings on either engine.
+
+</Note>
+
 ## Disabling Rails
 
-You can choose which categories of rails you want to apply by using the `rails` generation option. The four supported categories are: `input`, `dialog`, `retrieval` and `output`. By default, all are enabled.
+You can choose which categories of rails you want to apply by using the `rails` generation option. The supported categories are: `input`, `output`, `dialog`, `retrieval`, `tool_input`, and `tool_output`. By default, all are enabled.
+
+`IORails` runs input, output, and tool rails only.
+It ignores the `dialog` and `retrieval` categories rather than raising, because a configuration that declares dialog or retrieval rails routes to `LLMRails` in the first place.
 
 ```python
 res = rails.generate(messages=messages)
 ```
 
-is equivalent to:
+runs the same rails as:
 
 ```python
 res = rails.generate(messages=messages, options={
-    "rails": ["input", "dialog", "retrieval", "output"]
+    "rails": ["input", "output", "dialog", "retrieval", "tool_input", "tool_output"]
 })
 ```
+
+The two calls return different types, because passing `options` selects the structured `GenerationResponse` return.
+
+The list form is exhaustive: every category you leave out of the list is disabled.
+To disable one category and keep the rest, use the dictionary form instead.
+
+```python
+res = rails.generate(messages=messages, options={
+    "rails": {"dialog": False}
+})
+```
+
+<Warning>
+
+The rails-only patterns in the following three sections depend on disabling the dialog rails, which suppresses the main LLM call and echoes the supplied message back as the response.
+That behavior is specific to `LLMRails`.
+`IORails` has no dialog rails to disable, so it always calls the main model and returns a generated answer.
+To validate messages without generating on either engine, use [`check()` and `check_async()`](/run-guardrailed-inference/using-python-apis/check-messages) instead.
+
+</Warning>
 
 ### Input Rails Only
 
@@ -212,7 +270,42 @@ res.log.print_summary()
 - [0.31s] OUTPUT (self check output): 1 actions (self_check_output), 1 llm calls [0.31s]
 ```
 
+### Log Options on IORails
+
+`IORails` supports `activated_rails` and `llm_calls`, and it includes `stats` whenever you request either one, exactly as `LLMRails` does.
+
+`internal_events` and `colang_history` describe Colang runtime state, so `IORails` raises `NotImplementedError` when you set either to `True` rather than returning an empty value.
+
+```python
+res = rails.generate(messages=messages, options={
+    "log": {
+        "activated_rails": True,
+        "llm_calls": True
+    }
+})
+```
+
+`IORails` synthesizes the log from the record each rail leaves behind, so the structure matches `LLMRails` but the contents reflect the way `IORails` executes rails.
+
+- Each activated rail carries exactly one `ExecutedAction`, holding the rail's structured verdict in `return_value` and its single LLM or API call.
+  `IORails` runs one model-backed check per rail instead of a Colang action chain.
+- `activated_rails[].decisions` is always an empty list, because decisions are a Colang construct.
+- The main model call appears as a rail with `type` `generation`, `name` `generation`, and action name `generate_bot_message`.
+  On `LLMRails` the equivalent entries come from the Colang dialog rails, such as `generate user intent`.
+- `llm_calls[].prompt` is the conversation serialized as `"<role>: <content>"` lines.
+  The content matches what `LLMRails` logs, but the formatting differs.
+- Token usage, durations, timestamps, request IDs, model names, and provider names are populated for every call, and the `stats` totals aggregate them the same way as `LLMRails`.
+- A blocked request still returns the log for the rails that ran before the block.
+
 ## Output Variables
+
+<Warning>
+
+Output variables are an `LLMRails` capability.
+`IORails` raises `ValueError` when you pass `output_vars`, and its `GenerationResponse.output_data` is always `None`.
+There is no Colang context for `IORails` to read.
+
+</Warning>
 
 Some rails can store additional information in [Colang 1.0 Language Syntax: Variables](/configure-guardrails/colang/colang-1/colang-language-syntax-guide#variables). You can return the content of these variables by setting the `output_vars` generation option to the list of names for all the variables that you are interested in. If you want to return the complete context (this will also include some predefined variables), you can set `output_vars` to `True`.
 
@@ -248,6 +341,9 @@ rails.generate(messages=messages, options={
 
 The available parameters are determined by the specific LLM engine in use. The NeMo Guardrails library transmits values defined in the options parameter without modification.
 
+Both engines apply `llm_params` to the main model call only, not to the models that back the rails.
+`IORails` also accepts `llm_params` in `stream_async()`, and it is the supported way to pass tool definitions to the main model.
+
 ## Additional LLM Output
 
 You can receive additional output from the LLM generation by setting `llm_output` to `True` through the `options` parameter.
@@ -260,11 +356,105 @@ rails.generate(messages=messages, options={
 
 <Note>
 
+`GenerationResponse.llm_output` is currently `None` on both engines, because the raw provider response that populates it is not recorded on the LLM call.
+`IORails` accepts `llm_output: True` and ignores it.
+To inspect provider-specific response data, use `llm_metadata` or the `log.llm_calls` entries instead.
+
+</Note>
+
+<Note>
+
 The returned data is highly dependent on the underlying implementation of the LangChain connector for the LLM provider. For example, for OpenAI, it only returns `token_usage` and `model_name`.
 
 </Note>
 
+## IORails and LLMRails Differences
+
+This section collects the differences between the two engines in one place.
+For capability differences outside generation options, see [Engine Feature Support](/reference/engine-feature-support).
+
+### Method Signature
+
+`IORails.generate()` and `IORails.generate_async()` take the same first three parameters as `LLMRails`.
+
+```python
+def generate(
+    self,
+    prompt: Optional[str] = None,
+    messages: Optional[LLMMessages] = None,
+    options: Optional[Union[dict, GenerationOptions]] = None,
+    **kwargs,
+) -> Union[LLMMessage, GenerationResponse]:
+```
+
+Three argument-handling details differ from `LLMRails`.
+
+- When you pass both `prompt` and `messages`, `IORails` uses `messages` and ignores `prompt`.
+  `LLMRails` raises `ValueError`.
+- When you pass a `prompt` and `options`, `LLMRails` sets `GenerationResponse.response` to a plain string.
+  `IORails` always sets it to a one-element list holding the assistant message.
+- An empty `options={}` returns a `GenerationResponse` on `IORails` and raises `TypeError` on `LLMRails`.
+  Pass `options=GenerationOptions()` for the structured return with default settings on either engine.
+
+Passing a message list as the first positional argument raises `TypeError` on `IORails`, because that slot is `prompt`.
+Pass the list with the `messages=` keyword.
+
+```python
+# Raises TypeError on IORails.
+rails.generate([{"role": "user", "content": "Hello"}])
+
+# Correct.
+rails.generate(messages=[{"role": "user", "content": "Hello"}])
+```
+
+`IORails` does not support the `state` and `streaming_handler` keyword arguments that `LLMRails` accepts.
+`state` raises `ValueError`, because `IORails` is a stateless input and output rails engine with nothing to persist or resume.
+`streaming_handler` is accepted and ignored; use [`stream_async()`](/run-guardrailed-inference/using-python-apis/streaming) to stream from `IORails`.
+
+### GenerationOptions Support
+
+| Option | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| `rails.input`, `rails.output` | ✓ | ✓ | `IORails` also honors a list of rail names and runs only those rails; `LLMRails` treats any non-empty list as "enabled" |
+| `rails.tool_input`, `rails.tool_output` | ✓ | ✓ | `IORails` also honors a list of rail names |
+| `rails.dialog`, `rails.retrieval` | ✓ | n/a | `IORails` runs no dialog or retrieval rails and ignores both toggles |
+| `llm_params` | ✓ | ✓ | Applied to the main model call only |
+| `log.activated_rails`, `log.llm_calls` | ✓ | ✓ | Requesting either also populates `log.stats` |
+| `log.internal_events`, `log.colang_history` | ✓ | ✗ | `IORails` raises `NotImplementedError` |
+| `output_vars` | ✓ | ✗ | `IORails` raises `ValueError` |
+| `llm_output` | ◐ | ◐ | Accepted by both; the resulting `llm_output` field is `None` on both |
+
+Legend: ✓ supported · ✗ not supported · ◐ accepted but not populated · n/a not applicable to the engine.
+
+`IORails` raises on the options it cannot honor instead of silently returning empty data, so a request never looks like it succeeded with no findings when the option was never applied.
+
+### GenerationResponse Field Support
+
+| Field | LLMRails | IORails | Notes |
+|---|:---:|:---:|---|
+| `response` | ✓ | ✓ | `IORails` always returns a one-element message list, never a bare string |
+| `tool_calls` | ✓ | ✓ | Both use the canonical dictionary-argument shape, not the OpenAI JSON-string wire shape |
+| `reasoning_content` | ✓ | ✓ | Taken from the provider reasoning field, or extracted from `<think>` tags |
+| `log` | ✓ | ◐ | `activated_rails`, `llm_calls`, and `stats` only; see [Log Options on IORails](#log-options-on-iorails) |
+| `llm_metadata` | ✓ | ◐ | `IORails` reports the main model call; `LLMRails` reports the most recent model call, which is usually the last output rail |
+| `llm_output` | ◐ | ◐ | `None` on both engines |
+| `output_data` | ✓ | ✗ | Always `None` on `IORails` |
+| `state` | ✓ | ✗ | Always `None` on `IORails` |
+
+On the structured path, `IORails` keeps reasoning out of the message content and returns it in `reasoning_content`.
+Without `options`, the bare message dictionary carries reasoning inline as a `<think>` prefix, which is the shape earlier versions returned.
+
+`llm_metadata` holds the provider metadata blob verbatim, such as `response_headers`.
+It has no `usage` key on either engine: token usage lives in `log.llm_calls` and `log.stats`.
+It is `None` when the provider returns no metadata.
+
+### Blocked Requests
+
+When a rail blocks the request, both engines return the configured refusal message in `response`.
+On `IORails`, `tool_calls`, `reasoning_content`, and `llm_metadata` are `None` in that case, and `log` holds only the rails that ran before the block.
+
 ## Limitations
 
 - Only supported for the `generate`/`generate_async` methods (not for `generate_events`/`generate_events_async`).
-- Specifying which individual rails of a particular type to activate is not yet supported.
+- On `LLMRails`, specifying which individual rails of a particular type to activate is not yet supported. `IORails` supports it: pass a list of rail names to `rails.input`, `rails.output`, `rails.tool_input`, or `rails.tool_output`.
+- Generation options are not supported for Colang 2.x configurations on `LLMRails`. The `output_vars`, `log`, and `llm_output` options raise `ValueError`.

--- a/docs/run-rails/using-python-apis/generation-options.mdx
+++ b/docs/run-rails/using-python-apis/generation-options.mdx
@@ -9,7 +9,7 @@ content:
   type: "reference"
 ---
 
-The NeMo Guardrails library exposes a set of **generation options** that give you fine-grained control over how the LLM generation is performed (for example, what rails are enabled, additional parameters that should be passed to the LLM, what context data should be returned, what logging information should be returned).
+Generation options let you control which rails run, which parameters the main large language model (LLM) receives, and which context and logging data the NVIDIA NeMo Guardrails library returns.
 
 To use generation options, provide the `options` keyword argument to the `generate()` or `generate_async()` methods:
 
@@ -32,7 +32,7 @@ Generation options are also available through [Chat Completions: Control Generat
 Both the `LLMRails` and `IORails` engines accept generation options, and both return a structured `GenerationResponse` object when you pass `options`.
 Because `IORails` does not run the Colang runtime, the options that read or write Colang state are unavailable on it, and a few `GenerationResponse` fields are built differently.
 Each section below documents the shared behavior first and then the `IORails` difference.
-For the complete field-by-field comparison, see [IORails and LLMRails Differences](#iorails-and-llmrails-differences).
+For the complete field-by-field comparison, refer to [IORails and LLMRails Differences](#iorails-and-llmrails-differences).
 
 <Warning>
 
@@ -64,7 +64,9 @@ Pass `options=GenerationOptions()` when you want the structured return with defa
 
 ## Disabling Rails
 
-You can choose which categories of rails you want to apply by using the `rails` generation option. The supported categories are: `input`, `output`, `dialog`, `retrieval`, `tool_input`, and `tool_output`. By default, all are enabled.
+Use the `rails` generation option to choose which rail categories to apply.
+The supported categories are `input`, `output`, `dialog`, `retrieval`, `tool_input`, and `tool_output`.
+By default, all categories are enabled.
 
 `IORails` runs input, output, and tool rails only.
 It ignores the `dialog` and `retrieval` categories rather than raising, because a configuration that declares dialog or retrieval rails routes to `LLMRails` in the first place.
@@ -94,7 +96,8 @@ res = rails.generate(messages=messages, options={
 
 <Warning>
 
-The rails-only patterns in the following three sections depend on disabling the dialog rails, which suppresses the main LLM call and echoes the supplied message back as the response.
+The rails-only patterns in the following three sections depend on disabling the dialog rails.
+This setting suppresses the main LLM call and echoes the supplied message back as the response.
 That behavior is specific to `LLMRails`.
 `IORails` has no dialog rails to disable, so it always calls the main model and returns a generated answer.
 To validate messages without generating on either engine, use [`check()` and `check_async()`](/run-guardrailed-inference/using-python-apis/check-messages) instead.
@@ -103,7 +106,7 @@ To validate messages without generating on either engine, use [`check()` and `ch
 
 ### Input Rails Only
 
-If you only want to check a user's input by running the input rails from a guardrails configuration, you must disable all the others:
+To check a user's input with only the input rails from a guardrails configuration, disable all other rail categories:
 
 ```python
 res = rails.generate(messages=[{
@@ -215,7 +218,7 @@ res = rails.generate(messages=[{
 You can obtain detailed information about what happened under the hood during the generation process by setting the `log` generation option. This option has four different inner-options:
 
 - `activated_rails`: Include detailed information about the rails that were activated during generation.
-- `llm_calls`: Include information about all the LLM calls that were made. This includes: prompt, completion, token usage, raw response, etc.
+- `llm_calls`: Include the prompt, completion, timing, token usage, request ID, model, and provider information available for each LLM call.
 - `internal_events`: Include the array of internal generated events.
 - `colang_history`: Include the history of the conversation in Colang format.
 
@@ -275,6 +278,7 @@ res.log.print_summary()
 `IORails` supports `activated_rails` and `llm_calls`, and it includes `stats` whenever you request either one, exactly as `LLMRails` does.
 
 `internal_events` and `colang_history` describe Colang runtime state, so `IORails` raises `NotImplementedError` when you set either to `True` rather than returning an empty value.
+The following example requests the supported log fields:
 
 ```python
 res = rails.generate(messages=messages, options={
@@ -285,17 +289,18 @@ res = rails.generate(messages=messages, options={
 })
 ```
 
-`IORails` synthesizes the log from the record each rail leaves behind, so the structure matches `LLMRails` but the contents reflect the way `IORails` executes rails.
+`IORails` synthesizes the log from the record each rail leaves behind, so the structure matches `LLMRails` but the contents reflect the way `IORails` executes rails:
 
-- Each activated rail carries exactly one `ExecutedAction`, holding the rail's structured verdict in `return_value` and its single LLM or API call.
+- Each activated rail carries exactly one `ExecutedAction`, holding the rail's structured verdict in `return_value` and up to one LLM or API call.
   `IORails` runs one model-backed check per rail instead of a Colang action chain.
 - `activated_rails[].decisions` is always an empty list, because decisions are a Colang construct.
 - The main model call appears as a rail with `type` `generation`, `name` `generation`, and action name `generate_bot_message`.
   On `LLMRails` the equivalent entries come from the Colang dialog rails, such as `generate user intent`.
 - `llm_calls[].prompt` is the conversation serialized as `"<role>: <content>"` lines.
   The content matches what `LLMRails` logs, but the formatting differs.
-- Token usage, durations, timestamps, request IDs, model names, and provider names are populated for every call, and the `stats` totals aggregate them the same way as `LLMRails`.
-- A blocked request still returns the log for the rails that ran before the block.
+- Each call record includes timing and the request ID, token usage, model name, and provider name available from the provider.
+  The `stats` object aggregates the available values the same way as `LLMRails`.
+- A request stopped by a rail still returns the log for the rails that ran before processing stopped.
 
 ## Output Variables
 
@@ -363,16 +368,10 @@ To inspect provider-specific response data, use `llm_metadata` or the `log.llm_c
 
 </Note>
 
-<Note>
-
-The returned data is highly dependent on the underlying implementation of the LangChain connector for the LLM provider. For example, for OpenAI, it only returns `token_usage` and `model_name`.
-
-</Note>
-
 ## IORails and LLMRails Differences
 
 This section collects the differences between the two engines in one place.
-For capability differences outside generation options, see [Engine Feature Support](/reference/engine-feature-support).
+For capability differences outside generation options, refer to [Engine Feature Support](/reference/engine-feature-support).
 
 ### Method Signature
 
@@ -388,7 +387,7 @@ def generate(
 ) -> Union[LLMMessage, GenerationResponse]:
 ```
 
-Three argument-handling details differ from `LLMRails`.
+Three argument-handling details differ from `LLMRails`:
 
 - When you pass both `prompt` and `messages`, `IORails` uses `messages` and ignores `prompt`.
   `LLMRails` raises `ValueError`.
@@ -410,14 +409,17 @@ rails.generate(messages=[{"role": "user", "content": "Hello"}])
 
 `IORails` does not support the `state` and `streaming_handler` keyword arguments that `LLMRails` accepts.
 `state` raises `ValueError`, because `IORails` is a stateless input and output rails engine with nothing to persist or resume.
-`streaming_handler` is accepted and ignored; use [`stream_async()`](/run-guardrailed-inference/using-python-apis/streaming) to stream from `IORails`.
+`streaming_handler` is accepted and ignored.
+Use [`stream_async()`](/run-guardrailed-inference/using-python-apis/streaming) to stream from `IORails`.
 
 ### GenerationOptions Support
 
-This table covers `generate()` and `generate_async()`.
-`stream_async()` accepts `options` too, but reads only a subset of it and never yields a `GenerationResponse`; see [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
+`stream_async()` accepts `options` too, but reads only a subset of it and never yields a `GenerationResponse`.
+Refer to [Generation Options and Streaming](/run-guardrailed-inference/using-python-apis/streaming#generation-options-and-streaming).
 
 Legend: ✓ supported · ✗ not supported (raises) · ◐ accepted but not populated · n/a not applicable to the engine.
+
+The following table compares generation option support for `generate()` and `generate_async()`:
 
 | Field | Type | LLMRails | IORails | Notes |
 |---|---|:---:|:---:|---|
@@ -428,54 +430,59 @@ Legend: ✓ supported · ✗ not supported (raises) · ◐ accepted but not popu
 | `rails.dialog` | `bool` | ✓ | n/a | `IORails` runs no dialog rails and ignores the toggle. On `LLMRails`, `dialog: False` suppresses the main LLM call and echoes the supplied message back. |
 | `rails.retrieval` | `bool \| list[str]` | ✓ | n/a | `IORails` runs no retrieval rails and ignores the toggle. |
 | `llm_params` | `dict \| None` | ✓ | ✓ | Applied to the main model call only, never to the rail models. On `IORails` this is also how you pass tool definitions, and it is accepted by `stream_async()`. |
-| `llm_output` | `bool` | ◐ | ◐ | Accepted by both; the resulting `llm_output` field is `None` on both. |
+| `llm_output` | `bool` | ◐ | ◐ | Accepted by both. The resulting `llm_output` field is `None` on both. |
 | `output_vars` | `bool \| list[str] \| None` | ✓ | ✗ | `IORails` raises `ValueError`: it has no Colang context to read. |
-| `log` | `GenerationLogOptions` | ✓ | ◐ | See [GenerationLogOptions Support](#generationlogoptions-support). |
+| `log` | `GenerationLogOptions` | ✓ | ◐ | Refer to [GenerationLogOptions Support](#generationlogoptions-support). |
 
-`IORails` raises on the options it cannot honor instead of silently returning empty data, so a request never looks like it succeeded with no findings when the option was never applied.
+`IORails` raises for Colang-dependent options that it cannot honor, including `output_vars`, `log.internal_events`, and `log.colang_history`.
+It accepts and ignores `llm_output`, `rails.dialog`, and `rails.retrieval`.
 
 `state` is a `generate()` keyword argument rather than a `GenerationOptions` field.
 `enforce` is commented out in the source and is not a live field on either engine.
 
 ### GenerationLogOptions Support
 
+The following table compares generation log field support:
+
 | Field | Type | LLMRails | IORails | Notes |
 |---|---|:---:|:---:|---|
-| `activated_rails` | `bool` | ✓ | ✓ | `IORails` synthesizes one entry per rail, each with a single `ExecutedAction`; `decisions` is always empty. |
-| `llm_calls` | `bool` | ✓ | ✓ | Token usage, durations, timestamps, request IDs, and model and provider names are populated on both engines. |
+| `activated_rails` | `bool` | ✓ | ✓ | `IORails` synthesizes one entry per rail, each with a single `ExecutedAction`. `decisions` is always empty. |
+| `llm_calls` | `bool` | ✓ | ✓ | Both engines include the timing, usage, request ID, model, and provider information available for each call. |
 | `internal_events` | `bool` | ✓ | ✗ | `IORails` raises `NotImplementedError`: no Colang runtime. |
 | `colang_history` | `bool` | ✓ | ✗ | `IORails` raises `NotImplementedError`: no Colang runtime. |
 
 `GenerationLog.stats` is not a `GenerationLogOptions` field.
 Both engines populate it whenever you request either `activated_rails` or `llm_calls`.
 
-For the `IORails` log structure and how it differs from the Colang-derived log, see [Log Options on IORails](#log-options-on-iorails).
+For the `IORails` log structure and how it differs from the Colang-derived log, refer to [Log Options on IORails](#log-options-on-iorails).
 
 ### GenerationResponse Field Support
 
-The fields returned when `options` is passed to `generate()` or `generate_async()`.
+The following table compares the fields returned when you pass `options` to `generate()` or `generate_async()`:
 `stream_async()` never yields or returns a `GenerationResponse` on either engine.
 
 | Field | Type | LLMRails | IORails | Notes |
 |---|---|:---:|:---:|---|
 | `response` | `str \| list[dict]` | ✓ | ✓ | `IORails` always returns a one-element `[assistant_msg]` list. `LLMRails` returns a plain string when called with `prompt=` instead of `messages=`. |
-| `tool_calls` | `list \| None` | ✓ | ✓ | Both use the canonical `ToolCall.to_dict()` shape with dictionary arguments. The bare-message and streaming paths keep the OpenAI wire shape with `function.arguments` as a JSON string. |
-| `reasoning_content` | `str \| None` | ✓ | ✓ | Provider `reasoning` field, or content extracted from `<think>` tags. On this path `IORails` keeps the message content clean; the bare dictionary returned without `options` inlines reasoning as a `<think>` prefix. No streamed equivalent on either engine. |
-| `log` | `GenerationLog \| None` | ✓ | ◐ | `IORails` populates `activated_rails`, `llm_calls`, and `stats` only. See [Log Options on IORails](#log-options-on-iorails). |
-| `llm_metadata` | `dict \| None` | ✓ | ◐ | Provider metadata blob verbatim, such as `response_headers`. `IORails` reports the main model call; `LLMRails` reports the most recent call, usually the last output rail. No `usage` sub-key on either engine: token usage lives in `log`. `None` when the provider returns no metadata. |
+| `tool_calls` | `list \| None` | ✓ | ✓ | Both use the canonical `ToolCall.to_dict()` shape with dictionary arguments. On IORails, the bare-message and streaming paths use the OpenAI wire shape with `function.arguments` as a JSON string. |
+| `reasoning_content` | `str \| None` | ✓ | ✓ | Provider `reasoning` field, or content extracted from `<think>` tags. On this path `IORails` keeps the message content clean. The bare dictionary returned without `options` inlines reasoning as a `<think>` prefix. No streamed equivalent exists on either engine. |
+| `log` | `GenerationLog \| None` | ✓ | ◐ | `IORails` populates `activated_rails`, `llm_calls`, and `stats` only. Refer to [Log Options on IORails](#log-options-on-iorails). |
+| `llm_metadata` | `dict \| None` | ✓ | ◐ | Provider metadata blob verbatim, such as `response_headers`. `IORails` reports the main model call. `LLMRails` reports the most recent call, usually the last output rail. The library does not add normalized usage here. Read token counts from `log`. |
 | `llm_output` | `dict \| None` | ◐ | ◐ | Always `None` on both engines, because `LLMCallInfo.raw_response` is never assigned. |
-| `output_data` | `dict \| None` | ✓ | ✗ | Always `None` on `IORails`; passing `output_vars` raises `ValueError`. |
-| `state` | `dict \| None` | ✓ | ✗ | Always `None` on `IORails`; passing `state` raises `ValueError`. |
+| `output_data` | `dict \| None` | ✓ | ✗ | Always `None` on `IORails`. Passing `output_vars` raises `ValueError`. |
+| `state` | `dict \| None` | ◐ | ✗ | `LLMRails` supports public state through Colang 1.0. `IORails` leaves it `None`, and passing `state` raises `ValueError`. |
 
 Reasoning bypasses the output rails on both engines, so output rails check the final answer rather than the reasoning trace.
 
-### Blocked Requests
+### Requests Stopped by Rails
 
-When a rail blocks the request, both engines return the configured refusal message in `response`.
-On `IORails`, `tool_calls`, `reasoning_content`, and `llm_metadata` are `None` in that case, and `log` holds only the rails that ran before the block.
+When a rail blocks content, both engines return the configured refusal message in `response`.
+On `IORails`, a rail execution failure returns the internal-error message instead of the refusal message.
+In either `IORails` case, `tool_calls`, `reasoning_content`, and `llm_metadata` are `None`, and `log` holds the records through the rail that stopped processing.
+In `log.activated_rails`, that rail has `stop` set to `True`, and its action's `return_value["failed"]` value distinguishes a failure from a policy block.
 
 ## Limitations
 
 - Only supported for the `generate`/`generate_async` methods (not for `generate_events`/`generate_events_async`).
 - On `LLMRails`, specifying which individual rails of a particular type to activate is not yet supported. `IORails` supports it: pass a list of rail names to `rails.input`, `rails.output`, `rails.tool_input`, or `rails.tool_output`.
-- Generation options are not supported for Colang 2.x configurations on `LLMRails`. The `output_vars`, `log`, and `llm_output` options raise `ValueError`.
+- On `LLMRails` with a Colang 2.x configuration, `output_vars`, `log`, and `llm_output` raise `ValueError`.

--- a/docs/run-rails/using-python-apis/streaming.mdx
+++ b/docs/run-rails/using-python-apis/streaming.mdx
@@ -206,8 +206,49 @@ The following `IORails` specifics apply.
 A chunk that carries only provider metadata and no text is not emitted as a standalone empty frame.
 The provider metadata rides on the next text frame or on the terminal frame instead, which keeps per-chunk response headers from flooding the stream.
 
-Neither engine returns a `GenerationResponse` from `stream_async()`.
-Structured responses are a non-streaming feature; see [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options).
+## Generation Options and Streaming
+
+`stream_async()` accepts an `options` argument on both engines, but unlike `generate()` and `generate_async()`, passing it does not change what the iterator yields.
+The chunk shape is governed solely by `include_metadata`: plain strings when it is `False`, and `{"text": ..., "metadata": ...}` dictionaries when it is `True`.
+Neither engine yields or returns a `GenerationResponse` from a stream.
+
+```python
+# Identical chunk shapes: `options` does not select a structured return here.
+async for chunk in rails.stream_async(messages=messages):
+    ...  # str
+
+async for chunk in rails.stream_async(messages=messages, options={"llm_params": {"temperature": 0.2}}):
+    ...  # still str
+```
+
+What each engine reads from `options` while streaming:
+
+| Option | LLMRails | IORails |
+|---|---|---|
+| `llm_params` | Applied to the main model call | Applied to the main model call |
+| `rails.input`, `rails.output`, `rails.tool_input`, `rails.tool_output` | Applied | Applied |
+| `output_vars`, `log.*` | Computed, then discarded with the `GenerationResponse` | Not read |
+
+`LLMRails` runs `generate_async()` in a background task and forwards `options` to it, then discards the `GenerationResponse` that call returns.
+Anything you request through `log` or `output_vars` is therefore computed but unreachable from the stream.
+`IORails` reads only `llm_params` and the four rail toggles in its streaming path.
+
+<Warning>
+
+`IORails` validates `options` in `generate_async()` but not in `stream_async()`.
+`output_vars`, `log.internal_events`, and `log.colang_history` raise on the non-streaming path and are silently ignored on the streaming path.
+Do not rely on a stream rejecting an option that the non-streaming call refuses.
+
+</Warning>
+
+Two `GenerationResponse` fields have no streamed equivalent.
+
+- **`reasoning_content`**: neither engine emits provider reasoning deltas as chunk text. A model that instead embeds `<think>` tags in its content streams them as ordinary text, which means output rails see the reasoning; `IORails` logs a warning once per request when it detects this.
+- **`tool_calls`**: `IORails` emits assembled tool calls as a terminal chunk whose text is a `{"tool_calls": [...]}` JSON string, using the OpenAI wire shape with `function.arguments` as a JSON string. The non-streaming `GenerationResponse.tool_calls` uses dictionary arguments instead. `LLMRails` does not push tool calls into the stream at all; they reach only the discarded `GenerationResponse`.
+
+To obtain a `GenerationResponse` for a request, use `generate_async()`.
+To obtain token usage while streaming, read the `usage` metadata frame described above.
+For the non-streaming option and field tables, see [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
 
 ## Token Usage Tracking
 

--- a/docs/run-rails/using-python-apis/streaming.mdx
+++ b/docs/run-rails/using-python-apis/streaming.mdx
@@ -175,7 +175,9 @@ When the provider sent usage in a chunk of its own, that usage is folded into th
 ```
 
 The terminal frame always includes the `response_metadata` and `usage_metadata` keys.
-They are retained for backward compatibility and are currently always `None`; read token counts from `usage` instead.
+They are retained for backward compatibility, and no library code path populates them, so on `stream_async()` both are `None`.
+Read token counts from `usage` instead.
+A caller driving `StreamingHandler` directly can still push these keys, and the handler accumulates them onto the terminal frame.
 
 Without `include_metadata`, chunks are plain strings (default behavior).
 

--- a/docs/run-rails/using-python-apis/streaming.mdx
+++ b/docs/run-rails/using-python-apis/streaming.mdx
@@ -147,23 +147,35 @@ This feature enables seamless integration of the NeMo Guardrails library with an
 
 ## Streaming Metadata
 
-When using `stream_async()`, you can receive per-chunk metadata (e.g., token usage, finish reason) by setting `include_metadata=True`:
+When using `stream_async()`, you can receive per-chunk metadata (provider metadata and token usage) by setting `include_metadata=True`:
 
 ```python
 async for chunk in rails.stream_async(messages=messages, include_metadata=True):
     print(chunk)
 ```
 
-With `include_metadata=True`, each chunk is a `dict` with a mandatory `"text"` key. The final chunk also includes a `"metadata"` key containing `response_metadata` (finish reason, model name) and `usage_metadata` (token counts):
+With `include_metadata=True`, each chunk is a `dict` with a mandatory `"text"` key.
+A chunk that carries metadata also has a `"metadata"` key, which can hold the following:
+
+- `provider_metadata`: non-standard fields the provider returned with the chunk, such as `response_headers` and vendor extensions. Most providers send response headers with every chunk, so this key usually appears on every frame.
+- `usage`: token counts as `input_tokens`, `output_tokens`, and `total_tokens`. Providers normally send usage once, at the end of the stream, so this key appears on exactly one frame.
+
+The stream ends with a single terminal frame that has empty text.
+When the provider sent usage in a chunk of its own, that usage is folded into this terminal frame rather than emitted as a separate frame.
 
 ```python
-{"text": "Hello"}
-{"text": "!"}
+{"text": "Hello", "metadata": {"provider_metadata": {"response_headers": {"...": "..."}}}}
+{"text": "!", "metadata": {"provider_metadata": {"response_headers": {"...": "..."}}}}
 {"text": "", "metadata": {
-    "response_metadata": {"finish_reason": "stop", "model_name": "gpt-4o"},
-    "usage_metadata": {"input_tokens": 75, "output_tokens": 9, "total_tokens": 84}
+    "provider_metadata": {"response_headers": {"...": "..."}},
+    "usage": {"input_tokens": 75, "output_tokens": 9, "total_tokens": 84},
+    "response_metadata": None,
+    "usage_metadata": None
 }}
 ```
+
+The terminal frame always includes the `response_metadata` and `usage_metadata` keys.
+They are retained for backward compatibility and are currently always `None`; read token counts from `usage` instead.
 
 Without `include_metadata`, chunks are plain strings (default behavior).
 
@@ -173,9 +185,33 @@ The `include_generation_metadata` parameter is deprecated. Use `include_metadata
 
 </Warning>
 
+### Streaming Metadata on IORails
+
+`IORails` emits the same frames with the same metadata keys as `LLMRails`, so a consumer written against one engine works against the other.
+The following `IORails` specifics apply.
+
+- `IORails` sets `stream_options` to `{"include_usage": True}` on the main model request so the provider returns usage on the terminal chunk. Override it through `llm_params` if your provider needs different behavior.
+
+  ```python
+  async for chunk in rails.stream_async(
+      messages=messages,
+      options={"llm_params": {"stream_options": {"include_usage": False}}},
+      include_metadata=True,
+  ):
+      print(chunk)
+  ```
+
+- `IORails` raises `ValueError` when you combine `include_metadata=True` with output-rail streaming, because its buffer strategy operates on plain string chunks. Either set `include_metadata=False` or disable `rails.output.streaming.enabled`.
+
+A chunk that carries only provider metadata and no text is not emitted as a standalone empty frame.
+The provider metadata rides on the next text frame or on the terminal frame instead, which keeps per-chunk response headers from flooding the stream.
+
+Neither engine returns a `GenerationResponse` from `stream_async()`.
+Structured responses are a non-streaming feature; see [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options).
+
 ## Token Usage Tracking
 
-Token usage statistics are available when streaming responses, depending on provider support. When the provider does not return token usage statistics, the final chunk's `metadata` will contain `response_metadata` and `usage_metadata` set to `None`.
+Token usage statistics are available when streaming responses, depending on provider support. When the provider does not return token usage statistics, the terminal chunk's `metadata` has no `usage` key.
 
 ### Accessing Token Usage Information
 
@@ -196,12 +232,20 @@ for llm_call in response.log.llm_calls:
     print(f"Completion tokens: {llm_call.completion_tokens}")
 ```
 
-Alternatively, you can use the `explain()` method to get a summary of token usage:
+Alternatively, on `LLMRails` you can use the `explain()` method to get a summary of token usage:
 
 ```python
 info = rails.explain()
 info.print_llm_calls_summary()
 ```
+
+<Note>
+
+`explain()` is an `LLMRails` method and raises `NotImplementedError` when `IORails` is the active engine.
+On `IORails`, read token usage from `response.log.llm_calls` and `response.log.stats` as shown above, from the streamed `usage` metadata frame, or from the OpenTelemetry token metrics.
+For more information, see [Metrics](/observability/metrics).
+
+</Note>
 
 For more information about streaming token usage support across different providers, refer to the [LangChain documentation on token usage tracking](https://python.langchain.com/docs/how_to/chat_token_usage_tracking/#streaming). For detailed information about accessing generation logs and token usage, see [Generation Options: Detailed Logging Information](/run-guardrailed-inference/using-python-apis/generation-options#detailed-logging-information) and [Logging](/observability/logging).
 

--- a/docs/run-rails/using-python-apis/streaming.mdx
+++ b/docs/run-rails/using-python-apis/streaming.mdx
@@ -157,11 +157,14 @@ async for chunk in rails.stream_async(messages=messages, include_metadata=True):
 With `include_metadata=True`, each chunk is a `dict` with a mandatory `"text"` key.
 A chunk that carries metadata also has a `"metadata"` key, which can hold the following:
 
-- `provider_metadata`: non-standard fields the provider returned with the chunk, such as `response_headers` and vendor extensions. Most providers send response headers with every chunk, so this key usually appears on every frame.
-- `usage`: token counts as `input_tokens`, `output_tokens`, and `total_tokens`. Providers normally send usage once, at the end of the stream, so this key appears on exactly one frame.
+- `provider_metadata`: non-standard fields the provider returned with the chunk, such as `response_headers` and vendor extensions.
+- `usage`: normalized token counts as `input_tokens`, `output_tokens`, and `total_tokens`.
 
-The stream ends with a single terminal frame that has empty text.
-When the provider sent usage in a chunk of its own, that usage is folded into this terminal frame rather than emitted as a separate frame.
+For text responses, the stream ends with a single terminal frame that has empty text.
+If the provider attaches usage to a text chunk, the library includes `usage` on that text frame.
+If usage arrives in a chunk without text, `IORails` folds it into the terminal frame, while `LLMRails` emits it on a separate empty frame before the terminal frame.
+
+For example, an `IORails` stream with a final usage-only provider chunk has this shape:
 
 ```python
 {"text": "Hello", "metadata": {"provider_metadata": {"response_headers": {"...": "..."}}}}
@@ -174,10 +177,12 @@ When the provider sent usage in a chunk of its own, that usage is folded into th
 }}
 ```
 
-The terminal frame always includes the `response_metadata` and `usage_metadata` keys.
-They are retained for backward compatibility, and no library code path populates them, so on `stream_async()` both are `None`.
+The empty terminal frame always includes the `response_metadata` and `usage_metadata` keys.
+They are retained for backward compatibility, and the internal `stream_async()` paths leave both as `None`.
 Read token counts from `usage` instead.
 A caller driving `StreamingHandler` directly can still push these keys, and the handler accumulates them onto the terminal frame.
+
+An `IORails` tool-call response adds an assembled tool-call JSON frame after this empty frame, so the tool-call frame is the final frame in that stream.
 
 Without `include_metadata`, chunks are plain strings (default behavior).
 
@@ -189,8 +194,8 @@ The `include_generation_metadata` parameter is deprecated. Use `include_metadata
 
 ### Streaming Metadata on IORails
 
-`IORails` emits the same frames with the same metadata keys as `LLMRails`, so a consumer written against one engine works against the other.
-The following `IORails` specifics apply.
+`IORails` uses the same `provider_metadata` and `usage` keys as `LLMRails`.
+The following `IORails`-specific behaviors apply:
 
 - `IORails` sets `stream_options` to `{"include_usage": True}` on the main model request so the provider returns usage on the terminal chunk. Override it through `llm_params` if your provider needs different behavior.
 
@@ -205,12 +210,16 @@ The following `IORails` specifics apply.
 
 - `IORails` raises `ValueError` when you combine `include_metadata=True` with output-rail streaming, because its buffer strategy operates on plain string chunks. Either set `include_metadata=False` or disable `rails.output.streaming.enabled`.
 
+On `LLMRails`, `include_metadata=True` preserves metadata only when output-rail streaming is disabled.
+When output-rail streaming is enabled, the buffer yields plain strings and drops `provider_metadata` and `usage`.
+
 A chunk that carries only provider metadata and no text is not emitted as a standalone empty frame.
-The provider metadata rides on the next text frame or on the terminal frame instead, which keeps per-chunk response headers from flooding the stream.
+The metadata remains visible when the provider also includes it on a content or usage chunk, which keeps repeated response headers from flooding the stream.
 
 ## Generation Options and Streaming
 
-`stream_async()` accepts an `options` argument on both engines, but unlike `generate()` and `generate_async()`, passing it does not change what the iterator yields.
+`stream_async()` accepts an `options` argument on both engines.
+Unlike `generate()` and `generate_async()`, passing it does not change what the iterator yields.
 The chunk shape is governed solely by `include_metadata`: plain strings when it is `False`, and `{"text": ..., "metadata": ...}` dictionaries when it is `True`.
 Neither engine yields or returns a `GenerationResponse` from a stream.
 
@@ -219,7 +228,10 @@ Neither engine yields or returns a `GenerationResponse` from a stream.
 async for chunk in rails.stream_async(messages=messages):
     ...  # str
 
-async for chunk in rails.stream_async(messages=messages, options={"llm_params": {"temperature": 0.2}}):
+async for chunk in rails.stream_async(
+    messages=messages,
+    options={"llm_params": {"temperature": 0.2}},
+):
     ...  # still str
 ```
 
@@ -243,18 +255,23 @@ Do not rely on a stream rejecting an option that the non-streaming call refuses.
 
 </Warning>
 
-Two `GenerationResponse` fields have no streamed equivalent.
+Two `GenerationResponse` fields have no streamed equivalent:
 
-- **`reasoning_content`**: neither engine emits provider reasoning deltas as chunk text. A model that instead embeds `<think>` tags in its content streams them as ordinary text, which means output rails see the reasoning; `IORails` logs a warning once per request when it detects this.
-- **`tool_calls`**: `IORails` emits assembled tool calls as a terminal chunk whose text is a `{"tool_calls": [...]}` JSON string, using the OpenAI wire shape with `function.arguments` as a JSON string. The non-streaming `GenerationResponse.tool_calls` uses dictionary arguments instead. `LLMRails` does not push tool calls into the stream at all; they reach only the discarded `GenerationResponse`.
+- `reasoning_content`: Neither engine emits provider reasoning deltas as chunk text.
+  A model that embeds `<think>` tags in its content streams them as ordinary text, which means output rails see the reasoning.
+  `IORails` logs one warning per request when it detects this.
+- `tool_calls`: `IORails` emits assembled tool calls as a terminal chunk whose text is a `{"tool_calls": [...]}` JSON string.
+  The string uses the OpenAI wire shape with `function.arguments` as a JSON string, while the non-streaming `GenerationResponse.tool_calls` uses dictionary arguments.
+  `LLMRails` does not push tool calls into the stream, so they reach only the discarded `GenerationResponse`.
 
 To obtain a `GenerationResponse` for a request, use `generate_async()`.
 To obtain token usage while streaming, read the `usage` metadata frame described above.
-For the non-streaming option and field tables, see [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
+For the non-streaming option and field tables, refer to [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options#iorails-and-llmrails-differences).
 
 ## Token Usage Tracking
 
-Token usage statistics are available when streaming responses, depending on provider support. When the provider does not return token usage statistics, the terminal chunk's `metadata` has no `usage` key.
+Token usage statistics are available when streaming responses, depending on provider support.
+When the provider does not return token usage statistics, the terminal chunk's `metadata` has no `usage` key.
 
 ### Accessing Token Usage Information
 
@@ -286,7 +303,7 @@ info.print_llm_calls_summary()
 
 `explain()` is an `LLMRails` method and raises `NotImplementedError` when `IORails` is the active engine.
 On `IORails`, read token usage from `response.log.llm_calls` and `response.log.stats` as shown above, from the streamed `usage` metadata frame, or from the OpenTelemetry token metrics.
-For more information, see [Metrics](/observability/metrics).
+For more information, refer to [Metrics](/observability/metrics).
 
 </Note>
 


### PR DESCRIPTION
## Description

IORails added support for the [GenerationOptions](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/options.py#L161) to [`generate_async()`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/guardrails/iorails.py#L914), [`generate()`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/guardrails/iorails.py#L883), and [`stream_async()`](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/guardrails/iorails.py#L1479).

When `GenerationOptions` is provided, the return type of the non-streaming inference calls changes from a dict with the `role` and `content` fields to a [GenerationResponse](https://github.com/NVIDIA-NeMo/Guardrails/blob/bf9f06b2d9a315db9db0b957a29f69564fe748f1/nemoguardrails/rails/llm/options.py#L377) Pydantic object. 


#### GenerationOptions supported fields

| Field | Type | LLMRails | IORails | Notes |
|---|---|:---:|:---:|---|
| `rails.input` | `bool \| list[str]` | ✓ | ✓ | IORails runs only the named rails when given a list. LLMRails tests truthiness only, so any non-empty list means "all enabled". |
| `rails.output` | `bool \| list[str]` | ✓ | ✓ | Same list-selection difference as `rails.input`. |
| `rails.tool_input` | `bool \| list[str]` | ✓ | ✓ | Gates the tool-result rails. Same list-selection difference. |
| `rails.tool_output` | `bool \| list[str]` | ✓ | ✓ | Gates the tool-call rails. Same list-selection difference. |
| `rails.dialog` | `bool` | ✓ | n/a | IORails runs no dialog rails and ignores the toggle. A config declaring dialog rails routes to LLMRails. On LLMRails, `dialog: False` suppresses the main LLM call and echoes the supplied message back. |
| `rails.retrieval` | `bool \| list[str]` | ✓ | n/a | IORails runs no retrieval rails and ignores the toggle. A config declaring retrieval rails routes to LLMRails. |
| `llm_params` | `dict \| None` | ✓ | ✓ | Applied to the main model call only, never to the rail models. |
| `llm_output` | `bool` | ◐ | ◐ | Accepted by both; `GenerationResponse.llm_output` is always `None`. |
| `output_vars` | `bool \| list[str] \| None` | ✓ | ✗ | IORails raises `ValueError`: it has no Colang context to read. |
| `log` | `GenerationLogOptions` | ✓ | ◐ | See the next table. |

**Notes**

- Passing `options` at all switches the return type from an OpenAI-style message dictionary to a `GenerationResponse`, on both engines.
- An empty `options={}` returns a `GenerationResponse` on IORails but raises `TypeError` on LLMRails, because an empty dict is falsy and misses the dictionary branch in `llmrails.py`. Use `options=GenerationOptions()` for the structured return with defaults on either engine.
- The list form of `rails` is exhaustive: `{"rails": ["input"]}` sets all six categories to `False` and then re-enables only `input`.
- `state` is a `generate()` keyword argument rather than a `GenerationOptions` field. IORails raises `ValueError` for it; `GenerationResponse.state` is always `None`.
- `enforce` is commented out in `options.py` and is not a live field on either engine.
- On LLMRails with a Colang 2.x configuration, `output_vars`, `log`, and `llm_output` all raise `ValueError`.


#### GenerationLogOptions supported fields

| Field | Type | LLMRails | IORails | Notes |
|---|---|:---:|:---:|---|
| `activated_rails` | `bool` | ✓ | ✓ | IORails synthesizes one `ActivatedRail` per rail from its `RailCallRecord`, each with exactly one synthetic `ExecutedAction` holding the rail's verdict in `return_value`. `decisions` is always `[]` because decisions are a Colang construct. |
| `llm_calls` | `bool` | ✓ | ✓ | Flat list of `LLMCallInfo`. Token usage, durations, timestamps, request IDs, model names, and provider names are populated on both engines. IORails serializes `prompt` as `"<role>: <content>"` lines, so content matches LLMRails but formatting differs. |
| `internal_events` | `bool` | ✓ | ✗ | IORails raises `NotImplementedError`: no Colang runtime. |
| `colang_history` | `bool` | ✓ | ✗ | IORails raises `NotImplementedError`: no Colang runtime. |

**Notes:**

- `GenerationLog.stats` is not a `GenerationLogOptions` field. Both engines populate it whenever you request either `activated_rails` or `llm_calls`.
- On IORails, the main model call appears in the log as a rail with `type` `generation`, `name` `generation`, and action name `generate_bot_message`. On LLMRails the equivalent entries come from the Colang dialog rails, such as `generate user intent` / `generate_user_intent`.
- On IORails, a blocked request still returns the log for the rails that ran before the block.
- IORails raises on the options it cannot honor rather than returning empty data, so a request never looks like it succeeded with nothing to report when the option was never applied.


#### GenerationResponse supported fields

The fields returned when `options` is passed to `generate()` or `generate_async()`.
`stream_async()` never yields or returns a `GenerationResponse` on either engine.

| Field | Type | LLMRails | IORails | Notes |
|---|---|:---:|:---:|---|
| `response` | `str \| list[dict]` | ✓ | ✓ | IORails always returns a one-element `[assistant_msg]` list. LLMRails returns a plain string when called with `prompt=` instead of `messages=`. |
| `tool_calls` | `list \| None` | ✓ | ✓ | Both use the canonical `ToolCall.to_dict()` shape with dict arguments. The bare-message and streaming paths keep the OpenAI wire shape with `function.arguments` as a JSON string. |
| `reasoning_content` | `str \| None` | ✓ | ✓ | Provider `reasoning` field, or content extracted from `<think>` tags. On this path IORails keeps the message content clean; the bare dict returned without `options` inlines reasoning as a `<think>` prefix. No streamed equivalent on either engine. |
| `log` | `GenerationLog \| None` | ✓ | ◐ | IORails populates `activated_rails`, `llm_calls`, and `stats` only. Each rail carries exactly one synthetic `ExecutedAction`, `decisions` is always `[]`, and the main call appears as a `generation` rail named `generation`/`generate_bot_message`. See the `GenerationLogOptions` table above. |
| `llm_metadata` | `dict \| None` | ✓ | ◐ | Provider metadata blob verbatim, such as `response_headers`. IORails reports the **main** model call; LLMRails reports the **most recent** call, usually the last output rail. No `usage` sub-key on either engine: token usage lives in `log`. `None` when the provider returns no metadata. |
| `llm_output` | `dict \| None` | ◐ | ◐ | Always `None` on both engines, because `LLMCallInfo.raw_response` is never assigned anywhere in the codebase. |
| `output_data` | `dict \| None` | ✓ | ✗ | Always `None` on IORails; passing `output_vars` raises `ValueError`. |
| `state` | `dict \| None` | ✓ | ✗ | Always `None` on IORails; passing `state` raises `ValueError`. |

Notes:

- On a blocked request, IORails populates only `response` (the refusal message) and `log` (the rails that ran before the block). `tool_calls`, `reasoning_content`, and `llm_metadata` are `None`.
- Reasoning bypasses the output rails on both engines, so output rails check the final answer rather than the reasoning trace.


## Related Issue(s)

* #2178 
* #2198


## Verification

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 368 pages at /Users/tgasser/projects/nemo_guardrails_worktree/docs/iorails-generation-response/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries

node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
node scripts/run-fern-with-ref-sdk.mjs check
Found 0 errors and 4 warnings in 0.000 seconds. Run fern check --warnings to print out the warnings not shown.
```


## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for `LLMRails` and `IORails`, including supported options, limitations, errors, logging, and blocked requests.
  - Clarified prompt-based return values, structured responses, response fields, and engine-specific behavior.
  - Documented streaming metadata, token usage, tool calls, reasoning content, validation, and output-rail behavior.
  - Improved logging guidance, including log structure, LLM calls, execution failures, and policy blocks.
  - Added updated comparison tables and links to related streaming and logging references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->