### PR TITLE
fix(tracing): preserve span event bodies in filesystem traces

### DIFF
--- a/nemoguardrails/tracing/span_formatting.py
+++ b/nemoguardrails/tracing/span_formatting.py
@@ -65,6 +65,7 @@ def format_span_for_filesystem(span) -> Dict[str, Any]:
                     "name": event.name,
                     "timestamp": event.timestamp,
                     "attributes": event.attributes,
+                    "body": event.body,
                 }
                 for event in span.events
             ]

--- a/tests/tracing/test_span_formatting.py
+++ b/tests/tracing/test_span_formatting.py
@@ -95,6 +95,7 @@ class TestFormatSpanForFilesystem:
                 name="test_event",
                 timestamp=0.5,
                 attributes={"key": "value"},
+                body={"content": "body_content"},
             )
         ]
         span = InteractionSpan(
@@ -115,6 +116,30 @@ class TestFormatSpanForFilesystem:
         assert result["events"][0]["name"] == "test_event"
         assert result["events"][0]["timestamp"] == 0.5
         assert result["events"][0]["attributes"] == {"key": "value"}
+        assert result["events"][0]["body"] == {"content": "body_content"}
+
+    def test_format_span_event_without_body(self):
+        events = [
+            SpanEvent(
+                name="test_event",
+                timestamp=0.5,
+                attributes={"key": "value"},
+            )
+        ]
+        span = InteractionSpan(
+            name="interaction",
+            span_id="span_1",
+            parent_id=None,
+            start_time=0.0,
+            end_time=1.0,
+            duration=1.0,
+            span_kind="server",
+            events=events,
+        )
+
+        result = format_span_for_filesystem(span)
+
+        assert result["events"][0]["body"] is None
 
     def test_format_span_with_error(self):
         span = ActionSpan(


### PR DESCRIPTION
## Context
While working with the filesystem tracing adapter, I was inspecting the generated trace data to verify that LLM prompts and completions were being captured correctly.

The `SpanExtractorV2` was correctly creating `SpanEvent` objects containing the captured content in the body field. However, when inspecting the JSONL trace produced by the `FileSystemAdapter`, the event bodies were missing.

Tracing the data flow showed that the content was present in the span objects in memory, but was being dropped by `format_span_for_filesystem()` during serialization.

## Summary

The filesystem span formatter currently drops the body field from `SpanEvent` objects when serializing tracing data.

`SpanEvent` supports an optional body field, and `SpanExtractorV2` populates it for captured LLM prompt and completion content. However, `format_span_for_filesystem()` only serializes the event name, timestamp, and attributes.

As a result, event bodies were present in memory but silently lost when traces were written to the filesystem.

## Changes

- Preserve `SpanEvent.body` when formatting spans for filesystem storage.
- Add a test covering events with a body.
- Add a test covering events without a body.

## Testing

- `pytest tests/tracing -q` — 143 passed, 2 skipped
- `pytest tests/tracing/adapters/test_filesystem.py -q` — 10 passed, 2 skipped
