### PR TITLE
fix(server): drop unsupported BeforeValidator json_schema_input_type

### DIFF
--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -205,10 +205,7 @@ def _validate_openai_chat_message(message: Any) -> Any:
 
 OpenAIChatMessage = Annotated[
     dict[str, Any],
-    BeforeValidator(
-        _validate_openai_chat_message,
-        json_schema_input_type=_OpenAIChatMessageInput,
-    ),
+    BeforeValidator(_validate_openai_chat_message),
 ]
 
 


### PR DESCRIPTION
Fixes #2292

## Summary
Remove unsupported `json_schema_input_type` from `BeforeValidator` usage in OpenAI chat schema (Pydantic v2 compatibility).

## Test plan
- [x] Server schema imports cleanly on current Pydantic