### PR TITLE
feat(llm): add OrcaRouter as a first-class built-in provider

### DIFF
--- a/docs/about/supported-llms.mdx
+++ b/docs/about/supported-llms.mdx
@@ -40,6 +40,7 @@ Each engine is served by a framework that manages the underlying HTTP or SDK cal
 | `nvidia_ai_endpoints` | Built-in | yes | yes | yes | Alias for `nim`. |
 | `ollama` | Built-in | yes | yes | yes (where supported) | Default base URL `http://localhost:11434/v1`. |
 | `openai` | Built-in | yes | yes | yes | OpenAI public API or any OpenAI-compatible endpoint using `parameters.base_url`. For vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp, NVIDIA Nemotron, and similar providers, use `engine: openai` with `parameters.base_url` and `parameters.api_key`. |
+| `orcarouter` | Built-in | yes | yes | yes | OpenAI-compatible AI gateway routing across many models with adaptive routing, automatic failover, and zero-markup inference. Default base URL `https://api.orcarouter.ai/v1`; set `parameters.api_key` or `ORCAROUTER_API_KEY`. |
 | `vertexai` | LangChain (opt-in) | yes | yes | n/a | Requires `pip install langchain langchain-google-vertexai`. |
 | `vllm_openai`, `deepseek` | LangChain (opt-in) | yes | yes | yes | Legacy LangChain provider engines. They continue to work when you opt into LangChain. For new configurations, use `engine: openai` with `parameters.base_url` when the wire protocol is OpenAI-compatible. |
 | `<provider_name>` | LangChain (opt-in) | varies | varies | varies | Any community provider exposed through LangChain's chat-model integrations. Use the bare provider name as the engine name. |

--- a/docs/configure-rails/configuration-reference.mdx
+++ b/docs/configure-rails/configuration-reference.mdx
@@ -109,6 +109,7 @@ These engines work with `pip install nemoguardrails` and do not require extra pr
 | `nvidia_ai_endpoints`   | Alias for `nim`                                                                                                           |
 | `ollama`                | Ollama OpenAI-compatible endpoint at `http://localhost:11434/v1`                                                          |
 | `openai`                | OpenAI public API or any OpenAI-compatible endpoint using `parameters.base_url`                                           |
+| `orcarouter`            | OpenAI-compatible AI gateway at `https://api.orcarouter.ai/v1`; routes across many models with adaptive routing, automatic failover, and zero-markup inference. Set `parameters.api_key` or `ORCAROUTER_API_KEY`. |
 
 For OpenAI-compatible providers without a dedicated engine entry (vLLM, TGI, OpenRouter, Together.ai, Fireworks.ai, Groq, DeepSeek, llama.cpp server, and similar), use `engine: openai` with `parameters.base_url` and `parameters.api_key`.
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -79,6 +79,7 @@ _OPERATION_NAME = "chat"
 _ENGINE_BASE_URLS = {
     "nim": "https://integrate.api.nvidia.com",
     "openai": "https://api.openai.com",
+    "orcarouter": "https://api.orcarouter.ai",
 }
 
 _CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
@@ -679,6 +680,10 @@ class ModelEngine(BaseEngine):
 
         if engine == "openai":
             env_value = self._get_environment_variable("OPENAI_API_KEY")
+            return env_value
+
+        if engine == "orcarouter":
+            env_value = self._get_environment_variable("ORCAROUTER_API_KEY")
             return env_value
 
         # If no key is available, assume it's a local model that doesn't need one

--- a/nemoguardrails/llm/frameworks/default.py
+++ b/nemoguardrails/llm/frameworks/default.py
@@ -30,12 +30,14 @@ _DEFAULT_BASE_URLS: Dict[str, str] = {
     "nim": "https://integrate.api.nvidia.com/v1",
     "nvidia_ai_endpoints": "https://integrate.api.nvidia.com/v1",
     "ollama": "http://localhost:11434/v1",
+    "orcarouter": "https://api.orcarouter.ai/v1",
 }
 
 _API_KEY_ENV_VARS: Dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "nim": "NVIDIA_API_KEY",
     "nvidia_ai_endpoints": "NVIDIA_API_KEY",
+    "orcarouter": "ORCAROUTER_API_KEY",
     "azure": "AZURE_OPENAI_API_KEY",
     "azure_openai": "AZURE_OPENAI_API_KEY",
 }

--- a/nemoguardrails/llm/models/openai_chat.py
+++ b/nemoguardrails/llm/models/openai_chat.py
@@ -33,6 +33,7 @@ from nemoguardrails.types import (
 _KNOWN_PROVIDER_URLS: Dict[str, str] = {
     "https://api.openai.com/v1": "openai",
     "https://integrate.api.nvidia.com/v1": "nim",
+    "https://api.orcarouter.ai/v1": "orcarouter",
 }
 
 _FINISH_REASON_MAP: Dict[str, FinishReason] = {

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -213,6 +213,12 @@ class TestModelEngineBaseUrl:
         engine = ModelEngine(_make_model(engine="openai"))
         assert engine.base_url == _ENGINE_BASE_URLS["openai"]
 
+    @patch.dict("os.environ", {"ORCAROUTER_API_KEY": "test-key"})
+    def test_orcarouter_engine_uses_orcarouter_url(self):
+        """OrcaRouter engine resolves to the OrcaRouter API URL."""
+        engine = ModelEngine(_make_model(engine="orcarouter"))
+        assert engine.base_url == _ENGINE_BASE_URLS["orcarouter"]
+
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
     def test_explicit_base_url_overrides_engine_default(self):
         """A base_url in parameters takes priority over engine default."""
@@ -361,6 +367,12 @@ class TestModelEngineApiKey:
         """OpenAI engine reads OPENAI_API_KEY from environment."""
         engine = ModelEngine(_make_model(engine="openai"))
         assert engine.api_key == "openai-key-456"
+
+    @patch.dict("os.environ", {"ORCAROUTER_API_KEY": "orcarouter-key-789"})
+    def test_orcarouter_engine_reads_orcarouter_api_key(self):
+        """OrcaRouter engine reads ORCAROUTER_API_KEY from environment."""
+        engine = ModelEngine(_make_model(engine="orcarouter"))
+        assert engine.api_key == "orcarouter-key-789"
 
     @patch.dict("os.environ", {"MY_CUSTOM_KEY": "custom-key-789"})
     def test_api_key_env_var_overrides_engine_default(self):

--- a/tests/llm/clients/test_client_config.py
+++ b/tests/llm/clients/test_client_config.py
@@ -776,3 +776,4 @@ class TestDefaultFramework:
         assert "openai" in names
         assert "nim" in names
         assert "ollama" in names
+        assert "orcarouter" in names


### PR DESCRIPTION
## Description

NVIDIA NeMo Guardrails is an open-source toolkit for adding *programmable guardrails* to LLM-based conversational applications. It already treats OpenAI-compatible gateways as first-class citizens: `engine: openai` with `parameters.base_url` is the documented path for any compatible provider, and dedicated engines such as `nim` and `ollama` ship with their own default base URL and API-key env var.

This PR adds **[OrcaRouter](https://www.orcarouter.ai)** as a named built-in provider, mirroring the existing `nim` wiring end to end. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class engine means NeMo Guardrails users can use that stack directly — `engine: orcarouter` — without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change is fully parallel to the existing provider wiring:

| File | Change |
| --- | --- |
| `nemoguardrails/guardrails/model_engine.py` | Add `orcarouter` to `_ENGINE_BASE_URLS` and resolve `ORCAROUTER_API_KEY` in `_resolve_api_key`, mirroring `nim`/`openai`. |
| `nemoguardrails/llm/frameworks/default.py` | Add `orcarouter` to `_DEFAULT_BASE_URLS` (`https://api.orcarouter.ai/v1`) and `_API_KEY_ENV_VARS` (`ORCAROUTER_API_KEY`), mirroring `nim`/`ollama`. |
| `nemoguardrails/llm/models/openai_chat.py` | Add `https://api.orcarouter.ai/v1` to `_KNOWN_PROVIDER_URLS` so telemetry labels the provider correctly, mirroring `nim`. |
| `docs/about/supported-llms.mdx` | Add `orcarouter` row to the Inference Providers table. |
| `docs/configure-rails/configuration-reference.mdx` | Add `orcarouter` row to the Built-in Engines table. |
| `tests/guardrails/test_model_engine.py` | Base URL and API-key resolution tests for `orcarouter`, mirroring the `nim`/`openai` tests. |
| `tests/llm/clients/test_client_config.py` | Assert `orcarouter` is listed by `get_provider_names()`. |

## Related Issue(s)

No linked issue; this is a self-contained provider addition following the established pattern of existing built-in engines such as `nim` and `ollama`.

## Verification

- `ruff check` and `ruff format --check` pass on all changed files.
- `ty check` reports no new diagnostics vs. `develop` baseline (66 pre-existing on the touched files).
- `tests/guardrails/test_model_engine.py`: **227 passed** (includes the new `orcarouter` URL and API-key tests).
- `tests/llm/clients/test_client_config.py::TestDefaultFramework::test_get_provider_names`: **passed** with the new `orcarouter` assertion.
- Live test (L3): with `ORCAROUTER_API_KEY` set, `ModelEngine(engine="orcarouter", model="openai/gpt-4o-mini")` reached `https://api.orcarouter.ai/v1/chat/completions` and returned `200 OK` (`content: 'ORCA_ROUTER_OK'`); the `DefaultFramework` path returned `PING` with `provider_name == "orcarouter"`.
- Note: the SOCKS-proxy test failures in this environment (`httpx[socks]` not installed) are pre-existing on `develop` and unrelated to this change.

## AI Assistance

- [ ] No AI tools were used.
- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

---

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
