### PR TITLE
docs(iorails): Add message checks to docs

### DIFF
--- a/docs/observability/metrics/reference.mdx
+++ b/docs/observability/metrics/reference.mdx
@@ -13,6 +13,7 @@ This page lists the metrics emitted by the IORails engine and the instrumented c
 Metrics fall into three families:
 
 - **Request-level metrics** (`guardrails.*`) describe IORails request flow: volume, errors, blocks, latency, and saturation of the streaming and non-streaming admission paths.
+  They cover `generate_async()`, `stream_async()`, and the rails-only [`check_async()`](/run-guardrailed-inference/using-python-apis/check-messages), which shares the non-streaming admission path.
 - **LLM client-side metrics** (`gen_ai.client.*`) describe downstream LLM calls IORails issues.
   These follow the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) and use the bucket boundaries recommended by that spec.
 - **HTTP client-side metrics** (`http.client.*`) describe outbound requests sent through an explicitly instrumented canonical HTTP client.
@@ -25,7 +26,7 @@ IORails request and LLM metrics require `metrics.enabled: true` and a configured
 | --- | --- | --- | --- | --- |
 | `guardrails.requests` | Counter | `1` | — | Total IORails requests handled, incremented on entry. |
 | `guardrails.requests.errors` | Counter | `1` | `error.type` | Requests that ended in an unhandled error. `error.type` is the exception class name (for example `QueueFull`, `TimeoutError`). |
-| `guardrails.requests.blocked` | Counter | `1` | `rail.type` | Requests blocked by an input or output rail. `rail.type` is `input` or `output`. |
+| `guardrails.requests.blocked` | Counter | `1` | `rail.type` | Requests blocked by an input or output rail. `rail.type` is `Input` or `Output`. |
 | `guardrails.request.duration` | Histogram | `s` | — | End-to-end request duration. For non-streaming requests this includes queue-wait time. |
 | `guardrails.requests.active` | UpDownCounter | `1` | — | Requests currently in flight. Covers both streaming and non-streaming. |
 
@@ -153,7 +154,7 @@ When usage is absent, no observation is recorded; "no observation" is deliberate
 | Label | Used On | Values | Notes |
 | --- | --- | --- | --- |
 | `error.type` | Request, LLM, and HTTP error metrics | Exception class name or HTTP error status | For example `QueueFull`, `TimeoutError`, `HTTPConnectionError`, or `503`. |
-| `rail.type` | `guardrails.requests.blocked` | `input`, `output` | Identifies whether an input or output rail blocked the request. |
+| `rail.type` | `guardrails.requests.blocked` | `Input`, `Output` | Identifies whether an input or output rail blocked the request. Matches the `rail.type` span attribute. |
 | `gen_ai.operation.name` | All `gen_ai.client.*` | For example `chat`, `completion`, `embedding` | OpenTelemetry GenAI operation name. |
 | `gen_ai.provider.name` | All `gen_ai.client.*` | For example `openai`, `anthropic` | OpenTelemetry GenAI provider name. |
 | `gen_ai.request.model` | All `gen_ai.client.*` | For example `gpt-4o-mini` | The model name passed in the request. |

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -43,7 +43,8 @@ On a blocked request, the CLIENT span records the raw model response while the S
 Sampling parameters (`gen_ai.request.temperature`, `max_tokens`, and so on) and token-usage attributes are not content, so IORails records them on the CLIENT span whenever tracing is enabled, regardless of the content-capture setting.
 
 A rails-only [`check_async()`](/run-guardrailed-inference/using-python-apis/check-messages) captures the same way: the checked messages land in `guardrails.request.input` and the returned content in `guardrails.request.output`, and every rail that runs records its own `guardrails.rail` attributes.
-A check makes no main-model call, so it produces no CLIENT span for the protected model; the LLM calls its rail actions make are captured as usual.
+A check makes no main-model call, so it produces no CLIENT span for the protected model.
+IORails captures LLM calls from rail actions as usual.
 The synchronous `check()` runs on a short-lived engine with tracing disabled, so it captures nothing.
 
 ## Enabling Content Capture

--- a/docs/observability/tracing/content-capture.mdx
+++ b/docs/observability/tracing/content-capture.mdx
@@ -42,6 +42,10 @@ On a blocked request, the CLIENT span records the raw model response while the S
 
 Sampling parameters (`gen_ai.request.temperature`, `max_tokens`, and so on) and token-usage attributes are not content, so IORails records them on the CLIENT span whenever tracing is enabled, regardless of the content-capture setting.
 
+A rails-only [`check_async()`](/run-guardrailed-inference/using-python-apis/check-messages) captures the same way: the checked messages land in `guardrails.request.input` and the returned content in `guardrails.request.output`, and every rail that runs records its own `guardrails.rail` attributes.
+A check makes no main-model call, so it produces no CLIENT span for the protected model; the LLM calls its rail actions make are captured as usual.
+The synchronous `check()` runs on a short-lived engine with tracing disabled, so it captures nothing.
+
 ## Enabling Content Capture
 
 Content capture is active only when all of the following conditions are true:

--- a/docs/observability/tracing/span-reference.mdx
+++ b/docs/observability/tracing/span-reference.mdx
@@ -215,7 +215,7 @@ A single request produces one tree.
 Span nesting follows execution, so the parent of an LLM or API span depends on where the call is made.
 
 ```text
-guardrails.request                  SERVER     one per generate_async() or check_async() call
+guardrails.request                  SERVER     one per generate_async(), stream_async(), or check_async() call
 ├─ guardrails.rail                  INTERNAL   one per rail that runs
 │  └─ guardrails.action             INTERNAL   one per action the rail invokes
 │     ├─ chat {model}               CLIENT     LLM call issued by the action (for example a content-safety model)

--- a/docs/observability/tracing/span-reference.mdx
+++ b/docs/observability/tracing/span-reference.mdx
@@ -215,7 +215,7 @@ A single request produces one tree.
 Span nesting follows execution, so the parent of an LLM or API span depends on where the call is made.
 
 ```text
-guardrails.request                  SERVER     one per generate_async() call
+guardrails.request                  SERVER     one per generate_async() or check_async() call
 ├─ guardrails.rail                  INTERNAL   one per rail that runs
 │  └─ guardrails.action             INTERNAL   one per action the rail invokes
 │     ├─ chat {model}               CLIENT     LLM call issued by the action (for example a content-safety model)
@@ -226,6 +226,7 @@ guardrails.request                  SERVER     one per generate_async() call
 - The main generation call is a child of `guardrails.request`.
 - An LLM or API call made by a rail action is a child of that `guardrails.action` span.
 - Streaming requests propagate trace context across the internal task boundary, so streamed spans keep the same parent.
+- A [rails-only check](/run-guardrailed-inference/using-python-apis/check-messages) produces the same tree without the top-level `chat {model}` span, because the check makes no main-model call. The LLM and API calls its rail actions make still appear beneath those actions. The synchronous `check()` runs on a short-lived engine with tracing disabled and emits no spans.
 
 Every span sets ERROR status and records the exception when one propagates through it.
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -43,7 +43,7 @@ It runs the built-in NeMoGuard safety models (content safety, topic control, and
 It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
 
 `IORails` has a `start()` and `stop()` lifecycle that initializes and releases the engine's model clients and work queue.
-Both `generate_async()` and `stream_async()` call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to warm the clients and `stop()` at shutdown to release them.
+`generate_async()`, `stream_async()`, and `check_async()` all call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to warm the clients and `stop()` at shutdown to release them.
 When you use the `Guardrails` facade described below, that lifecycle is managed for you through `startup()` and `shutdown()` (or by using `Guardrails` as an async context manager).
 
 ### Choosing an Engine
@@ -147,7 +147,7 @@ Tool calls are returned in the OpenAI-style `tool_calls` field of the response m
 | `generate` / `generate_async` | ✓ | ✓ | |
 | `stream_async` | ✓ | ✓ | |
 | Event-based API (`generate_events` / `process_events`) | ✓ | ✗ | Requires the Colang runtime |
-| `check` / `check_async` (rails-only validation) | ✓ | ✓ | |
+| `check` / `check_async` (rails-only validation) | ✓ | ✓ | Input and output rails only on both engines. Neither runs tool rails |
 | `GenerationOptions` | ✓ | ◐ | IORails supports rail toggles, `llm_params`, and the `log` options that do not need Colang. `output_vars` raises. The separate `state` keyword argument also raises. |
 | `GenerationResponse` (structured response object) | ✓ | ✓ | Returned by both engines when `options` is passed |
 | `GenerationLog` `internal_events` / `colang_history` | ✓ | ✗ | Colang runtime only. IORails raises `NotImplementedError`. |
@@ -169,6 +169,12 @@ For the field-by-field comparison, refer to [Generation Options: IORails and LLM
 
 The event-based API and `explain()` are not available on `IORails`.
 On the `Guardrails` facade, these raise `NotImplementedError` when `IORails` is the active engine.
+
+Both engines accept the same `check` arguments and return the same `RailsResult`, and neither runs tool rails from a check.
+`LLMRails` runs the check through the Colang runtime with the main model call disabled.
+`IORails` runs the rails directly through its rails manager and reuses the `generate_async` admission queue, request span, and request metrics.
+The two differ in what a blocked check reports and in how a direction with no content to check is handled.
+For those differences, refer to [Checking Messages Against Rails: Engine Differences](/run-guardrailed-inference/using-python-apis/check-messages#engine-differences).
 
 ### Streaming
 
@@ -310,13 +316,15 @@ The community and third-party integrations in the [Guardrail Catalog](/configure
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
-| Guardrails server (OpenAI-compatible REST API) | ✓ | ✗ | Bundled server runs LLMRails; use IORails through the Python API |
+| Guardrails server (OpenAI-compatible REST API) | ✓ | ◐ | Runs on LLMRails by default; `NEMO_GUARDRAILS_IORAILS_ENGINE=1` routes supported configurations to IORails |
 | Server-side threads and multi-config | ✓ | ✗ | LLMRails only |
 
-The bundled Guardrails server exposes an OpenAI-compatible REST API and runs on `LLMRails`.
+The bundled Guardrails server exposes an OpenAI-compatible REST API and runs on `LLMRails` by default.
 Server-side threads and multi-config serving are provided through that server.
 
-`IORails` is consumed through the in-process `Guardrails` Python API rather than the bundled server.
+`IORails` is normally consumed through the in-process `Guardrails` Python API.
+Setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` aliases the top-level `LLMRails` import to `Guardrails`, so the server's endpoints, including `/v1/chat/completions` and `/v1/checks`, run on `IORails` for configurations IORails can serve and fall back to `LLMRails` for the rest.
+This path is early release: validate it against your own configurations before depending on it in production.
 
 ### Configuration and Operations
 

--- a/docs/reference/engine-feature-support.mdx
+++ b/docs/reference/engine-feature-support.mdx
@@ -43,7 +43,9 @@ It runs the built-in NeMoGuard safety models (content safety, topic control, and
 It does not run the Colang dialog runtime, retrieval, custom actions, or accept a custom LLM, and it accepts Colang 1.0 configurations only.
 
 `IORails` has a `start()` and `stop()` lifecycle that initializes and releases the engine's model clients and work queue.
-`generate_async()`, `stream_async()`, and `check_async()` all call `start()` automatically (it is idempotent), so a bare `IORails` does not need a manual `start()` before use; call `start()` at service startup to warm the clients and `stop()` at shutdown to release them.
+`generate_async()`, `stream_async()`, and `check_async()` all call `start()` automatically.
+The operation is idempotent, so a bare `IORails` does not need a manual `start()` before use.
+Call `start()` at service startup to warm the clients and `stop()` at shutdown to release them.
 When you use the `Guardrails` facade described below, that lifecycle is managed for you through `startup()` and `shutdown()` (or by using `Guardrails` as an async context manager).
 
 ### Choosing an Engine
@@ -316,14 +318,15 @@ The community and third-party integrations in the [Guardrail Catalog](/configure
 
 | Feature | LLMRails | IORails | Notes |
 |---|:---:|:---:|---|
-| Guardrails server (OpenAI-compatible REST API) | ✓ | ◐ | Runs on LLMRails by default; `NEMO_GUARDRAILS_IORAILS_ENGINE=1` routes supported configurations to IORails |
+| Guardrails server (OpenAI-compatible REST API) | ✓ | ◐ | Runs on LLMRails by default. `NEMO_GUARDRAILS_IORAILS_ENGINE=1` routes supported configurations to IORails |
 | Server-side threads and multi-config | ✓ | ✗ | LLMRails only |
 
 The bundled Guardrails server exposes an OpenAI-compatible REST API and runs on `LLMRails` by default.
 Server-side threads and multi-config serving are provided through that server.
 
 `IORails` is normally consumed through the in-process `Guardrails` Python API.
-Setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` aliases the top-level `LLMRails` import to `Guardrails`, so the server's endpoints, including `/v1/chat/completions` and `/v1/checks`, run on `IORails` for configurations IORails can serve and fall back to `LLMRails` for the rest.
+Setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` aliases the top-level `LLMRails` import to `Guardrails`.
+The server endpoints, including `/v1/chat/completions` and `/v1/checks`, then run on `IORails` for supported configurations and fall back to `LLMRails` for the rest.
 This path is early release: validate it against your own configurations before depending on it in production.
 
 ### Configuration and Operations

--- a/docs/run-rails/using-python-apis/check-messages.mdx
+++ b/docs/run-rails/using-python-apis/check-messages.mdx
@@ -12,8 +12,8 @@ content:
 The `check_async()` and `check()` methods validate messages against input and output rails without triggering full LLM generation. Use these methods instead of [generation options](/run-guardrailed-inference/using-python-apis/generation-options) when you only need to run rails without generating a response. If you need to run generation while selectively disabling rail categories, see [Generation Options: Disabling Rails](/run-guardrailed-inference/using-python-apis/generation-options#disabling-rails).
 
 Both the `LLMRails` and `IORails` engines implement these methods, and the `Guardrails` facade forwards the call to whichever engine it selected.
-The method signatures, the rail-type selection rules, and the returned `RailsResult` are the same on both engines.
-For the behavior that does differ, refer to [Engine Differences](#engine-differences).
+The method signatures and returned `RailsResult` type are the same on both engines.
+For engine-specific rail selection and execution behavior, refer to [Engine Differences](#engine-differences).
 
 ## Method Signatures
 
@@ -95,7 +95,7 @@ result = await rails.check_async(
 | `RailType.INPUT` | Run input rails |
 | `RailType.OUTPUT` | Run output rails |
 
-On `IORails`, passing an empty list (`rail_types=[]`) runs no rails and returns a passed result.
+On either engine, passing an empty list (`rail_types=[]`) runs no rails and returns a passed result.
 
 <Note>
 
@@ -136,7 +136,8 @@ The `RailStatus` enum represents the three possible outcomes of a rails check.
 ### Which Content Is Reported
 
 The `content` field reports the direction the caller asked about.
-A check that runs output rails reports the assistant text; a check that runs input rails only reports the user text.
+A check that runs output rails reports the assistant text.
+A check that runs input rails only reports the user text.
 
 Both engines compare the reported text against its original value to decide between `PASSED` and `MODIFIED`.
 When a check runs both directions and only the user message is rewritten, the status is `PASSED`, because the reported assistant text is unchanged.
@@ -226,19 +227,19 @@ For more information, refer to [Engine Feature Support](/reference/engine-featur
 
 ## Engine Differences
 
-The API surface is identical on both engines, but the two run the check differently.
+The API surface is identical on both engines, but each engine executes a check differently:
 
 | Behavior | LLMRails | IORails |
 |---|---|---|
 | How the check runs | Through the Colang runtime, as a generation with dialog rails and the unrequested rail types disabled | Directly through the engine's rails manager, with no Colang runtime |
-| Rails that can run | Every configured input and output flow, including community, third-party, and custom-action rails | The input and output rails IORails supports; a configuration outside that set routes to `LLMRails` |
+| Rails that can run | Every configured input and output flow, including community, third-party, and custom-action rails | The input and output rails IORails supports. A configuration outside that set routes to `LLMRails` |
 | Main LLM call | Not made | Not made |
 | Tool rails | Not run | Not run |
 | `BLOCKED` content | The refusal message defined by the configuration's Colang flow | A fixed refusal message that the configuration does not change |
 | Rail that fails to execute | Handled by the Colang runtime's internal-error path | `BLOCKED` with an internal-error message that is distinct from the refusal message |
 | Requested direction with no content to check | An output-only check with no user message runs with an empty user message supplied as context | The direction is skipped and the result is `PASSED` |
 | Admission control | None | Shares the non-streaming admission queue with `generate_async()`, and raises `asyncio.QueueFull` when the queue is full |
-| Tracing and metrics | Spans through a tracing adapter; no OpenTelemetry metrics | The same request span and request metrics as `generate_async()`; refer to [Observability for IORails Checks](#observability-for-iorails-checks) |
+| Tracing and metrics | Spans through a tracing adapter with no OpenTelemetry metrics | The same request span and request metrics as `generate_async()`. Refer to [Observability for IORails Checks](#observability-for-iorails-checks) |
 | Synchronous `check()` | Runs `check_async()` on the calling thread's event loop | Runs `check_async()` on a short-lived engine with tracing and metrics disabled |
 
 ### Blocked Content
@@ -248,7 +249,8 @@ On `IORails`, a blocked check returns the engine's fixed refusal message, `I'm s
 That is the same string the built-in rails use by default, so an unmodified configuration produces the same text on both engines.
 
 `IORails` also distinguishes a rail that fired from a rail that broke.
-When a rail fails to execute, the check returns `BLOCKED` with `I'm sorry, an internal error has occurred.` instead of the refusal message, so an operational failure is not reported to your application as a content refusal.
+When a rail fails to execute, the check returns `BLOCKED` with `I'm sorry, an internal error has occurred.` instead of the refusal message.
+This distinction prevents the application from reporting an operational failure as a content refusal.
 That wording matches the sentence the Colang runtime produces on `LLMRails` when an action fails.
 
 In every case, treat `status` as the decision and `content` as the message to show a user. Do not match on the message text.
@@ -271,7 +273,8 @@ When your application requires that a rail actually ran, assert that the message
 `check_async()` is instrumented like `generate_async()` on the IORails engine.
 
 - Tracing produces one `guardrails.request` SERVER span per check, with one `guardrails.rail` INTERNAL span per rail that runs and a `guardrails.action` span per action.
-  The check makes no main-model call, so the tree has no top-level `chat {model}` CLIENT span; the LLM calls a rail action makes still appear beneath that action.
+  The check makes no main-model call, so the tree has no top-level `chat {model}` CLIENT span.
+  LLM calls from rail actions still appear beneath those actions.
   For more information, refer to [Span Reference](/observability/tracing/span-reference#iorails).
 - Metrics record the check in the request-level instruments: `guardrails.requests`, `guardrails.requests.active`, `guardrails.request.duration`, `guardrails.requests.errors`, and, on a block, `guardrails.requests.blocked` with the `rail.type` label.
   A check rejected by a full admission queue increments `guardrails.nonstream.rejections`.

--- a/docs/run-rails/using-python-apis/check-messages.mdx
+++ b/docs/run-rails/using-python-apis/check-messages.mdx
@@ -3,13 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Checking Messages Against Rails"
 sidebar-title: "Check Messages"
-description: "Validate messages against input and output rails using check_async and check methods."
-keywords: ["check_async", "check", "RailsResult", "RailStatus", "RailType", "input rails", "output rails", "validation"]
+description: "Validate messages against input and output rails using check_async and check methods on the LLMRails and IORails engines."
+keywords: ["check_async", "check", "RailsResult", "RailStatus", "RailType", "input rails", "output rails", "validation", "IORails", "LLMRails"]
 content:
   type: "reference"
 ---
 
 The `check_async()` and `check()` methods validate messages against input and output rails without triggering full LLM generation. Use these methods instead of [generation options](/run-guardrailed-inference/using-python-apis/generation-options) when you only need to run rails without generating a response. If you need to run generation while selectively disabling rail categories, see [Generation Options: Disabling Rails](/run-guardrailed-inference/using-python-apis/generation-options#disabling-rails).
+
+Both the `LLMRails` and `IORails` engines implement these methods, and the `Guardrails` facade forwards the call to whichever engine it selected.
+The method signatures, the rail-type selection rules, and the returned `RailsResult` are the same on both engines.
+For the behavior that does differ, refer to [Engine Differences](#engine-differences).
 
 ## Method Signatures
 
@@ -45,6 +49,12 @@ def check(
 | `rail_types` | `Optional[List[RailType]]` | Optional list of rail types to run. When provided, overrides automatic detection based on message roles. |
 
 **Returns:** `RailsResult` object containing validation results.
+
+<Note>
+
+Calling the synchronous `check()` from inside a running event loop raises `RuntimeError` on both engines. Use `await check_async(...)` in async code.
+
+</Note>
 
 ## Rail Type Selection
 
@@ -85,6 +95,8 @@ result = await rails.check_async(
 | `RailType.INPUT` | Run input rails |
 | `RailType.OUTPUT` | Run output rails |
 
+On `IORails`, passing an empty list (`rail_types=[]`) runs no rails and returns a passed result.
+
 <Note>
 
 Requesting a rail type that has no configured flows raises
@@ -93,6 +105,13 @@ example, passing `rail_types=[RailType.OUTPUT]` on a config that only defines
 input flows will raise an error instead of silently returning a passed result.
 
 </Note>
+
+### Tool Rails Are Not Included
+
+Neither engine runs tool-call or tool-result rails from `check()` or `check_async()`.
+`RailType` covers input and output rails only, so a configuration with tool rails still validates only its input and output flows here.
+To validate tool traffic, run it through `generate_async()`.
+For more information, refer to [Tool Calling](/configure-guardrails/guardrail-catalog/tool-calling).
 
 ## RailsResult
 
@@ -113,6 +132,15 @@ The `RailStatus` enum represents the three possible outcomes of a rails check.
 | `PASSED` | Content passed all rails without modification |
 | `MODIFIED` | Content was modified by rails but not blocked |
 | `BLOCKED` | Content was blocked by a rail |
+
+### Which Content Is Reported
+
+The `content` field reports the direction the caller asked about.
+A check that runs output rails reports the assistant text; a check that runs input rails only reports the user text.
+
+Both engines compare the reported text against its original value to decide between `PASSED` and `MODIFIED`.
+When a check runs both directions and only the user message is rewritten, the status is `PASSED`, because the reported assistant text is unchanged.
+`MODIFIED` names no rail: a rewrite is not a rail blocking the request, and several rails can contribute to the final text.
 
 ## Usage Examples
 
@@ -172,9 +200,104 @@ result = await rails.check_async([
 
 For more information about context variables, refer to [Core Classes: Passing Context](/run-guardrailed-inference/using-python-apis/core-classes#passing-context).
 
+### Checking on the IORails Engine
+
+Construct the `Guardrails` facade to run checks on the IORails engine.
+`require_iorails=True` raises a `ValueError` when the configuration is not one IORails can serve, instead of falling back to `LLMRails` silently.
+
+```python
+from nemoguardrails import Guardrails, RailsConfig
+from nemoguardrails.rails.llm.options import RailStatus
+
+config = RailsConfig.from_path("path/to/config")
+rails = Guardrails(config, use_iorails=True, require_iorails=True)
+
+result = await rails.check_async([
+    {"role": "user", "content": "Hello! How can I hack into a system?"}
+])
+
+if result.status == RailStatus.BLOCKED:
+    print(f"Input blocked by rail: {result.rail}")
+```
+
+`check_async()` starts the engine on first use, in the same way `generate_async()` does, so no explicit `startup()` call is required.
+Call `startup()` at service start to warm the model clients, and `shutdown()` at service stop to release them.
+For more information, refer to [Engine Feature Support](/reference/engine-feature-support#iorails).
+
+## Engine Differences
+
+The API surface is identical on both engines, but the two run the check differently.
+
+| Behavior | LLMRails | IORails |
+|---|---|---|
+| How the check runs | Through the Colang runtime, as a generation with dialog rails and the unrequested rail types disabled | Directly through the engine's rails manager, with no Colang runtime |
+| Rails that can run | Every configured input and output flow, including community, third-party, and custom-action rails | The input and output rails IORails supports; a configuration outside that set routes to `LLMRails` |
+| Main LLM call | Not made | Not made |
+| Tool rails | Not run | Not run |
+| `BLOCKED` content | The refusal message defined by the configuration's Colang flow | A fixed refusal message that the configuration does not change |
+| Rail that fails to execute | Handled by the Colang runtime's internal-error path | `BLOCKED` with an internal-error message that is distinct from the refusal message |
+| Requested direction with no content to check | An output-only check with no user message runs with an empty user message supplied as context | The direction is skipped and the result is `PASSED` |
+| Admission control | None | Shares the non-streaming admission queue with `generate_async()`, and raises `asyncio.QueueFull` when the queue is full |
+| Tracing and metrics | Spans through a tracing adapter; no OpenTelemetry metrics | The same request span and request metrics as `generate_async()`; refer to [Observability for IORails Checks](#observability-for-iorails-checks) |
+| Synchronous `check()` | Runs `check_async()` on the calling thread's event loop | Runs `check_async()` on a short-lived engine with tracing and metrics disabled |
+
+### Blocked Content
+
+On `LLMRails`, the blocked content is the bot message the Colang flow defines, so a configuration that customizes `bot refuse to respond` sees its own wording.
+On `IORails`, a blocked check returns the engine's fixed refusal message, `I'm sorry, I can't respond to that.`, which the configuration cannot change.
+That is the same string the built-in rails use by default, so an unmodified configuration produces the same text on both engines.
+
+`IORails` also distinguishes a rail that fired from a rail that broke.
+When a rail fails to execute, the check returns `BLOCKED` with `I'm sorry, an internal error has occurred.` instead of the refusal message, so an operational failure is not reported to your application as a content refusal.
+That wording matches the sentence the Colang runtime produces on `LLMRails` when an action fails.
+
+In every case, treat `status` as the decision and `content` as the message to show a user. Do not match on the message text.
+
+### Missing Content for a Requested Direction
+
+`IORails` skips a direction when the messages carry no content for it, and reports `PASSED`.
+An explicit `rail_types=[RailType.OUTPUT]` on a message list with no assistant text runs no output rails, and an explicit `rail_types=[RailType.INPUT]` with no user text runs no input rails.
+This keeps a rail that requires the missing text from raising and surfacing as a false block.
+
+<Warning>
+
+A `PASSED` result from `IORails` means no rail blocked the messages, which includes the case where a requested direction had nothing to check.
+When your application requires that a rail actually ran, assert that the message you are validating is present and non-empty before calling `check_async()`.
+
+</Warning>
+
+### Observability for IORails Checks
+
+`check_async()` is instrumented like `generate_async()` on the IORails engine.
+
+- Tracing produces one `guardrails.request` SERVER span per check, with one `guardrails.rail` INTERNAL span per rail that runs and a `guardrails.action` span per action.
+  The check makes no main-model call, so the tree has no top-level `chat {model}` CLIENT span; the LLM calls a rail action makes still appear beneath that action.
+  For more information, refer to [Span Reference](/observability/tracing/span-reference#iorails).
+- Metrics record the check in the request-level instruments: `guardrails.requests`, `guardrails.requests.active`, `guardrails.request.duration`, `guardrails.requests.errors`, and, on a block, `guardrails.requests.blocked` with the `rail.type` label.
+  A check rejected by a full admission queue increments `guardrails.nonstream.rejections`.
+  For more information, refer to [Metric Reference](/observability/metrics/reference).
+- Content capture records the checked messages in `guardrails.request.input` and the returned content in `guardrails.request.output` on the check's request span.
+  For more information, refer to [Capturing Prompt and Response Content](/observability/tracing/content-capture).
+
+The synchronous `check()` builds a short-lived engine with tracing and metrics disabled, so it emits no spans and no metrics. Use `check_async()` on instrumented paths.
+
+### Guardrails Server
+
+The bundled server exposes checks through the `/v1/checks` endpoint, which calls `check_async()` on the engine serving the requested configuration.
+The server resolves that engine through the top-level `LLMRails` import, so setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` makes the endpoint run on `IORails` for configurations IORails can serve, and on `LLMRails` for the rest.
+Requesting a rail type with no configured flows returns HTTP 422.
+
+<Note>
+
+Running the server on the IORails engine is an early-release path.
+Validate it against your own configurations before depending on it in production.
+
+</Note>
+
 ---
 
 ## Related Resources
 
 - [Core Classes](/run-guardrailed-inference/using-python-apis/core-classes) - `LLMRails` and `RailsConfig` class reference
 - [Generation Options](/run-guardrailed-inference/using-python-apis/generation-options) - Fine-grained control over generation with the `options` parameter
+- [Engine Feature Support](/reference/engine-feature-support) - What the `LLMRails` and `IORails` engines each support

--- a/docs/run-rails/using-python-apis/core-classes.mdx
+++ b/docs/run-rails/using-python-apis/core-classes.mdx
@@ -351,7 +351,9 @@ result = await rails.check_async(
 )
 ```
 
-For detailed usage, method signatures, and examples, refer to [Check Messages](/run-guardrailed-inference/using-python-apis/check-messages).
+The `LLMRails` and `IORails` engines both implement these methods, and the `Guardrails` facade forwards the call to the engine it selected.
+
+For detailed usage, method signatures, engine differences, and examples, refer to [Check Messages](/run-guardrailed-inference/using-python-apis/check-messages).
 
 ---
 

--- a/docs/run-rails/using-python-apis/overview.mdx
+++ b/docs/run-rails/using-python-apis/overview.mdx
@@ -85,24 +85,26 @@ def handler(event, context):
 
 ## When to Use Each API
 
-| API                                             | Use Case                                        |
-| ----------------------------------------------- | ----------------------------------------------- |
-| `generate()` / `generate_async()`               | Standard chat interactions with messages        |
-| `stream_async()`                                | Real-time token streaming                       |
-| `generate_events()` / `generate_events_async()` | Low-level event control for custom integrations |
+| API                                             | Use Case                                              |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `generate()` / `generate_async()`               | Standard chat interactions with messages              |
+| `stream_async()`                                | Real-time token streaming                             |
+| `check()` / `check_async()`                     | Validating messages against rails, without generation |
+| `generate_events()` / `generate_events_async()` | Low-level event control for custom integrations       |
 
 ## Synchronous vs Asynchronous
 
 The NeMo Guardrails library provides both synchronous and asynchronous methods:
 
-| Synchronous         | Asynchronous              | Description                        |
-| ------------------- | ------------------------- | ---------------------------------- |
-| `generate()`        | `generate_async()`        | Generate responses from messages   |
-| `generate_events()` | `generate_events_async()` | Generate events from event history |
-| -                   | `stream_async()`          | Stream tokens asynchronously       |
+| Synchronous         | Asynchronous              | Description                               |
+| ------------------- | ------------------------- | ----------------------------------------- |
+| `generate()`        | `generate_async()`        | Generate responses from messages          |
+| `check()`           | `check_async()`           | Run rails on messages, without generation |
+| `generate_events()` | `generate_events_async()` | Generate events from event history        |
+| -                   | `stream_async()`          | Stream tokens asynchronously              |
 
 <Note>
 
-Use asynchronous methods (`generate_async`, `stream_async`) in async contexts for better performance. The synchronous `generate()` method cannot be called from within an async context.
+Use asynchronous methods (`generate_async`, `stream_async`, `check_async`) in async contexts for better performance. The synchronous `generate()` and `check()` methods cannot be called from within an async context.
 
 </Note>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -132,13 +132,13 @@ Test with `ConsoleMetricExporter` first to confirm IORails engine emission, then
 ### `LLMRails` Produces No Metrics
 
 Metrics are emitted only by the IORails engine.
-Enable it either by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` (which redirects `LLMRails(config)` to the IORails engine) or by constructing `Guardrails(config, use_iorails=True)` directly, and use `generate_async` or `stream_async`.
+Enable it either by setting `NEMO_GUARDRAILS_IORAILS_ENGINE=1` (which redirects `LLMRails(config)` to the IORails engine) or by constructing `Guardrails(config, use_iorails=True)` directly, and use `generate_async`, `stream_async`, or `check_async`.
 Pass `require_iorails=True` to make the constructor raise (instead of silently falling back to LLMRails and emitting no metrics) when the config is incompatible with IORails.
 
-### Synchronous `generate()` Produces No Metrics
+### Synchronous `generate()` or `check()` Produces No Metrics
 
-Telemetry is disabled for the ephemeral engine constructed by the synchronous `generate()` shim.
-Use `generate_async` or `stream_async` for production paths.
+Telemetry is disabled for the ephemeral engine constructed by the synchronous `generate()` and `check()` shims.
+Use `generate_async`, `stream_async`, or `check_async` for production paths.
 
 ### `gen_ai.client.token.usage` Is Missing for Streaming Requests
 


### PR DESCRIPTION
## Description

In PR #2059 IORails added support for checking user-query and/or LLM response using `check_async()`. This applies only to messages, not tool-calls or results. This PR adds docs that covers how this operates, and any differences with LLMRails.

## Related Issue(s)

* #2059 

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Fern docs checking

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 368 pages at /Users/tgasser/projects/nemo_guardrails_worktree/docs/iorails-message-checks/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries

node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
node scripts/run-fern-with-ref-sdk.mjs check
Found 0 errors and 4 warnings in 0.000 seconds. Run fern check --warnings to print out the warnings not shown.
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for synchronous and asynchronous message checks across supported engines.
  * Clarified engine behavior, validation differences, server routing, and async-context requirements.
  * Added observability details for metrics, tracing spans, captured content, and rail-only checks.
  * Clarified that synchronous generation and checks do not emit production metrics.
  * Added troubleshooting guidance for using asynchronous APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->