### PR TITLE
fix(llm): add opt-in context length validation before LLM inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - *(llm)* Add LangChain adapter and framework registry ([#1759](https://github.com/NVIDIA-NeMo/Guardrails/issues/1759))
 - *(llm)* Add streaming tool call accumulation and LLMResponse parity ([#1789](https://github.com/NVIDIA-NeMo/Guardrails/issues/1789))
 - *(llm)* Add default framework with OpenAI-compatible client ([#1797](https://github.com/NVIDIA-NeMo/Guardrails/issues/1797))
+- *(llm)* Add context length validation before LLM inference ([#1983](https://github.com/NVIDIA-NeMo/Guardrails/issues/1983))
 - *(llm/frameworks)* Validate framework on registration ([#1863](https://github.com/NVIDIA-NeMo/Guardrails/issues/1863))
 - *(types)* Add framework-agnostic LLM type system ([#1745](https://github.com/NVIDIA-NeMo/Guardrails/issues/1745))
 - *(compat)* Transitional compat layer to migrate from 0.21 to 0.22+ ([#1841](https://github.com/NVIDIA-NeMo/Guardrails/issues/1841))

--- a/nemoguardrails/llm/call.py
+++ b/nemoguardrails/llm/call.py
@@ -41,6 +41,7 @@ from nemoguardrails.context import (
     tool_calls_var,
 )
 from nemoguardrails.exceptions import LLMCallException, LLMClientError
+from nemoguardrails.llm.token_counter import validate_context_length
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.llm_tracker import track_llm_call
 from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
@@ -71,7 +72,32 @@ async def llm_call(
     stop: Optional[List[str]] = None,
     llm_params: Optional[dict] = None,
     streaming_handler: Optional["StreamingHandler"] = None,
+    context_window_tokens: Optional[int] = None,
+    check_context_length: bool = False,
 ) -> LLMResponse:
+    """Call the LLM with the given prompt.
+
+    Args:
+        llm: The LLM model instance.
+        prompt: The prompt string or list of message dicts.
+        model_name: Model name used for context-length look-up; falls back to
+            the model's own ``model_name`` attribute when omitted.
+        model_provider: Optional provider identifier for logging.
+        stop: Optional list of stop sequences.
+        llm_params: Extra keyword arguments forwarded verbatim to the model
+            call.
+        streaming_handler: If provided, the response is streamed through this
+            handler instead of being returned as a single object.
+        context_window_tokens: Override the context-window size used **only**
+            for pre-call length validation (i.e. passed to
+            ``validate_context_length``). This value is *not* forwarded to the
+            model. Passing this implicitly enables context-length validation
+            even when ``check_context_length`` is False.
+        check_context_length: When True, validate that the assembled prompt
+            fits within the model's context window before calling the model.
+            Defaults to False to preserve backward compatibility with
+            deployments that use custom or unlisted model names.
+    """
     if llm is None:
         raise LLMCallException(ValueError("No LLM provided to llm_call()"))
 
@@ -89,6 +115,14 @@ async def llm_call(
     chat_prompt = _ensure_chat_messages(prompt)
     call_params = dict(llm_params or {})
     stop = call_params.pop("stop", stop)
+
+    # Validate context length only when explicitly requested or when a caller-supplied
+    # window override is present. The check is opt-in (False by default) so that
+    # deployments using custom/unlisted model names are not broken by the conservative
+    # 4096-token fallback. ContextLengthExceededError must propagate directly (not
+    # wrapped in LLMCallException) so callers can handle it specifically.
+    if check_context_length or context_window_tokens is not None:
+        validate_context_length(prompt, model_name=model_name or model.model_name, max_tokens=context_window_tokens)
 
     if streaming_handler:
         return await _stream_llm_call(model, chat_prompt, streaming_handler, stop, call_params)

--- a/nemoguardrails/llm/token_counter.py
+++ b/nemoguardrails/llm/token_counter.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Token counting and context length validation utilities.
+
+Provides methods to estimate token counts for prompts and validate
+that prompts don't exceed model context windows.
+"""
+
+import logging
+import re
+from typing import List, Optional, Union
+
+log = logging.getLogger(__name__)
+
+
+class ContextLengthExceededError(ValueError):
+    """Raised when prompt exceeds model context length."""
+
+    def __init__(
+        self,
+        message: str,
+        prompt_tokens: int,
+        max_tokens: int,
+        model_name: Optional[str] = None,
+    ):
+        self.prompt_tokens = prompt_tokens
+        self.max_tokens = max_tokens
+        self.model_name = model_name
+        super().__init__(message)
+
+
+class TokenCounter:
+    """Estimates token counts for various model types."""
+
+    # Approximate tokens per character ratios for different model families
+    # These are conservative estimates; actual counts depend on tokenizer
+    TOKENS_PER_CHAR = {
+        "gpt": 0.25,  # OpenAI models: ~4 chars per token
+        "claude": 0.27,  # Anthropic: ~3.7 chars per token
+        "llama": 0.28,  # Meta: ~3.6 chars per token
+        "mistral": 0.28,
+        "gemini": 0.26,
+        "default": 0.27,
+    }
+
+    # Model context window limits (in tokens).
+    # Callers should pass max_tokens explicitly for deployment-specific variants
+    # not listed here, as partial-name matching may resolve to a conservative value.
+    MODEL_CONTEXT_WINDOWS = {
+        # OpenAI
+        "gpt-4o": 128000,
+        "gpt-4-turbo": 128000,
+        "gpt-4": 8192,
+        "gpt-3.5-turbo": 4096,
+        # Anthropic
+        "claude-3-opus": 200000,
+        "claude-3-sonnet": 200000,
+        "claude-3-haiku": 200000,
+        "claude-2.1": 100000,
+        "claude-2": 100000,
+        # Meta Llama
+        "llama-2": 4096,
+        "llama-2-70b": 4096,
+        "llama-3": 8192,
+        "llama-3-70b": 8192,
+        # Mistral
+        "mistral-7b": 32768,
+        "mistral-large": 32768,
+        # Google
+        "gemini-pro": 32768,
+        "gemini-2.0-flash": 1000000,
+        # Default fallback
+        "default": 4096,
+    }
+
+    @staticmethod
+    def estimate_tokens(text: str, model_name: Optional[str] = None) -> int:
+        """Estimate token count for text.
+
+        Args:
+            text: The text to estimate tokens for
+            model_name: Optional model name for family-specific estimation
+
+        Returns:
+            Approximate token count
+        """
+        if not text:
+            return 0
+
+        # Determine ratio based on model family
+        ratio = TokenCounter.TOKENS_PER_CHAR.get("default", 0.27)
+        if model_name:
+            model_lower = model_name.lower()
+            for family, family_ratio in TokenCounter.TOKENS_PER_CHAR.items():
+                if family in model_lower:
+                    ratio = family_ratio
+                    break
+
+        return max(1, int(len(text) * ratio))
+
+    @staticmethod
+    def estimate_message_tokens(messages: List[dict], model_name: Optional[str] = None) -> int:
+        """Estimate total token count for message list.
+
+        Accounts for message structure overhead.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content' keys
+            model_name: Optional model name for family-specific estimation
+
+        Returns:
+            Approximate total token count including formatting
+        """
+        if not messages:
+            return 0
+
+        total_tokens = 0
+        # Account for message structure overhead (~4 tokens per message)
+        total_tokens += len(messages) * 4
+
+        for msg in messages:
+            if isinstance(msg, dict):
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    total_tokens += TokenCounter.estimate_tokens(content, model_name)
+                elif isinstance(content, list):
+                    # For multimodal content
+                    for item in content:
+                        if isinstance(item, dict):
+                            if item.get("type") == "text":
+                                total_tokens += TokenCounter.estimate_tokens(item.get("text", ""), model_name)
+                            elif item.get("type") == "image_url":
+                                # Image tokens vary; rough estimate
+                                total_tokens += 85
+                            elif item.get("type") == "image":
+                                total_tokens += 85
+
+        return total_tokens
+
+    @staticmethod
+    def _tokenize(s: str):
+        """Split a model name into tokens on non-alphanumeric separators."""
+        return [t for t in re.split(r"[^a-z0-9]+", s.lower()) if t]
+
+    @staticmethod
+    def get_model_context_window(model_name: Optional[str]) -> int:
+        """Get context window size for a model.
+
+        Args:
+            model_name: Name of the model
+
+        Returns:
+            Context window in tokens, or default if unknown
+        """
+        if not model_name:
+            return TokenCounter.MODEL_CONTEXT_WINDOWS["default"]
+
+        model_name_lower = model_name.lower()
+
+        # Exact match first
+        if model_name_lower in TokenCounter.MODEL_CONTEXT_WINDOWS:
+            return TokenCounter.MODEL_CONTEXT_WINDOWS[model_name_lower]
+
+        # Token-based matching using coverage ratio.
+        # Coverage ratio = overlap / key_token_count prevents longer irrelevant keys
+        # from beating shorter fully-matching keys.
+        # e.g., "gpt-4-custom-variant" vs keys "gpt-4" and "gpt-4-turbo":
+        #   "gpt-4"       tokens {gpt,4}:        overlap=2, ratio=2/2=1.00 -> wins
+        #   "gpt-4-turbo" tokens {gpt,4,turbo}:  overlap=2, ratio=2/3=0.67
+        model_tokens = set(TokenCounter._tokenize(model_name_lower))
+
+        best_key = None
+        best_ratio = 0.0
+        best_key_len = 0
+
+        for key in TokenCounter.MODEL_CONTEXT_WINDOWS:
+            if key == "default":
+                continue
+
+            key_tokens = set(TokenCounter._tokenize(key.lower()))
+            if not key_tokens:
+                continue
+
+            overlap = len(model_tokens & key_tokens)
+            if overlap == 0:
+                continue
+
+            # Coverage ratio: fraction of key's tokens present in the model name
+            ratio = overlap / len(key_tokens)
+
+            # Prefer higher ratio; tie-break on longer key (more specific)
+            if ratio > best_ratio or (ratio == best_ratio and len(key) > best_key_len):
+                best_ratio = ratio
+                best_key = key
+                best_key_len = len(key)
+
+        if best_key:
+            return TokenCounter.MODEL_CONTEXT_WINDOWS[best_key]
+
+        # Default fallback
+        return TokenCounter.MODEL_CONTEXT_WINDOWS["default"]
+
+    @staticmethod
+    def validate_context_length(
+        prompt: Union[str, List[dict]],
+        model_name: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> None:
+        """Validate that prompt fits within model context window.
+
+        Args:
+            prompt: The prompt (string or message list) to validate
+            model_name: Name of the model (for context window lookup)
+            max_tokens: Override context window size
+
+        Raises:
+            ContextLengthExceededError: If prompt exceeds context window
+        """
+        if isinstance(prompt, str):
+            prompt_tokens = TokenCounter.estimate_tokens(prompt, model_name)
+        elif isinstance(prompt, list):
+            prompt_tokens = TokenCounter.estimate_message_tokens(prompt, model_name)
+        else:
+            return  # Can't validate unknown type
+
+        # Determine context window
+        if max_tokens is None:
+            max_tokens = TokenCounter.get_model_context_window(model_name)
+
+        # Validate (reserve 10% for safety margin and output tokens)
+        safety_threshold = int(max_tokens * 0.9)
+
+        if prompt_tokens > safety_threshold:
+            raise ContextLengthExceededError(
+                f"Prompt exceeds model context length. "
+                f"Prompt tokens: {prompt_tokens}, "
+                f"Model context window: {max_tokens} "
+                f"(using 90% threshold: {safety_threshold} tokens). "
+                f"Context length exceeded by {prompt_tokens - safety_threshold} tokens. "
+                f"Please reduce prompt length or use a model with larger context window.",
+                prompt_tokens=prompt_tokens,
+                max_tokens=max_tokens,
+                model_name=model_name,
+            )
+
+        log.debug(
+            f"Prompt token validation passed: {prompt_tokens}/{safety_threshold} tokens "
+            f"(model: {model_name or 'unknown'})"
+        )
+
+
+def validate_context_length(
+    prompt: Union[str, List[dict]],
+    model_name: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+) -> None:
+    """Convenience function to validate context length.
+
+    Args:
+        prompt: The prompt to validate
+        model_name: Name of the model
+        max_tokens: Override context window size
+
+    Raises:
+        ContextLengthExceededError: If prompt exceeds context window
+    """
+    TokenCounter.validate_context_length(prompt, model_name, max_tokens)

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -329,6 +329,74 @@ class TestLlmCallDictToChatMessageConversion:
         assert received_prompt == []
 
 
+class TestLlmCallContextLengthValidation:
+    """check_context_length / context_window_tokens opt-in wiring on llm_call."""
+
+    class _Model:
+        model_name = "gpt-4"
+        provider_name = "test"
+        provider_url = None
+
+        async def generate_async(self, prompt, *, stop=None, **kwargs):
+            return LLMResponse(content="ok")
+
+        async def stream_async(self, prompt, *, stop=None, **kwargs):
+            yield LLMResponseChunk(delta_content="ok")
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_even_for_oversized_prompt(self):
+        model = self._Model()
+        # gpt-4's window is small (8192 tokens); this prompt would fail validation
+        # if it ran, but check_context_length defaults to False.
+        huge_prompt = "x" * 100_000
+        response = await llm_call(model, huge_prompt)
+
+        assert response.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_raises_context_length_exceeded_when_enabled(self):
+        from nemoguardrails.llm.token_counter import ContextLengthExceededError
+
+        model = self._Model()
+        huge_prompt = "x" * 100_000
+
+        with pytest.raises(ContextLengthExceededError):
+            await llm_call(model, huge_prompt, check_context_length=True)
+
+    @pytest.mark.asyncio
+    async def test_context_length_exceeded_is_not_wrapped_in_llm_call_exception(self):
+        from nemoguardrails.exceptions import LLMCallException
+        from nemoguardrails.llm.token_counter import ContextLengthExceededError
+
+        model = self._Model()
+        huge_prompt = "x" * 100_000
+
+        try:
+            await llm_call(model, huge_prompt, check_context_length=True)
+        except LLMCallException:
+            pytest.fail("ContextLengthExceededError must propagate directly, not wrapped in LLMCallException")
+        except ContextLengthExceededError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_passes_within_window(self):
+        model = self._Model()
+        response = await llm_call(model, "a short prompt", check_context_length=True)
+
+        assert response.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_context_window_tokens_override_implicitly_enables_validation(self):
+        from nemoguardrails.llm.token_counter import ContextLengthExceededError
+
+        model = self._Model()
+        # A prompt well within gpt-4's real window, but larger than a tiny
+        # caller-supplied override -- passing the override alone must trigger
+        # validation even though check_context_length is left at its default.
+        with pytest.raises(ContextLengthExceededError):
+            await llm_call(model, "a moderately long prompt " * 20, context_window_tokens=10)
+
+
 def _make_chunk_model(chunks):
     class _Model:
         model_name = "test-model"

--- a/tests/llm/test_token_counter.py
+++ b/tests/llm/test_token_counter.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for token counting and context length validation."""
+
+import pytest
+
+from nemoguardrails.llm.token_counter import (
+    ContextLengthExceededError,
+    TokenCounter,
+    validate_context_length,
+)
+
+
+class TestTokenCounter:
+    """Test suite for TokenCounter."""
+
+    def test_estimate_tokens_empty_string(self):
+        """Empty string should return 0 tokens."""
+        assert TokenCounter.estimate_tokens("") == 0
+
+    def test_estimate_tokens_short_text(self):
+        """Short text estimation."""
+        text = "Hello"
+        tokens = TokenCounter.estimate_tokens(text)
+        assert tokens >= 1
+
+    def test_estimate_tokens_long_text(self):
+        """Long text should estimate reasonable token count."""
+        text = "a" * 1000  # 1000 characters
+        tokens = TokenCounter.estimate_tokens(text)
+        # Roughly 4 chars per token, so ~250 tokens
+        assert 200 < tokens < 300
+
+    def test_estimate_tokens_realistic_prompt(self):
+        """Realistic prompt should estimate reasonable tokens."""
+        prompt = "What is the capital of France? " * 10  # Repeat to get ~320 chars
+        tokens = TokenCounter.estimate_tokens(prompt)
+        assert tokens > 0
+
+    def test_estimate_message_tokens_empty_list(self):
+        """Empty message list should return 0."""
+        assert TokenCounter.estimate_message_tokens([]) == 0
+
+    def test_estimate_message_tokens_single_message(self):
+        """Single message token count."""
+        messages = [{"role": "user", "content": "Hello"}]
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        assert tokens > 0
+
+    def test_estimate_message_tokens_multiple_messages(self):
+        """Multiple messages token count."""
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "2+2 equals 4"},
+        ]
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        # Should account for message overhead + content
+        assert tokens > 10
+
+    def test_estimate_message_tokens_includes_overhead(self):
+        """Message token count should include structure overhead."""
+        messages = [{"role": "user", "content": ""}]
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        # Even empty message should account for structure
+        assert tokens >= 4
+
+    def test_get_model_context_window_known_model(self):
+        """Known model should return correct context window."""
+        assert TokenCounter.get_model_context_window("gpt-4o") == 128000
+        assert TokenCounter.get_model_context_window("claude-3-opus") == 200000
+
+    def test_get_model_context_window_partial_match(self):
+        """Partial model name match should work."""
+        # Test partial match: 'gpt-4' key matches in 'gpt-4-custom-variant'
+        assert TokenCounter.get_model_context_window("gpt-4-custom-variant") == 8192
+        # Test exact match preferred over partial: 'gpt-4-turbo' is more specific than 'gpt-4'
+        assert TokenCounter.get_model_context_window("gpt-4-turbo") == 128000
+        # Test partial match with claude
+        assert TokenCounter.get_model_context_window("my-claude-3-custom") == 200000
+
+    def test_get_model_context_window_unknown_model(self):
+        """Unknown model should return default."""
+        default_window = TokenCounter.get_model_context_window("unknown-model-xyz")
+        assert default_window == TokenCounter.MODEL_CONTEXT_WINDOWS["default"]
+
+    def test_get_model_context_window_none(self):
+        """None model should return default."""
+        default_window = TokenCounter.get_model_context_window(None)
+        assert default_window == TokenCounter.MODEL_CONTEXT_WINDOWS["default"]
+
+    def test_validate_context_length_string_prompt_valid(self):
+        """Valid string prompt should not raise."""
+        prompt = "What is the capital of France?"
+        # Should not raise
+        TokenCounter.validate_context_length(prompt, model_name="gpt-4")
+
+    def test_validate_context_length_string_prompt_too_long(self):
+        """String prompt exceeding limit should raise."""
+        prompt = "a" * 100000  # Very long prompt
+        with pytest.raises(ContextLengthExceededError) as exc_info:
+            TokenCounter.validate_context_length(prompt, model_name="gpt-3.5-turbo")
+        assert exc_info.value.model_name == "gpt-3.5-turbo"
+
+    def test_validate_context_length_message_list_valid(self):
+        """Valid message list should not raise."""
+        messages = [{"role": "user", "content": "What is the capital of France?"}]
+        # Should not raise
+        TokenCounter.validate_context_length(messages, model_name="gpt-4")
+
+    def test_validate_context_length_message_list_too_long(self):
+        """Message list exceeding limit should raise."""
+        messages = [{"role": "user", "content": "a" * 100000}]
+        with pytest.raises(ContextLengthExceededError):
+            TokenCounter.validate_context_length(messages, model_name="gpt-3.5-turbo")
+
+    def test_validate_context_length_uses_safety_threshold(self):
+        """Should use 90% safety threshold."""
+        # Create prompt that fits in 90% but exceeds 100%
+        # gpt-4 has 8192 token window, so 90% = 7372
+        # A prompt with ~8000 chars should exceed threshold
+        prompt = "a" * 32000  # ~8000 tokens
+        with pytest.raises(ContextLengthExceededError):
+            TokenCounter.validate_context_length(prompt, model_name="gpt-4")
+
+    def test_validate_context_length_with_custom_max_tokens(self):
+        """Should respect custom max_tokens parameter."""
+        prompt = "test" * 100  # ~100 tokens
+        # Custom limit of 50 tokens should raise
+        with pytest.raises(ContextLengthExceededError):
+            TokenCounter.validate_context_length(prompt, max_tokens=50)
+
+    def test_validate_context_length_exception_details(self):
+        """Exception should contain useful debugging info."""
+        prompt = "a" * 50000
+        with pytest.raises(ContextLengthExceededError) as exc_info:
+            TokenCounter.validate_context_length(prompt, model_name="gpt-3.5-turbo")
+        e = exc_info.value
+        assert e.prompt_tokens > 0
+        assert e.max_tokens == 4096
+        assert e.model_name == "gpt-3.5-turbo"
+        assert "tokens" in str(e).lower()
+
+    def test_validate_context_length_unknown_type(self):
+        """Should handle unknown prompt types gracefully."""
+        # Should not raise for unknown types
+        TokenCounter.validate_context_length(12345)  # Invalid type
+        TokenCounter.validate_context_length(None)  # None
+        TokenCounter.validate_context_length({})  # Dict
+
+    def test_convenience_function_validate_context_length(self):
+        """Convenience function should work."""
+        prompt = "What is the capital of France?"
+        # Should not raise
+        validate_context_length(prompt, model_name="gpt-4")
+
+    def test_convenience_function_raises(self):
+        """Convenience function should raise on too long prompt."""
+        prompt = "a" * 100000
+        with pytest.raises(ContextLengthExceededError):
+            validate_context_length(prompt, model_name="gpt-3.5-turbo")
+
+    def test_message_with_missing_content(self):
+        """Messages with missing content should be handled."""
+        messages = [
+            {"role": "user"},  # Missing content
+            {"role": "user", "content": None},  # None content
+        ]
+        # Should not raise
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        assert tokens >= 0
+
+    def test_message_with_multimodal_content(self):
+        """Messages with multimodal content should be estimated."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+                ],
+            }
+        ]
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        # Should account for text + image
+        assert tokens > 0
+
+    def test_small_prompt_validation_passes(self):
+        """Very small prompts should always pass."""
+        tiny_prompts = [
+            "Hi",
+            "2+2",
+            "What?",
+        ]
+        for prompt in tiny_prompts:
+            # Should not raise
+            validate_context_length(prompt, model_name="gpt-3.5-turbo")
+
+    def test_large_context_model_allows_longer_prompts(self):
+        """Large context models should accept longer prompts."""
+        prompt = "a" * 50000  # ~12500 tokens
+        # Claude has 200k context, should accept this
+        validate_context_length(prompt, model_name="claude-3-opus")
+
+        # GPT-3.5 with 4k context should reject it
+        with pytest.raises(ContextLengthExceededError):
+            validate_context_length(prompt, model_name="gpt-3.5-turbo")
+
+    def test_context_length_error_inheritance(self):
+        """ContextLengthExceededError should be ValueError."""
+        assert issubclass(ContextLengthExceededError, ValueError)
+
+    def test_estimate_message_tokens_image_type(self):
+        """Multimodal content with 'image' type should be counted as ~85 tokens."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "base64", "data": "..."}},
+                ],
+            }
+        ]
+        tokens = TokenCounter.estimate_message_tokens(messages)
+        assert tokens >= 85
+
+    def test_get_model_context_window_empty_key_tokens_skipped(self):
+        """Keys that tokenize to empty should be skipped during partial matching."""
+        TokenCounter.MODEL_CONTEXT_WINDOWS["---"] = 1000
+        try:
+            result = TokenCounter.get_model_context_window("completely-unknown-xyz-999")
+            assert result == TokenCounter.MODEL_CONTEXT_WINDOWS["default"]
+        finally:
+            TokenCounter.MODEL_CONTEXT_WINDOWS.pop("---", None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What
Adds `TokenCounter` / `validate_context_length` (`nemoguardrails/llm/token_counter.py`) and wires an opt-in `check_context_length` flag (plus a `context_window_tokens` override) into `llm_call()` in `nemoguardrails/llm/call.py`.

Addresses #1983.

## Why a fresh PR instead of updating #1999
#1999 was branched on top of an earlier, unmerged prompt-injection-detection branch (#1979). By the time #1999 was opened its actual diff against `develop` (not just its own commit history) still carried that unrelated feature, despite a PR comment claiming it had been fully removed — the removal only reverted the wiring in the old `generate()`/`generate_async()`/`stream_async()` call sites, and a later commit re-added an opt-in `check_prompt_injection` flag into `llm_call()` itself, which is why `injections.py` and its tests kept showing up in the PR's file list.

`develop` has also moved since #1999 branched — `llm_call()` was refactored out of `nemoguardrails/actions/llm/utils.py` into `nemoguardrails/llm/call.py` (a Colang-free module) in the meantime, so #1999's diff no longer applies to where the function actually lives.

This PR is a clean rebuild off current `develop`, scoped to context-length validation only:
- No prompt-injection-detection code (`injections.py` not touched).
- `check_context_length` defaults to `False` for backward compatibility with custom/unlisted model names.
- `ContextLengthExceededError` propagates directly, not wrapped in `LLMCallException`.
- New tests in `tests/llm/test_call.py` cover the opt-in default, the override, and the no-wrapping behavior; `tests/llm/test_call_import_graph.py`'s Colang-independence guard still passes.

Closing #1999 in favor of this.

## Test plan
- `pytest tests/llm/test_token_counter.py tests/llm/test_call.py tests/llm/test_call_import_graph.py` — 75 passed
- `ruff check` / `ruff format --check` clean