### PR TITLE
chore: bump to 0.25.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nemoguardrails"
-version = "0.24.0"
+version = "0.25.0.dev0"
 description = "NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems."
 license = "Apache-2.0"
 license-files = ["LICENSE*", "LICENCES*"]

--- a/uv.lock
+++ b/uv.lock
@@ -2333,7 +2333,7 @@ wheels = [
 
 [[package]]
 name = "nemoguardrails"
-version = "0.24.0"
+version = "0.25.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Description

Bump the project version from 0.24.0 to 0.25.0.dev0 after the v0.24.0 release. This updates pyproject.toml and the root package metadata in uv.lock.

## Related Issue(s)

Maintainer-directed release follow-up; no linked issue.

## Verification

- uv lock --check
- uv run --locked pre-commit run --files pyproject.toml uv.lock

## AI Assistance

- [x] AI tools were used. OpenAI Codex made the two-line metadata update and ran the listed validation; maintainer review remains required.

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My PR title follows the project commit convention.
- [x] Documentation and tests are not applicable to this metadata-only version bump.
- [x] I noted the verification performed.
- [x] I did not update generated changelog files manually.