### PR TITLE
feat(logging): redact sensitive data from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - *(llm)* Add LangChain adapter and framework registry ([#1759](https://github.com/NVIDIA-NeMo/Guardrails/issues/1759))
 - *(llm)* Add streaming tool call accumulation and LLMResponse parity ([#1789](https://github.com/NVIDIA-NeMo/Guardrails/issues/1789))
 - *(llm)* Add default framework with OpenAI-compatible client ([#1797](https://github.com/NVIDIA-NeMo/Guardrails/issues/1797))
+- *(logging)* Redact sensitive data (PII, credentials) from logs ([#1982](https://github.com/NVIDIA-NeMo/Guardrails/issues/1982))
 - *(llm/frameworks)* Validate framework on registration ([#1863](https://github.com/NVIDIA-NeMo/Guardrails/issues/1863))
 - *(types)* Add framework-agnostic LLM type system ([#1745](https://github.com/NVIDIA-NeMo/Guardrails/issues/1745))
 - *(compat)* Transitional compat layer to migrate from 0.21 to 0.22+ ([#1841](https://github.com/NVIDIA-NeMo/Guardrails/issues/1841))

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -36,6 +36,7 @@ from nemoguardrails.guardrails import configure_logging
 from nemoguardrails.guardrails.guardrails_types import LLMMessages
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.logging.explain import ExplainInfo
+from nemoguardrails.logging.sensitive_filter import setup_sensitive_data_filter
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationOptions, GenerationResponse, RailsResult, RailType
@@ -80,6 +81,14 @@ class Guardrails(BaseGuardrails):
         # nemoguardrails.guardrails from the handlers the application installed on the root logger.
         if verbose:
             configure_logging(logging.DEBUG)
+
+        # Redact sensitive data (PII, credentials) from logs to prevent data leaks.
+        # Best-effort: a broken logging setup in the host application must not block
+        # Guardrails from initializing.
+        try:
+            setup_sensitive_data_filter(logging.getLogger())
+        except Exception as e:
+            log.warning(f"Failed to setup sensitive data filter: {e}")
 
         if use_iorails:
             fallback_reason = IORails.unsupported_reason(config, llm)

--- a/nemoguardrails/logging/redactor.py
+++ b/nemoguardrails/logging/redactor.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sensitive data redaction for logging.
+
+Redacts PII and sensitive patterns from logs to prevent data leaks.
+Supports custom redaction patterns and configurable masking strategies.
+"""
+
+import re
+from typing import Any, Callable, Dict, List, Optional, Union
+
+# Default sensitive patterns to redact.
+# ORDER MATTERS — patterns are applied sequentially; more specific patterns must come first
+# to prevent partial matches by broader patterns (e.g. credit-card digits being swallowed by
+# the phone pattern, or URL credentials being matched as an email address).
+DEFAULT_REDACTION_PATTERNS = {
+    # URL-with-creds must precede email: "password@host.example.com" would otherwise be
+    # treated as an email address before the full credential URL is matched.
+    "url_with_creds": (r"(?:https?://)?(?:[a-zA-Z0-9_-]+):(?:[a-zA-Z0-9_-]+)@[^\s]+", "[URL_WITH_CREDS]"),
+    "email": (r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", "[EMAIL]"),
+    "ssn": (r"\b\d{3}-\d{2}-\d{4}\b", "[SSN]"),
+    # Credit-card must precede phone: the phone pattern can partially match the first
+    # 8 digits of a 16-digit card number (e.g. "1234-5678" in "1234-5678-9012-3456").
+    "credit_card": (r"\b(?:\d{4}[-\s]?){3}\d{4}\b|\b\d{16}\b", "[CREDIT_CARD]"),
+    "phone": (r"\b(?:\+?1[-.]?)?(?:\(?[0-9]{3}\)?[-.]?)?[0-9]{3}[-.]?[0-9]{4}\b", "[PHONE]"),
+    "api_key": (
+        r'(?:api[\s_-]?key|apikey|api_secret|secret)["\']?\s*[:=]\s*["\']?([A-Za-z0-9_\-]{8,})["\']?',
+        "[API_KEY]",
+    ),
+    "password": (r'(?:password|passwd|pwd)["\']?\s*[:=]\s*["\']?([^"\'\s,}\]]+)["\']?', "[PASSWORD]"),
+    "token": (r'(?:token|auth_token|access_token|bearer)["\']?\s*[:=\s]\s*["\']?([A-Za-z0-9_\-\.]+)["\']?', "[TOKEN]"),
+    "aws_key": (r"AKIA[0-9A-Z]{16}", "[AWS_KEY]"),
+    "ip_address": (
+        r"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b",
+        "[IP_ADDRESS]",
+    ),
+}
+
+# Sensitive keywords that indicate sensitive content
+SENSITIVE_KEYWORDS = {
+    "password",
+    "secret",
+    "token",
+    "key",
+    "credential",
+    "private",
+    "ssn",
+    "social_security",
+    "credit_card",
+    "card_number",
+    "api_key",
+    "auth",
+    "authorization",
+    "access_token",
+    "bearer",
+    "api_secret",
+    "client_secret",
+    "private_key",
+    "aws_secret",
+    "gcp_key",
+    "azure_key",
+}
+
+
+class SensitiveDataRedactor:
+    """Redacts sensitive information from text."""
+
+    def __init__(
+        self,
+        patterns: Optional[Dict[str, tuple]] = None,
+        custom_patterns: Optional[Dict[str, tuple]] = None,
+        custom_redactor: Optional[Callable[[str], str]] = None,
+    ):
+        """Initialize the redactor.
+
+        Args:
+            patterns: Redaction patterns (regex, replacement) dict
+            custom_patterns: Additional custom patterns
+            custom_redactor: Custom redaction function
+        """
+        self.patterns = patterns or DEFAULT_REDACTION_PATTERNS.copy()
+        if custom_patterns:
+            self.patterns.update(custom_patterns)
+
+        self.custom_redactor = custom_redactor
+        self._compile_patterns()
+
+    def _compile_patterns(self) -> None:
+        """Compile regex patterns for efficiency."""
+        self.compiled_patterns: List[tuple] = []
+        for pattern_name, (regex_str, replacement) in self.patterns.items():
+            try:
+                compiled = re.compile(regex_str, re.IGNORECASE)
+                self.compiled_patterns.append((compiled, replacement, pattern_name))
+            except re.error as e:
+                raise ValueError(f"Invalid regex pattern '{regex_str}': {e}")
+
+    def redact(self, text: str) -> str:
+        """Redact sensitive data from text.
+
+        Args:
+            text: The text to redact
+
+        Returns:
+            Text with sensitive data replaced with placeholders
+        """
+        if not text or not isinstance(text, str):
+            return text
+
+        redacted = text
+        for compiled_pattern, replacement, pattern_name in self.compiled_patterns:
+            redacted = compiled_pattern.sub(replacement, redacted)
+
+        # Apply custom redactor if provided
+        if self.custom_redactor:
+            redacted = self.custom_redactor(redacted)
+
+        return redacted
+
+    def should_redact_value(self, key: str, value: Any) -> bool:
+        """Determine if a key-value pair should be redacted.
+
+        Args:
+            key: The key name
+            value: The value
+
+        Returns:
+            True if value should be redacted
+        """
+        if not isinstance(key, str):
+            return False
+
+        key_lower = key.lower()
+        # Split on separators so 'prompt_tokens' → {'prompt','tokens'} which does not
+        # match the 'token' keyword; the unsplit key is also included to catch
+        # multi-word keywords like 'api_key' and 'access_token'.
+        parts = set(re.split(r"[_\-\s]+", key_lower))
+        parts.add(key_lower)
+        return any(keyword in parts for keyword in SENSITIVE_KEYWORDS)
+
+    def redact_dict(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Redact sensitive values in a dictionary.
+
+        Args:
+            data: Dictionary to redact
+
+        Returns:
+            Dictionary with sensitive values redacted
+        """
+        if not isinstance(data, dict):
+            return data
+
+        redacted = {}
+        for key, value in data.items():
+            if self.should_redact_value(key, value) and value is not None:
+                redacted[key] = f"[{key.upper()}]"
+            elif isinstance(value, str):
+                redacted[key] = self.redact(value)
+            elif isinstance(value, dict):
+                redacted[key] = self.redact_dict(value)
+            elif isinstance(value, (list, tuple)):
+                redacted[key] = type(value)(
+                    self.redact(item)
+                    if isinstance(item, str)
+                    else self.redact_dict(item)
+                    if isinstance(item, dict)
+                    else item
+                    for item in value
+                )
+            else:
+                redacted[key] = value
+
+        return redacted
+
+    def redact_list(self, data: Union[List[Any], tuple]) -> Union[List[Any], tuple]:
+        """Redact sensitive data in a list or tuple.
+
+        Args:
+            data: List or tuple to redact
+
+        Returns:
+            List or tuple with sensitive data redacted
+        """
+        if isinstance(data, tuple):
+            return tuple(
+                self.redact(item)
+                if isinstance(item, str)
+                else self.redact_dict(item)
+                if isinstance(item, dict)
+                else item
+                for item in data
+            )
+        elif isinstance(data, list):
+            return [
+                self.redact(item)
+                if isinstance(item, str)
+                else self.redact_dict(item)
+                if isinstance(item, dict)
+                else item
+                for item in data
+            ]
+        else:
+            return data
+
+
+def create_sensitive_redactor(
+    patterns: Optional[Dict[str, tuple]] = None,
+    custom_patterns: Optional[Dict[str, tuple]] = None,
+) -> SensitiveDataRedactor:
+    """Factory function to create a configured redactor.
+
+    Args:
+        patterns: Override default patterns
+        custom_patterns: Add custom patterns
+
+    Returns:
+        Configured SensitiveDataRedactor instance
+    """
+    return SensitiveDataRedactor(patterns=patterns, custom_patterns=custom_patterns)
+
+
+# Global redactor instance
+_global_redactor: Optional[SensitiveDataRedactor] = None
+
+
+def get_redactor() -> SensitiveDataRedactor:
+    """Get or create the global redactor instance."""
+    global _global_redactor
+    if _global_redactor is None:
+        _global_redactor = SensitiveDataRedactor()
+    return _global_redactor
+
+
+def redact_text(text: str) -> str:
+    """Redact sensitive data from text using global redactor.
+
+    Args:
+        text: Text to redact
+
+    Returns:
+        Redacted text
+    """
+    return get_redactor().redact(text)
+
+
+def redact_value(value: Any) -> Any:
+    """Redact sensitive data from any value.
+
+    Handles strings, dicts, lists, and nested structures.
+
+    Args:
+        value: Value to redact
+
+    Returns:
+        Redacted value
+    """
+    redactor = get_redactor()
+
+    if isinstance(value, str):
+        return redactor.redact(value)
+    elif isinstance(value, dict):
+        return redactor.redact_dict(value)
+    elif isinstance(value, (list, tuple)):
+        return redactor.redact_list(value)
+    else:
+        return value

--- a/nemoguardrails/logging/sensitive_filter.py
+++ b/nemoguardrails/logging/sensitive_filter.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging filter for redacting sensitive data from log records.
+
+Integrates with Python's standard logging to automatically redact
+sensitive information from all log messages.
+"""
+
+import logging
+from typing import Optional
+
+from nemoguardrails.logging.redactor import SensitiveDataRedactor, get_redactor
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Logging filter that redacts sensitive data from log records."""
+
+    def __init__(self, redactor: Optional[SensitiveDataRedactor] = None):
+        """Initialize the filter.
+
+        Args:
+            redactor: Optional custom redactor instance
+        """
+        super().__init__()
+        self.redactor = redactor or get_redactor()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Filter log record by redacting sensitive data.
+
+        Args:
+            record: The log record to filter
+
+        Returns:
+            True (always allow the record to be logged)
+        """
+        # Pre-format %-style records before redacting so that a sensitive keyword
+        # in the template (e.g. "password: %s") cannot corrupt the format spec,
+        # which would cause TypeError in getMessage() called by the log handler.
+        if isinstance(record.msg, str) and record.args:
+            try:
+                record.msg = record.getMessage()
+                record.args = None
+            except Exception:
+                pass
+
+        # Redact the main message
+        if record.msg:
+            if isinstance(record.msg, str):
+                record.msg = self.redactor.redact(record.msg)
+            elif isinstance(record.msg, dict):
+                record.msg = self.redactor.redact_dict(record.msg)
+
+        # Redact message arguments (fallback when pre-formatting was skipped or failed)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = self.redactor.redact_dict(record.args)
+            elif isinstance(record.args, (tuple, list)):
+                new_args = []
+                for arg in record.args:
+                    if isinstance(arg, str):
+                        new_args.append(self.redactor.redact(arg))
+                    elif isinstance(arg, dict):
+                        new_args.append(self.redactor.redact_dict(arg))
+                    else:
+                        new_args.append(arg)
+                record.args = tuple(new_args)
+
+        # Redact exception information if present
+        if record.exc_info:
+            exc_type, exc_value, exc_tb = record.exc_info
+            if exc_value:
+                exc_str = str(exc_value)
+                exc_str = self.redactor.redact(exc_str)
+                # Update the exception with redacted message
+                try:
+                    exc_value.args = (exc_str,)
+                except (AttributeError, TypeError):
+                    pass
+
+        return True
+
+
+def setup_sensitive_data_filter(
+    logger: Optional[logging.Logger] = None,
+    redactor: Optional[SensitiveDataRedactor] = None,
+) -> SensitiveDataFilter:
+    """Add sensitive data filter to a logger's handlers.
+
+    Args:
+        logger: Logger whose handlers to protect (root logger if None)
+        redactor: Optional custom redactor instance
+
+    Returns:
+        The created filter instance
+    """
+    if logger is None:
+        logger = logging.getLogger()
+
+    # Attach to handlers, not the logger itself. Logger.filter() is never
+    # invoked for records propagated from child loggers, so a logger-level
+    # filter silently bypasses every named logger in the codebase.
+    _fallback = logging.lastResort
+    handlers: list[logging.Handler] = logger.handlers or ([_fallback] if _fallback is not None else [])
+
+    # Reuse an existing instance so multiple setup calls share the same
+    # redactor state, but still add to every handler that lacks it.
+    existing: Optional[SensitiveDataFilter] = None
+    for handler in handlers:
+        for f in handler.filters:
+            if isinstance(f, SensitiveDataFilter):
+                existing = f
+                break
+        if existing:
+            break
+
+    filter_instance = existing or SensitiveDataFilter(redactor=redactor)
+    for handler in handlers:
+        if not any(isinstance(f, SensitiveDataFilter) for f in handler.filters):
+            handler.addFilter(filter_instance)
+    return filter_instance
+
+
+def setup_all_loggers(redactor: Optional[SensitiveDataRedactor] = None) -> None:
+    """Add sensitive data filter to the root logger's handlers.
+
+    Args:
+        redactor: Optional custom redactor instance
+    """
+    root_logger = logging.getLogger()
+    setup_sensitive_data_filter(root_logger, redactor=redactor)
+
+    # For loggers that own their own handlers (propagate=False or extra
+    # handlers attached), also protect those directly.
+    for logger_name in ["nemoguardrails", "langchain", "llama_index", "openai"]:
+        logger = logging.getLogger(logger_name)
+        if logger.handlers:
+            setup_sensitive_data_filter(logger, redactor=redactor)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -2291,3 +2291,26 @@ class TestScopeGateCharacterization:
     def test_the_refusal_reason_names_the_limitation(self, flow, direction, expected):
         """Each class of refusal reports why, in wording a config author can act on."""
         assert self._surface_reason(flow, direction) == expected
+
+
+class TestGuardrailsSensitiveDataFilterSetup:
+    """__init__ sets up the sensitive-data logging filter, best-effort."""
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_setup_sensitive_data_filter_exception_caught(self, mock_llmrails_class, _nemoguards_rails_config):
+        """A broken logging setup in the host application must not block Guardrails from initializing."""
+        mock_llmrails_class.return_value = MagicMock()
+        with patch(
+            "nemoguardrails.guardrails.guardrails.setup_sensitive_data_filter",
+            side_effect=RuntimeError("filter setup failed"),
+        ):
+            # Should not raise -- the error is caught and logged as a warning.
+            g = Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        assert g is not None
+
+    @patch("nemoguardrails.guardrails.guardrails.LLMRails")
+    def test_setup_sensitive_data_filter_called_on_init(self, mock_llmrails_class, _nemoguards_rails_config):
+        mock_llmrails_class.return_value = MagicMock()
+        with patch("nemoguardrails.guardrails.guardrails.setup_sensitive_data_filter") as mock_setup:
+            Guardrails(config=_nemoguards_rails_config, use_iorails=False)
+        mock_setup.assert_called_once()

--- a/tests/logging/test_sensitive_redaction.py
+++ b/tests/logging/test_sensitive_redaction.py
@@ -1,0 +1,695 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for sensitive data redaction in logging."""
+
+import logging
+
+import pytest
+
+from nemoguardrails.logging.redactor import (
+    SensitiveDataRedactor,
+    get_redactor,
+    redact_text,
+    redact_value,
+)
+from nemoguardrails.logging.sensitive_filter import SensitiveDataFilter
+
+
+class TestSensitiveDataRedactor:
+    """Test suite for SensitiveDataRedactor."""
+
+    @pytest.fixture
+    def redactor(self):
+        """Create a redactor instance."""
+        return SensitiveDataRedactor()
+
+    def test_redact_email(self, redactor):
+        """Email addresses should be redacted."""
+        text = "Contact us at john@example.com for support"
+        redacted = redactor.redact(text)
+        assert "john@example.com" not in redacted
+        assert "[EMAIL]" in redacted
+
+    def test_redact_phone(self, redactor):
+        """Phone numbers should be redacted."""
+        text = "Call us at 555-123-4567 during business hours"
+        redacted = redactor.redact(text)
+        assert "555-123-4567" not in redacted
+        assert "[PHONE]" in redacted
+
+    def test_redact_ssn(self, redactor):
+        """SSN should be redacted."""
+        text = "SSN: 123-45-6789"
+        redacted = redactor.redact(text)
+        assert "123-45-6789" not in redacted
+        assert "[SSN]" in redacted
+
+    def test_redact_credit_card(self, redactor):
+        """Credit card numbers should be redacted."""
+        text = "Card: 1234-5678-9012-3456"
+        redacted = redactor.redact(text)
+        assert "1234-5678-9012-3456" not in redacted
+        assert "[CREDIT_CARD]" in redacted
+
+    def test_redact_api_key(self, redactor):
+        """API keys should be redacted."""
+        text = 'api_key="sk_live_1234567890abcdefghij"'
+        redacted = redactor.redact(text)
+        assert "sk_live_1234567890abcdefghij" not in redacted
+        assert "[API_KEY]" in redacted
+
+    def test_redact_password(self, redactor):
+        """Passwords should be redacted."""
+        text = 'password="super_secret_password123"'
+        redacted = redactor.redact(text)
+        assert "super_secret_password123" not in redacted
+        assert "[PASSWORD]" in redacted
+
+    def test_redact_token(self, redactor):
+        """Tokens should be redacted."""
+        text = 'token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"'
+        redacted = redactor.redact(text)
+        assert "[TOKEN]" in redacted
+
+    def test_redact_bearer_token_space_separated(self, redactor):
+        """Authorization: Bearer <token> (space separator) should be redacted."""
+        text = "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"
+        redacted = redactor.redact(text)
+        assert "eyJhbGciOiJSUzI1NiJ9" not in redacted
+        assert "[TOKEN]" in redacted
+
+    def test_redact_aws_key(self, redactor):
+        """AWS keys should be redacted."""
+        text = "AWS Key: AKIAIOSFODNN7EXAMPLE"
+        redacted = redactor.redact(text)
+        assert "AKIAIOSFODNN7EXAMPLE" not in redacted
+        assert "[AWS_KEY]" in redacted
+
+    def test_redact_ip_address(self, redactor):
+        """IP addresses should be redacted."""
+        text = "Server at 192.168.1.100 is down"
+        redacted = redactor.redact(text)
+        assert "192.168.1.100" not in redacted
+        assert "[IP_ADDRESS]" in redacted
+
+    def test_redact_url_with_creds(self, redactor):
+        """URLs with embedded credentials should be redacted."""
+        text = "Database: https://user:password@db.example.com/prod"
+        redacted = redactor.redact(text)
+        assert "user:password" not in redacted
+        assert "[URL_WITH_CREDS]" in redacted
+
+    def test_clean_text_unchanged(self, redactor):
+        """Clean text without sensitive data should be unchanged."""
+        text = "What is the capital of France?"
+        redacted = redactor.redact(text)
+        assert redacted == text
+
+    def test_redact_dict_with_sensitive_keys(self, redactor):
+        """Dict values with sensitive keys should be redacted."""
+        data = {
+            "username": "john",
+            "password": "secret123",
+            "api_key": "sk_live_xyz",
+        }
+        redacted = redactor.redact_dict(data)
+        assert redacted["password"] == "[PASSWORD]"
+        assert redacted["api_key"] == "[API_KEY]"
+        assert redacted["username"] == "john"
+
+    def test_redact_dict_with_sensitive_values(self, redactor):
+        """Dict values containing sensitive data should be redacted."""
+        data = {
+            "contact": "john@example.com",
+            "phone": "555-123-4567",
+        }
+        redacted = redactor.redact_dict(data)
+        assert "[EMAIL]" in redacted["contact"]
+        assert "[PHONE]" in redacted["phone"]
+
+    def test_redact_nested_dict(self, redactor):
+        """Nested dicts should be recursively redacted."""
+        data = {
+            "user": {
+                "email": "john@example.com",
+                "password": "secret",
+            }
+        }
+        redacted = redactor.redact_dict(data)
+        assert "[EMAIL]" in redacted["user"]["email"]
+        assert redacted["user"]["password"] == "[PASSWORD]"
+
+    def test_redact_list(self, redactor):
+        """Lists should be redacted."""
+        data = [
+            "john@example.com",
+            "555-123-4567",
+            "normal text",
+        ]
+        redacted = redactor.redact_list(data)
+        assert "[EMAIL]" in redacted[0]
+        assert "[PHONE]" in redacted[1]
+        assert redacted[2] == "normal text"
+
+    def test_should_redact_value_sensitive_keys(self, redactor):
+        """Sensitive keys should be identified."""
+        sensitive_keys = ["password", "api_key", "secret", "token"]
+        for key in sensitive_keys:
+            assert redactor.should_redact_value(key, "some_value") is True
+
+    def test_should_redact_value_non_sensitive_keys(self, redactor):
+        """Non-sensitive keys should not be redacted."""
+        non_sensitive_keys = [
+            "username",
+            "email_address",
+            "phone_number",
+            # False-positive regression: 'tokens' (plural) is not the 'token' keyword
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            # False-positive regression: 'auth' substring must not match these
+            "authenticated",
+            "authentication_method",
+            "is_authorized",
+        ]
+        for key in non_sensitive_keys:
+            assert redactor.should_redact_value(key, "some_value") is False, f"key '{key}' should NOT be redacted"
+
+    def test_should_redact_value_true_positives_still_work(self, redactor):
+        """Keys that genuinely contain sensitive segments are still redacted."""
+        sensitive_keys = [
+            "auth_token",
+            "access_token",
+            "bearer_token",
+            "user_password",
+            "my_secret",
+            "private_key",
+            "api_key",
+            "auth",
+            "token",
+        ]
+        for key in sensitive_keys:
+            assert redactor.should_redact_value(key, "value") is True, f"key '{key}' SHOULD be redacted"
+
+    def test_redact_none_values(self, redactor):
+        """None values should be handled gracefully."""
+        data = {
+            "password": None,
+            "api_key": None,
+        }
+        redacted = redactor.redact_dict(data)
+        assert redacted["password"] is None
+        assert redacted["api_key"] is None
+
+    def test_convenience_function_redact_text(self):
+        """Convenience function should work."""
+        text = "Email: john@example.com"
+        redacted = redact_text(text)
+        assert "[EMAIL]" in redacted
+
+    def test_convenience_function_redact_value(self):
+        """Convenience function should handle various types."""
+        # String
+        assert "[EMAIL]" in redact_value("john@example.com")
+
+        # Dict
+        redacted_dict = redact_value({"password": "secret"})
+        assert redacted_dict["password"] == "[PASSWORD]"
+
+        # List
+        redacted_list = redact_value(["john@example.com"])
+        assert "[EMAIL]" in redacted_list[0]
+
+    def test_get_redactor_singleton(self):
+        """get_redactor should return consistent instance."""
+        r1 = get_redactor()
+        r2 = get_redactor()
+        assert r1 is r2
+
+    def test_redact_multiple_patterns_in_text(self, redactor):
+        """Multiple sensitive patterns should be redacted."""
+        text = "User: john@example.com, Phone: 555-123-4567, API Key: sk_live_xyz"
+        redacted = redactor.redact(text)
+        assert "[EMAIL]" in redacted
+        assert "[PHONE]" in redacted
+        assert "[API_KEY]" in redacted
+
+    def test_case_insensitive_redaction(self, redactor):
+        """Redaction should be case insensitive."""
+        text1 = "API_KEY=secret123"
+        text2 = "api_key=secret123"
+        redacted1 = redactor.redact(text1)
+        redacted2 = redactor.redact(text2)
+        # Both should be redacted (patterns are case-insensitive)
+        assert redacted1 == redacted2 or "[" in redacted1
+
+    def test_custom_patterns_in_constructor(self):
+        """Custom patterns are merged into self.patterns (line 96)."""
+        custom = {"zip_code": (r"\b\d{5}(?:-\d{4})?\b", "[ZIP]")}
+        r = SensitiveDataRedactor(custom_patterns=custom)
+        result = r.redact("Zip: 90210")
+        assert "[ZIP]" in result
+
+    def test_invalid_regex_raises_value_error(self):
+        """Invalid regex in patterns dict raises ValueError (lines 108-109)."""
+        bad_patterns = {"bad": (r"[invalid(", "[BAD]")}
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            SensitiveDataRedactor(patterns=bad_patterns)
+
+    def test_redact_non_string_input_returns_input(self):
+        """Non-string passed to redact() returns unchanged (line 121)."""
+        r = SensitiveDataRedactor()
+        assert r.redact(42) == 42
+        assert r.redact(None) is None
+        assert r.redact([]) == []
+
+    def test_custom_redactor_applied(self, redactor):
+        """Custom redactor function is applied after pattern redaction (line 129)."""
+        marker = []
+
+        def custom_fn(text):
+            marker.append(True)
+            return text.replace("foo", "[FOO]")
+
+        r = SensitiveDataRedactor(custom_redactor=custom_fn)
+        result = r.redact("foo bar")
+        assert "[FOO]" in result
+        assert marker  # custom_fn was called
+
+    def test_should_redact_non_string_key_returns_false(self, redactor):
+        """Non-string key returns False (line 144)."""
+        assert redactor.should_redact_value(123, "secret") is False
+        assert redactor.should_redact_value(None, "token") is False
+
+    def test_redact_dict_list_value_with_nested_dict(self, redactor):
+        """Dict elements inside list values are recursively redacted (line 170)."""
+        data = {
+            "items": [
+                {"password": "secret", "name": "alice"},
+                "plain text",
+            ]
+        }
+        result = redactor.redact_dict(data)
+        assert result["items"][0]["password"] == "[PASSWORD]"
+        assert result["items"][1] == "plain text"
+
+    def test_redact_list_tuple_input_returns_tuple(self, redactor):
+        """redact_list with tuple input returns a tuple (line 193)."""
+        data = ("john@example.com", "normal")
+        result = redactor.redact_list(data)
+        assert isinstance(result, tuple)
+        assert "[EMAIL]" in result[0]
+        assert result[1] == "normal"
+
+    def test_redact_dict_non_dict_input_returns_unchanged(self, redactor):
+        """redact_dict with a non-dict argument returns it unchanged (line 159)."""
+        assert redactor.redact_dict("a string") == "a string"
+        assert redactor.redact_dict(42) == 42
+        assert redactor.redact_dict(None) is None
+
+    def test_redact_list_non_iterable_returns_as_is(self, redactor):
+        """redact_list with non-list/tuple returns unchanged (line 211)."""
+        result = redactor.redact_list(42)
+        assert result == 42
+
+    def test_create_sensitive_redactor_factory(self):
+        """create_sensitive_redactor factory function (line 227)."""
+        from nemoguardrails.logging.redactor import create_sensitive_redactor
+
+        r = create_sensitive_redactor()
+        assert isinstance(r, SensitiveDataRedactor)
+
+    def test_redact_value_non_redactable_type(self):
+        """redact_value with int/etc returns value unchanged (line 274)."""
+        result = redact_value(42)
+        assert result == 42
+        result = redact_value(3.14)
+        assert result == 3.14
+
+
+class TestSensitiveDataFilter:
+    """Test suite for SensitiveDataFilter logging filter."""
+
+    def test_filter_redacts_message(self):
+        """Filter should redact main log message."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="User email: john@example.com",
+            args=(),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert "[EMAIL]" in record.msg
+
+    def test_filter_redacts_args(self):
+        """Filter should redact message arguments."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="User: %s",
+            args=("john@example.com",),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        # Args are merged into msg during pre-format; redaction operates on the
+        # fully formatted string.
+        assert record.args is None
+        assert "[EMAIL]" in record.msg
+
+    def test_filter_redacts_dict_args(self):
+        """Filter should redact sensitive values in dict-style log record args."""
+        filter_instance = SensitiveDataFilter()
+        # Template embeds the key name so the api_key pattern still matches in
+        # the fully formatted string after pre-format merges args into msg.
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="api_key=%(api_key)s env=%(env)s",
+            args={"api_key": "sk_live_abc12345", "env": "prod"},
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert record.args is None
+        assert "[API_KEY]" in record.msg
+
+    def test_filter_format_template_sensitive_keyword_no_typeerror(self):
+        """Template containing a sensitive keyword must not raise TypeError.
+
+        logger.debug("password: %s", value) stores "password: %s" in record.msg.
+        Without pre-formatting, the redactor matches "password: %s" and replaces
+        the whole string (including %s) with "[PASSWORD]", so getMessage() later
+        executes "[PASSWORD]" % (value,) and raises TypeError, silently dropping
+        the record.
+        """
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="password: %s",
+            args=("hunter2",),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert record.args is None
+        assert "[PASSWORD]" in record.msg
+        assert "hunter2" not in record.msg
+
+    def test_filter_returns_true(self):
+        """Filter should always return True to allow logging."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        result = filter_instance.filter(record)
+        assert result is True
+
+    def test_filter_handles_none_values(self):
+        """Filter should handle None values gracefully."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg=None,
+            args=None,
+            exc_info=None,
+        )
+        result = filter_instance.filter(record)
+        assert result is True
+
+    def test_filter_redacts_dict_msg(self):
+        """Filter should redact sensitive values when record.msg is a dict (lines 53-54)."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg={"password": "supersecret", "user": "alice"},
+            args=None,
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert record.msg["password"] == "[PASSWORD]"
+        assert record.msg["user"] == "alice"
+
+    def test_filter_tuple_args_with_dict_item(self):
+        """Filter should redact sensitive data when dict items appear in tuple args."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Log entry: %s and %s",
+            args=({"password": "secret123", "env": "prod"}, {"user": "alice", "env": "dev"}),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        # Args are pre-formatted into msg; the password key+value in the string
+        # representation of the dict is caught by the password pattern.
+        assert record.args is None
+        assert "[PASSWORD]" in record.msg
+        assert "alice" in record.msg
+
+    def test_filter_tuple_args_with_non_string_item(self):
+        """Non-string args are pre-formatted into msg; args is cleared."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Count: %s",
+            args=(42,),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert record.args is None
+        assert "42" in record.msg
+
+    def test_filter_preformat_typeerror_hits_except_branch(self):
+        """When getMessage() raises, the except branch (lines 56-57) is taken and args are kept."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="%d",  # integer format spec
+            args=("not-a-number",),  # causes TypeError in %d % ("not-a-number",)
+            exc_info=None,
+        )
+        result = filter_instance.filter(record)
+        assert result is True
+        # getMessage() raised, so args were NOT cleared by the pre-format block
+        assert record.args is not None
+
+    def test_filter_dict_args_direct_redaction(self):
+        """Dict args are redacted via the args branch (lines 68-69) when pre-format is skipped."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg=1,  # non-string msg skips the pre-format branch at line 52
+            args={"password": "hunter2", "user": "alice"},
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert record.args["password"] == "[PASSWORD]"
+        assert record.args["user"] == "alice"
+
+    def test_filter_tuple_args_direct_redaction_mixed(self):
+        """Mixed tuple args (str, dict, int) hit all sub-branches of lines 70-79."""
+        filter_instance = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg=1,  # non-string msg skips the pre-format branch at line 52
+            args=("password=hunter2", {"api_key": "sk_live_abc12345"}, 42),
+            exc_info=None,
+        )
+        filter_instance.filter(record)
+        assert "[PASSWORD]" in record.args[0]  # str arg redacted  (lines 73-74)
+        assert record.args[1]["api_key"] == "[API_KEY]"  # dict arg redacted  (lines 75-76)
+        assert record.args[2] == 42  # int arg unchanged  (lines 78-79)
+
+    def test_filter_exc_info_redacts_exception_string(self):
+        """Filter should redact sensitive data in exception args (lines 73-76)."""
+        filter_instance = SensitiveDataFilter()
+        exc = ValueError("password=supersecret connection failed")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="An error occurred",
+            args=None,
+            exc_info=(type(exc), exc, None),
+        )
+        filter_instance.filter(record)
+        # The exception args should be updated with redacted string
+        assert "supersecret" not in str(exc.args[0])
+        assert "[PASSWORD]" in str(exc.args[0])
+
+    def test_filter_exc_info_frozen_args_handled(self):
+        """Filter handles exc_value.args assignment failure gracefully (lines 78-81)."""
+        filter_instance = SensitiveDataFilter()
+
+        class _FrozenArgsExc:
+            """Exception-like object with read-only args property."""
+
+            def __str__(self):
+                return "password=topsecret"
+
+            @property
+            def args(self):
+                return ("password=topsecret",)
+
+            @args.setter
+            def args(self, value):
+                raise AttributeError("args is read-only")
+
+            def __bool__(self):
+                return True
+
+        frozen_exc = _FrozenArgsExc()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="Error",
+            args=None,
+            exc_info=(Exception, frozen_exc, None),
+        )
+        # Should not raise even though args assignment fails
+        result = filter_instance.filter(record)
+        assert result is True
+
+
+class TestSetupSensitiveDataFilter:
+    """Tests for setup_sensitive_data_filter and setup_all_loggers."""
+
+    def test_setup_sensitive_data_filter_defaults_to_root_logger(self):
+        """When logger=None, filter is attached to the root logger's handlers."""
+        from nemoguardrails.logging.sensitive_filter import setup_sensitive_data_filter
+
+        root = logging.getLogger()
+        handler = logging.StreamHandler()
+        root.addHandler(handler)
+        try:
+            f = setup_sensitive_data_filter()
+            assert isinstance(f, SensitiveDataFilter)
+            assert any(isinstance(fl, SensitiveDataFilter) for fl in handler.filters)
+        finally:
+            root.removeHandler(handler)
+            handler.filters.clear()
+
+    def test_setup_sensitive_data_filter_returns_existing(self):
+        """When filter already exists on a handler, return the same instance."""
+        from nemoguardrails.logging.sensitive_filter import setup_sensitive_data_filter
+
+        test_logger = logging.getLogger("test.setup_filter.idempotent")
+        handler = logging.StreamHandler()
+        test_logger.addHandler(handler)
+        try:
+            first = setup_sensitive_data_filter(test_logger)
+            second = setup_sensitive_data_filter(test_logger)
+            assert second is first
+            assert len([f for f in handler.filters if isinstance(f, SensitiveDataFilter)]) == 1
+        finally:
+            test_logger.removeHandler(handler)
+            handler.filters.clear()
+
+    def test_setup_all_loggers_adds_filters(self):
+        """setup_all_loggers adds filter to the root logger's handlers."""
+        from nemoguardrails.logging.sensitive_filter import setup_all_loggers
+
+        root_logger = logging.getLogger()
+        handler = logging.StreamHandler()
+        root_logger.addHandler(handler)
+        try:
+            setup_all_loggers()
+            assert any(isinstance(f, SensitiveDataFilter) for f in handler.filters)
+        finally:
+            root_logger.removeHandler(handler)
+            handler.filters.clear()
+
+    def test_setup_all_loggers_covers_named_logger_with_own_handler(self):
+        """setup_all_loggers attaches the filter to a named logger that owns its own handler (line 150)."""
+        from nemoguardrails.logging.sensitive_filter import setup_all_loggers
+
+        named_logger = logging.getLogger("nemoguardrails")
+        handler = logging.StreamHandler()
+        named_logger.addHandler(handler)
+        try:
+            setup_all_loggers()
+            assert any(isinstance(f, SensitiveDataFilter) for f in handler.filters)
+        finally:
+            named_logger.removeHandler(handler)
+            handler.filters.clear()
+
+    def test_child_logger_records_are_redacted(self):
+        """Filter on root handler intercepts records propagated from child loggers."""
+        import io
+
+        from nemoguardrails.logging.sensitive_filter import setup_sensitive_data_filter
+
+        root = logging.getLogger()
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.DEBUG)
+        root.addHandler(handler)
+        original_level = root.level
+        root.setLevel(logging.DEBUG)
+        try:
+            setup_sensitive_data_filter(root)
+            child = logging.getLogger("test.child.propagation.redact")
+            child.debug("password=supersecret123")
+            output = stream.getvalue()
+            assert "supersecret123" not in output
+            assert "[PASSWORD]" in output
+        finally:
+            root.removeHandler(handler)
+            handler.filters.clear()
+            root.setLevel(original_level)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What
Adds `SensitiveDataRedactor` (`nemoguardrails/logging/redactor.py`) and `SensitiveDataFilter`, a `logging.Filter` (`nemoguardrails/logging/sensitive_filter.py`), that redacts PII and credential patterns (emails, SSNs, credit cards, API keys, passwords, tokens, AWS keys, IP addresses) from log records before they reach handlers. Wired into `Guardrails.__init__` via `setup_sensitive_data_filter()`, best-effort so a broken logging setup in the host application can't block initialization.

Addresses #1982.

## Why a fresh PR instead of updating #2000
Same root cause as #2344 (which replaced #1999): #2000 was branched on top of the unmerged #1999 branch, which was itself branched on top of the unmerged #1979 (prompt-injection-detection) branch. Its live diff against `develop` (via `gh pr diff`, not just commit history) carried 13 files spanning three unrelated bundled features -- log redaction, leftover prompt-injection-detection code, and the entire context-length-validation feature.

This PR is a clean rebuild off current `develop`, scoped to log redaction only:
- No prompt-injection-detection code, no context-length-validation code.
- `redactor.py` and `sensitive_filter.py` ported verbatim (self-contained, no cross-feature deps).
- `setup_sensitive_data_filter()` wired into `Guardrails.__init__` only, wrapped in try/except.
- New tests in `tests/guardrails/test_guardrails.py` cover the wiring (called on init, exception is swallowed) alongside the full `tests/logging/test_sensitive_redaction.py` suite.
- Confirmed the original branch's `tests/tracing/adapters/test_opentelemetry.py` hardening isn't needed here -- that test passes cleanly against this scoped diff, run standalone and after the full `test_guardrails.py` suite; it was compensating for the leftover injection-detection wiring this PR excludes.

Closing #2000 in favor of this.

## Test plan
- `pytest tests/logging/test_sensitive_redaction.py tests/guardrails/test_guardrails.py` — 203 passed, 1 skipped
- `ruff check` / `ruff format --check` clean