### PR TITLE
ci(docs): run a token-free Fern check on fork pull requests

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -87,7 +87,8 @@ jobs:
 
       # Fork pull requests do not receive repository secrets, so FERN_TOKEN is
       # empty there and the SDK reference cannot be regenerated. Fall back to the
-      # token-free docs check instead of failing before any docs are validated.
+      # cache-only docs check instead of failing before any docs are validated;
+      # it never generates, and a cache miss fails with an explicit message.
       - name: Check Fern docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -74,10 +74,30 @@ jobs:
       - name: Test Fern documentation scripts
         run: make test-docs-scripts
 
+      # The docs check may check out historical refs whose SDK reference the
+      # post-checkout hook regenerates on a cache miss, which needs FERN_TOKEN.
+      # Restoring the cache first keeps the token-free path free of generation.
+      - name: Restore historical SDK references
+        uses: actions/cache/restore@v6
+        with:
+          path: .fern-cache/fern-ref-sdk
+          key: fern-ref-sdk-${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'fern/fern.config.json', 'fern/docs.yml', 'scripts/cache-fern-ref-sdk.mjs', 'scripts/fern-ref-sdk-environment.mjs', 'scripts/fern-ref-sdk-hooks/**', 'scripts/normalize-fern-sdk-reference.mjs') }}
+          restore-keys: |
+            fern-ref-sdk-${{ runner.os }}-
+
+      # Fork pull requests do not receive repository secrets, so FERN_TOKEN is
+      # empty there and the SDK reference cannot be regenerated. Fall back to the
+      # token-free docs check instead of failing before any docs are validated.
       - name: Check Fern docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
-        run: make docs-fern-strict
+        run: |
+          if [ -n "${FERN_TOKEN}" ]; then
+            make docs-fern-strict
+          else
+            echo "FERN_TOKEN is not available (fork pull request); running the token-free docs check."
+            make docs-fern-check
+          fi
 
   preview-docs:
     name: Publish Fern preview

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,12 @@ docs-fern-strict: docs-fern-generate-sdk
 	node scripts/run-fern-with-ref-sdk.mjs check
 
 # Token-free variant for environments without FERN_TOKEN (for example fork
-# pull requests): validates the docs without regenerating the SDK reference.
+# pull requests). Historical SDK references must already be in
+# .fern-cache/fern-ref-sdk: FERN_REF_SDK_CACHE_ONLY=1 makes the post-checkout
+# hook fail with an explicit message on a cache miss instead of trying to
+# generate, which would need FERN_TOKEN.
 docs-fern-check: docs-fern-node-dependencies
-	node scripts/run-fern-with-ref-sdk.mjs check
+	FERN_REF_SDK_CACHE_ONLY=1 node scripts/run-fern-with-ref-sdk.mjs check
 
 docs-fern-live: docs-fern-generate-sdk
 	FERN_VERSION=$$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@$${FERN_VERSION}" docs dev
@@ -163,7 +166,7 @@ help:
 		'  test-docs-scripts     Run unit tests for Fern documentation scripts' \
 		'  docs-fern             Check Fern docs using the pinned Fern CLI' \
 		'  docs-fern-strict      Check Fern docs using the pinned Fern CLI' \
-		'  docs-fern-check       Check Fern docs without regenerating the SDK reference (no FERN_TOKEN needed)' \
+		'  docs-fern-check       Check Fern docs from cached SDK references only (no FERN_TOKEN; fails on a cache miss)' \
 		'  docs-fern-live        Serve Fern docs locally' \
 		'  docs-fern-publish-staging Publish Fern docs to the staging instance' \
 		'  docs-fern-publish-public Publish Fern docs to the public instance' \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help install
 .PHONY: test test-parallel test-serial test-benchmark test-watch test-coverage test-profile record-cassettes rewrite-cassettes replay-cassettes snapshot-cassettes check-record-test-env warm-fastembed-cache
-.PHONY: test-docs-scripts docs-fern-node-dependencies docs-fern docs-fern-strict docs-fern-live docs-fern-preview-watch docs-fern-generate-sdk docs-fern-fix-empty-links docs-fern-publish-staging docs-fern-publish-public
+.PHONY: test-docs-scripts docs-fern-node-dependencies docs-fern docs-fern-strict docs-fern-check docs-fern-live docs-fern-preview-watch docs-fern-generate-sdk docs-fern-fix-empty-links docs-fern-publish-staging docs-fern-publish-public
 .PHONY: pre-commit pre-commit-install
 
 .DEFAULT_GOAL := help
@@ -97,6 +97,11 @@ docs-fern: docs-fern-strict
 docs-fern-strict: docs-fern-generate-sdk
 	node scripts/run-fern-with-ref-sdk.mjs check
 
+# Token-free variant for environments without FERN_TOKEN (for example fork
+# pull requests): validates the docs without regenerating the SDK reference.
+docs-fern-check: docs-fern-node-dependencies
+	node scripts/run-fern-with-ref-sdk.mjs check
+
 docs-fern-live: docs-fern-generate-sdk
 	FERN_VERSION=$$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@$${FERN_VERSION}" docs dev
 
@@ -158,6 +163,7 @@ help:
 		'  test-docs-scripts     Run unit tests for Fern documentation scripts' \
 		'  docs-fern             Check Fern docs using the pinned Fern CLI' \
 		'  docs-fern-strict      Check Fern docs using the pinned Fern CLI' \
+		'  docs-fern-check       Check Fern docs without regenerating the SDK reference (no FERN_TOKEN needed)' \
 		'  docs-fern-live        Serve Fern docs locally' \
 		'  docs-fern-publish-staging Publish Fern docs to the staging instance' \
 		'  docs-fern-publish-public Publish Fern docs to the public instance' \

--- a/scripts/cache-fern-ref-sdk.mjs
+++ b/scripts/cache-fern-ref-sdk.mjs
@@ -95,6 +95,13 @@ export function main(args = process.argv.slice(2), environment = process.env) {
     return;
   }
 
+  if (environment.FERN_REF_SDK_CACHE_ONLY === "1") {
+    throw new Error(
+      `No cached SDK reference for ${libraryConfig.input.ref} (${sdkInputCommit.slice(0, 12)}) at ${cacheDirectory}, ` +
+        "and FERN_REF_SDK_CACHE_ONLY=1 forbids generating it. Restore the .fern-cache/fern-ref-sdk cache or run " +
+        "`make docs-fern-generate-sdk` with FERN_TOKEN set.",
+    );
+  }
   console.log(`Generating ${libraryName} for ${libraryConfig.input.ref} (${sdkInputCommit.slice(0, 12)}).`);
   rmSync(outputRoot, { force: true, recursive: true });
   const originalFernConfig = readFileSync(fernConfigPath, "utf8");

--- a/scripts/tests/cache-fern-ref-sdk.test.mjs
+++ b/scripts/tests/cache-fern-ref-sdk.test.mjs
@@ -169,6 +169,43 @@ test("cache helper restores a reference through its command entrypoint", (t) => 
   assert.equal(readFileSync(path.join(outputRoot, libraryName, "page-0.mdx"), "utf8"), "restored-0");
 });
 
+test("cache-only mode refuses to generate on a cache miss", (t) => {
+  const root = temporaryDirectory(t);
+  const repoRoot = path.join(root, "repo-root");
+  const worktreeRoot = path.join(root, "historical-worktree");
+  const cacheRoot = path.join(root, "cache");
+  const sdkInputCommit = "d".repeat(40);
+  const fernVersion = "5.91.0";
+
+  for (const inputPath of generatorInputPaths) {
+    writeFile(repoRoot, inputPath, inputPath);
+  }
+  writeFile(
+    worktreeRoot,
+    "fern/docs.yml",
+    `libraries:\n  ${libraryName}:\n    input:\n      git: https://example.com/repo.git\n      ref: ${sdkInputCommit}\n    output:\n      path: ../docs/_static/python-sdk-reference\n`,
+  );
+  writeFile(worktreeRoot, "fern/fern.config.json", `${JSON.stringify({ version: fernVersion })}\n`);
+  initializeGitRepository(worktreeRoot);
+  const snapshotCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: worktreeRoot,
+    encoding: "utf8",
+  }).trim();
+
+  assert.throws(
+    () =>
+      main([worktreeRoot, snapshotCommit], {
+        FERN_REF_SDK_CACHE_ROOT: cacheRoot,
+        FERN_REF_SDK_REPO_ROOT: repoRoot,
+        FERN_REF_SDK_VERSION: fernVersion,
+        FERN_REF_SDK_CACHE_ONLY: "1",
+      }),
+    /FERN_REF_SDK_CACHE_ONLY=1 forbids generating/,
+  );
+  const outputRoot = path.join(worktreeRoot, "docs/_static/python-sdk-reference");
+  assert.equal(existsSync(outputRoot), false);
+});
+
 test("invalid Git configuration is rejected before Fern starts", (t) => {
   const root = temporaryDirectory(t);
   assert.throws(


### PR DESCRIPTION
## Description

Makes the `Check Fern docs` job useful on fork pull requests. It currently regenerates the SDK reference through Fern's cloud first, which needs `DOCS_FERN_TOKEN`, and forks never receive that secret, so the job failed before validating any docs. This adds a cache-only, token-free `docs-fern-check` target (a cache miss fails with an explicit message instead of generating), restores the historical SDK reference cache in `build-docs`, and falls back to the token-free check when `FERN_TOKEN` is empty. Same-repo PRs and `develop` pushes keep the token-bearing path.

Split out of #2366 following CodeRabbit's out-of-scope note.

## Related Issue(s)

Fixes #2367

Issue assignee: @yixinh-nv

## Verification

- `make docs-fern-check` locally without `FERN_TOKEN` (cache-only mode): `Found 0 errors and 1 warning` (the warning is pre-existing).
- `make test-docs-scripts`: 9 pass, 0 fail, including the new "cache-only mode refuses to generate on a cache miss" case.
- `uv run --locked pre-commit run --files Makefile .github/workflows/docs-build.yaml`: all hooks pass, including zizmor.
- The same change ran in CI on fork PR #2366 (commits ad3586e and 14c1f45): `Check Fern docs` went from failing on authentication to passing, and the run log shows the fallback branch taken and no SDK generation triggered.

Not run: the token-bearing `docs-fern-strict` path, which is unchanged and only runs for same-repo events.

## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation validation for environments without access to required credentials.
  * Added a tokenless documentation check option for fork-based pull requests.
  * Documentation checks now restore cached SDK references when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
