### PR TITLE
fix(generation-log): avoid TypeError when print_summary hits missing …

### DIFF
--- a/nemoguardrails/rails/llm/options.py
+++ b/nemoguardrails/rails/llm/options.py
@@ -311,65 +311,70 @@ class GenerationLog(BaseModel):
     def print_summary(self):
         print("\n# General stats\n")
 
-        # Percent accounted so far
-        pc = 0
-        duration = 0
+        if self.stats.total_duration is None:
+            print("No stats available")
+        else:
+            pc = 0
+            duration = 0
 
-        print(f"- Total time: {self.stats.total_duration:.2f}s")
-        if self.stats.input_rails_duration and self.stats.total_duration:
-            _pc = round(100 * self.stats.input_rails_duration / self.stats.total_duration, 2)
-            pc += _pc
-            duration += self.stats.input_rails_duration
+            print(f"- Total time: {self.stats.total_duration:.2f}s")
+            if self.stats.input_rails_duration:
+                _pc = round(100 * self.stats.input_rails_duration / self.stats.total_duration, 2)
+                pc += _pc
+                duration += self.stats.input_rails_duration
 
-            print(f"  - [{self.stats.input_rails_duration:.2f}s][{_pc}%]: INPUT Rails")
-        if self.stats.dialog_rails_duration and self.stats.total_duration:
-            _pc = round(100 * self.stats.dialog_rails_duration / self.stats.total_duration, 2)
-            pc += _pc
-            duration += self.stats.dialog_rails_duration
+                print(f"  - [{self.stats.input_rails_duration:.2f}s][{_pc}%]: INPUT Rails")
+            if self.stats.dialog_rails_duration:
+                _pc = round(100 * self.stats.dialog_rails_duration / self.stats.total_duration, 2)
+                pc += _pc
+                duration += self.stats.dialog_rails_duration
 
-            print(f"  - [{self.stats.dialog_rails_duration:.2f}s][{_pc}%]: DIALOG Rails")
-        if self.stats.generation_rails_duration and self.stats.total_duration:
-            _pc = round(
-                100 * self.stats.generation_rails_duration / self.stats.total_duration,
-                2,
-            )
-            pc += _pc
-            duration += self.stats.generation_rails_duration
+                print(f"  - [{self.stats.dialog_rails_duration:.2f}s][{_pc}%]: DIALOG Rails")
+            if self.stats.generation_rails_duration:
+                _pc = round(
+                    100 * self.stats.generation_rails_duration / self.stats.total_duration,
+                    2,
+                )
+                pc += _pc
+                duration += self.stats.generation_rails_duration
 
-            print(f"  - [{self.stats.generation_rails_duration:.2f}s][{_pc}%]: GENERATION Rails")
-        if self.stats.output_rails_duration and self.stats.total_duration:
-            _pc = round(100 * self.stats.output_rails_duration / self.stats.total_duration, 2)
-            pc += _pc
-            duration += self.stats.output_rails_duration
+                print(f"  - [{self.stats.generation_rails_duration:.2f}s][{_pc}%]: GENERATION Rails")
+            if self.stats.output_rails_duration:
+                _pc = round(100 * self.stats.output_rails_duration / self.stats.total_duration, 2)
+                pc += _pc
+                duration += self.stats.output_rails_duration
 
-            print(f"  - [{self.stats.output_rails_duration:.2f}s][{_pc}%]: OUTPUT Rails")
+                print(f"  - [{self.stats.output_rails_duration:.2f}s][{_pc}%]: OUTPUT Rails")
 
-        processing_overhead = (self.stats.total_duration or 0) - duration
-        if processing_overhead >= 0.01:
-            _pc = round(100 - pc, 2)
-            print(f"  - [{processing_overhead:.2f}s][{_pc}%]: Processing overhead ")
+            processing_overhead = self.stats.total_duration - duration
+            if processing_overhead >= 0.01:
+                _pc = round(100 - pc, 2)
+                print(f"  - [{processing_overhead:.2f}s][{_pc}%]: Processing overhead ")
 
-        if self.stats.llm_calls_count:
-            print(
-                f"- {self.stats.llm_calls_count} LLM calls, "
-                f"{self.stats.llm_calls_duration:.2f}s total duration, "
-                f"{self.stats.llm_calls_total_prompt_tokens} total prompt tokens, "
-                f"{self.stats.llm_calls_total_completion_tokens} total completion tokens, "
-                f"{self.stats.llm_calls_total_tokens} total tokens."
-            )
+            if self.stats.llm_calls_count:
+                dur = f"{self.stats.llm_calls_duration:.2f}s" if self.stats.llm_calls_duration is not None else "n/a"
+                print(
+                    f"- {self.stats.llm_calls_count} LLM calls, "
+                    f"{dur} total duration, "
+                    f"{self.stats.llm_calls_total_prompt_tokens} total prompt tokens, "
+                    f"{self.stats.llm_calls_total_completion_tokens} total completion tokens, "
+                    f"{self.stats.llm_calls_total_tokens} total tokens."
+                )
 
         print("\n# Detailed stats\n")
         for activated_rail in self.activated_rails:
-            action_names = ", ".join(action.action_name for action in activated_rail.executed_actions)
+            action_names = ", ".join(action.action_name for action in activated_rail.executed_actions) or "n/a"
             llm_calls_count = 0
             llm_calls_durations = []
             for action in activated_rail.executed_actions:
                 llm_calls_count += len(action.llm_calls)
                 llm_calls_durations.extend([f"{round(llm_call.duration or 0, 2)}s" for llm_call in action.llm_calls])
+            dur = f"{activated_rail.duration:.2f}s" if activated_rail.duration is not None else "n/a"
+            llm_calls_dur = ", ".join(llm_calls_durations) or "n/a"
             print(
-                f"- [{activated_rail.duration:.2f}s] {activated_rail.type.upper()} ({activated_rail.name}): "
+                f"- [{dur}] {activated_rail.type.upper()} ({activated_rail.name}): "
                 f"{len(activated_rail.executed_actions)} actions ({action_names}), "
-                f"{llm_calls_count} llm calls [{', '.join(llm_calls_durations)}]"
+                f"{llm_calls_count} llm calls [{llm_calls_dur}]"
             )
         print("\n")
 

--- a/tests/test_generation_options.py
+++ b/tests/test_generation_options.py
@@ -20,6 +20,7 @@ import pytest
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.actions.rail_outcome import RailOutcome, TransformTarget
 from nemoguardrails.rails.llm.options import (
+    ActivatedRail,
     GenerationLog,
     GenerationResponse,
     GenerationStats,
@@ -435,7 +436,7 @@ def test_only_input_output_validation():
 
 
 def test_generation_log_print_summary(capsys):
-    """Test printing rais stats with dummy data"""
+    """Test printing rails stats with dummy data"""
 
     stats = GenerationStats(
         input_rails_duration=1.0,
@@ -466,6 +467,89 @@ def test_generation_log_print_summary(capsys):
     assert (
         capture_lines[8]
         == "- 4 LLM calls, 8.00s total duration, 1000 total prompt tokens, 2000 total completion tokens, 3000 total tokens."
+    )
+
+
+def _dummy_activated_rails(durations: list[float | None]) -> list[ActivatedRail]:
+    names = [
+        ("input", "dummy input rail"),
+        ("dialog", "dummy dialog rail"),
+        ("generation", "dummy generation rail"),
+        ("output", "dummy output rail"),
+    ]
+    return [
+        ActivatedRail(type=rail_type, name=name, duration=duration)
+        for (rail_type, name), duration in zip(names, durations, strict=True)
+    ]
+
+
+def test_generation_log_print_summary_no_total_duration(capsys):
+    """Missing total_duration must not crash, and activated rails still print."""
+    generation_log = GenerationLog(
+        activated_rails=[ActivatedRail(type="tool_output", name="tool output check", duration=0.5)],
+        stats=GenerationStats(),
+    )
+
+    generation_log.print_summary()
+    lines = capsys.readouterr().out.splitlines()
+
+    assert "No stats available" in lines
+    assert "- Total time: 10.00s" not in lines
+    assert "- [0.50s] TOOL_OUTPUT (tool output check): 0 actions (n/a), 0 llm calls [n/a]" in lines
+
+
+def test_generation_log_print_summary_no_llm_calls_duration(capsys):
+    """Missing llm_calls_duration prints n/a instead of raising."""
+    stats = GenerationStats(
+        input_rails_duration=1.0,
+        dialog_rails_duration=2.0,
+        generation_rails_duration=3.0,
+        output_rails_duration=4.0,
+        total_duration=10.0,
+        llm_calls_duration=None,
+        llm_calls_count=4,
+        llm_calls_total_prompt_tokens=1000,
+        llm_calls_total_completion_tokens=2000,
+        llm_calls_total_tokens=3000,
+    )
+
+    GenerationLog(activated_rails=[], stats=stats).print_summary()
+    lines = capsys.readouterr().out.splitlines()
+
+    assert (
+        "- 4 LLM calls, n/a total duration, 1000 total prompt tokens, 2000 total completion tokens, 3000 total tokens."
+        in lines
+    )
+
+
+def test_generation_log_print_summary_no_activated_rail_duration(capsys):
+    """Missing activated_rail.duration prints n/a instead of raising."""
+    stats = GenerationStats(
+        input_rails_duration=1.0,
+        dialog_rails_duration=2.0,
+        generation_rails_duration=3.0,
+        output_rails_duration=4.0,
+        total_duration=10.0,
+        llm_calls_duration=8.0,
+        llm_calls_count=4,
+        llm_calls_total_prompt_tokens=1000,
+        llm_calls_total_completion_tokens=2000,
+        llm_calls_total_tokens=3000,
+    )
+
+    GenerationLog(
+        activated_rails=_dummy_activated_rails([None, None, None, None]),
+        stats=stats,
+    ).print_summary()
+    lines = capsys.readouterr().out.splitlines()
+
+    assert "- [n/a] INPUT (dummy input rail): 0 actions (n/a), 0 llm calls [n/a]" in lines
+    assert "- [n/a] DIALOG (dummy dialog rail): 0 actions (n/a), 0 llm calls [n/a]" in lines
+    assert "- [n/a] GENERATION (dummy generation rail): 0 actions (n/a), 0 llm calls [n/a]" in lines
+    assert "- [n/a] OUTPUT (dummy output rail): 0 actions (n/a), 0 llm calls [n/a]" in lines
+    assert (
+        "- 4 LLM calls, 8.00s total duration, 1000 total prompt tokens, 2000 total completion tokens, 3000 total tokens."
+        in lines
     )
 
 


### PR DESCRIPTION
…durations

Optional stats fields were formatted with :.2f, which crashes when they are None. Print n/a (and skip the totals block when total_duration is missing) instead.

## Description
Updates `GenerationLog.print_summary`:
* When `total_duration` is `None`, print "No stats available" instead of the totals block. Still print `# Detailed stats` and any activated rails
* When `llm_calls_duration is missing`, still print the LLM-calls line if there are calls, with `n/a` for duration
* When `activated_rail.duration` is missing, print `[n/a]` instead of crashing. Empty action names and empty per-call duration lists also print `n/a`

Adds tests to `tests/test_generation_options.py` to verify `None`-type guarding.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. Include any areas that need careful
  review. -->

## Related Issue(s)
#2206 


<!--
  Every PR must link to a triaged issue assigned to the PR author.
  - Fixes #<issue_number>
  - Issue assignee: @<username>
-->

## Verification

<!-- CI runs the automated test suite. Note any verification beyond CI (manual
  checks, live/credentialed paths, docs build) and any relevant check you could
  not run, with residual risk. -->
Ran the script, `print_summary.py`, that @Pouyanpi provided in the linked issue. The following output verifies that there are no TypeErrors from formatting None as a float. 

```
Python:        3.13.2
nemoguardrails: 0.18.0

========================================================================
Crash 1: GenerationStats.total_duration is None (options.py ~line 318)
========================================================================

# General stats

No stats available

# Detailed stats

- [0.50s] TOOL_OUTPUT (tool output check): 0 actions (n/a), 0 llm calls [n/a]


No error raised - bug NOT reproduced.

========================================================================
Crash 2: ActivatedRail.duration is None (options.py ~line 370)
========================================================================

# General stats

- Total time: 0.50s
  - [0.50s][100%]: Processing overhead 

# Detailed stats

- [n/a] TOOL_OUTPUT (tool output check): 1 actions (tool_output_check), 0 llm calls [n/a]


No error raised - bug NOT reproduced.

```

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generation summaries now display clear fallback values when timing information is unavailable.
  * Summaries no longer fail when total, language-model, or rail duration data is missing.
  * Detailed output identifies unavailable rail durations and unnamed actions or calls as `n/a`.

* **Tests**
  * Added coverage for generation summaries with incomplete timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->