### PR TITLE
docs: Fix VDR 0.17 issues in docs

### DIFF
--- a/docs/integration/langchain/langgraph-integration.mdx
+++ b/docs/integration/langchain/langgraph-integration.mdx
@@ -24,6 +24,20 @@ LangGraph is a library for building stateful, multi-actor applications with LLMs
 - **Graph-Based Control**: Conditional routing with safety considerations.
 - **Conversation Memory**: Maintained context with continuous safety monitoring.
 
+The following diagram shows the basic data flow through a guarded LangGraph agent:
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'background': 'transparent' }}}%%
+
+flowchart LR
+    A[User input] --> B[Input rails]
+    B --> C[Agent / LLM node]
+    C -->|tool call| D[Tool node]
+    D --> C
+    C -->|final answer| E[Output rails]
+    E --> F[Response]
+```
+
 ---
 
 ## Prerequisites
@@ -162,6 +176,22 @@ result_unsafe = graph.invoke({"messages": [{"role": "user", "content": "You are 
 
 To enhance the functionality of your LangGraph agents, you can combine tool calling with guardrails. This ensures that both the decision to call tools and the tool results are safely validated.
 
+`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
+
+The following diagram shows where guardrails sit relative to the `ToolNode`/`tools_condition` conditional edge:
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'background': 'transparent' }}}%%
+
+flowchart LR
+    A[chatbot node<br/>prompt | guardrails | llm_with_tools] -->|tools_condition| B{Tool calls<br/>present?}
+    B -->|yes| C[ToolNode<br/>executes tools]
+    C --> A
+    B -->|no, final answer| D[END]
+```
+
+`tools_condition` inspects the `AIMessage` that `chatbot` returns. Because guardrails wrap the model call inside `chatbot`, both the decision to call a tool and the tool's result pass through guardrail checks on every trip through the `chatbot` node, not just on the final answer.
+
 ### Tool Definition
 
 Define the following simplified example tools that demonstrate the integration pattern with the NeMo Guardrails library.
@@ -245,6 +275,25 @@ result = graph.invoke({
     "messages": [{"role": "user", "content": "What is the capital of Peru?"}]
 })
 ```
+
+### Failure Handling in Tool-Calling Graphs
+
+The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`. If the underlying LLM call fails, a bound tool raises, or a guardrail action itself errors, `RunnableRails` raises a `ValueError` (see [Error Handling](/integration/langchain/runnable-rails#error-handling)), and that exception propagates uncaught through `graph.invoke()` and crashes the run.
+
+The following variant wraps the same node with a `try`/`except` and returns a fallback message into `state["messages"]` instead of letting the graph crash. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
+
+```python
+from langchain_core.messages import AIMessage
+
+def chatbot(state: State):
+    try:
+        result = runnable_with_guardrails.invoke(state)
+    except ValueError:
+        return {"messages": [AIMessage(content="Sorry, I couldn't process that request.")]}
+    return {"messages": [result]}
+```
+
+A rail that blocks the request, as opposed to an outright error, does not raise. It returns the normal `AIMessage` shape described in [Rejection Behavior](/integration/langchain/runnable-rails#rejection-behavior), so `chatbot` does not need a separate branch for that case.
 
 ---
 
@@ -450,5 +499,16 @@ guardrails = RunnableRails(config=config, passthrough=True, verbose=True)
 
 - LangGraph integration with RunnableRails produces single large chunks after processing delays.
 - Token-level streaming is not preserved when RunnableRails is integrated into LangGraph nodes.
+
+### Why
+
+LangGraph nodes return their full state update atomically. A node that wraps `RunnableRails` or an LLM call can only hand its return value back to the graph edge once the node function returns; it cannot emit partial tokens through the edge while the node is still running. The graph observes the node's final state update, not intermediate chunks, regardless of whether the wrapped call streamed internally.
+
+No tracking issue currently exists in the [`NVIDIA-NeMo/Guardrails`](https://github.com/NVIDIA-NeMo/Guardrails) repository for LangGraph token streaming support.
+
+### Workarounds
+
+- Stream directly from `RunnableRails` or the LLM outside the LangGraph node (`guardrails.astream(...)`, as shown earlier in this guide), and use LangGraph only for the non-streaming orchestration and tool-calling parts of your flow.
+- Consider a hybrid architecture: stream the final synthesis call directly to the client, and keep guardrail-gated intermediate steps inside the graph non-streaming.
 
 RunnableRails supports streaming when used directly, but integration with LangGraph fundamentally conflicts with real-time streaming due to node execution requirements and safety validation needs.

--- a/docs/integration/langchain/langgraph-integration.mdx
+++ b/docs/integration/langchain/langgraph-integration.mdx
@@ -278,22 +278,29 @@ result = graph.invoke({
 
 ### Failure Handling in Tool-Calling Graphs
 
-The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`. If the underlying LLM call fails, a bound tool raises, or a guardrail action itself errors, `RunnableRails` raises a `ValueError` (see [Error Handling](/integration/langchain/runnable-rails#error-handling)), and that exception propagates uncaught through `graph.invoke()` and crashes the run.
+The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`. See [Error Handling](/integration/langchain/runnable-rails#error-handling) for what actually raises here: an LLM provider failure (main model or safety-check model) surfaces as a `ValueError` and, if uncaught, crashes `graph.invoke()`. A failure inside a bound tool or a guardrail action, by contrast, does not raise; the runtime converts it into a normal-looking response with the content `"I'm sorry, an internal error has occurred."`, so `graph.invoke()` completes without an exception in that case.
 
-The following variant wraps the same node with a `try`/`except` and returns a fallback message into `state["messages"]` instead of letting the graph crash. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
+The following variant wraps the same node with a `try`/`except` to catch the LLM-provider-failure case, and also checks the response content for the internal-error message so both failure modes get the same fallback treatment. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
 
 ```python
 from langchain_core.messages import AIMessage
+
+FALLBACK_MESSAGE = "Sorry, I couldn't process that request."
+INTERNAL_ERROR_TEXT = "I'm sorry, an internal error has occurred."
 
 def chatbot(state: State):
     try:
         result = runnable_with_guardrails.invoke(state)
     except ValueError:
-        return {"messages": [AIMessage(content="Sorry, I couldn't process that request.")]}
+        return {"messages": [AIMessage(content=FALLBACK_MESSAGE)]}
+
+    if result.content == INTERNAL_ERROR_TEXT:
+        return {"messages": [AIMessage(content=FALLBACK_MESSAGE)]}
+
     return {"messages": [result]}
 ```
 
-A rail that blocks the request, as opposed to an outright error, does not raise. It returns the normal `AIMessage` shape described in [Rejection Behavior](/integration/langchain/runnable-rails#rejection-behavior), so `chatbot` does not need a separate branch for that case.
+A rail that blocks the request, as opposed to an outright error, does not raise either. It returns the normal `AIMessage` shape described in [Rejection Behavior](/integration/langchain/runnable-rails#rejection-behavior), with the rail's configured refusal text rather than the internal-error text, so `chatbot` does not need a separate branch for that case.
 
 ---
 

--- a/docs/integration/langchain/langgraph-integration.mdx
+++ b/docs/integration/langchain/langgraph-integration.mdx
@@ -509,7 +509,9 @@ guardrails = RunnableRails(config=config, passthrough=True, verbose=True)
 
 ### Why
 
-LangGraph nodes return their full state update atomically. A node that wraps `RunnableRails` or an LLM call can only hand its return value back to the graph edge once the node function returns; it cannot emit partial tokens through the edge while the node is still running. The graph observes the node's final state update, not intermediate chunks, regardless of whether the wrapped call streamed internally.
+This is a `RunnableRails`-specific limitation, not a general LangGraph one. LangGraph itself supports token-level streaming from inside a node through `stream_mode="messages"`, which hooks the LLM's own streaming callbacks independently of what the node returns.
+
+The `chatbot` node in the examples above calls `runnable_with_guardrails.invoke(state)`. `RunnableRails.invoke()` calls `LLMRails.generate()`, which makes a single blocking call and returns one fully formatted result; no incremental LLM callback events fire during it for LangGraph's `messages` mode to observe. `RunnableRails.astream()` does stream token-by-token, but it yields chunks directly to whatever calls it; it does not forward those chunks into LangGraph's callback-based streaming machinery. Calling `astream()` from inside a node, instead of `invoke()`, would still not surface as `messages`-mode events without additional wiring.
 
 No tracking issue currently exists in the [`NVIDIA-NeMo/Guardrails`](https://github.com/NVIDIA-NeMo/Guardrails) repository for LangGraph token streaming support.
 

--- a/docs/integration/langchain/langgraph-integration.mdx
+++ b/docs/integration/langchain/langgraph-integration.mdx
@@ -280,13 +280,12 @@ result = graph.invoke({
 
 The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`. See [Error Handling](/integration/langchain/runnable-rails#error-handling) for what actually raises here: an LLM provider failure (main model or safety-check model) surfaces as a `ValueError` and, if uncaught, crashes `graph.invoke()`. A failure inside a bound tool or a guardrail action, by contrast, does not raise; the runtime converts it into a normal-looking response with the content `"I'm sorry, an internal error has occurred."`, so `graph.invoke()` completes without an exception in that case.
 
-The following variant wraps the same node with a `try`/`except` to catch the LLM-provider-failure case, and also checks the response content for the internal-error message so both failure modes get the same fallback treatment. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
+The following variant catches failures that `RunnableRails` exposes as exceptions. Failures inside a bound tool or a guardrail action are converted by the runtime into a normal-looking response instead, so they cannot be distinguished reliably at this boundary; matching on the response content is not a safe way to detect them, since a legitimate model or rail response could coincidentally contain the same text. Handle those failures inside the tool or action itself if you need a fallback for them. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
 
 ```python
 from langchain_core.messages import AIMessage
 
 FALLBACK_MESSAGE = "Sorry, I couldn't process that request."
-INTERNAL_ERROR_TEXT = "I'm sorry, an internal error has occurred."
 
 def chatbot(state: State):
     try:
@@ -294,13 +293,10 @@ def chatbot(state: State):
     except ValueError:
         return {"messages": [AIMessage(content=FALLBACK_MESSAGE)]}
 
-    if result.content == INTERNAL_ERROR_TEXT:
-        return {"messages": [AIMessage(content=FALLBACK_MESSAGE)]}
-
     return {"messages": [result]}
 ```
 
-A rail that blocks the request, as opposed to an outright error, does not raise either. It returns the normal `AIMessage` shape described in [Rejection Behavior](/integration/langchain/runnable-rails#rejection-behavior), with the rail's configured refusal text rather than the internal-error text, so `chatbot` does not need a separate branch for that case.
+A rail that blocks the request, as opposed to an outright error, does not raise either. It returns the normal `AIMessage` shape described in [Rejection Behavior](/integration/langchain/runnable-rails#rejection-behavior), with the rail's configured refusal text.
 
 ---
 

--- a/docs/integration/langchain/langgraph-integration.mdx
+++ b/docs/integration/langchain/langgraph-integration.mdx
@@ -176,7 +176,7 @@ result_unsafe = graph.invoke({"messages": [{"role": "user", "content": "You are 
 
 To enhance the functionality of your LangGraph agents, you can combine tool calling with guardrails. This ensures that both the decision to call tools and the tool results are safely validated.
 
-`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
+`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NVIDIA NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
 
 The following diagram shows where guardrails sit relative to the `ToolNode`/`tools_condition` conditional edge:
 
@@ -278,9 +278,13 @@ result = graph.invoke({
 
 ### Failure Handling in Tool-Calling Graphs
 
-The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`. See [Error Handling](/integration/langchain/runnable-rails#error-handling) for what actually raises here: an LLM provider failure (main model or safety-check model) surfaces as a `ValueError` and, if uncaught, crashes `graph.invoke()`. A failure inside a bound tool or a guardrail action, by contrast, does not raise; the runtime converts it into a normal-looking response with the content `"I'm sorry, an internal error has occurred."`, so `graph.invoke()` completes without an exception in that case.
+The `chatbot` node above has no exception handling around `runnable_with_guardrails.invoke(state)`, and the graph has three distinct failure modes that behave differently:
 
-The following variant catches failures that `RunnableRails` exposes as exceptions. Failures inside a bound tool or a guardrail action are converted by the runtime into a normal-looking response instead, so they cannot be distinguished reliably at this boundary; matching on the response content is not a safe way to detect them, since a legitimate model or rail response could coincidentally contain the same text. Handle those failures inside the tool or action itself if you need a fallback for them. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
+- **Failures that `RunnableRails` surfaces in the `chatbot` node** raise a `ValueError`, which crashes `graph.invoke()` if uncaught. See [Error Handling](/integration/langchain/runnable-rails#error-handling); this covers LLM provider failures and other errors alike, so `except ValueError` in the node catches all of them, not just provider failures.
+- **Failures in a tool executed by the `tools` node** are LangGraph's concern, not the guardrail configuration's. In this example the tools run inside `ToolNode`, outside `RunnableRails`, so the guardrail runtime never sees them. LangGraph's default `handle_tool_errors` handler returns a message only for tool-invocation errors, such as malformed arguments, and re-raises everything else out of `graph.invoke()`. Pass `ToolNode(tools=tools, handle_tool_errors=...)` to change that. A `try`/`except` in `chatbot` does not catch these, because they are raised from a different node.
+- **Failures in a tool or action registered with the guardrail configuration** (for example, tools passed as `RunnableRails(config=config, tools=[...])`) are caught by the action dispatcher, which converts them into a normal-looking response with the content `"I'm sorry, an internal error has occurred."` The dispatcher forwards LLM call failures rather than catching them, so those still surface as in the first case.
+
+The following variant catches the first case. Do not extend it by matching on the response content to detect the third case: that response is indistinguishable from a normal answer, and a legitimate model or rail response can contain the same text. Handle those failures inside the tool or action itself if you need a fallback for them. Everything else about `create_tool_calling_agent` stays the same; only `chatbot` changes.
 
 ```python
 from langchain_core.messages import AIMessage

--- a/docs/integration/langchain/runnable-rails.mdx
+++ b/docs/integration/langchain/runnable-rails.mdx
@@ -302,6 +302,8 @@ The following steps are required to use tool calling with `RunnableRails`:
 
 Avoid Python's built-in `eval()` for evaluating LLM-provided expressions, even with a `__builtins__` whitelist. Sandbox-escape techniques (for example, attribute traversal through `__class__`) can bypass a manually constructed whitelist. Use a restricted expression evaluator such as [`simpleeval`](https://github.com/danthedeckie/simpleeval) instead. `simpleeval` is already a NeMo Guardrails library dependency, so no extra install is required.
 
+Do not map a custom `pow` function into `functions`. `simpleeval`'s built-in `**` operator is guarded by `simpleeval.MAX_POWER` against oversized exponents, but that guard does not apply to a function you supply yourself, so a mapped `pow` lets an expression like `pow(2, 999999999)` consume seconds of CPU time and hundreds of megabytes of memory. Let callers use `**` for exponentiation instead.
+
 </Note>
 
 ```python
@@ -316,7 +318,7 @@ from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails
 @tool
 def calculator(expression: str) -> str:
     """Evaluates mathematical expressions like '2 + 2' or 'sqrt(16)'."""
-    evaluator = SimpleEval(functions={"sqrt": math.sqrt, "pow": pow})
+    evaluator = SimpleEval(functions={"sqrt": math.sqrt})
     try:
         return str(evaluator.eval(expression))
     except Exception as e:

--- a/docs/integration/langchain/runnable-rails.mdx
+++ b/docs/integration/langchain/runnable-rails.mdx
@@ -249,12 +249,12 @@ print(result.response_metadata)     # {}
 
 `RunnableRails.invoke()`/`ainvoke()` wrap the underlying rails call in a `try`/`except`, but whether a failure reaches that `except` block depends on where the failure happens:
 
-- **LLM provider failures** (the main model or a safety-check model call itself fails, for example a timeout or an API error) propagate all the way up and surface as a raised `ValueError` (or a more specific error for a few recognized cases, such as binding tools directly on the LLM), with the original exception chained through `from e`.
-- **A registered tool or a guardrail action that raises for any other reason** (a bug in your tool function, a non-LLM network call failing, and so on) does not propagate. The runtime catches it internally and returns an ordinary-looking response with the content `"I'm sorry, an internal error has occurred."` This response has the same shape as a normal, non-blocked answer; it is not distinguishable from a real answer by type, and it does not raise.
+- **Failures that `RunnableRails` itself surfaces** raise a `ValueError`, with the original exception chained through `from e`. This covers LLM provider failures (the main model or a safety-check model call fails, for example a timeout or an API error), unsupported input types, and any other error that escapes the underlying rails call. A few recognized cases raise a more specific message, such as binding tools directly on the LLM.
+- **A tool or guardrail action registered with the guardrail configuration that raises** (a bug in your tool function, a non-LLM network call failing, and so on) does not propagate. The action dispatcher catches it, and the runtime returns an ordinary-looking response with the content `"I'm sorry, an internal error has occurred."` This response has the same shape as a normal, non-blocked answer. LLM call failures are the exception: the dispatcher forwards those, so they surface as in the first case.
 
-Because of this, do not rely on a `try`/`except` around `invoke()`/`ainvoke()` alone to catch every possible failure. Check the response content, or handle the failure inside the tool/action itself, if a distinguishable outcome matters to your application. Your calling code still needs to catch the exceptions that do propagate; `RunnableRails` does not return a structured error payload for those.
+Because this second response is indistinguishable from a normal answer, do not use its content as an error sentinel; a legitimate model or rail response can contain the same text. If you need a distinguishable outcome, handle the failure inside the tool or action itself. Your calling code still needs to catch the exceptions that do propagate; `RunnableRails` does not return a structured error payload for those.
 
-In a LangGraph node, an uncaught exception from `runnable_with_guardrails.invoke(state)` propagates as a normal Python exception through `graph.invoke()`. LangGraph does not catch node exceptions for you. Wrap the node body in a `try`/`except` if you want the graph to continue with a fallback message instead of raising, keeping in mind this only catches the LLM-provider-failure case above. See [Failure Handling in Tool-Calling Graphs](/integration/langchain/langgraph-integration#failure-handling-in-tool-calling-graphs) for an example.
+In a LangGraph node, an uncaught exception from `runnable_with_guardrails.invoke(state)` propagates as a normal Python exception through `graph.invoke()`. LangGraph does not catch node exceptions for you. Wrap the node body in a `try`/`except ValueError` if you want the graph to continue with a fallback message instead of raising. See [Failure Handling in Tool-Calling Graphs](/integration/langchain/langgraph-integration#failure-handling-in-tool-calling-graphs) for an example, including how tools executed by a LangGraph `ToolNode` differ from tools registered with the guardrail configuration.
 
 ### Custom Input/Output Keys
 
@@ -288,7 +288,7 @@ When a guardrail is triggered and predefined messages must be returned instead o
 
 `RunnableRails` supports LangChain tool calling with full metadata preservation and streaming. Tool calling requires `passthrough=True` to work properly.
 
-`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
+`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NVIDIA NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
 
 The following steps are required to use tool calling with `RunnableRails`:
 
@@ -300,7 +300,7 @@ The following steps are required to use tool calling with `RunnableRails`:
 
 <Note>
 
-Avoid Python's built-in `eval()` for evaluating LLM-provided expressions, even with a `__builtins__` whitelist. Sandbox-escape techniques (for example, attribute traversal through `__class__`) can bypass a manually constructed whitelist. Use a restricted expression evaluator such as [`simpleeval`](https://github.com/danthedeckie/simpleeval) instead. `simpleeval` is already a NeMo Guardrails library dependency, so no extra install is required.
+Avoid Python's built-in `eval()` for evaluating LLM-provided expressions, even with a `__builtins__` whitelist. Sandbox-escape techniques (for example, attribute traversal through `__class__`) can bypass a manually constructed whitelist. Use a restricted expression evaluator such as [`simpleeval`](https://github.com/danthedeckie/simpleeval) instead. `simpleeval` is already an NVIDIA NeMo Guardrails library dependency, so no extra install is required.
 
 Do not map a custom `pow` function into `functions`. `simpleeval`'s built-in `**` operator is guarded by `simpleeval.MAX_POWER` against oversized exponents, but that guard does not apply to a function you supply yourself, so a mapped `pow` lets an expression like `pow(2, 999999999)` consume seconds of CPU time and hundreds of megabytes of memory. Let callers use `**` for exponentiation instead.
 

--- a/docs/integration/langchain/runnable-rails.mdx
+++ b/docs/integration/langchain/runnable-rails.mdx
@@ -208,6 +208,49 @@ guardrails = RunnableRails(config, passthrough=False)
 
 **Tool Calling Requirement**: Set `passthrough=True` for proper tool call handling.
 
+**What `passthrough=False` changes about the prompt**: instead of sending your original messages to the LLM, the library renders its own prompt from the `general` task template, which prepends general instructions and reformats the conversation as a completion-style transcript. For example, a `ChatPromptValue` built from `HumanMessage(content="Hello!")` is not sent to the LLM as-is. The library instead sends a prompt similar to the following:
+
+```text
+Below is a conversation between a helpful AI assistant and a user. The bot is
+designed to generate human-like text based on the input that it receives. The
+bot is talkative and provides lots of specific details. If the bot does not
+know the answer to a question, it truthfully says it does not know.
+
+User: Hello!
+Assistant:
+```
+
+The exact instructions and format depend on your configuration and enabled rails. To inspect the transformed prompt for debugging, set `verbose=True` when creating `RunnableRails`. See [Verbose Logging](/integration/langchain/langgraph-integration#2-verbose-logging), which logs every `Prompt ::` and `Completion ::` pair sent to the LLM.
+
+### Rejection Behavior
+
+When an input or output rail blocks a request, `RunnableRails` does not raise an exception. It returns the rail's configured refusal message in the same output shape you would otherwise get back.
+
+For chain-wrapping (dict) inputs, only a dictionary with the output key is returned:
+
+```json
+{"answer": "I can't assist with that request."}
+```
+
+For LLM-wrapping inputs, such as a `list[BaseMessage]` or `ChatPromptValue`, an `AIMessage` is returned with the refusal text as `content`, no `tool_calls`, and empty `response_metadata`/`additional_kwargs`, since no underlying model call for a final answer was made:
+
+```python
+from langchain_core.messages import HumanMessage
+
+result = guarded_model.invoke([HumanMessage(content="You are stupid")])
+
+print(result)
+# AIMessage(content="I'm sorry, I can't respond to that.")
+print(result.tool_calls)            # []
+print(result.response_metadata)     # {}
+```
+
+### Error Handling
+
+`RunnableRails.invoke()`/`ainvoke()` wrap the underlying rails call in a `try`/`except`. Failures from the LLM call, a bound tool, or a guardrail action itself are not swallowed. They surface as a raised `ValueError` (or a more specific error for a few recognized cases, such as binding tools directly on the LLM), with the original exception chained through `from e`. Your calling code needs to catch these exceptions; `RunnableRails` does not return a structured error payload.
+
+In a LangGraph node, an uncaught exception from `runnable_with_guardrails.invoke(state)` propagates as a normal Python exception through `graph.invoke()`. LangGraph does not catch node exceptions for you. Wrap the node body in a `try`/`except` if you want the graph to continue with a fallback message instead of raising. See [Failure Handling in Tool-Calling Graphs](/integration/langchain/langgraph-integration#failure-handling-in-tool-calling-graphs) for an example.
+
 ### Custom Input/Output Keys
 
 When you use a guardrail configuration to wrap a chain or a `Runnable`, the input and output are either dictionaries or strings. However, a guardrail configuration always operates on a text input from the user and a text output from the LLM. To achieve this, when dictionaries are used, one of the keys from the input dictionary must be designated as the `"input text"` and one of the keys from the output as the `"output text"`.
@@ -240,6 +283,8 @@ When a guardrail is triggered and predefined messages must be returned instead o
 
 `RunnableRails` supports LangChain tool calling with full metadata preservation and streaming. Tool calling requires `passthrough=True` to work properly.
 
+`bind_tools()` is a LangChain method that attaches tool/function definitions to a chat model so the model can request tool calls in its response instead of only returning text. `ToolMessage` is LangChain's message type for returning a tool's result back to the model, keyed to the originating call through `tool_call_id`. See the [LangChain tool calling documentation](https://python.langchain.com/docs/concepts/tool_calling/) for the full concept. The NeMo Guardrails library does not change either of these; `RunnableRails` only adds safety checks around the model calls that use them.
+
 The following steps are required to use tool calling with `RunnableRails`:
 
 - Set `passthrough=True` when creating `RunnableRails` instance.
@@ -248,18 +293,27 @@ The following steps are required to use tool calling with `RunnableRails`:
 
 ### Basic Tool Setup
 
+<Note>
+
+Avoid Python's built-in `eval()` for evaluating LLM-provided expressions, even with a `__builtins__` whitelist. Sandbox-escape techniques (for example, attribute traversal through `__class__`) can bypass a manually constructed whitelist. Use a restricted expression evaluator such as [`simpleeval`](https://github.com/danthedeckie/simpleeval) instead. `simpleeval` is already a NeMo Guardrails library dependency, so no extra install is required.
+
+</Note>
+
 ```python
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
+from simpleeval import SimpleEval
+import math
+
 from nemoguardrails import RailsConfig
 from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails
 
 @tool
 def calculator(expression: str) -> str:
     """Evaluates mathematical expressions like '2 + 2' or 'sqrt(16)'."""
+    evaluator = SimpleEval(functions={"sqrt": math.sqrt, "pow": pow})
     try:
-        safe_dict = {'sqrt': __import__('math').sqrt, 'pow': pow, '__builtins__': {}}
-        return str(eval(expression, safe_dict))
+        return str(evaluator.eval(expression))
     except Exception as e:
         return f"Error: {e}"
 

--- a/docs/integration/langchain/runnable-rails.mdx
+++ b/docs/integration/langchain/runnable-rails.mdx
@@ -247,9 +247,14 @@ print(result.response_metadata)     # {}
 
 ### Error Handling
 
-`RunnableRails.invoke()`/`ainvoke()` wrap the underlying rails call in a `try`/`except`. Failures from the LLM call, a bound tool, or a guardrail action itself are not swallowed. They surface as a raised `ValueError` (or a more specific error for a few recognized cases, such as binding tools directly on the LLM), with the original exception chained through `from e`. Your calling code needs to catch these exceptions; `RunnableRails` does not return a structured error payload.
+`RunnableRails.invoke()`/`ainvoke()` wrap the underlying rails call in a `try`/`except`, but whether a failure reaches that `except` block depends on where the failure happens:
 
-In a LangGraph node, an uncaught exception from `runnable_with_guardrails.invoke(state)` propagates as a normal Python exception through `graph.invoke()`. LangGraph does not catch node exceptions for you. Wrap the node body in a `try`/`except` if you want the graph to continue with a fallback message instead of raising. See [Failure Handling in Tool-Calling Graphs](/integration/langchain/langgraph-integration#failure-handling-in-tool-calling-graphs) for an example.
+- **LLM provider failures** (the main model or a safety-check model call itself fails, for example a timeout or an API error) propagate all the way up and surface as a raised `ValueError` (or a more specific error for a few recognized cases, such as binding tools directly on the LLM), with the original exception chained through `from e`.
+- **A registered tool or a guardrail action that raises for any other reason** (a bug in your tool function, a non-LLM network call failing, and so on) does not propagate. The runtime catches it internally and returns an ordinary-looking response with the content `"I'm sorry, an internal error has occurred."` This response has the same shape as a normal, non-blocked answer; it is not distinguishable from a real answer by type, and it does not raise.
+
+Because of this, do not rely on a `try`/`except` around `invoke()`/`ainvoke()` alone to catch every possible failure. Check the response content, or handle the failure inside the tool/action itself, if a distinguishable outcome matters to your application. Your calling code still needs to catch the exceptions that do propagate; `RunnableRails` does not return a structured error payload for those.
+
+In a LangGraph node, an uncaught exception from `runnable_with_guardrails.invoke(state)` propagates as a normal Python exception through `graph.invoke()`. LangGraph does not catch node exceptions for you. Wrap the node body in a `try`/`except` if you want the graph to continue with a fallback message instead of raising, keeping in mind this only catches the LLM-provider-failure case above. See [Failure Handling in Tool-Calling Graphs](/integration/langchain/langgraph-integration#failure-handling-in-tool-calling-graphs) for an example.
 
 ### Custom Input/Output Keys
 

--- a/docs/integration/tools-integration.mdx
+++ b/docs/integration/tools-integration.mdx
@@ -52,7 +52,7 @@ For detailed information on creating custom tools, refer to the [LangChain Tools
 
 ## Tool Call Schema
 
-The NeMo Guardrails library does not define its own tool-call schema, but the shape you get back depends on how you call it.
+The NVIDIA NeMo Guardrails library does not define its own tool-call schema, but the shape you get back depends on how you call it.
 
 `RunnableRails` converts tool calls into LangChain's `ToolCall` `TypedDict` shape:
 
@@ -77,7 +77,7 @@ Calling `rails.generate()` directly does not go through this conversion. `respon
 
 If your code reads `tool_call["name"]` or `tool_call["args"]` against a direct `rails.generate()` response, it is reading the wrong keys; use `tool_call["function"]["name"]` and `tool_call["function"]["arguments"]` instead, or wrap the model with `RunnableRails` to get the normalized LangChain shape.
 
-The NeMo Guardrails library only reads `tool_calls` off the model response to decide whether output rails apply. It does not otherwise transform the tool-call arguments or names.
+The NVIDIA NeMo Guardrails library only reads `tool_calls` off the model response to decide whether output rails apply. It does not otherwise transform the tool-call arguments or names.
 
 ## Configuration Settings
 

--- a/docs/integration/tools-integration.mdx
+++ b/docs/integration/tools-integration.mdx
@@ -50,6 +50,19 @@ def get_stock_price(symbol: str) -> str:
 
 For detailed information on creating custom tools, refer to the [LangChain Tools Documentation](https://python.langchain.com/docs/concepts/tools/).
 
+## Tool Call Schema
+
+The NeMo Guardrails library does not define its own tool-call schema. It converts the tool-call payload the underlying model returns into LangChain's `ToolCall` `TypedDict` shape, so every tool call your application handles has the same four fields, whether you call `rails.generate()` directly or wrap a model with `RunnableRails`.
+
+| Field | Type | Role |
+|-------|------|------|
+| `name` | `str` | The name of the tool to invoke, matching a registered tool's `name`. |
+| `args` | `dict` | The arguments to pass to the tool, keyed by parameter name. |
+| `id` | `str` | A unique identifier for this tool call, used to match a later `ToolMessage` result back to it via `tool_call_id`. |
+| `type` | `"tool_call"` | A fixed literal that identifies the dict as a tool call. |
+
+The NeMo Guardrails library only reads `tool_calls` off the model response to decide whether output rails apply. It does not otherwise transform the tool-call arguments or names.
+
 ## Configuration Settings
 
 ### Passthrough Mode

--- a/docs/integration/tools-integration.mdx
+++ b/docs/integration/tools-integration.mdx
@@ -217,8 +217,8 @@ messages_with_tools = [
 ]
 
 for tool_call in result["tool_calls"]:
-    tool_name = tool_call["name"]
-    tool_args = tool_call["args"]
+    tool_name = tool_call["function"]["name"]
+    tool_args = tool_call["function"]["arguments"]
     tool_id = tool_call["id"]
 
     selected_tool = tools_by_name[tool_name]
@@ -367,11 +367,12 @@ def execute_with_tools(rails_instance, config_name):
     ]
 
     for tool_call in result["tool_calls"]:
-        tool_result = tools_by_name[tool_call["name"]].invoke(tool_call["args"])
+        tool_name = tool_call["function"]["name"]
+        tool_result = tools_by_name[tool_name].invoke(tool_call["function"]["arguments"])
         messages_with_tools.append({
             "role": "tool",
             "content": str(tool_result),
-            "name": tool_call["name"],
+            "name": tool_name,
             "tool_call_id": tool_call["id"]
         })
 

--- a/docs/integration/tools-integration.mdx
+++ b/docs/integration/tools-integration.mdx
@@ -52,7 +52,9 @@ For detailed information on creating custom tools, refer to the [LangChain Tools
 
 ## Tool Call Schema
 
-The NeMo Guardrails library does not define its own tool-call schema. It converts the tool-call payload the underlying model returns into LangChain's `ToolCall` `TypedDict` shape, so every tool call your application handles has the same four fields, whether you call `rails.generate()` directly or wrap a model with `RunnableRails`.
+The NeMo Guardrails library does not define its own tool-call schema, but the shape you get back depends on how you call it.
+
+`RunnableRails` converts tool calls into LangChain's `ToolCall` `TypedDict` shape:
 
 | Field | Type | Role |
 |-------|------|------|
@@ -60,6 +62,20 @@ The NeMo Guardrails library does not define its own tool-call schema. It convert
 | `args` | `dict` | The arguments to pass to the tool, keyed by parameter name. |
 | `id` | `str` | A unique identifier for this tool call, used to match a later `ToolMessage` result back to it via `tool_call_id`. |
 | `type` | `"tool_call"` | A fixed literal that identifies the dict as a tool call. |
+
+Calling `rails.generate()` directly does not go through this conversion. `response.tool_calls` retains the model-native, OpenAI-style function-call structure instead:
+
+```python
+[
+    {
+        "id": "...",
+        "type": "function",
+        "function": {"name": "...", "arguments": {...}},
+    }
+]
+```
+
+If your code reads `tool_call["name"]` or `tool_call["args"]` against a direct `rails.generate()` response, it is reading the wrong keys; use `tool_call["function"]["name"]` and `tool_call["function"]["arguments"]` instead, or wrap the model with `RunnableRails` to get the normalized LangChain shape.
 
 The NeMo Guardrails library only reads `tool_calls` off the model response to decide whether output rails apply. It does not otherwise transform the tool-call arguments or names.
 


### PR DESCRIPTION
## Description

Our VDR process found several issues in our docs in v0.17. This PR addresses the remaining ones which weren't already fixed.

## Related Issue(s)

* NGUARD-486
* NGUARD-488
* NGUARD-489
* NGUARD-490
* NGUARD-493
* NGUARD-494

## Verification

```
$ make docs-fern-strict
FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" docs md generate --library guardrails-python-sdk
Library 'guardrails-python-sdk': generated 368 pages at /Users/tgasser/projects/nemo_guardrails_worktree/docs/vdr-017-fixes/docs/_static/python-sdk-reference
✓ Generated library documentation for 1 libraries

node scripts/normalize-fern-sdk-reference.mjs
Moved 0 generated package overview pages to index.mdx.
Removed 0 duplicate package overview pages with existing index.mdx.
node scripts/run-fern-with-ref-sdk.mjs check
Found 0 errors and 4 warnings in 0.000 seconds. Run fern check --warnings to print out the warnings not shown.
```

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a guarded LangGraph data-flow diagram and clarified LangChain tool-calling behavior.
  - Expanded guidance on failure handling across `RunnableRails`, `ToolNode`, and guardrail actions.
  - Documented direct and hybrid streaming approaches and clarified streaming limitations within LangGraph.
  - Clarified prompt transformation, rejection responses, and error handling for `RunnableRails`.
  - Updated tool-call examples to distinguish nested function fields from direct API calls.
  - Updated calculator examples to use safer expression evaluation, removed custom power support, and documented exponent limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->