### PR TITLE
docs(benchmark): drop AIPerf comparison from Locust README

### DIFF
--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -5,7 +5,8 @@ This directory contains a Locust-based load testing framework for the NeMo Guard
 ## Introduction
 
 The [Locust](https://locust.io/) stress-testing tool ramps up concurrent users making API calls to the `/v1/chat/completions` endpoint of an OpenAI-compatible LLM with configurable parameters.
-This complements [ai-perf](https://github.com/ai-dynamo/aiperf), which measures steady-state performance.  Locust instead focuses on ramping up load potentially beyond what a system can handle, and measure how gracefully it degrades under higher-than-expected load.
+The focus is on ramping load up potentially beyond what a system can handle, and measuring how
+gracefully it degrades under higher-than-expected load.
 
 ## Quickstart
 


### PR DESCRIPTION
## Description

The Locust README introduction contrasted this harness with [AIPerf](https://github.com/ai-dynamo/aiperf), saying AIPerf "measures steady-state performance" while Locust ramps past capacity. AIPerf also supports [gradual ramping](https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/ramping.md) and can be driven past a system's capacity, so the contrast does not hold.

Rather than restate the comparison in a narrower form, this drops it: the intro now just describes what the Locust harness does. 

Docs-only change; no code or behavior touched.

## Related Issue

Closes #2355

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (n/a — documentation only)
- [x] The documentation is up to date with these changes.