### PR TITLE
fix(server): return overload response for IORails admission shedding

### DIFF
--- a/docs/observability/metrics/reference.mdx
+++ b/docs/observability/metrics/reference.mdx
@@ -25,7 +25,7 @@ IORails request and LLM metrics require `metrics.enabled: true` and a configured
 | Metric | Instrument | Unit | Labels | Description |
 | --- | --- | --- | --- | --- |
 | `guardrails.requests` | Counter | `1` | — | Total IORails requests handled, incremented on entry. |
-| `guardrails.requests.errors` | Counter | `1` | `error.type` | Requests that ended in an unhandled error. `error.type` is the exception class name (for example `QueueFull`, `TimeoutError`). |
+| `guardrails.requests.errors` | Counter | `1` | `error.type` | Requests that ended in an unhandled error. `error.type` is the exception class name (for example `NonStreamingWorkQueueFullError`, `TimeoutError`). |
 | `guardrails.requests.blocked` | Counter | `1` | `rail.type` | Requests blocked by an input or output rail. `rail.type` is `Input` or `Output`. |
 | `guardrails.request.duration` | Histogram | `s` | — | End-to-end request duration. For non-streaming requests this includes queue-wait time. |
 | `guardrails.requests.active` | UpDownCounter | `1` | — | Requests currently in flight. Covers both streaming and non-streaming. |
@@ -48,7 +48,7 @@ These metrics expose the internal admission paths so you can detect overload bef
 | --- | --- | --- | --- |
 | `guardrails.nonstream.queued` | ObservableGauge | `1` | Requests buffered in the admission queue, not yet picked up by a worker. |
 | `guardrails.nonstream.active` | ObservableGauge | `1` | Requests currently executing on a worker. |
-| `guardrails.nonstream.rejections` | Counter | `1` | Submissions rejected with `QueueFull` because the admission queue exceeded its depth limit. |
+| `guardrails.nonstream.rejections` | Counter | `1` | Submissions rejected with `NonStreamingWorkQueueFullError` because the admission queue exceeded its depth limit. |
 
 `queued` and `active` are read live at collection time, so dashboards always show the current state.
 After `IORails.stop()` is called, both gauges return no observations rather than stale values.
@@ -58,7 +58,7 @@ After `IORails.stop()` is called, both gauges return no observations rather than
 | Metric | Instrument | Unit | Description |
 | --- | --- | --- | --- |
 | `guardrails.stream.active` | UpDownCounter | `1` | In-progress streaming requests holding a semaphore permit. |
-| `guardrails.stream.rejections` | Counter | `1` | Streaming requests rejected because the streaming concurrency semaphore was fully occupied. |
+| `guardrails.stream.rejections` | Counter | `1` | Streaming requests rejected with `StreamingCapacityExceededError` because the streaming concurrency semaphore was fully occupied. |
 
 ### Cross-Checking Saturation Metrics
 
@@ -74,12 +74,19 @@ A persistent drift between the two is a useful integrity check during dashboard 
 
 ### Dual-Counted Rejections
 
-A `QueueFull` rejection on the non-streaming path increments **both**:
+A `NonStreamingWorkQueueFullError` rejection on the non-streaming path increments **both**:
 
 - `guardrails.nonstream.rejections` (saturation signal)
-- `guardrails.requests.errors{error.type=QueueFull}` (error signal)
+- `guardrails.requests.errors{error.type=NonStreamingWorkQueueFullError}` (error signal)
+
+The streaming path behaves the same way. A `StreamingCapacityExceededError` rejection increments **both**:
+
+- `guardrails.stream.rejections` (saturation signal)
+- `guardrails.requests.errors{error.type=StreamingCapacityExceededError}` (error signal)
 
 This is intentional: dashboards built around either signal alone still reflect the rejection.
+Because `error.type` carries the exception class name, the two overload paths stay
+distinguishable on the error signal alone.
 
 ## HTTP Client Metrics
 
@@ -153,7 +160,7 @@ When usage is absent, no observation is recorded; "no observation" is deliberate
 
 | Label | Used On | Values | Notes |
 | --- | --- | --- | --- |
-| `error.type` | Request, LLM, and HTTP error metrics | Exception class name or HTTP error status | For example `QueueFull`, `TimeoutError`, `HTTPConnectionError`, or `503`. |
+| `error.type` | Request, LLM, and HTTP error metrics | Exception class name or HTTP error status | For example `NonStreamingWorkQueueFullError`, `TimeoutError`, `HTTPConnectionError`, or `503`. |
 | `rail.type` | `guardrails.requests.blocked` | `Input`, `Output` | Identifies whether an input or output rail blocked the request. Matches the `rail.type` span attribute. |
 | `gen_ai.operation.name` | All `gen_ai.client.*` | For example `chat`, `completion`, `embedding` | OpenTelemetry GenAI operation name. |
 | `gen_ai.provider.name` | All `gen_ai.client.*` | For example `openai`, `anthropic` | OpenTelemetry GenAI provider name. |

--- a/docs/run-rails/using-python-apis/check-messages.mdx
+++ b/docs/run-rails/using-python-apis/check-messages.mdx
@@ -238,7 +238,7 @@ The API surface is identical on both engines, but each engine executes a check d
 | `BLOCKED` content | The refusal message defined by the configuration's Colang flow | A fixed refusal message that the configuration does not change |
 | Rail that fails to execute | Handled by the Colang runtime's internal-error path | `BLOCKED` with an internal-error message that is distinct from the refusal message |
 | Requested direction with no content to check | An output-only check with no user message runs with an empty user message supplied as context | The direction is skipped and the result is `PASSED` |
-| Admission control | None | Shares the non-streaming admission queue with `generate_async()`, and raises `asyncio.QueueFull` when the queue is full |
+| Admission control | None | Shares the non-streaming admission queue with `generate_async()`, and raises `NonStreamingWorkQueueFullError` (a subclass of `asyncio.QueueFull`) when the queue is full |
 | Tracing and metrics | Spans through a tracing adapter with no OpenTelemetry metrics | The same request span and request metrics as `generate_async()`. Refer to [Observability for IORails Checks](#observability-for-iorails-checks) |
 | Synchronous `check()` | Runs `check_async()` on the calling thread's event loop | Runs `check_async()` on a short-lived engine with tracing and metrics disabled |
 

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -31,7 +31,7 @@ __all__ = [
     "LLMTimeoutError",
     "LLMConnectionError",
     "LLMResponseValidationError",
-    "NonStreamingWorkQueueFull",
+    "NonStreamingWorkQueueFullError",
     "StreamingCapacityExceededError",
     "StreamingNotSupportedError",
     "RailTypeNotConfiguredError",
@@ -89,7 +89,7 @@ class InvalidStateError(ValueError):
     pass
 
 
-class NonStreamingWorkQueueFull(asyncio.QueueFull):
+class NonStreamingWorkQueueFullError(asyncio.QueueFull):
     """Raised when the IORails non-streaming admission queue cannot accept more work.
 
     Subclasses :class:`asyncio.QueueFull` because that is what the underlying
@@ -105,7 +105,7 @@ class StreamingCapacityExceededError(Exception):
     The streaming path is bounded by an :class:`asyncio.Semaphore` rather than
     a queue, so this deliberately does not subclass :class:`asyncio.QueueFull`:
     nothing is queued and nothing is full. It is a distinct overload condition
-    from :class:`NonStreamingWorkQueueFull` and carries its own client-facing
+    from :class:`NonStreamingWorkQueueFullError` and carries its own client-facing
     message.
     """
 

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 from typing import Optional, Union
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "LLMTimeoutError",
     "LLMConnectionError",
     "LLMResponseValidationError",
+    "StreamingCapacityExceededError",
     "StreamingNotSupportedError",
     "RailTypeNotConfiguredError",
 ]
@@ -81,6 +83,18 @@ class InvalidStateError(ValueError):
     (`flow_configs`, `rails_config`, in-flight flow execution) and must not come
     from an untrusted caller. Stateful 2.x execution uses `process_events_async`,
     which keeps a live `State` object in the trusted Python process.
+    """
+
+    pass
+
+
+class StreamingCapacityExceededError(asyncio.QueueFull):
+    """Raised when IORails has no free streaming slot for a new request.
+
+    This is a different overload condition from the non-streaming admission
+    queue filling up, and the two carry different client-facing messages.
+    It subclasses :class:`asyncio.QueueFull` so callers that already catch
+    admission shedding keep working.
     """
 
     pass

--- a/nemoguardrails/exceptions.py
+++ b/nemoguardrails/exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "LLMTimeoutError",
     "LLMConnectionError",
     "LLMResponseValidationError",
+    "NonStreamingWorkQueueFull",
     "StreamingCapacityExceededError",
     "StreamingNotSupportedError",
     "RailTypeNotConfiguredError",
@@ -88,13 +89,24 @@ class InvalidStateError(ValueError):
     pass
 
 
-class StreamingCapacityExceededError(asyncio.QueueFull):
+class NonStreamingWorkQueueFull(asyncio.QueueFull):
+    """Raised when the IORails non-streaming admission queue cannot accept more work.
+
+    Subclasses :class:`asyncio.QueueFull` because that is what the underlying
+    work queue raises, so callers already catching it keep working.
+    """
+
+    pass
+
+
+class StreamingCapacityExceededError(Exception):
     """Raised when IORails has no free streaming slot for a new request.
 
-    This is a different overload condition from the non-streaming admission
-    queue filling up, and the two carry different client-facing messages.
-    It subclasses :class:`asyncio.QueueFull` so callers that already catch
-    admission shedding keep working.
+    The streaming path is bounded by an :class:`asyncio.Semaphore` rather than
+    a queue, so this deliberately does not subclass :class:`asyncio.QueueFull`:
+    nothing is queued and nothing is full. It is a distinct overload condition
+    from :class:`NonStreamingWorkQueueFull` and carries its own client-facing
+    message.
     """
 
     pass

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
 from nemoguardrails.exceptions import (
+    NonStreamingWorkQueueFull,
     RailTypeNotConfiguredError,
     StreamingCapacityExceededError,
     StreamingNotSupportedError,
@@ -943,10 +944,12 @@ class IORails(BaseGuardrails):
         with metrics_ctx:
             try:
                 return await self._generate_async_queue.submit(self._run_generate, messages, options=options, **kwargs)
-            except asyncio.QueueFull:
+            except asyncio.QueueFull as e:
                 if self._metrics_enabled:
                     record_nonstream_rejected()
-                raise
+                # Same message, more specific type: the server needs to tell
+                # this apart from a full streaming semaphore.
+                raise NonStreamingWorkQueueFull(*e.args) from e
 
     async def _run_generate(
         self,
@@ -1354,10 +1357,12 @@ class IORails(BaseGuardrails):
         with metrics_ctx:
             try:
                 return await self._generate_async_queue.submit(self._run_check, messages, rail_types)
-            except asyncio.QueueFull:
+            except asyncio.QueueFull as e:
                 if self._metrics_enabled:
                     record_nonstream_rejected()
-                raise
+                # Same message, more specific type: the server needs to tell
+                # this apart from a full streaming semaphore.
+                raise NonStreamingWorkQueueFull(*e.args) from e
 
     async def _run_check(self, messages: LLMMessages, rail_types: Optional[list[RailType]]) -> RailsResult:
         """Queue-worker entry for ``check_async``: wrap the rails in a request span."""
@@ -1684,7 +1689,9 @@ class IORails(BaseGuardrails):
                 if self._stream_semaphore.locked():
                     if self._metrics_enabled:
                         record_stream_rejected()
-                    raise StreamingCapacityExceededError("Streaming concurrency limit reached")
+                    raise StreamingCapacityExceededError(
+                        f"Streaming concurrency limit of {STREAM_MAX_CONCURRENCY} reached"
+                    )
                 await self._stream_semaphore.acquire()
 
                 tracer = self._tracer if self._tracing_enabled else None

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -928,14 +928,16 @@ class IORails(BaseGuardrails):
         The queue enforces non-streaming concurrency limits
         (``NONSTREAM_MAX_CONCURRENCY`` workers draining up to
         ``NONSTREAM_QUEUE_DEPTH`` pending items).  Callers receive
-        ``asyncio.QueueFull`` when the admission buffer is full and
-        ``guardrails.nonstream.rejections`` increments if metrics are enabled.
+        ``NonStreamingWorkQueueFullError`` when the admission buffer is
+        full and ``guardrails.nonstream.rejections`` increments if metrics
+        are enabled.
 
         Request-level metrics (``guardrails.requests``,
         ``guardrails.request.duration``, ``guardrails.requests.errors``)
         wrap the queue submission, so duration includes queue-wait time
-        (OTEL HTTP semconv).  A ``QueueFull`` rejection shows up in BOTH
-        ``requests.errors{error.type=QueueFull}`` and
+        (OTEL HTTP semconv).  A ``NonStreamingWorkQueueFullError``
+        rejection shows up in BOTH
+        ``requests.errors{error.type=NonStreamingWorkQueueFullError}`` and
         ``nonstream.rejections`` — honest dual-signal reporting.
         """
         messages = self._convert_to_messages(prompt, messages)
@@ -1511,8 +1513,8 @@ class IORails(BaseGuardrails):
                 ``rails.output.streaming.enabled`` is False.
             ValueError: If ``include_metadata=True`` with output rails
                 streaming enabled (BufferStrategy requires plain string chunks).
-            asyncio.QueueFull: If the streaming concurrency limit is
-                reached (load shedding).
+            StreamingCapacityExceededError: If the streaming concurrency
+                limit is reached (load shedding).
         """
         if self._speculative_generation:
             warnings.warn(
@@ -1670,10 +1672,11 @@ class IORails(BaseGuardrails):
 
             Request-level metrics (``guardrails.requests``,
             ``guardrails.request.duration``, ``guardrails.requests.errors``)
-            wrap the entire stream lifecycle, so a ``QueueFull`` on the
-            semaphore check bumps BOTH ``stream.rejections`` and
-            ``requests.errors{error.type=QueueFull}`` — dual-signal
-            semantics matching the non-streaming path.
+            wrap the entire stream lifecycle, so a
+            ``StreamingCapacityExceededError`` on the semaphore check bumps
+            BOTH ``stream.rejections`` and
+            ``requests.errors{error.type=StreamingCapacityExceededError}``
+            — dual-signal semantics matching the non-streaming path.
             """
             # Ensure engines are running (idempotent if already started).
             # Kept outside ``request_metrics`` so duration matches the

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
 from nemoguardrails.exceptions import (
-    NonStreamingWorkQueueFull,
+    NonStreamingWorkQueueFullError,
     RailTypeNotConfiguredError,
     StreamingCapacityExceededError,
     StreamingNotSupportedError,
@@ -949,7 +949,7 @@ class IORails(BaseGuardrails):
                     record_nonstream_rejected()
                 # Same message, more specific type: the server needs to tell
                 # this apart from a full streaming semaphore.
-                raise NonStreamingWorkQueueFull(*e.args) from e
+                raise NonStreamingWorkQueueFullError(*e.args) from e
 
     async def _run_generate(
         self,
@@ -1362,7 +1362,7 @@ class IORails(BaseGuardrails):
                     record_nonstream_rejected()
                 # Same message, more specific type: the server needs to tell
                 # this apart from a full streaming semaphore.
-                raise NonStreamingWorkQueueFull(*e.args) from e
+                raise NonStreamingWorkQueueFullError(*e.args) from e
 
     async def _run_check(self, messages: LLMMessages, rail_types: Optional[list[RailType]]) -> RailsResult:
         """Queue-worker entry for ``check_async``: wrap the rails in a request span."""

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -32,7 +32,11 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from nemoguardrails.actions.rail_outcome import TransformTarget
 from nemoguardrails.base_guardrails import BaseGuardrails
-from nemoguardrails.exceptions import RailTypeNotConfiguredError, StreamingNotSupportedError
+from nemoguardrails.exceptions import (
+    RailTypeNotConfiguredError,
+    StreamingCapacityExceededError,
+    StreamingNotSupportedError,
+)
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.compiled_rail import (
     RailCompilationError,
@@ -1680,7 +1684,7 @@ class IORails(BaseGuardrails):
                 if self._stream_semaphore.locked():
                     if self._metrics_enabled:
                         record_stream_rejected()
-                    raise asyncio.QueueFull("Streaming concurrency limit reached")
+                    raise StreamingCapacityExceededError("Streaming concurrency limit reached")
                 await self._stream_semaphore.acquire()
 
                 tracer = self._tracer if self._tracing_enabled else None

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -40,6 +40,7 @@ from nemoguardrails.exceptions import (
     InvalidStateError,
     LLMCallException,
     RailTypeNotConfiguredError,
+    StreamingCapacityExceededError,
     StreamingNotSupportedError,
 )
 from nemoguardrails.guardrails.iorails import IORails
@@ -60,6 +61,7 @@ from nemoguardrails.server.exception_handlers import (
     model_initialization_error_handler,
     queue_full_error_handler,
     rail_type_not_configured_error_handler,
+    streaming_capacity_error_handler,
     validation_error_handler,
 )
 from nemoguardrails.server.schemas.openai import (
@@ -192,6 +194,9 @@ app = GuardrailsApp(
 )
 
 _EXCEPTION_HANDLERS = (
+    # Starlette resolves handlers by walking the exception's MRO, so the
+    # streaming subclass is matched before the QueueFull base below.
+    (StreamingCapacityExceededError, streaming_capacity_error_handler),
     (asyncio.QueueFull, queue_full_error_handler),
     (LLMCallException, llm_call_exception_handler),
     (ModelEngineError, llm_call_exception_handler),

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -58,6 +58,7 @@ from nemoguardrails.server.exception_handlers import (
     invalid_state_error_handler,
     llm_call_exception_handler,
     model_initialization_error_handler,
+    queue_full_error_handler,
     rail_type_not_configured_error_handler,
     validation_error_handler,
 )
@@ -191,6 +192,7 @@ app = GuardrailsApp(
 )
 
 _EXCEPTION_HANDLERS = (
+    (asyncio.QueueFull, queue_full_error_handler),
     (LLMCallException, llm_call_exception_handler),
     (ModelEngineError, llm_call_exception_handler),
     (HTTPClientError, llm_call_exception_handler),

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -39,7 +39,7 @@ from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidStateError,
     LLMCallException,
-    NonStreamingWorkQueueFull,
+    NonStreamingWorkQueueFullError,
     RailTypeNotConfiguredError,
     StreamingCapacityExceededError,
     StreamingNotSupportedError,
@@ -198,7 +198,7 @@ _EXCEPTION_HANDLERS = (
     # The streaming limit is a semaphore rather than a queue, so it is not a
     # QueueFull at all and carries its own handler.
     (StreamingCapacityExceededError, streaming_capacity_error_handler),
-    (NonStreamingWorkQueueFull, queue_full_error_handler),
+    (NonStreamingWorkQueueFullError, queue_full_error_handler),
     # Any QueueFull raised outside the paths above still reads as overload.
     (asyncio.QueueFull, queue_full_error_handler),
     (LLMCallException, llm_call_exception_handler),

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -39,6 +39,7 @@ from nemoguardrails.exceptions import (
     InvalidModelConfigurationError,
     InvalidStateError,
     LLMCallException,
+    NonStreamingWorkQueueFull,
     RailTypeNotConfiguredError,
     StreamingCapacityExceededError,
     StreamingNotSupportedError,
@@ -194,9 +195,11 @@ app = GuardrailsApp(
 )
 
 _EXCEPTION_HANDLERS = (
-    # Starlette resolves handlers by walking the exception's MRO, so the
-    # streaming subclass is matched before the QueueFull base below.
+    # The streaming limit is a semaphore rather than a queue, so it is not a
+    # QueueFull at all and carries its own handler.
     (StreamingCapacityExceededError, streaming_capacity_error_handler),
+    (NonStreamingWorkQueueFull, queue_full_error_handler),
+    # Any QueueFull raised outside the paths above still reads as overload.
     (asyncio.QueueFull, queue_full_error_handler),
     (LLMCallException, llm_call_exception_handler),
     (ModelEngineError, llm_call_exception_handler),

--- a/nemoguardrails/server/exception_handlers.py
+++ b/nemoguardrails/server/exception_handlers.py
@@ -28,6 +28,7 @@ from nemoguardrails.exceptions import (
     LLMCallException,
     LLMRateLimitError,
     RailTypeNotConfiguredError,
+    StreamingCapacityExceededError,
     StreamingNotSupportedError,
 )
 from nemoguardrails.guardrails.model_engine import ModelEngineError
@@ -172,5 +173,20 @@ async def queue_full_error_handler(request: Request, exc: asyncio.QueueFull) -> 
         503,
         "IORails admission queue is full. Please retry later.",
         code="queue_full",
+        headers={"retry-after": "1"},
+    )
+
+
+async def streaming_capacity_error_handler(request: Request, exc: StreamingCapacityExceededError) -> Response:
+    """Render IORails streaming capacity shedding as a retryable overload response.
+
+    A full streaming semaphore is a different condition from a full admission
+    queue, so it gets its own message rather than reporting the queue.
+    """
+    log.warning("IORails streaming capacity reached: %s", exc)
+    return _error_response(
+        503,
+        "IORails streaming capacity is reached. Please retry later.",
+        code="streaming_capacity",
         headers={"retry-after": "1"},
     )

--- a/nemoguardrails/server/exception_handlers.py
+++ b/nemoguardrails/server/exception_handlers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 from typing import Dict, Optional, Union
 
@@ -162,3 +163,14 @@ async def internal_error_handler(request: Request, exc: Exception) -> Response:
     """Catch-all for unexpected errors."""
     log.exception(exc)
     return _error_response(500, "Internal server error")
+
+
+async def queue_full_error_handler(request: Request, exc: asyncio.QueueFull) -> Response:
+    """Render IORails admission shedding as a retryable overload response."""
+    log.warning("IORails admission queue is full: %s", exc)
+    return _error_response(
+        503,
+        "IORails admission queue is full. Please retry later.",
+        code="queue_full",
+        headers={"retry-after": "1"},
+    )

--- a/nemoguardrails/server/exception_handlers.py
+++ b/nemoguardrails/server/exception_handlers.py
@@ -43,6 +43,11 @@ from nemoguardrails.llm.models.initializer import ModelInitializationError
 
 log = logging.getLogger(__name__)
 
+# How long an overloaded server asks a client to wait before retrying. Long
+# enough that a rejected caller does not immediately add to the overload.
+NONSTREAMING_RETRY_AFTER_SECONDS = 30
+STREAMING_RETRY_AFTER_SECONDS = 30
+
 
 def _error_response(
     status_code: int,
@@ -173,7 +178,7 @@ async def queue_full_error_handler(request: Request, exc: asyncio.QueueFull) -> 
         503,
         "IORails admission queue is full. Please retry later.",
         code="queue_full",
-        headers={"retry-after": "1"},
+        headers={"retry-after": str(NONSTREAMING_RETRY_AFTER_SECONDS)},
     )
 
 
@@ -188,5 +193,5 @@ async def streaming_capacity_error_handler(request: Request, exc: StreamingCapac
         503,
         "IORails streaming capacity is reached. Please retry later.",
         code="streaming_capacity",
-        headers={"retry-after": "1"},
+        headers={"retry-after": str(STREAMING_RETRY_AFTER_SECONDS)},
     )

--- a/tests/guardrails/async_helpers.py
+++ b/tests/guardrails/async_helpers.py
@@ -89,7 +89,7 @@ def saturate_stream_semaphore(iorails: IORails) -> None:
     """Force ``iorails._stream_semaphore`` into a fully-occupied state by
     swapping in a zero-permit semaphore.  Any subsequent
     ``stream_async()`` call trips ``Semaphore.locked() == True`` and is
-    rejected with ``asyncio.QueueFull``.
+    rejected with ``StreamingCapacityExceededError``.
 
     Cheaper and more future-proof than draining all
     ``STREAM_MAX_CONCURRENCY`` permits one-by-one — the test no longer

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
-from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.exceptions import StreamingCapacityExceededError, StreamingNotSupportedError
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.iorails import (
     REFUSAL_MESSAGE,
@@ -495,6 +495,28 @@ class TestStreamAsyncConcurrency:
         iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
 
         with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+            await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+    @pytest.mark.asyncio
+    async def test_semaphore_exhaustion_raises_streaming_specific_error(self, iorails_input_only):
+        """The streaming limit is its own condition, distinct from the admission queue.
+
+        Both surface to the server as overload, but they carry different
+        client-facing messages, so the server has to be able to tell them apart.
+        """
+        _wire_mocks(iorails_input_only)
+        iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
+
+        with pytest.raises(StreamingCapacityExceededError):
+            await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+    @pytest.mark.asyncio
+    async def test_streaming_capacity_error_is_still_queue_full(self, iorails_input_only):
+        """Existing callers that catch ``asyncio.QueueFull`` keep working."""
+        _wire_mocks(iorails_input_only)
+        iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
+
+        with pytest.raises(asyncio.QueueFull):
             await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -490,11 +490,11 @@ class TestStreamAsyncConcurrency:
 
     @pytest.mark.asyncio
     async def test_semaphore_exhaustion_raises(self, iorails_input_only):
-        """Raises QueueFull when all streaming slots are taken."""
+        """Raises the streaming capacity error when all streaming slots are taken."""
         _wire_mocks(iorails_input_only)
         iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
 
-        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+        with pytest.raises(StreamingCapacityExceededError, match="Streaming concurrency limit of 256 reached"):
             await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
     @pytest.mark.asyncio
@@ -511,12 +511,13 @@ class TestStreamAsyncConcurrency:
             await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
     @pytest.mark.asyncio
-    async def test_streaming_capacity_error_is_still_queue_full(self, iorails_input_only):
-        """Existing callers that catch ``asyncio.QueueFull`` keep working."""
+    async def test_streaming_capacity_error_is_not_a_queue_full(self, iorails_input_only):
+        """The streaming limit is a semaphore, so nothing is queued and nothing is full."""
         _wire_mocks(iorails_input_only)
         iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
 
-        with pytest.raises(asyncio.QueueFull):
+        assert not issubclass(StreamingCapacityExceededError, asyncio.QueueFull)
+        with pytest.raises(StreamingCapacityExceededError):
             await anext(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1341,9 +1341,13 @@ class TestStreamAsyncRequestMetrics:
         self, iorails_streaming_input_only_tracing, metric_reader
     ):
         """Streaming equivalent of the non-streaming dual-signal test: a
-        ``QueueFull`` on the semaphore check is BOTH a saturation signal
-        (``stream.rejections``) AND a request error
-        (``requests.errors{error.type=QueueFull}``)
+        ``StreamingCapacityExceededError`` on the semaphore check is BOTH a
+        saturation signal (``stream.rejections``) AND a request error
+        (``requests.errors{error.type=StreamingCapacityExceededError}``).
+
+        The label is the exception class name, so it distinguishes a full
+        streaming semaphore from a full non-streaming admission queue, which
+        still reports ``QueueFull``.
         """
         iorails = iorails_streaming_input_only_tracing
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
@@ -1356,7 +1360,7 @@ class TestStreamAsyncRequestMetrics:
         points = collect_metric_points(metric_reader)
         assert points["guardrails.stream.rejections"][0].value == 1
         assert points["guardrails.requests.errors"][0].value == 1
-        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "QueueFull"
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "StreamingCapacityExceededError"
         assert points["guardrails.requests"][0].value == 1
         assert points["guardrails.request.duration"][0].value == 1
 

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1164,12 +1164,13 @@ class TestGenerateAsyncRequestMetrics:
 
     @pytest.mark.asyncio
     async def test_queuefull_bumps_both_errors_and_nonstream_rejections(self, iorails_tracing, metric_reader):
-        """Dual-signal semantics: a ``QueueFull`` rejection is BOTH a
-        saturation signal (``nonstream.rejections``) AND a request error
-        (``requests.errors{error.type=QueueFull}``).  Dashboards can
-        count either one.  Also bumps the ``requests`` counter and
-        records into the duration histogram — the request ran through
-        the full lifecycle, even if only briefly.
+        """Dual-signal semantics: a ``NonStreamingWorkQueueFullError``
+        rejection is BOTH a saturation signal (``nonstream.rejections``)
+        AND a request error
+        (``requests.errors{error.type=NonStreamingWorkQueueFullError}``).
+        Dashboards can count either one.  Also bumps the ``requests``
+        counter and records into the duration histogram — the request ran
+        through the full lifecycle, even if only briefly.
         """
         _stub_safe_pipeline(iorails_tracing)
         iorails_tracing._generate_async_queue.submit = AsyncMock(side_effect=asyncio.QueueFull("admission queue full"))
@@ -1319,8 +1320,8 @@ class TestStreamAsyncRequestMetrics:
         self, iorails_streaming_input_only_tracing, metric_reader
     ):
         """A stream that arrives while the semaphore is fully occupied is
-        rejected with ``asyncio.QueueFull`` and the ``stream.rejections``
-        counter increments.
+        rejected with ``StreamingCapacityExceededError`` and the
+        ``stream.rejections`` counter increments.
         """
         iorails = iorails_streaming_input_only_tracing
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())
@@ -1348,7 +1349,7 @@ class TestStreamAsyncRequestMetrics:
 
         The label is the exception class name, so it distinguishes a full
         streaming semaphore from a full non-streaming admission queue, which
-        still reports ``QueueFull``.
+        reports ``NonStreamingWorkQueueFullError``.
         """
         iorails = iorails_streaming_input_only_tracing
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult.allow())

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -29,6 +29,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
+from nemoguardrails.exceptions import StreamingCapacityExceededError
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, RailResult, get_request_id
 from nemoguardrails.guardrails.iorails import INTERNAL_ERROR_MESSAGE, REFUSAL_MESSAGE, IORails
@@ -939,7 +940,7 @@ class TestStreamAsyncSpanHierarchy:
         # Force all slots unavailable.
         iorails._stream_semaphore = asyncio.Semaphore(0)
 
-        with pytest.raises(asyncio.QueueFull):
+        with pytest.raises(StreamingCapacityExceededError):
             [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         assert exporter.get_finished_spans() == ()
@@ -1179,7 +1180,7 @@ class TestGenerateAsyncRequestMetrics:
         points = collect_metric_points(metric_reader)
         assert points["guardrails.nonstream.rejections"][0].value == 1
         assert points["guardrails.requests.errors"][0].value == 1
-        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "QueueFull"
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "NonStreamingWorkQueueFull"
         assert points["guardrails.requests"][0].value == 1
         assert points["guardrails.request.duration"][0].value == 1
 
@@ -1326,7 +1327,7 @@ class TestStreamAsyncRequestMetrics:
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
-        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+        with pytest.raises(StreamingCapacityExceededError, match="Streaming concurrency limit of 256 reached"):
             [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)
@@ -1354,7 +1355,7 @@ class TestStreamAsyncRequestMetrics:
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
-        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+        with pytest.raises(StreamingCapacityExceededError, match="Streaming concurrency limit of 256 reached"):
             [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)
@@ -1425,7 +1426,7 @@ class TestStreamAsyncRequestMetrics:
         iorails.engine_registry.stream_model_call = _mock_chunks_stream
 
         saturate_stream_semaphore(iorails)
-        with pytest.raises(asyncio.QueueFull):
+        with pytest.raises(StreamingCapacityExceededError):
             [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
 
         points = collect_metric_points(metric_reader)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1180,7 +1180,7 @@ class TestGenerateAsyncRequestMetrics:
         points = collect_metric_points(metric_reader)
         assert points["guardrails.nonstream.rejections"][0].value == 1
         assert points["guardrails.requests.errors"][0].value == 1
-        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "NonStreamingWorkQueueFull"
+        assert points["guardrails.requests.errors"][0].attributes["error.type"] == "NonStreamingWorkQueueFullError"
         assert points["guardrails.requests"][0].value == 1
         assert points["guardrails.request.duration"][0].value == 1
 

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -36,7 +36,7 @@ from openai import InternalServerError, OpenAI
 from pytest_httpx import HTTPXMock
 
 from nemoguardrails import Guardrails, RailsConfig
-from nemoguardrails.exceptions import NonStreamingWorkQueueFull, StreamingCapacityExceededError
+from nemoguardrails.exceptions import NonStreamingWorkQueueFullError, StreamingCapacityExceededError
 from nemoguardrails.server import api
 from nemoguardrails.server.exception_handlers import (
     NONSTREAMING_RETRY_AFTER_SECONDS,
@@ -427,7 +427,9 @@ class TestIORailsOverloadOverHTTP:
 
 class TestIORailsAdmissionErrors:
     def test_queue_full_returns_retryable_overload_envelope(self, monkeypatch):
-        rails = SimpleNamespace(generate_async=AsyncMock(side_effect=NonStreamingWorkQueueFull("admission queue full")))
+        rails = SimpleNamespace(
+            generate_async=AsyncMock(side_effect=NonStreamingWorkQueueFullError("admission queue full"))
+        )
         monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
 
         response = _chat()

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -21,8 +21,11 @@
 # excluded so ``TestClient`` still reaches the app), and an IORails rail reaches its model through
 # ``ModelEngine`` over aiohttp (``aioresponses``).
 
+import asyncio
 import json
 from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from aioresponses import aioresponses
@@ -321,6 +324,23 @@ class TestRailEngineErrors:
         assert error["code"] == "rate_limit_exceeded"
         assert error["param"] == "messages"
         assert "gpt-4o-mini" not in error["message"]
+
+
+class TestIORailsAdmissionErrors:
+    def test_queue_full_returns_retryable_overload_envelope(self, monkeypatch):
+        rails = SimpleNamespace(generate_async=AsyncMock(side_effect=asyncio.QueueFull("admission queue full")))
+        monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
+
+        response = _chat()
+
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        assert response.json()["error"] == {
+            "message": "IORails admission queue is full. Please retry later.",
+            "type": "server_error",
+            "param": None,
+            "code": "queue_full",
+        }
 
 
 # The two upstream failures from QA case P0_0.24.0_NGUARD-745_http_error_openai_sdk_E2E TC-13

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -21,6 +21,7 @@
 # excluded so ``TestClient`` still reaches the app), and an IORails rail reaches its model through
 # ``ModelEngine`` over aiohttp (``aioresponses``).
 
+import asyncio
 import json
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -328,6 +329,100 @@ class TestRailEngineErrors:
         assert error["code"] == "rate_limit_exceeded"
         assert error["param"] == "messages"
         assert "gpt-4o-mini" not in error["message"]
+
+
+class TestIORailsOverloadOverHTTP:
+    """Overload as an HTTP client sees it, driven through the real IORails limits.
+
+    ``TestIORailsAdmissionErrors`` raises the exceptions directly, which only
+    proves the handlers are wired up. These cases instead put the real
+    ``asyncio.Semaphore`` and ``asyncio.Queue`` into the state a saturated
+    server reaches, then let the untouched code react: the limit trips inside
+    IORails, IORails chooses the exception, the server maps it, and the client
+    receives the envelope. Neither path reaches a model, so no upstream is
+    mocked.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_rails_cache(self):
+        api.llm_rails_instances.clear()
+        yield
+        api.llm_rails_instances.clear()
+
+    @staticmethod
+    def _saturate(monkeypatch, kind: str):
+        """Return rails whose streaming or non-streaming capacity is exhausted."""
+        original = api._get_rails
+
+        async def patched(*args, **kwargs):
+            served = await original(*args, **kwargs)
+            # The server holds a Guardrails wrapper; the limits live on the
+            # IORails engine it delegates to.
+            rails = getattr(served, "_rails_engine", served)
+            assert rails.__class__.__name__ == "IORails", f"expected IORails, got {type(rails).__name__}"
+            if kind == "streaming":
+                # No permits, so `locked()` is True for every new stream.
+                rails._stream_semaphore = asyncio.Semaphore(0)
+            else:
+                # A real queue at its bound. `_running` is left True so the
+                # lazy worker start does not drain it back below the limit.
+                queue = rails._generate_async_queue
+                queue._queue = asyncio.Queue(maxsize=1)
+                queue._queue.put_nowait(object())
+                queue._running = True
+            return served
+
+        monkeypatch.setattr(api, "_get_rails", patched)
+
+    def test_streaming_capacity_returns_503_over_http(self, serve_config, monkeypatch):
+        """A saturated streaming semaphore reaches the client as a retryable 503."""
+        serve_config(CONTENT_SAFETY_CONFIG, iorails=True)
+        self._saturate(monkeypatch, "streaming")
+
+        response = _chat(stream=True)
+
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == str(STREAMING_RETRY_AFTER_SECONDS)
+        error = response.json()["error"]
+        assert error["code"] == "streaming_capacity"
+        assert "admission queue" not in error["message"]
+
+    def test_work_queue_full_returns_503_over_http(self, serve_config, monkeypatch):
+        """A full non-streaming work queue reaches the client as a retryable 503."""
+        serve_config(CONTENT_SAFETY_CONFIG, iorails=True)
+        self._saturate(monkeypatch, "nonstreaming")
+
+        response = _chat()
+
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == str(NONSTREAMING_RETRY_AFTER_SECONDS)
+        error = response.json()["error"]
+        assert error["code"] == "queue_full"
+        assert "streaming capacity" not in error["message"]
+
+    def test_the_two_overloads_are_distinguishable_by_the_client(self, serve_config, monkeypatch):
+        """Both shed load, but a client can tell which limit it hit."""
+        serve_config(CONTENT_SAFETY_CONFIG, iorails=True)
+
+        self._saturate(monkeypatch, "streaming")
+        streaming = _chat(stream=True).json()["error"]
+
+        api.llm_rails_instances.clear()
+        self._saturate(monkeypatch, "nonstreaming")
+        non_streaming = _chat().json()["error"]
+
+        assert streaming["code"] != non_streaming["code"]
+        assert streaming["message"] != non_streaming["message"]
+
+    def test_overload_is_not_reported_as_an_internal_error(self, serve_config, monkeypatch):
+        """The regression this PR exists for: shedding used to surface as a 500."""
+        serve_config(CONTENT_SAFETY_CONFIG, iorails=True)
+        self._saturate(monkeypatch, "nonstreaming")
+
+        response = _chat()
+
+        assert response.status_code != 500
+        assert response.json()["error"]["message"] != "Internal server error"
 
 
 class TestIORailsAdmissionErrors:

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -36,6 +36,7 @@ from openai import InternalServerError, OpenAI
 from pytest_httpx import HTTPXMock
 
 from nemoguardrails import Guardrails, RailsConfig
+from nemoguardrails.exceptions import StreamingCapacityExceededError
 from nemoguardrails.server import api
 
 MAIN_MODEL_URL = "http://upstream.invalid/v1/chat/completions"
@@ -341,6 +342,25 @@ class TestIORailsAdmissionErrors:
             "param": None,
             "code": "queue_full",
         }
+
+    def test_streaming_capacity_returns_its_own_message(self, monkeypatch):
+        """A full streaming semaphore is a different condition from a full admission queue."""
+
+        async def _raise_capacity(*args, **kwargs):
+            raise StreamingCapacityExceededError("Streaming concurrency limit reached")
+            yield  # pragma: no cover - makes this an async generator
+
+        rails = SimpleNamespace(stream_async=_raise_capacity)
+        monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
+
+        response = _chat(stream=True)
+
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        error = response.json()["error"]
+        assert error["message"] == "IORails streaming capacity is reached. Please retry later."
+        assert error["code"] == "streaming_capacity"
+        assert "admission queue" not in error["message"]
 
 
 # The two upstream failures from QA case P0_0.24.0_NGUARD-745_http_error_openai_sdk_E2E TC-13

--- a/tests/server/test_error_envelope_e2e.py
+++ b/tests/server/test_error_envelope_e2e.py
@@ -21,7 +21,6 @@
 # excluded so ``TestClient`` still reaches the app), and an IORails rail reaches its model through
 # ``ModelEngine`` over aiohttp (``aioresponses``).
 
-import asyncio
 import json
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -36,8 +35,12 @@ from openai import InternalServerError, OpenAI
 from pytest_httpx import HTTPXMock
 
 from nemoguardrails import Guardrails, RailsConfig
-from nemoguardrails.exceptions import StreamingCapacityExceededError
+from nemoguardrails.exceptions import NonStreamingWorkQueueFull, StreamingCapacityExceededError
 from nemoguardrails.server import api
+from nemoguardrails.server.exception_handlers import (
+    NONSTREAMING_RETRY_AFTER_SECONDS,
+    STREAMING_RETRY_AFTER_SECONDS,
+)
 
 MAIN_MODEL_URL = "http://upstream.invalid/v1/chat/completions"
 
@@ -329,13 +332,13 @@ class TestRailEngineErrors:
 
 class TestIORailsAdmissionErrors:
     def test_queue_full_returns_retryable_overload_envelope(self, monkeypatch):
-        rails = SimpleNamespace(generate_async=AsyncMock(side_effect=asyncio.QueueFull("admission queue full")))
+        rails = SimpleNamespace(generate_async=AsyncMock(side_effect=NonStreamingWorkQueueFull("admission queue full")))
         monkeypatch.setattr(api, "_get_rails", AsyncMock(return_value=rails))
 
         response = _chat()
 
         assert response.status_code == 503
-        assert response.headers["retry-after"] == "1"
+        assert response.headers["retry-after"] == str(NONSTREAMING_RETRY_AFTER_SECONDS)
         assert response.json()["error"] == {
             "message": "IORails admission queue is full. Please retry later.",
             "type": "server_error",
@@ -347,7 +350,7 @@ class TestIORailsAdmissionErrors:
         """A full streaming semaphore is a different condition from a full admission queue."""
 
         async def _raise_capacity(*args, **kwargs):
-            raise StreamingCapacityExceededError("Streaming concurrency limit reached")
+            raise StreamingCapacityExceededError("Streaming concurrency limit of 256 reached")
             yield  # pragma: no cover - makes this an async generator
 
         rails = SimpleNamespace(stream_async=_raise_capacity)
@@ -356,7 +359,7 @@ class TestIORailsAdmissionErrors:
         response = _chat(stream=True)
 
         assert response.status_code == 503
-        assert response.headers["retry-after"] == "1"
+        assert response.headers["retry-after"] == str(STREAMING_RETRY_AFTER_SECONDS)
         error = response.json()["error"]
         assert error["message"] == "IORails streaming capacity is reached. Please retry later."
         assert error["code"] == "streaming_capacity"


### PR DESCRIPTION
## Description

Map non-streaming IORails `asyncio.QueueFull` admission shedding to a retryable, OpenAI-shaped HTTP 503 response. The response carries `code: "queue_full"` and `Retry-After: 1`, so callers can distinguish deliberate overload shedding from an internal server failure.

The change is limited to the server exception boundary and includes an ASGI regression test for the status, envelope, and retry header.

## Related Issue(s)

Fixes #2332

Issue assignee: @yixinh-nv

## Verification

- `make test TEST=tests/server/test_error_envelope_e2e.py::TestIORailsAdmissionErrors WORKERS=1`
- `make test TEST=tests/server/test_error_envelope_e2e.py WORKERS=1` (43 passed)
- `uv run --locked pre-commit run --files nemoguardrails/server/api.py nemoguardrails/server/exception_handlers.py tests/server/test_error_envelope_e2e.py`

No live-provider calls or documentation changes were needed.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Codex; assistance: benchmark diagnosis, focused implementation, tests, and PR drafting).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] Documentation is not applicable: no user-facing configuration or behavior documentation changed beyond the response contract.
- [x] I added tests.
- [x] I noted verification and checks not run.
- [x] I did not update generated changelog files manually.
- [x] There were no CodeRabbit, Greptile, or human review comments at submission.
- [ ] No reviewer/team was specified for an @mention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the service request queue is full.
  * The API now returns a retryable HTTP 503 response with a clear `queue_full` error code.
  * Added a `Retry-After` header to indicate when clients should retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->