### PR TITLE
docs: document writing dialogue state from a custom action (#306)

### DIFF
--- a/docs/configure-rails/actions/action-parameters.mdx
+++ b/docs/configure-rails/actions/action-parameters.mdx
@@ -54,6 +54,8 @@ async def my_action(context: Optional[dict] = None):
     return True
 ```
 
+To write a value back into the context, return an `ActionResult` from the action. See [ActionResult and Context Updates](/configure-guardrails/actions/creating-actions#actionresult-and-context-updates).
+
 ### Common Context Variables
 
 | Variable            | Description                               | Availability                               |

--- a/docs/configure-rails/actions/creating-actions.mdx
+++ b/docs/configure-rails/actions/creating-actions.mdx
@@ -198,6 +198,97 @@ if not $is_safe
   stop
 ```
 
+### ActionResult and Context Updates
+
+Return an `ActionResult` when the action must write dialogue state rather than only hand a value back to the flow. Use it to fill slots such as a user's name, an order ID, or a shipping address, and then read them back as `$variables` later in the conversation.
+
+`ActionResult` carries three fields:
+
+| Field | Type | Description |
+| ----------------- | ------------ | ------------------------------------------------------------------------------------------------ |
+| `return_value`    | `Any`        | The value the flow receives, the same as a plain return                                            |
+| `context_updates` | `Optional[dict]` | Keys merged into the conversation context and readable as `$variables`. Must be a dict or omitted; Colang 1.0 raises if it is explicitly `None`, Colang 2.0 does not |
+| `events`          | `List[dict]` | Extra events added to the stream. Colang 1.0 only; Colang 2.0 attaches them to the action's `ActionFinished` event and never applies them |
+
+<Tabs>
+
+<Tab title="Colang 2.0">
+
+Declare the variable as `global` in the flow that reads it, otherwise the flow sees a local variable that the action never touched:
+
+~~~python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.actions import ActionResult
+
+
+@action(name="RememberSlotAction")
+async def remember_slot(value: str):
+    return ActionResult(context_updates={"user_name": value})
+~~~
+
+~~~text
+flow bot say $text
+  await UtteranceBotAction(script=$text)
+
+flow main
+  global $user_name
+  match UtteranceUserActionFinished(final_transcript="hi")
+  await RememberSlotAction(value="Ngoc")
+  bot say "Hello {$user_name}"
+  match UtteranceUserActionFinished(final_transcript="again")
+  bot say "Still {$user_name}"
+~~~
+
+The value survives the turn that wrote it, so the second turn also says `Still Ngoc`.
+
+</Tab>
+
+<Tab title="Colang 1.0">
+
+The runtime merges `context_updates` into a single `ContextUpdate` event, so the keys are available to the rest of the flow and to bot message templates:
+
+~~~python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.actions import ActionResult
+
+
+@action()
+async def remember_slot():
+    return ActionResult(context_updates={"user_name": "Ngoc"})
+~~~
+
+~~~text
+define bot name user
+  "Got it $user_name"
+
+define flow
+  user express greeting
+  execute remember_slot
+  bot name user
+~~~
+
+<Warning>
+
+Never return a module-level mutable object, such as a dict you keep between calls and update in place. Colang 1.0 stores the action result by reference and re-runs the flow from its first element on every internal event, so an object you mutate changes underneath that replay and the `if` guards that read it flip. Later slots stay `unknown` and render blank, and once enough of them do, the whole reply comes back empty. Nothing is raised.
+
+Return a copy instead:
+
+~~~python
+@action()
+async def update_user_info(value: str, key: str):
+    user_info[key] = value
+    snapshot = dict(user_info)
+    return ActionResult(return_value=snapshot, context_updates={"user_info": snapshot})
+~~~
+
+</Warning>
+
+</Tab>
+
+</Tabs>
+
+To have the LLM extract the value before you store it, see [Extract User-Provided Values](/configure-guardrails/colang/usage-examples/extract-user-provided-values).
+
 ## Error Handling
 
 Handle errors gracefully within actions:

--- a/docs/configure-rails/colang/colang-2/language-reference/python-actions.mdx
+++ b/docs/configure-rails/colang/colang-2/language-reference/python-actions.mdx
@@ -60,8 +60,10 @@ In addition to all the custom user-defined parameters, the parameters listed bel
 
 ```python
 events: list # Recent history of events
-context: dict # Contains all global variables and can be updated via ContextUpdate event
+context: dict # Contains all global variables. See below for how to write to it
 config: dict # All configurations from the `config.yml` file
 llm_task_manager: LLMTaskManager # The llm task manage object of type LLMTaskManager
 state: State # The state machine state object
 ```
+
+To write a value back into the context, return `ActionResult(context_updates={"user_name": value})` from the action and declare the variable as `global` in the flow that reads it. A `ContextUpdate` event placed in `ActionResult.events` does not work here: Colang 2.0 attaches those events to the action's `ActionFinished` event and never applies them. See [ActionResult and Context Updates](/configure-guardrails/actions/creating-actions#actionresult-and-context-updates).

--- a/docs/configure-rails/colang/usage-examples/extract-user-provided-values.mdx
+++ b/docs/configure-rails/colang/usage-examples/extract-user-provided-values.mdx
@@ -299,3 +299,85 @@ $value = ...
 | String interpolation | `{$var}` in strings | Context variable access |
 | Flow definition | `flow name` | `define flow` |
 | Action execution | `await ActionName()` | `execute action_name()` |
+
+## Store Extracted Values Across Turns
+
+Extraction only puts the value in a flow variable. To keep it available to later turns, write it into the conversation context from a custom action that returns [`ActionResult`](/configure-guardrails/actions/creating-actions):
+
+<Tabs>
+
+<Tab title="Colang 2.0">
+
+~~~python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.actions import ActionResult
+
+
+@action(name="RememberSlotAction")
+async def remember_slot(value: str):
+    return ActionResult(context_updates={"user_name": value})
+~~~
+
+~~~text
+import core
+import llm
+
+flow main
+  activate llm continuation
+  global $user_name
+
+  user provided name
+  $name = ..."Extract the name of the user. Return the name as a single string."
+  await RememberSlotAction(value=$name)
+  bot say "Hello, {$user_name}!"
+
+flow user provided name
+  user said "my name is" or user said "I am" or user said "call me"
+~~~
+
+<Note>
+
+Colang 2.0 keeps this state on the runtime `State` object. `generate()` and `generate_async()` return `None` for that state, and the `output_vars` generation option raises for a Colang 2.0 configuration, so `process_events()` and `process_events_async()` are the only way to hold the state across calls. Pass the state you get back into the next call. The state is an in-process object and is not yet serializable, so it does not survive a restart or move between worker processes.
+
+</Note>
+
+</Tab>
+
+<Tab title="Colang 1.0">
+
+~~~python
+from nemoguardrails.actions import action
+from nemoguardrails.actions.actions import ActionResult
+
+
+@action()
+async def remember_slot(name: str):
+    return ActionResult(context_updates={"user_name": name})
+~~~
+
+~~~text
+define user provide name
+  "My name is John"
+  "I am Alice"
+  "Call me Bob"
+
+define bot greet user
+  "Hello, $user_name!"
+
+define flow
+  user provide name
+  # Extract the name of the user.
+  $name = ...
+  execute remember_slot(name=$name)
+  bot greet user
+~~~
+
+<Note>
+
+Colang 1.0 rebuilds the context from the event history on each call. When you use `generate()` with the full message list, the library caches that history internally and matches the longest prefix of your messages, so context set on an earlier turn is still there on the next one. The cache lives in the process, so it does not survive a restart or move between worker processes. Pass an explicit state to `generate()` if you need to hold the history yourself.
+
+</Note>
+
+</Tab>
+
+</Tabs>

--- a/tests/test_context_updates.py
+++ b/tests/test_context_updates.py
@@ -17,7 +17,7 @@ import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.actions.actions import ActionResult
-from tests.utils import FakeLLMModel, any_event_conforms, event_conforms
+from tests.utils import FakeLLMModel, TestChat, any_event_conforms, event_conforms
 
 
 @pytest.fixture
@@ -78,3 +78,43 @@ async def test_simple_context_update_from_action(rails_config):
     # The last event before listen should be a context update for the counter to "2"
     assert any_event_conforms({"type": "ContextUpdate", "data": {"counter": 2}}, new_events)
     assert event_conforms({"type": "Listen"}, new_events[-1])
+
+
+def test_action_result_context_update_renders_in_bot_message():
+    """A Colang 1.0 flow reads a slot an action wrote with `context_updates`.
+
+    Pins the Colang 1.0 snippet documented under "ActionResult and Context
+    Updates" in `docs/configure-rails/actions/creating-actions.mdx`. The 1.0
+    runtime turns `context_updates` into a single `ContextUpdate` event
+    (`nemoguardrails/colang/v1_0/runtime/runtime.py`), so the key is readable as
+    `$user_name` in the rest of the flow.
+    """
+    config = RailsConfig.from_content(
+        """
+        define user express greeting
+            "hello"
+
+        define bot name user
+            "Got it $user_name"
+
+        define flow
+            user express greeting
+            execute remember_slot
+            bot name user
+        """
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+        ],
+    )
+
+    async def remember_slot():
+        return ActionResult(context_updates={"user_name": "Ngoc"})
+
+    chat.app.register_action(remember_slot, "remember_slot")
+
+    chat >> "hello"
+    chat << "Got it Ngoc"

--- a/tests/v2_x/test_run_actions.py
+++ b/tests/v2_x/test_run_actions.py
@@ -20,6 +20,7 @@ import pytest
 from rich.logging import RichHandler
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.actions.actions import ActionResult
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
 from nemoguardrails.llm.filters import co_v2
 from nemoguardrails.utils import new_event_dict
@@ -149,6 +150,51 @@ async def test_manifest_owned_action_result_is_hidden_from_history():
 
     assert event["is_rail_action"] is True
     assert co_v2([event]) == ""
+
+
+def test_action_writes_dialogue_state_via_context_updates():
+    """An action stores a slot with `ActionResult(context_updates=...)`.
+
+    Pins the Colang 2.0 snippet documented under "ActionResult and Context
+    Updates" in `docs/configure-rails/actions/creating-actions.mdx`. The second
+    turn is what proves the value outlives the turn that wrote it: the runtime
+    merges `context_updates` into `state.context`
+    (`nemoguardrails/colang/v2_x/runtime/runtime.py`), and `TestChat` carries
+    that state forward.
+    """
+    config = RailsConfig.from_content(
+        colang_content="""
+        flow bot say $text
+          await UtteranceBotAction(script=$text)
+
+        flow main
+          global $user_name
+          match UtteranceUserActionFinished(final_transcript="hi")
+          await RememberSlotAction(value="Ngoc")
+          bot say "Hello {$user_name}"
+          match UtteranceUserActionFinished(final_transcript="again")
+          bot say "Still {$user_name}"
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    async def remember_slot(value: str):
+        return ActionResult(context_updates={"user_name": value})
+
+    chat.app.register_action(remember_slot, "RememberSlotAction")
+
+    chat >> "hi"
+    chat << "Hello Ngoc"
+
+    chat >> "again"
+    chat << "Still Ngoc"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

[#306](https://github.com/NVIDIA-NeMo/Guardrails/issues/306) asks how to manage dialogue state from a custom action. The capability exists and works in both Colang versions, but it is not documented anywhere. `ActionResult` is the mechanism: Colang 1.0 turns `context_updates` into a `ContextUpdate` event, and Colang 2.0 merges the same field into `state.context`. The page that owns return values, Creating Actions, covers Simple, Dictionary and Boolean returns and never mentions `ActionResult`.

Four files, no new pages, `docs/index.yml` untouched.

- **Creating Actions** gets an `ActionResult and Context Updates` section under Return Values: a field table, and a Colang 2.0 / Colang 1.0 tab pair. `events` is marked Colang 1.0 only, since Colang 2.0 attaches those events to the action's `ActionFinished` event and never applies them.
- **Extract User-provided Values** gets a `Store Extracted Values Across Turns` section. Extraction only puts the value in a flow variable; this is the missing half. Per-tab notes on how far the state actually carries: Colang 1.0 rebuilds context from the cached event history, Colang 2.0 needs `process_events()` because `generate()` returns `None` for the state and `output_vars` raises for a 2.0 config. Neither survives a restart.
- **Action Parameters** and the **Colang 2.0 Python actions reference** get a pointer each. The reference page also had a wrong line: it said `context` "can be updated via ContextUpdate event", true of the event in general but not of the path an action controls.

The Colang 1.0 tab warns about returning a module-level mutable object, which is [#424](https://github.com/NVIDIA-NeMo/Guardrails/issues/424). Colang 1.0 stores the action result by reference and re-runs the flow from element 0 on every internal event, so an object mutated in place changes underneath that replay and the `if` guards reading it flip. Colang 2.0 cannot hit this: it updates the context once per action and does not re-slide over the stored result.

## Related Issue(s)

Closes #306

Issue assignee: none yet — filed under label `question`, not assigned to me. Flagging per CONTRIBUTING rather than assigning it myself.

## Verification

Two new tests, both pinning the snippets the pages publish:

```
$ make test TEST=tests/v2_x/test_run_actions.py
5 passed in 117.03s (0:01:57)      # was 4
```

The second turn is load-bearing: it asserts the slot outlives the turn that wrote it. Replacing `ActionResult(context_updates={"user_name": value})` with a plain `return value` fails it with `Expected 'Hello Ngoc' and received 'Hello None'`.

```
$ make test TEST=tests/test_context_updates.py
2 passed in 191.57s (0:03:11)      # was 1
```

The #424 warning is reproduced, not inferred: running the reporter's shape with a module-level dict returns an empty assistant message with slots stuck at `unknown`; returning `dict(user_info)` instead, one word changed, fills all of them.

```
$ make test TEST="tests/v2_x tests/test_context_updates.py"
211 passed, 1 skipped in 168.53s (0:02:48)
```

`pre-commit` passes on all six changed files. `make docs-fern` was not run locally (needs network); CI's `docs-build.yaml` covers `docs/**` on PRs to `develop`.

One added snippet does not execute under `TestChat`: the Colang 2.0 example in Extract User-provided Values follows the `activate llm continuation` + `user said "<prefix>"` shape the page's six existing 2.0 examples already use, and that shape doesn't run under the harness today (not a regression — the page's own existing snippets fail the same way at this commit).

## AI Assistance

- [x] AI tools were used; a human reviewed and can explain every change (tool: Claude Code).

## Checklist

- [x] I've read the CONTRIBUTING guidelines.
- [ ] This PR links to a triaged issue assigned to me. (issue is unassigned — see Related Issue(s))
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [x] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed. (CodeAnt flagged `creating-actions.mdx:211` typing `context_updates` as `dict` instead of `Optional[dict]`; fixed, see `pr-review.md`)
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
