### PR TITLE
feat: nemotron-3.5-content-safety parser 

### DIFF
--- a/examples/configs/nemotron-3.5-content-safety/README.md
+++ b/examples/configs/nemotron-3.5-content-safety/README.md
@@ -1,0 +1,99 @@
+# Nemotron 3.5 Content Safety Usage Example
+
+Input and output content-safety rails backed by
+[`nvidia/nemotron-3.5-content-safety`](https://build.nvidia.com/nvidia/nemotron-3.5-content-safety).
+
+```bash
+export NVIDIA_API_KEY=nvapi-...
+nemoguardrails chat --config=examples/configs/nemotron-3.5-content-safety --verbose
+```
+
+`--verbose` prints each LLM call, so the content-safety call and its raw verdict are visible alongside the
+conversation.
+
+## How this differs from the NemoGuard 8B example
+
+The older `nvidia/llama-3.1-nemoguard-8b-content-safety` returns a JSON object while this model returns
+flat text strings.
+
+Its chat template builds the whole safety prompt itself: the taxonomy, the instructions and the output format are
+all injected server-side, and whatever the prompt sends is inserted between `<BEGIN CONVERSATION>` and
+`<END CONVERSATION>` as the material to classify. The reply is plain lines, not JSON:
+
+```text
+User Safety: unsafe
+Response Safety: safe
+Safety Categories: Criminal Planning/Confessions, Violence
+```
+
+So `prompts.yml` uses `messages:` carrying only the turns to classify, and the
+`nemotron_content_safety_parse_*` output parsers. Pasting a taxonomy into the prompt, as the 8B example does,
+would have the model classify the taxonomy as if the user had written it.
+
+## Running against a local model
+
+The chat template ships inside the model repository, so any stack that applies it -- vLLM, SGLang, a locally
+downloaded NIM -- behaves the same way as build.nvidia.com. The prompts do not change. Point the model entry at
+the local server:
+
+```yaml
+  - type: content_safety
+    engine: openai
+    model: nvidia/Nemotron-3.5-Content-Safety
+    parameters:
+      base_url: http://localhost:8000/v1
+      api_key: EMPTY
+      chat_template_kwargs:
+        enable_thinking: false
+        request_categories: "/categories"
+```
+
+```bash
+vllm serve nvidia/Nemotron-3.5-Content-Safety
+```
+
+`engine: openai` plus `parameters.base_url` reaches any OpenAI-compatible server through the built-in client,
+with no LangChain dependency.
+
+Two things to be aware of:
+
+- **If a proxy strips unknown body fields, `chat_template_kwargs` never arrives** and the template falls back to
+  its defaults, `/no_think` and `/no_categories`. Verdicts still parse, but the `Safety Categories` line silently
+  disappears and `policy_violations` stays empty. Nothing errors, so check a known-unsafe prompt returns categories
+  before trusting them.
+- **A server that does not apply the chat template needs a different prompt**, one that reproduces the taxonomy
+  and the output-format instructions itself. This example does not ship that variant: it would hand-copy roughly
+  fifty lines out of the model repository's `chat_template.jinja`, and the copy drifts silently when NVIDIA
+  revises the checkpoint. If you need it, add it as a second prompt with `mode:` set and select it with the
+  config-level `prompting_mode`; do not edit the prompt below in place, because a self-contained prompt sent to a
+  server that *does* template gets wrapped a second time and the model then classifies your taxonomy as the user's
+  input.
+
+Note that the prompt cannot bypass templating from this side: the default framework always calls
+`/v1/chat/completions`, and `mode: text` on a model entry is ignored on that path.
+
+## Notes
+
+- **Do not add a system message.** The chat template reads `messages[0]` when it is a system message and then never
+  emits it, so its content is silently dropped.
+- **Roles must alternate, starting with `user`.** An output rail invoked with no user message in context renders an
+  empty first message, which `_render_messages` drops, leaving an assistant-only list that the endpoint rejects with
+  `Conversation roles must alternate`.
+- **`request_categories: "/categories"` is required** for a `Safety Categories` line to appear at all. Without it
+  the model defaults to `/no_categories` and `policy_violations` is always empty.
+- **`rails.config.content_safety.reasoning.enabled` does not control this model.** That flag only feeds the
+  `reasoning_enabled` Jinja variable used by the Nemotron Content Safety Reasoning 4B text prompt. Here reasoning is
+  `parameters.chat_template_kwargs.enable_thinking`.
+- **Raise `max_tokens` before enabling thinking.** With `enable_thinking: true` the reasoning phase consumes the
+  budget; measured completions ranged 38-184 tokens, so use ~512. Too small a budget returns empty content with
+  `finish_reason="length"`, which the parser reports as an unparseable verdict and the rail fails closed.
+- **`Safety Categories` is one flat list with no turn attribution.** On a mixed verdict the output rail's
+  `policy_violations` may carry categories triggered by the user turn. Read them as "categories seen in this
+  exchange", not "categories the bot response violated".
+- **On the NIM the reasoning trace arrives in `reasoning_content`, never inline in `content`.** A raw vLLM or
+  `transformers` deployment may emit `<think>...</think>` inline instead; the parsers handle both.
+
+## Files
+
+- `config.yml` - the main and content-safety models, the `chat_template_kwargs`, and the rail flows.
+- `prompts.yml` - the message-based prompts and the output parsers.

--- a/examples/configs/nemotron-3.5-content-safety/config.yml
+++ b/examples/configs/nemotron-3.5-content-safety/config.yml
@@ -1,0 +1,24 @@
+models:
+  - type: main
+    engine: nim
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
+
+  - type: content_safety
+    engine: nim
+    model: nvidia/nemotron-3.5-content-safety
+    parameters:
+      chat_template_kwargs:
+        # Reasoning is a chat-template argument for this model, not prompt text. The
+        # `rails.config.content_safety.reasoning.enabled` flag does not reach it.
+        enable_thinking: false
+        # Without this the model defaults to /no_categories and omits the
+        # `Safety Categories` line, leaving `policy_violations` empty.
+        request_categories: "/categories"
+
+rails:
+  input:
+    flows:
+      - content safety check input $model=content_safety
+  output:
+    flows:
+      - content safety check output $model=content_safety

--- a/examples/configs/nemotron-3.5-content-safety/prompts.yml
+++ b/examples/configs/nemotron-3.5-content-safety/prompts.yml
@@ -1,0 +1,21 @@
+# The model's chat template supplies the safety instructions, the taxonomy and the required
+# output format. The prompt carries only the turns to classify: anything else placed here is
+# wrapped inside <BEGIN CONVERSATION> and classified as though the user had written it.
+prompts:
+  - task: content_safety_check_input $model=content_safety
+    messages:
+      - type: user
+        content: "{{ user_input }}"
+    output_parser: nemotron_content_safety_parse_prompt_safety
+    max_tokens: 100
+    max_length: 128000
+
+  - task: content_safety_check_output $model=content_safety
+    messages:
+      - type: user
+        content: "{{ user_input }}"
+      - type: assistant
+        content: "{{ bot_response }}"
+    output_parser: nemotron_content_safety_parse_response_safety
+    max_tokens: 100
+    max_length: 128000

--- a/nemoguardrails/llm/output_parsers.py
+++ b/nemoguardrails/llm/output_parsers.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import json
 import re
-from typing import Sequence, Union
+from typing import List, Sequence, Union
 
 
 def _replace_prefix(s: str, prefix: str, repl: str):
@@ -318,3 +318,110 @@ def nemotron_reasoning_parse_response_safety(
         return [True]
     else:
         return [False]
+
+
+_THINK_OPEN_TAG = "<think>"
+
+_CONTENT_SAFETY_PARSE_ERROR = "Failed to parse content safety model response"
+
+
+def _extract_safety_verdict(response: str, field_name: str) -> str:
+    """Helper function to extract the safe/unsafe verdict for a given field.
+
+    Args:
+        response: The model response text, with or without a reasoning trace.
+        field_name: The field to look for (e.g. "User Safety" or "Response Safety").
+
+    Returns:
+        The extracted verdict, either "safe" or "unsafe".
+
+    Raises:
+        ValueError: If the field is absent, carries a value other than safe or unsafe, or the
+            reasoning trace is unterminated.
+    """
+    cleaned_response = _strip_think_tags(response)
+
+    # Reasoning traces may be truncated due to token limits.
+    # Make sure both think-tags were found and removed
+    if _THINK_OPEN_TAG in cleaned_response:
+        raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
+
+    # Anchored to the start of a line, and restricted to the two permitted values, so prose
+    # that merely mentions the field cannot be mistaken for a verdict.
+    pattern = rf"^\s*{re.escape(field_name)}\s*:\s*(safe|unsafe)\b"
+    match = re.search(pattern, cleaned_response, re.IGNORECASE | re.MULTILINE)
+    if match is None:
+        raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
+
+    return match.group(1).lower()
+
+
+def _extract_safety_categories(response: str) -> List[str]:
+    """Helper function to extract the violated safety categories.
+
+    Args:
+        response: The model response text, with or without a reasoning trace.
+
+    Returns:
+        The categories listed by the model, or an empty list when it omitted the line.
+    """
+    cleaned_response = _strip_think_tags(response)
+
+    match = re.search(r"^\s*Safety Categories\s*:\s*(.*)$", cleaned_response, re.IGNORECASE | re.MULTILINE)
+    if match is None:
+        return []
+
+    return [category.strip() for category in match.group(1).split(",") if category.strip()]
+
+
+def nemotron_content_safety_parse_prompt_safety(response: str) -> Sequence[Union[bool, str]]:
+    """Analyzes a response from the Nemotron Content Safety models and determines if the user input is safe.
+
+    These models emit plain lines rather than JSON. `Response Safety` is present only when the request
+    carried an assistant turn, and `Safety Categories` only when a verdict is unsafe:
+
+        User Safety: unsafe
+        Response Safety: safe
+        Safety Categories: Criminal Planning/Confessions, Violence
+
+    Args:
+        response (str): The response string to analyze.
+
+    Returns:
+        Sequence[Union[bool, str]]: A sequence where the first element is a boolean indicating the safety of the
+        content (True if safe, False otherwise), and the remaining elements are strings representing violated
+        safety categories, if any.
+
+    Raises:
+        ValueError: If the model response cannot be parsed as a content safety verdict.
+    """
+    if _extract_safety_verdict(response, "User Safety") == "safe":
+        return [True]
+
+    return [False] + _extract_safety_categories(response)
+
+
+def nemotron_content_safety_parse_response_safety(
+    response: str,
+) -> Sequence[Union[bool, str]]:
+    """Analyzes a response from the Nemotron Content Safety models and determines if the bot response is safe.
+
+    Reads `Response Safety` and never falls back to `User Safety`: the models rate the two turns
+    independently, so an unsafe user turn must not block a safe refusal.
+
+    Args:
+        response (str): The response string to analyze.
+
+    Returns:
+        Sequence[Union[bool, str]]: A sequence where the first element is a boolean indicating the safety of the
+        content (True if safe, False otherwise), and the remaining elements are strings representing violated
+        safety categories, if any.
+
+    Raises:
+        ValueError: If the model response cannot be parsed as a content safety verdict. A response with no
+            `Response Safety` line is unparseable rather than safe.
+    """
+    if _extract_safety_verdict(response, "Response Safety") == "safe":
+        return [True]
+
+    return [False] + _extract_safety_categories(response)

--- a/nemoguardrails/llm/output_parsers.py
+++ b/nemoguardrails/llm/output_parsers.py
@@ -327,11 +327,16 @@ _CONTENT_SAFETY_PARSE_ERROR = "Failed to parse content safety model response"
 _VERDICT_FIELDS = ("User Safety", "Response Safety")
 
 
-def _verdict_pattern(field_name: str) -> str:
-    """Helper function to build the pattern matching one verdict field."""
-    # Anchored to the start of a line, and restricted to the two permitted values, so prose
-    # that merely mentions the field cannot be mistaken for a verdict.
-    return rf"^\s*{re.escape(field_name)}\s*:\s*(safe|unsafe)\b"
+def _verdict_mention_pattern(field_name: str) -> str:
+    """Helper function to build the pattern matching one verdict field anywhere in the text."""
+    return rf"{re.escape(field_name)}\s*:\s*(safe|unsafe)\b"
+
+
+def _verdict_line_pattern(field_name: str) -> str:
+    """Helper function to build the pattern matching one verdict field at the start of a line."""
+    # Anchored to the start of a line, so prose that merely mentions the field cannot be
+    # mistaken for a verdict. Built from the mention pattern so the two cannot drift apart.
+    return rf"^\s*{_verdict_mention_pattern(field_name)}"
 
 
 def _reject_duplicate_verdicts(response: str) -> None:
@@ -345,10 +350,12 @@ def _reject_duplicate_verdicts(response: str) -> None:
             one is being read: a model that states a verdict twice has broken its own output
             contract, so no statement in the response can be trusted. Taking the first match
             would let a later contradicting verdict be silently discarded, which fails open
-            when the discarded one is the unsafe verdict.
+            when the discarded one is the unsafe verdict. A repeat counts wherever it appears,
+            not only where it starts a line, since `User Safety: safe; User Safety: unsafe`
+            contradicts itself just as much as the same two verdicts on separate lines.
     """
     for field_name in _VERDICT_FIELDS:
-        if len(re.findall(_verdict_pattern(field_name), response, re.IGNORECASE | re.MULTILINE)) > 1:
+        if len(re.findall(_verdict_mention_pattern(field_name), response, re.IGNORECASE)) > 1:
             raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
 
 
@@ -377,7 +384,7 @@ def _extract_safety_verdict(response: str, field_name: str) -> str:
     # restating them: counting duplicates first would reject every reasoning-enabled response.
     _reject_duplicate_verdicts(cleaned_response)
 
-    match = re.search(_verdict_pattern(field_name), cleaned_response, re.IGNORECASE | re.MULTILINE)
+    match = re.search(_verdict_line_pattern(field_name), cleaned_response, re.IGNORECASE | re.MULTILINE)
     if match is None:
         raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
 

--- a/nemoguardrails/llm/output_parsers.py
+++ b/nemoguardrails/llm/output_parsers.py
@@ -324,6 +324,33 @@ _THINK_OPEN_TAG = "<think>"
 
 _CONTENT_SAFETY_PARSE_ERROR = "Failed to parse content safety model response"
 
+_VERDICT_FIELDS = ("User Safety", "Response Safety")
+
+
+def _verdict_pattern(field_name: str) -> str:
+    """Helper function to build the pattern matching one verdict field."""
+    # Anchored to the start of a line, and restricted to the two permitted values, so prose
+    # that merely mentions the field cannot be mistaken for a verdict.
+    return rf"^\s*{re.escape(field_name)}\s*:\s*(safe|unsafe)\b"
+
+
+def _reject_duplicate_verdicts(response: str) -> None:
+    """Helper function to reject a response that states either verdict field more than once.
+
+    Args:
+        response: The model response text, with any reasoning trace already stripped.
+
+    Raises:
+        ValueError: If either field appears more than once. Both fields are checked whichever
+            one is being read: a model that states a verdict twice has broken its own output
+            contract, so no statement in the response can be trusted. Taking the first match
+            would let a later contradicting verdict be silently discarded, which fails open
+            when the discarded one is the unsafe verdict.
+    """
+    for field_name in _VERDICT_FIELDS:
+        if len(re.findall(_verdict_pattern(field_name), response, re.IGNORECASE | re.MULTILINE)) > 1:
+            raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
+
 
 def _extract_safety_verdict(response: str, field_name: str) -> str:
     """Helper function to extract the safe/unsafe verdict for a given field.
@@ -336,8 +363,8 @@ def _extract_safety_verdict(response: str, field_name: str) -> str:
         The extracted verdict, either "safe" or "unsafe".
 
     Raises:
-        ValueError: If the field is absent, carries a value other than safe or unsafe, or the
-            reasoning trace is unterminated.
+        ValueError: If the field is absent, carries a value other than safe or unsafe, is
+            stated more than once, or the reasoning trace is unterminated.
     """
     cleaned_response = _strip_think_tags(response)
 
@@ -346,10 +373,11 @@ def _extract_safety_verdict(response: str, field_name: str) -> str:
     if _THINK_OPEN_TAG in cleaned_response:
         raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
 
-    # Anchored to the start of a line, and restricted to the two permitted values, so prose
-    # that merely mentions the field cannot be mistaken for a verdict.
-    pattern = rf"^\s*{re.escape(field_name)}\s*:\s*(safe|unsafe)\b"
-    match = re.search(pattern, cleaned_response, re.IGNORECASE | re.MULTILINE)
+    # Checked after the strip, because a reasoning trace quotes the verdict lines back before
+    # restating them: counting duplicates first would reject every reasoning-enabled response.
+    _reject_duplicate_verdicts(cleaned_response)
+
+    match = re.search(_verdict_pattern(field_name), cleaned_response, re.IGNORECASE | re.MULTILINE)
     if match is None:
         raise ValueError(_CONTENT_SAFETY_PARSE_ERROR)
 
@@ -393,7 +421,8 @@ def nemotron_content_safety_parse_prompt_safety(response: str) -> Sequence[Union
         safety categories, if any.
 
     Raises:
-        ValueError: If the model response cannot be parsed as a content safety verdict.
+        ValueError: If the model response cannot be parsed as a content safety verdict, including
+            when either verdict field is stated more than once.
     """
     if _extract_safety_verdict(response, "User Safety") == "safe":
         return [True]
@@ -419,7 +448,8 @@ def nemotron_content_safety_parse_response_safety(
 
     Raises:
         ValueError: If the model response cannot be parsed as a content safety verdict. A response with no
-            `Response Safety` line is unparseable rather than safe.
+            `Response Safety` line is unparseable rather than safe, as is one that states either verdict
+            field more than once.
     """
     if _extract_safety_verdict(response, "Response Safety") == "safe":
         return [True]

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -43,6 +43,8 @@ from nemoguardrails.llm.output_parsers import (
     is_content_safe,
     nemoguard_parse_prompt_safety,
     nemoguard_parse_response_safety,
+    nemotron_content_safety_parse_prompt_safety,
+    nemotron_content_safety_parse_response_safety,
     nemotron_reasoning_parse_prompt_safety,
     nemotron_reasoning_parse_response_safety,
     user_intent_parser,
@@ -88,6 +90,8 @@ class LLMTaskManager:
             "is_content_safe": is_content_safe,
             "nemoguard_parse_prompt_safety": nemoguard_parse_prompt_safety,
             "nemoguard_parse_response_safety": nemoguard_parse_response_safety,
+            "nemotron_content_safety_parse_prompt_safety": nemotron_content_safety_parse_prompt_safety,
+            "nemotron_content_safety_parse_response_safety": nemotron_content_safety_parse_response_safety,
             "nemotron_reasoning_parse_prompt_safety": nemotron_reasoning_parse_prompt_safety,
             "nemotron_reasoning_parse_response_safety": nemotron_reasoning_parse_response_safety,
         }

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -19,14 +19,19 @@ These tests verify that the modified parser interface (list format instead of tu
 works correctly with the actual content safety actions and their iterable unpacking logic.
 """
 
+import copy
 import textwrap
-from unittest.mock import MagicMock
+from dataclasses import dataclass
+from typing import Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.rail_outcome import RailOutcome
 from nemoguardrails.guardrails.compiled_rail import RailDependencies, compile_rail
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.library.content_safety.actions import (
     content_safety_check_input,
     content_safety_check_output,
@@ -35,10 +40,13 @@ from nemoguardrails.llm.output_parsers import (
     is_content_safe,
     nemoguard_parse_prompt_safety,
     nemoguard_parse_response_safety,
+    nemotron_content_safety_parse_prompt_safety,
+    nemotron_content_safety_parse_response_safety,
     nemotron_reasoning_parse_prompt_safety,
     nemotron_reasoning_parse_response_safety,
 )
 from nemoguardrails.manifests import RailDirection
+from nemoguardrails.types import LLMResponse
 from tests.utils import FakeLLMModel, TestChat
 
 
@@ -443,3 +451,250 @@ class TestNemotronReasoningParserIntegration:
 
         assert result.is_blocked == (not expected_allowed)
         assert result.metadata["policy_violations"] == []
+
+
+PROMPT_SAFE = "User Safety: safe"
+PROMPT_UNSAFE = "User Safety: unsafe\nSafety Categories: Criminal Planning/Confessions"
+PROMPT_SAFE_RESPONSE_SAFE = "User Safety: safe\nResponse Safety: safe"
+PROMPT_SAFE_RESPONSE_UNSAFE = (
+    "User Safety: safe\nResponse Safety: unsafe\nSafety Categories: Violence, Criminal Planning/Confessions"
+)
+PROMPT_UNSAFE_RESPONSE_SAFE = (
+    "User Safety: unsafe\nResponse Safety: safe\nSafety Categories: Criminal Planning/Confessions, Violence"
+)
+PROMPT_UNSAFE_RESPONSE_UNSAFE = (
+    "User Safety: unsafe\nResponse Safety: unsafe\nSafety Categories: Criminal Planning/Confessions, Violence"
+)
+
+UNSAFE_CATEGORIES = ["Criminal Planning/Confessions", "Violence"]
+
+
+class TestNemotronContentSafetyParserIntegration:
+    """Integration tests for Nemotron content safety parsers with content safety actions."""
+
+    @pytest.mark.parametrize(
+        "response,expected_allowed,expected_violations",
+        [
+            (PROMPT_SAFE, True, []),
+            (PROMPT_UNSAFE, False, ["Criminal Planning/Confessions"]),
+            (PROMPT_SAFE_RESPONSE_SAFE, True, []),
+            (PROMPT_SAFE_RESPONSE_UNSAFE, True, []),
+            (PROMPT_UNSAFE_RESPONSE_SAFE, False, UNSAFE_CATEGORIES),
+            (PROMPT_UNSAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_content_safety_input_with_nemotron_content_safety_parser(
+        self, response, expected_allowed, expected_violations
+    ):
+        """Test input action with nemotron_content_safety_parse_prompt_safety parser."""
+        parsed_result = nemotron_content_safety_parse_prompt_safety(response)
+        llms, mock_task_manager = _create_mock_setup([response], parsed_result)
+        context = _create_input_context()
+
+        result = await content_safety_check_input(
+            llms=llms,
+            llm_task_manager=mock_task_manager,
+            model_name="test_model",
+            context=context,
+        )
+
+        assert result.is_blocked == (not expected_allowed)
+        assert sorted(result.metadata["policy_violations"]) == sorted(expected_violations)
+
+    @pytest.mark.parametrize(
+        "response,expected_allowed,expected_violations",
+        [
+            (PROMPT_SAFE_RESPONSE_SAFE, True, []),
+            (PROMPT_SAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
+            (PROMPT_UNSAFE_RESPONSE_SAFE, True, []),
+            (PROMPT_UNSAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_content_safety_output_with_nemotron_content_safety_parser(
+        self, response, expected_allowed, expected_violations
+    ):
+        """Test output action with nemotron_content_safety_parse_response_safety parser."""
+        parsed_result = nemotron_content_safety_parse_response_safety(response)
+        llms, mock_task_manager = _create_mock_setup([response], parsed_result)
+        context = _create_output_context()
+
+        result = await content_safety_check_output(
+            llms=llms,
+            llm_task_manager=mock_task_manager,
+            model_name="test_model",
+            context=context,
+        )
+
+        assert result.is_blocked == (not expected_allowed)
+        assert sorted(result.metadata["policy_violations"]) == sorted(expected_violations)
+
+    @pytest.mark.parametrize(
+        ("action", "parser", "context"),
+        [
+            (
+                content_safety_check_input,
+                nemotron_content_safety_parse_prompt_safety,
+                _create_input_context("Some content"),
+            ),
+            (
+                content_safety_check_output,
+                nemotron_content_safety_parse_response_safety,
+                _create_output_context(),
+            ),
+        ],
+        ids=["input", "output"],
+    )
+    @pytest.mark.asyncio
+    async def test_content_safety_action_propagates_nemotron_parser_error(self, action, parser, context):
+        """Test an unparseable Nemotron verdict surfaces as an error rather than a silent block."""
+        llms, mock_task_manager = _create_mock_setup([""], None)
+        mock_task_manager.parse_task_output.side_effect = lambda task, output: parser(output)
+
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            await action(
+                llms=llms,
+                llm_task_manager=mock_task_manager,
+                model_name="test_model",
+                context=context,
+            )
+
+    @pytest.mark.asyncio
+    async def test_content_safety_nemotron_parser_error_fails_closed_through_compiled_rail(self):
+        """Test a truncated Nemotron verdict fails the compiled rail closed with a parse reason."""
+        llms, mock_task_manager = _create_mock_setup([""], None)
+        mock_task_manager.parse_task_output.side_effect = lambda task, output: (
+            nemotron_content_safety_parse_prompt_safety(output)
+        )
+        dependencies = RailDependencies(llms=llms, llm_task_manager=mock_task_manager, config=MagicMock())
+
+        outcome = await compile_rail(
+            "content safety check input $model=test_model", RailDirection.INPUT, dependencies
+        ).run([{"role": "user", "content": "Some content"}])
+
+        assert outcome == RailOutcome.failure(
+            reason="content safety check input error: Failed to parse content safety model response"
+        )
+
+
+CROSS_ENGINE_USER_INPUT = "hello there"
+CROSS_ENGINE_MAIN_OUTPUT = "Hello! How can I help?"
+
+CROSS_ENGINE_CONFIG = {
+    "models": [
+        {"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"},
+        {"type": "content_safety", "engine": "nim", "model": "nvidia/nemotron-3.5-content-safety"},
+    ],
+    "rails": {
+        "input": {"flows": ["content safety check input $model=content_safety"]},
+        "output": {"flows": ["content safety check output $model=content_safety"]},
+    },
+    "prompts": [
+        {
+            "task": "content_safety_check_input $model=content_safety",
+            "content": "{{ user_input }}",
+            "output_parser": "nemotron_content_safety_parse_prompt_safety",
+            "max_tokens": 100,
+        },
+        {
+            "task": "content_safety_check_output $model=content_safety",
+            "content": "{{ user_input }}\n{{ bot_response }}",
+            "output_parser": "nemotron_content_safety_parse_response_safety",
+            "max_tokens": 100,
+        },
+    ],
+}
+
+
+@dataclass(frozen=True)
+class CrossEngineCase:
+    """One scripted content-safety verdict sequence and the outcome both engines must reach."""
+
+    case_id: str
+    safety_replies: Tuple[str, ...]
+    expect_blocked: bool
+    expected_safety_calls: int
+
+
+CROSS_ENGINE_CASES = [
+    CrossEngineCase(
+        case_id="input_safe",
+        safety_replies=(PROMPT_SAFE, PROMPT_SAFE_RESPONSE_SAFE),
+        expect_blocked=False,
+        expected_safety_calls=2,
+    ),
+    CrossEngineCase(
+        case_id="input_unsafe",
+        safety_replies=(PROMPT_UNSAFE,),
+        expect_blocked=True,
+        expected_safety_calls=1,
+    ),
+    CrossEngineCase(
+        case_id="input_safe_output_unsafe",
+        safety_replies=(PROMPT_SAFE, PROMPT_SAFE_RESPONSE_UNSAFE),
+        expect_blocked=True,
+        expected_safety_calls=2,
+    ),
+    CrossEngineCase(
+        case_id="input_unsafe_output_safe",
+        safety_replies=(PROMPT_UNSAFE, PROMPT_UNSAFE_RESPONSE_SAFE),
+        expect_blocked=True,
+        expected_safety_calls=1,
+    ),
+]
+
+
+def _assistant_content(response: object) -> str:
+    """Return the assistant message content from a generate_async result."""
+    assert isinstance(response, dict), f"expected a message dict, got {type(response).__name__}"
+    return response["content"]
+
+
+async def _llmrails_turn(safety_replies: Tuple[str, ...]) -> Tuple[str, int]:
+    """Run one turn through LLMRails with a scripted content-safety model."""
+    config = RailsConfig.from_content(config=copy.deepcopy(CROSS_ENGINE_CONFIG))
+    chat = TestChat(config, llm_completions=[CROSS_ENGINE_MAIN_OUTPUT])
+
+    safety_llm = FakeLLMModel(responses=list(safety_replies))
+    chat.app.runtime.registered_action_params["llms"]["content_safety"] = safety_llm
+
+    response = await chat.app.generate_async(messages=[{"role": "user", "content": CROSS_ENGINE_USER_INPUT}])
+    return _assistant_content(response), safety_llm.inference_count
+
+
+async def _iorails_turn(safety_replies: Tuple[str, ...]) -> Tuple[str, int]:
+    """Run one turn through IORails with a scripted content-safety model."""
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        iorails = IORails(RailsConfig.from_content(config=copy.deepcopy(CROSS_ENGINE_CONFIG)))
+
+    async with iorails:
+        safety_mock = AsyncMock(side_effect=[LLMResponse(content=reply) for reply in safety_replies])
+        for name, engine in iorails.engine_registry._engines.items():
+            if not isinstance(engine, ModelEngine):
+                continue
+            if name == "main":
+                engine.chat_completion = AsyncMock(return_value=LLMResponse(content=CROSS_ENGINE_MAIN_OUTPUT))
+            else:
+                engine.chat_completion = safety_mock
+
+        response = await iorails.generate_async(messages=[{"role": "user", "content": CROSS_ENGINE_USER_INPUT}])
+        return _assistant_content(response), safety_mock.await_count
+
+
+ENGINE_RUNNERS = {"llmrails": _llmrails_turn, "iorails": _iorails_turn}
+
+
+class TestNemotronContentSafetyAcrossEngines:
+    """Both engines reach the same decision from one scripted Nemotron content-safety model."""
+
+    @pytest.mark.parametrize("engine", sorted(ENGINE_RUNNERS), ids=sorted(ENGINE_RUNNERS))
+    @pytest.mark.parametrize("case", CROSS_ENGINE_CASES, ids=[case.case_id for case in CROSS_ENGINE_CASES])
+    @pytest.mark.asyncio
+    async def test_engines_reach_the_same_decision(self, case: CrossEngineCase, engine: str):
+        """Test each engine blocks or allows as the scripted verdicts dictate, calling the guard equally often."""
+        content, safety_calls = await ENGINE_RUNNERS[engine](case.safety_replies)
+
+        expected_content = REFUSAL_MESSAGE if case.expect_blocked else CROSS_ENGINE_MAIN_OUTPUT
+        assert content == expected_content
+        assert safety_calls == case.expected_safety_calls

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -19,10 +19,10 @@ These tests verify that the modified parser interface (list format instead of tu
 works correctly with the actual content safety actions and their iterable unpacking logic.
 """
 
-import copy
 import textwrap
 from dataclasses import dataclass
-from typing import Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -581,30 +581,47 @@ class TestNemotronContentSafetyParserIntegration:
 CROSS_ENGINE_USER_INPUT = "hello there"
 CROSS_ENGINE_MAIN_OUTPUT = "Hello! How can I help?"
 
-CROSS_ENGINE_CONFIG = {
-    "models": [
-        {"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"},
-        {"type": "content_safety", "engine": "nim", "model": "nvidia/nemotron-3.5-content-safety"},
-    ],
-    "rails": {
-        "input": {"flows": ["content safety check input $model=content_safety"]},
-        "output": {"flows": ["content safety check output $model=content_safety"]},
-    },
-    "prompts": [
-        {
-            "task": "content_safety_check_input $model=content_safety",
-            "content": "{{ user_input }}",
-            "output_parser": "nemotron_content_safety_parse_prompt_safety",
-            "max_tokens": 100,
-        },
-        {
-            "task": "content_safety_check_output $model=content_safety",
-            "content": "{{ user_input }}\n{{ bot_response }}",
-            "output_parser": "nemotron_content_safety_parse_response_safety",
-            "max_tokens": 100,
-        },
-    ],
-}
+EXAMPLE_CONFIG_PATH = Path(__file__).parent.parent / "examples" / "configs" / "nemotron-3.5-content-safety"
+
+EXAMPLE_CHAT_TEMPLATE_KWARGS = {"enable_thinking": False, "request_categories": "/categories"}
+
+
+def _load_example_config() -> RailsConfig:
+    """Load the shipped example config, so these tests break when it drifts."""
+    return RailsConfig.from_path(str(EXAMPLE_CONFIG_PATH))
+
+
+def _turns(messages: Sequence[Any]) -> Tuple[Tuple[str, str], ...]:
+    """Normalise ChatMessage objects (LLMRails) or wire dicts (IORails) to (role, content) pairs."""
+    normalised = []
+    for message in messages:
+        if isinstance(message, dict):
+            normalised.append((message["role"], message["content"]))
+        else:
+            normalised.append((message.role.value, message.content))
+    return tuple(normalised)
+
+
+class _RecordingFakeLLMModel(FakeLLMModel):
+    """FakeLLMModel that also records the messages of every call."""
+
+    def __init__(self, responses: List[str]):
+        super().__init__(responses=responses)
+        self.recorded_messages: List[Any] = []
+
+    async def generate_async(self, prompt, *, stop=None, **kwargs):
+        self.recorded_messages.append(prompt)
+        return await super().generate_async(prompt, stop=stop, **kwargs)
+
+
+@dataclass(frozen=True)
+class EngineRun:
+    """What one turn through an engine produced, and what the guard model was asked for."""
+
+    content: str
+    safety_calls: int
+    safety_turns: Tuple[Tuple[Tuple[str, str], ...], ...]
+    safety_params: Tuple[Dict[str, Any], ...]
 
 
 @dataclass(frozen=True)
@@ -644,6 +661,8 @@ CROSS_ENGINE_CASES = [
     ),
 ]
 
+ALL_SAFE_REPLIES = (PROMPT_SAFE, PROMPT_SAFE_RESPONSE_SAFE)
+
 
 def _assistant_content(response: object) -> str:
     """Return the assistant message content from a generate_async result."""
@@ -651,22 +670,27 @@ def _assistant_content(response: object) -> str:
     return response["content"]
 
 
-async def _llmrails_turn(safety_replies: Tuple[str, ...]) -> Tuple[str, int]:
+async def _llmrails_turn(safety_replies: Tuple[str, ...]) -> EngineRun:
     """Run one turn through LLMRails with a scripted content-safety model."""
-    config = RailsConfig.from_content(config=copy.deepcopy(CROSS_ENGINE_CONFIG))
-    chat = TestChat(config, llm_completions=[CROSS_ENGINE_MAIN_OUTPUT])
+    chat = TestChat(_load_example_config(), llm_completions=[CROSS_ENGINE_MAIN_OUTPUT])
 
-    safety_llm = FakeLLMModel(responses=list(safety_replies))
+    safety_llm = _RecordingFakeLLMModel(list(safety_replies))
     chat.app.runtime.registered_action_params["llms"]["content_safety"] = safety_llm
 
     response = await chat.app.generate_async(messages=[{"role": "user", "content": CROSS_ENGINE_USER_INPUT}])
-    return _assistant_content(response), safety_llm.inference_count
+    return EngineRun(
+        content=_assistant_content(response),
+        safety_calls=safety_llm.inference_count,
+        safety_turns=tuple(_turns(messages) for messages in safety_llm.recorded_messages),
+        # The fake replaces the configured model outright, so there is no request body to inspect.
+        safety_params=(),
+    )
 
 
-async def _iorails_turn(safety_replies: Tuple[str, ...]) -> Tuple[str, int]:
+async def _iorails_turn(safety_replies: Tuple[str, ...]) -> EngineRun:
     """Run one turn through IORails with a scripted content-safety model."""
     with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        iorails = IORails(RailsConfig.from_content(config=copy.deepcopy(CROSS_ENGINE_CONFIG)))
+        iorails = IORails(_load_example_config())
 
     async with iorails:
         safety_mock = AsyncMock(side_effect=[LLMResponse(content=reply) for reply in safety_replies])
@@ -679,7 +703,14 @@ async def _iorails_turn(safety_replies: Tuple[str, ...]) -> Tuple[str, int]:
                 engine.chat_completion = safety_mock
 
         response = await iorails.generate_async(messages=[{"role": "user", "content": CROSS_ENGINE_USER_INPUT}])
-        return _assistant_content(response), safety_mock.await_count
+        return EngineRun(
+            content=_assistant_content(response),
+            safety_calls=safety_mock.await_count,
+            safety_turns=tuple(_turns(call.args[0]) for call in safety_mock.await_args_list),
+            # generate_from_messages merges the model's `parameters` into the per-call kwargs before
+            # reaching chat_completion, so the mock observes the request body the engine assembled.
+            safety_params=tuple(dict(call.kwargs) for call in safety_mock.await_args_list),
+        )
 
 
 ENGINE_RUNNERS = {"llmrails": _llmrails_turn, "iorails": _iorails_turn}
@@ -693,8 +724,38 @@ class TestNemotronContentSafetyAcrossEngines:
     @pytest.mark.asyncio
     async def test_engines_reach_the_same_decision(self, case: CrossEngineCase, engine: str):
         """Test each engine blocks or allows as the scripted verdicts dictate, calling the guard equally often."""
-        content, safety_calls = await ENGINE_RUNNERS[engine](case.safety_replies)
+        run = await ENGINE_RUNNERS[engine](case.safety_replies)
 
         expected_content = REFUSAL_MESSAGE if case.expect_blocked else CROSS_ENGINE_MAIN_OUTPUT
-        assert content == expected_content
-        assert safety_calls == case.expected_safety_calls
+        assert run.content == expected_content
+        assert run.safety_calls == case.expected_safety_calls
+
+
+class TestNemotronContentSafetyExampleConfigWiring:
+    """The shipped example config renders the turns and request parameters the model requires."""
+
+    @pytest.mark.parametrize("engine", sorted(ENGINE_RUNNERS), ids=sorted(ENGINE_RUNNERS))
+    @pytest.mark.asyncio
+    async def test_input_rail_sends_only_the_user_turn(self, engine: str):
+        """Test the input rail sends a lone user turn, which is why the model omits Response Safety there."""
+        run = await ENGINE_RUNNERS[engine](ALL_SAFE_REPLIES)
+        assert run.safety_turns[0] == (("user", CROSS_ENGINE_USER_INPUT),)
+
+    @pytest.mark.parametrize("engine", sorted(ENGINE_RUNNERS), ids=sorted(ENGINE_RUNNERS))
+    @pytest.mark.asyncio
+    async def test_output_rail_sends_the_user_turn_then_the_assistant_turn(self, engine: str):
+        """Test the output rail sends both turns in the order the model's chat template requires."""
+        run = await ENGINE_RUNNERS[engine](ALL_SAFE_REPLIES)
+        assert run.safety_turns[1] == (
+            ("user", CROSS_ENGINE_USER_INPUT),
+            ("assistant", CROSS_ENGINE_MAIN_OUTPUT),
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_template_kwargs_reach_every_guard_request(self):
+        """Test the example config's chat_template_kwargs are merged into every content-safety request."""
+        run = await _iorails_turn(ALL_SAFE_REPLIES)
+
+        assert len(run.safety_params) == 2
+        for params in run.safety_params:
+            assert params["chat_template_kwargs"] == EXAMPLE_CHAT_TEMPLATE_KWARGS

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -40,8 +40,6 @@ from nemoguardrails.llm.output_parsers import (
     is_content_safe,
     nemoguard_parse_prompt_safety,
     nemoguard_parse_response_safety,
-    nemotron_content_safety_parse_prompt_safety,
-    nemotron_content_safety_parse_response_safety,
     nemotron_reasoning_parse_prompt_safety,
     nemotron_reasoning_parse_response_safety,
 )
@@ -462,122 +460,6 @@ PROMPT_SAFE_RESPONSE_UNSAFE = (
 PROMPT_UNSAFE_RESPONSE_SAFE = (
     "User Safety: unsafe\nResponse Safety: safe\nSafety Categories: Criminal Planning/Confessions, Violence"
 )
-PROMPT_UNSAFE_RESPONSE_UNSAFE = (
-    "User Safety: unsafe\nResponse Safety: unsafe\nSafety Categories: Criminal Planning/Confessions, Violence"
-)
-
-UNSAFE_CATEGORIES = ["Criminal Planning/Confessions", "Violence"]
-
-
-class TestNemotronContentSafetyParserIntegration:
-    """Integration tests for Nemotron content safety parsers with content safety actions."""
-
-    @pytest.mark.parametrize(
-        "response,expected_allowed,expected_violations",
-        [
-            (PROMPT_SAFE, True, []),
-            (PROMPT_UNSAFE, False, ["Criminal Planning/Confessions"]),
-            (PROMPT_SAFE_RESPONSE_SAFE, True, []),
-            (PROMPT_SAFE_RESPONSE_UNSAFE, True, []),
-            (PROMPT_UNSAFE_RESPONSE_SAFE, False, UNSAFE_CATEGORIES),
-            (PROMPT_UNSAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_content_safety_input_with_nemotron_content_safety_parser(
-        self, response, expected_allowed, expected_violations
-    ):
-        """Test input action with nemotron_content_safety_parse_prompt_safety parser."""
-        parsed_result = nemotron_content_safety_parse_prompt_safety(response)
-        llms, mock_task_manager = _create_mock_setup([response], parsed_result)
-        context = _create_input_context()
-
-        result = await content_safety_check_input(
-            llms=llms,
-            llm_task_manager=mock_task_manager,
-            model_name="test_model",
-            context=context,
-        )
-
-        assert result.is_blocked == (not expected_allowed)
-        assert sorted(result.metadata["policy_violations"]) == sorted(expected_violations)
-
-    @pytest.mark.parametrize(
-        "response,expected_allowed,expected_violations",
-        [
-            (PROMPT_SAFE_RESPONSE_SAFE, True, []),
-            (PROMPT_SAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
-            (PROMPT_UNSAFE_RESPONSE_SAFE, True, []),
-            (PROMPT_UNSAFE_RESPONSE_UNSAFE, False, UNSAFE_CATEGORIES),
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_content_safety_output_with_nemotron_content_safety_parser(
-        self, response, expected_allowed, expected_violations
-    ):
-        """Test output action with nemotron_content_safety_parse_response_safety parser."""
-        parsed_result = nemotron_content_safety_parse_response_safety(response)
-        llms, mock_task_manager = _create_mock_setup([response], parsed_result)
-        context = _create_output_context()
-
-        result = await content_safety_check_output(
-            llms=llms,
-            llm_task_manager=mock_task_manager,
-            model_name="test_model",
-            context=context,
-        )
-
-        assert result.is_blocked == (not expected_allowed)
-        assert sorted(result.metadata["policy_violations"]) == sorted(expected_violations)
-
-    @pytest.mark.parametrize(
-        ("action", "parser", "context"),
-        [
-            (
-                content_safety_check_input,
-                nemotron_content_safety_parse_prompt_safety,
-                _create_input_context("Some content"),
-            ),
-            (
-                content_safety_check_output,
-                nemotron_content_safety_parse_response_safety,
-                _create_output_context(),
-            ),
-        ],
-        ids=["input", "output"],
-    )
-    @pytest.mark.asyncio
-    async def test_content_safety_action_propagates_nemotron_parser_error(self, action, parser, context):
-        """Test an unparseable Nemotron verdict surfaces as an error rather than a silent block."""
-        llms, mock_task_manager = _create_mock_setup([""], None)
-        mock_task_manager.parse_task_output.side_effect = lambda task, output: parser(output)
-
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            await action(
-                llms=llms,
-                llm_task_manager=mock_task_manager,
-                model_name="test_model",
-                context=context,
-            )
-
-    @pytest.mark.asyncio
-    async def test_content_safety_nemotron_parser_error_fails_closed_through_compiled_rail(self):
-        """Test a truncated Nemotron verdict fails the compiled rail closed with a parse reason."""
-        llms, mock_task_manager = _create_mock_setup([""], None)
-        mock_task_manager.parse_task_output.side_effect = lambda task, output: (
-            nemotron_content_safety_parse_prompt_safety(output)
-        )
-        dependencies = RailDependencies(llms=llms, llm_task_manager=mock_task_manager, config=MagicMock())
-
-        outcome = await compile_rail(
-            "content safety check input $model=test_model", RailDirection.INPUT, dependencies
-        ).run([{"role": "user", "content": "Some content"}])
-
-        assert outcome == RailOutcome.failure(
-            reason="content safety check input error: Failed to parse content safety model response"
-        )
-
-
 CROSS_ENGINE_USER_INPUT = "hello there"
 CROSS_ENGINE_MAIN_OUTPUT = "Hello! How can I help?"
 

--- a/tests/test_content_safety_output_parsers.py
+++ b/tests/test_content_safety_output_parsers.py
@@ -18,8 +18,6 @@ import pytest
 
 from nemoguardrails.llm.output_parsers import (
     _extract_harm_value,
-    _extract_safety_categories,
-    _extract_safety_verdict,
     _strip_think_tags,
     is_content_safe,
     nemoguard_parse_prompt_safety,
@@ -651,104 +649,6 @@ MODEL_EXCHANGE_ALL_UNSAFE = (
 ARSON_CATEGORIES = ["Criminal Planning/Confessions", "Violence"]
 
 
-class TestExtractSafetyVerdict:
-    """Test the _extract_safety_verdict helper function."""
-
-    def test_extract_safe(self):
-        """Test extracting a safe verdict."""
-        assert _extract_safety_verdict("User Safety: safe", "User Safety") == "safe"
-
-    def test_extract_unsafe(self):
-        """Test extracting an unsafe verdict."""
-        assert _extract_safety_verdict("User Safety: unsafe", "User Safety") == "unsafe"
-
-    def test_response_safety_field(self):
-        """Test extracting the Response Safety field from a two-line verdict."""
-        assert _extract_safety_verdict(MODEL_EXCHANGE_RESPONSE_UNSAFE, "Response Safety") == "unsafe"
-
-    def test_user_safety_field_ignores_response_safety_line(self):
-        """Test the User Safety field is read independently of the Response Safety line."""
-        assert _extract_safety_verdict(MODEL_EXCHANGE_RESPONSE_UNSAFE, "User Safety") == "safe"
-
-    def test_case_insensitive_field(self):
-        """Test the field name is matched case insensitively."""
-        assert _extract_safety_verdict("USER SAFETY: safe", "User Safety") == "safe"
-
-    def test_case_insensitive_value(self):
-        """Test the verdict value is lowercased."""
-        assert _extract_safety_verdict("User Safety: SAFE", "User Safety") == "safe"
-
-    def test_extra_whitespace_around_colon(self):
-        """Test extra whitespace around the colon is tolerated."""
-        assert _extract_safety_verdict("User Safety  :   unsafe", "User Safety") == "unsafe"
-
-    def test_strips_think_tags_before_matching(self):
-        """Test a reasoning trace is removed before the verdict is matched."""
-        response = "<think>The user asked about the weather.</think>User Safety: safe"
-        assert _extract_safety_verdict(response, "User Safety") == "safe"
-
-    def test_missing_field_raises(self):
-        """Test a missing field raises rather than defaulting to a verdict."""
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            _extract_safety_verdict("User Safety: safe", "Response Safety")
-
-    def test_empty_response_raises(self):
-        """Test an empty response raises."""
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            _extract_safety_verdict("", "User Safety")
-
-    def test_unterminated_think_block_raises(self):
-        """Test a truncated reasoning trace raises instead of matching inside the trace."""
-        response = "<think>We need to output:\n\nUser Safety: unsafe\n\nNo extra text."
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            _extract_safety_verdict(response, "User Safety")
-
-    def test_non_verdict_value_raises(self):
-        """Test a value outside safe/unsafe raises rather than being treated as unsafe."""
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            _extract_safety_verdict("User Safety: undetermined", "User Safety")
-
-
-class TestExtractSafetyCategories:
-    """Test the _extract_safety_categories helper function."""
-
-    def test_single_category(self):
-        """Test a single category is returned as a one-element list."""
-        assert _extract_safety_categories(MODEL_UNSAFE) == ["Criminal Planning/Confessions"]
-
-    def test_multiple_categories(self):
-        """Test a comma-separated list is split into separate categories."""
-        assert _extract_safety_categories(MODEL_EXCHANGE_ALL_UNSAFE) == ARSON_CATEGORIES
-
-    def test_category_containing_slash_is_not_split(self):
-        """Test a category name containing a slash is kept intact."""
-        assert "Criminal Planning/Confessions" in _extract_safety_categories(MODEL_EXCHANGE_ALL_UNSAFE)
-
-    def test_absent_line_returns_empty(self):
-        """Test an absent Safety Categories line yields no categories."""
-        assert _extract_safety_categories(MODEL_EXCHANGE_ALL_SAFE) == []
-
-    def test_whitespace_is_trimmed(self):
-        """Test surrounding whitespace is trimmed from each category."""
-        response = "User Safety: unsafe\nSafety Categories:   Violence ,  Threat  "
-        assert _extract_safety_categories(response) == ["Violence", "Threat"]
-
-    def test_empty_entries_are_dropped(self):
-        """Test empty entries from a trailing comma are dropped."""
-        response = "User Safety: unsafe\nSafety Categories: Violence,,"
-        assert _extract_safety_categories(response) == ["Violence"]
-
-    def test_categories_line_does_not_absorb_later_lines(self):
-        """Test extraction stops at the end of the Safety Categories line."""
-        response = "User Safety: unsafe\nSafety Categories: Violence\nResponse Safety: safe"
-        assert _extract_safety_categories(response) == ["Violence"]
-
-    def test_strips_think_tags_before_matching(self):
-        """Test a reasoning trace is removed before categories are matched."""
-        response = "<think>Categories: nothing here</think>User Safety: unsafe\nSafety Categories: Violence"
-        assert _extract_safety_categories(response) == ["Violence"]
-
-
 class TestNemotronContentSafetyParsePromptSafety:
     """Test the nemotron_content_safety_parse_prompt_safety output parser."""
 
@@ -777,23 +677,10 @@ class TestNemotronContentSafetyParsePromptSafety:
         assert is_safe is expected_safe
         assert sorted(violated_policies) == sorted(expected_categories)
 
-    def test_categories_dropped_when_user_turn_is_safe(self):
-        """Test categories triggered by the assistant turn are not reported as prompt violations."""
-        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(MODEL_EXCHANGE_RESPONSE_UNSAFE)
-        assert is_safe is True
-        assert violated_policies == []
-
     def test_unsafe_without_categories_line(self):
         """Test an unsafe verdict under /no_categories parses without raising."""
         is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety("User Safety: unsafe")
         assert is_safe is False
-        assert violated_policies == []
-
-    def test_inline_think_trace_on_one_line(self):
-        """Test a verdict emitted immediately after a closing think tag is parsed."""
-        response = "<think>\nWe need to output:\n\nUser Safety: safe\n</think>User Safety: safe"
-        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(response)
-        assert is_safe is True
         assert violated_policies == []
 
     def test_multiline_think_trace(self):
@@ -808,20 +695,14 @@ class TestNemotronContentSafetyParsePromptSafety:
         is_safe, *_ = nemotron_content_safety_parse_prompt_safety("USER SAFETY: UNSAFE")
         assert is_safe is False
 
-    def test_empty_response_raises(self):
-        """Test an empty response raises rather than silently blocking."""
+    @pytest.mark.parametrize(
+        "response",
+        ["", "<think>truncated reasoning", '{"User Safety": "safe"}', "User Safety: undetermined"],
+        ids=["empty", "truncated_reasoning", "json", "unknown_verdict"],
+    )
+    def test_invalid_response_raises(self, response):
         with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            nemotron_content_safety_parse_prompt_safety("")
-
-    def test_truncated_response_raises(self):
-        """Test a response truncated inside its reasoning trace raises."""
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            nemotron_content_safety_parse_prompt_safety("<think>We need to determine whether the user input")
-
-    def test_json_response_raises(self):
-        """Test the older NemoGuard JSON verdict is not accepted by this parser."""
-        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
-            nemotron_content_safety_parse_prompt_safety('{"User Safety": "safe"}')
+            nemotron_content_safety_parse_prompt_safety(response)
 
 
 class TestNemotronContentSafetyParseResponseSafety:
@@ -848,12 +729,6 @@ class TestNemotronContentSafetyParseResponseSafety:
         assert is_safe is expected_safe
         assert sorted(violated_policies) == sorted(expected_categories)
 
-    def test_safe_refusal_to_unsafe_prompt_is_allowed(self):
-        """Test a safe assistant refusal is allowed even though the user turn was unsafe."""
-        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(MODEL_EXCHANGE_PROMPT_UNSAFE)
-        assert is_safe is True
-        assert violated_policies == []
-
     @pytest.mark.parametrize("response", [MODEL_SAFE, MODEL_UNSAFE], ids=["input_safe", "input_unsafe"])
     def test_missing_response_safety_line_raises(self, response):
         """Test a verdict with no assistant turn raises rather than reusing the user verdict."""
@@ -867,26 +742,7 @@ class TestNemotronContentSafetyParseResponseSafety:
         assert is_safe is False
         assert violated_policies == []
 
-    def test_multiline_think_trace(self):
-        """Test a multi-line reasoning trace preceding the verdict is stripped."""
-        response = "<think>\nThe assistant supplied arson instructions.\n</think>\n\n" + MODEL_EXCHANGE_RESPONSE_UNSAFE
-        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(response)
-        assert is_safe is False
-        assert sorted(violated_policies) == sorted(ARSON_CATEGORIES)
-
-    def test_case_insensitive_parsing(self):
-        """Test parsing is case insensitive."""
-        is_safe, *_ = nemotron_content_safety_parse_response_safety("User Safety: safe\nRESPONSE SAFETY: UNSAFE")
-        assert is_safe is False
-
     def test_empty_response_raises(self):
         """Test an empty response raises rather than silently blocking."""
         with pytest.raises(ValueError, match="Failed to parse content safety model response"):
             nemotron_content_safety_parse_response_safety("")
-
-    def test_starred_unpacking_compatibility(self):
-        """Test parser output is compatible with starred unpacking."""
-        result = nemotron_content_safety_parse_response_safety(MODEL_EXCHANGE_ALL_UNSAFE)
-        is_safe, *violated_policies = result
-        assert is_safe is False
-        assert sorted(violated_policies) == sorted(ARSON_CATEGORIES)

--- a/tests/test_content_safety_output_parsers.py
+++ b/tests/test_content_safety_output_parsers.py
@@ -659,6 +659,16 @@ MODEL_LEAKED_TRACE_WITH_REVISED_VERDICT = (
     "User Safety: unsafe"
 )
 
+# A repeat need not start its own line. Every one of these keeps a well-formed line for the other
+# field, so each case is red for the duplicate rather than for a field that is simply missing.
+MODEL_SAME_LINE_DUPLICATE_USER_SAFETY = "User Safety: safe; User Safety: unsafe\nResponse Safety: safe"
+MODEL_SAME_LINE_DUPLICATE_RESPONSE_SAFETY = "User Safety: safe\nResponse Safety: safe; Response Safety: unsafe"
+MODEL_SAME_LINE_DUPLICATE_COMMA_SEPARATED = "User Safety: unsafe, User Safety: safe\nResponse Safety: safe"
+
+# Trailing prose on an otherwise well-formed verdict line is tolerated rather than rejected, so a
+# single stray remark cannot take the rail down. Only a repeated field is treated as a malfunction.
+MODEL_VERDICT_WITH_TRAILING_PROSE = "User Safety: safe (no assistant response present)\nResponse Safety: safe"
+
 # Shaped after a reasoning_content trace captured from the live NIM, which quotes the verdict lines
 # back before restating them as the answer. Stripping has to happen before duplicates are counted.
 MODEL_THINK_TRACE_REPEATING_VERDICTS = (
@@ -789,8 +799,19 @@ class TestNemotronContentSafetyDuplicateVerdicts:
             MODEL_DUPLICATE_RESPONSE_SAFETY,
             MODEL_DUPLICATE_AGREEING_VERDICT,
             MODEL_LEAKED_TRACE_WITH_REVISED_VERDICT,
+            MODEL_SAME_LINE_DUPLICATE_USER_SAFETY,
+            MODEL_SAME_LINE_DUPLICATE_RESPONSE_SAFETY,
+            MODEL_SAME_LINE_DUPLICATE_COMMA_SEPARATED,
         ],
-        ids=["user_safety_twice", "response_safety_twice", "same_verdict_twice", "leaked_trace_revises_verdict"],
+        ids=[
+            "user_safety_twice",
+            "response_safety_twice",
+            "same_verdict_twice",
+            "leaked_trace_revises_verdict",
+            "user_safety_twice_on_one_line",
+            "response_safety_twice_on_one_line",
+            "same_line_comma_separated",
+        ],
     )
     def test_duplicate_verdict_field_raises(self, parser, response):
         """Test either field stated twice raises for both parsers, rather than trusting the first match."""
@@ -809,3 +830,13 @@ class TestNemotronContentSafetyDuplicateVerdicts:
         """Test verdicts repeated inside a stripped reasoning trace do not count toward the duplicate check."""
         is_safe, *_ = parser(MODEL_THINK_TRACE_REPEATING_VERDICTS)
         assert is_safe is expected_safe
+
+    @pytest.mark.parametrize(
+        "parser",
+        [nemotron_content_safety_parse_prompt_safety, nemotron_content_safety_parse_response_safety],
+        ids=["prompt", "response"],
+    )
+    def test_trailing_prose_on_a_verdict_line_is_not_a_duplicate(self, parser):
+        """Test a verdict line carrying trailing prose still parses, since the field is stated only once."""
+        is_safe, *_ = parser(MODEL_VERDICT_WITH_TRAILING_PROSE)
+        assert is_safe is True

--- a/tests/test_content_safety_output_parsers.py
+++ b/tests/test_content_safety_output_parsers.py
@@ -648,6 +648,32 @@ MODEL_EXCHANGE_ALL_UNSAFE = (
 
 ARSON_CATEGORIES = ["Criminal Planning/Confessions", "Violence"]
 
+MODEL_DUPLICATE_USER_SAFETY = "User Safety: safe\nUser Safety: unsafe\nResponse Safety: safe"
+MODEL_DUPLICATE_RESPONSE_SAFETY = "User Safety: safe\nResponse Safety: safe\nResponse Safety: unsafe"
+MODEL_DUPLICATE_AGREEING_VERDICT = "User Safety: safe\nUser Safety: safe\nResponse Safety: safe"
+MODEL_LEAKED_TRACE_WITH_REVISED_VERDICT = (
+    "We need to decide.\n"
+    "Response Safety: safe\n"
+    "On reflection the assistant supplied arson instructions.\n"
+    "Response Safety: unsafe\n"
+    "User Safety: unsafe"
+)
+
+# Shaped after a reasoning_content trace captured from the live NIM, which quotes the verdict lines
+# back before restating them as the answer. Stripping has to happen before duplicates are counted.
+MODEL_THINK_TRACE_REPEATING_VERDICTS = (
+    "<think>\n"
+    "We need to output:\n\n"
+    "User Safety: unsafe\n"
+    "Response Safety: safe\n\n"
+    "Thus output exactly:\n\n"
+    "User Safety: unsafe\n"
+    "Response Safety: safe\n\n"
+    "No extra text.\n"
+    "</think>\n"
+    "User Safety: unsafe\nResponse Safety: safe"
+)
+
 
 class TestNemotronContentSafetyParsePromptSafety:
     """Test the nemotron_content_safety_parse_prompt_safety output parser."""
@@ -746,3 +772,40 @@ class TestNemotronContentSafetyParseResponseSafety:
         """Test an empty response raises rather than silently blocking."""
         with pytest.raises(ValueError, match="Failed to parse content safety model response"):
             nemotron_content_safety_parse_response_safety("")
+
+
+class TestNemotronContentSafetyDuplicateVerdicts:
+    """A verdict field stated more than once means the model contradicted itself and cannot be trusted."""
+
+    @pytest.mark.parametrize(
+        "parser",
+        [nemotron_content_safety_parse_prompt_safety, nemotron_content_safety_parse_response_safety],
+        ids=["prompt", "response"],
+    )
+    @pytest.mark.parametrize(
+        "response",
+        [
+            MODEL_DUPLICATE_USER_SAFETY,
+            MODEL_DUPLICATE_RESPONSE_SAFETY,
+            MODEL_DUPLICATE_AGREEING_VERDICT,
+            MODEL_LEAKED_TRACE_WITH_REVISED_VERDICT,
+        ],
+        ids=["user_safety_twice", "response_safety_twice", "same_verdict_twice", "leaked_trace_revises_verdict"],
+    )
+    def test_duplicate_verdict_field_raises(self, parser, response):
+        """Test either field stated twice raises for both parsers, rather than trusting the first match."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            parser(response)
+
+    @pytest.mark.parametrize(
+        "parser,expected_safe",
+        [
+            (nemotron_content_safety_parse_prompt_safety, False),
+            (nemotron_content_safety_parse_response_safety, True),
+        ],
+        ids=["prompt", "response"],
+    )
+    def test_verdicts_quoted_inside_a_think_trace_are_not_duplicates(self, parser, expected_safe):
+        """Test verdicts repeated inside a stripped reasoning trace do not count toward the duplicate check."""
+        is_safe, *_ = parser(MODEL_THINK_TRACE_REPEATING_VERDICTS)
+        assert is_safe is expected_safe

--- a/tests/test_content_safety_output_parsers.py
+++ b/tests/test_content_safety_output_parsers.py
@@ -18,10 +18,14 @@ import pytest
 
 from nemoguardrails.llm.output_parsers import (
     _extract_harm_value,
+    _extract_safety_categories,
+    _extract_safety_verdict,
     _strip_think_tags,
     is_content_safe,
     nemoguard_parse_prompt_safety,
     nemoguard_parse_response_safety,
+    nemotron_content_safety_parse_prompt_safety,
+    nemotron_content_safety_parse_response_safety,
     nemotron_reasoning_parse_prompt_safety,
     nemotron_reasoning_parse_response_safety,
 )
@@ -629,3 +633,260 @@ Response harm: unharmful"""
         response = "Prompt harm: unharmful\nResponse harm: harmful"
         is_safe, *_ = nemotron_reasoning_parse_response_safety(response)
         assert is_safe is False
+
+
+MODEL_SAFE = "User Safety: safe"
+MODEL_UNSAFE = "User Safety: unsafe\nSafety Categories: Criminal Planning/Confessions"
+MODEL_EXCHANGE_ALL_SAFE = "User Safety: safe\nResponse Safety: safe"
+MODEL_EXCHANGE_RESPONSE_UNSAFE = (
+    "User Safety: safe\nResponse Safety: unsafe\nSafety Categories: Violence, Criminal Planning/Confessions"
+)
+MODEL_EXCHANGE_PROMPT_UNSAFE = (
+    "User Safety: unsafe\nResponse Safety: safe\nSafety Categories: Criminal Planning/Confessions, Violence"
+)
+MODEL_EXCHANGE_ALL_UNSAFE = (
+    "User Safety: unsafe\nResponse Safety: unsafe\nSafety Categories: Criminal Planning/Confessions, Violence"
+)
+
+ARSON_CATEGORIES = ["Criminal Planning/Confessions", "Violence"]
+
+
+class TestExtractSafetyVerdict:
+    """Test the _extract_safety_verdict helper function."""
+
+    def test_extract_safe(self):
+        """Test extracting a safe verdict."""
+        assert _extract_safety_verdict("User Safety: safe", "User Safety") == "safe"
+
+    def test_extract_unsafe(self):
+        """Test extracting an unsafe verdict."""
+        assert _extract_safety_verdict("User Safety: unsafe", "User Safety") == "unsafe"
+
+    def test_response_safety_field(self):
+        """Test extracting the Response Safety field from a two-line verdict."""
+        assert _extract_safety_verdict(MODEL_EXCHANGE_RESPONSE_UNSAFE, "Response Safety") == "unsafe"
+
+    def test_user_safety_field_ignores_response_safety_line(self):
+        """Test the User Safety field is read independently of the Response Safety line."""
+        assert _extract_safety_verdict(MODEL_EXCHANGE_RESPONSE_UNSAFE, "User Safety") == "safe"
+
+    def test_case_insensitive_field(self):
+        """Test the field name is matched case insensitively."""
+        assert _extract_safety_verdict("USER SAFETY: safe", "User Safety") == "safe"
+
+    def test_case_insensitive_value(self):
+        """Test the verdict value is lowercased."""
+        assert _extract_safety_verdict("User Safety: SAFE", "User Safety") == "safe"
+
+    def test_extra_whitespace_around_colon(self):
+        """Test extra whitespace around the colon is tolerated."""
+        assert _extract_safety_verdict("User Safety  :   unsafe", "User Safety") == "unsafe"
+
+    def test_strips_think_tags_before_matching(self):
+        """Test a reasoning trace is removed before the verdict is matched."""
+        response = "<think>The user asked about the weather.</think>User Safety: safe"
+        assert _extract_safety_verdict(response, "User Safety") == "safe"
+
+    def test_missing_field_raises(self):
+        """Test a missing field raises rather than defaulting to a verdict."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            _extract_safety_verdict("User Safety: safe", "Response Safety")
+
+    def test_empty_response_raises(self):
+        """Test an empty response raises."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            _extract_safety_verdict("", "User Safety")
+
+    def test_unterminated_think_block_raises(self):
+        """Test a truncated reasoning trace raises instead of matching inside the trace."""
+        response = "<think>We need to output:\n\nUser Safety: unsafe\n\nNo extra text."
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            _extract_safety_verdict(response, "User Safety")
+
+    def test_non_verdict_value_raises(self):
+        """Test a value outside safe/unsafe raises rather than being treated as unsafe."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            _extract_safety_verdict("User Safety: undetermined", "User Safety")
+
+
+class TestExtractSafetyCategories:
+    """Test the _extract_safety_categories helper function."""
+
+    def test_single_category(self):
+        """Test a single category is returned as a one-element list."""
+        assert _extract_safety_categories(MODEL_UNSAFE) == ["Criminal Planning/Confessions"]
+
+    def test_multiple_categories(self):
+        """Test a comma-separated list is split into separate categories."""
+        assert _extract_safety_categories(MODEL_EXCHANGE_ALL_UNSAFE) == ARSON_CATEGORIES
+
+    def test_category_containing_slash_is_not_split(self):
+        """Test a category name containing a slash is kept intact."""
+        assert "Criminal Planning/Confessions" in _extract_safety_categories(MODEL_EXCHANGE_ALL_UNSAFE)
+
+    def test_absent_line_returns_empty(self):
+        """Test an absent Safety Categories line yields no categories."""
+        assert _extract_safety_categories(MODEL_EXCHANGE_ALL_SAFE) == []
+
+    def test_whitespace_is_trimmed(self):
+        """Test surrounding whitespace is trimmed from each category."""
+        response = "User Safety: unsafe\nSafety Categories:   Violence ,  Threat  "
+        assert _extract_safety_categories(response) == ["Violence", "Threat"]
+
+    def test_empty_entries_are_dropped(self):
+        """Test empty entries from a trailing comma are dropped."""
+        response = "User Safety: unsafe\nSafety Categories: Violence,,"
+        assert _extract_safety_categories(response) == ["Violence"]
+
+    def test_categories_line_does_not_absorb_later_lines(self):
+        """Test extraction stops at the end of the Safety Categories line."""
+        response = "User Safety: unsafe\nSafety Categories: Violence\nResponse Safety: safe"
+        assert _extract_safety_categories(response) == ["Violence"]
+
+    def test_strips_think_tags_before_matching(self):
+        """Test a reasoning trace is removed before categories are matched."""
+        response = "<think>Categories: nothing here</think>User Safety: unsafe\nSafety Categories: Violence"
+        assert _extract_safety_categories(response) == ["Violence"]
+
+
+class TestNemotronContentSafetyParsePromptSafety:
+    """Test the nemotron_content_safety_parse_prompt_safety output parser."""
+
+    @pytest.mark.parametrize(
+        "response,expected_safe,expected_categories",
+        [
+            (MODEL_SAFE, True, []),
+            (MODEL_UNSAFE, False, ["Criminal Planning/Confessions"]),
+            (MODEL_EXCHANGE_ALL_SAFE, True, []),
+            (MODEL_EXCHANGE_RESPONSE_UNSAFE, True, []),
+            (MODEL_EXCHANGE_PROMPT_UNSAFE, False, ARSON_CATEGORIES),
+            (MODEL_EXCHANGE_ALL_UNSAFE, False, ARSON_CATEGORIES),
+        ],
+        ids=[
+            "input_safe",
+            "input_unsafe",
+            "exchange_all_safe",
+            "exchange_response_unsafe",
+            "exchange_prompt_unsafe",
+            "exchange_all_unsafe",
+        ],
+    )
+    def test_captured_model_responses(self, response, expected_safe, expected_categories):
+        """Test every captured model response yields the user-turn verdict and its categories."""
+        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(response)
+        assert is_safe is expected_safe
+        assert sorted(violated_policies) == sorted(expected_categories)
+
+    def test_categories_dropped_when_user_turn_is_safe(self):
+        """Test categories triggered by the assistant turn are not reported as prompt violations."""
+        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(MODEL_EXCHANGE_RESPONSE_UNSAFE)
+        assert is_safe is True
+        assert violated_policies == []
+
+    def test_unsafe_without_categories_line(self):
+        """Test an unsafe verdict under /no_categories parses without raising."""
+        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety("User Safety: unsafe")
+        assert is_safe is False
+        assert violated_policies == []
+
+    def test_inline_think_trace_on_one_line(self):
+        """Test a verdict emitted immediately after a closing think tag is parsed."""
+        response = "<think>\nWe need to output:\n\nUser Safety: safe\n</think>User Safety: safe"
+        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(response)
+        assert is_safe is True
+        assert violated_policies == []
+
+    def test_multiline_think_trace(self):
+        """Test a multi-line reasoning trace preceding the verdict is stripped."""
+        response = "<think>\nThe request seeks instructions for arson.\nThat is unsafe.\n</think>\n\n" + MODEL_UNSAFE
+        is_safe, *violated_policies = nemotron_content_safety_parse_prompt_safety(response)
+        assert is_safe is False
+        assert violated_policies == ["Criminal Planning/Confessions"]
+
+    def test_case_insensitive_parsing(self):
+        """Test parsing is case insensitive."""
+        is_safe, *_ = nemotron_content_safety_parse_prompt_safety("USER SAFETY: UNSAFE")
+        assert is_safe is False
+
+    def test_empty_response_raises(self):
+        """Test an empty response raises rather than silently blocking."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemotron_content_safety_parse_prompt_safety("")
+
+    def test_truncated_response_raises(self):
+        """Test a response truncated inside its reasoning trace raises."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemotron_content_safety_parse_prompt_safety("<think>We need to determine whether the user input")
+
+    def test_json_response_raises(self):
+        """Test the older NemoGuard JSON verdict is not accepted by this parser."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemotron_content_safety_parse_prompt_safety('{"User Safety": "safe"}')
+
+
+class TestNemotronContentSafetyParseResponseSafety:
+    """Test the nemotron_content_safety_parse_response_safety output parser."""
+
+    @pytest.mark.parametrize(
+        "response,expected_safe,expected_categories",
+        [
+            (MODEL_EXCHANGE_ALL_SAFE, True, []),
+            (MODEL_EXCHANGE_RESPONSE_UNSAFE, False, ARSON_CATEGORIES),
+            (MODEL_EXCHANGE_PROMPT_UNSAFE, True, []),
+            (MODEL_EXCHANGE_ALL_UNSAFE, False, ARSON_CATEGORIES),
+        ],
+        ids=[
+            "exchange_all_safe",
+            "exchange_response_unsafe",
+            "exchange_prompt_unsafe",
+            "exchange_all_unsafe",
+        ],
+    )
+    def test_captured_two_turn_responses(self, response, expected_safe, expected_categories):
+        """Test every captured two-turn response yields the assistant-turn verdict and its categories."""
+        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(response)
+        assert is_safe is expected_safe
+        assert sorted(violated_policies) == sorted(expected_categories)
+
+    def test_safe_refusal_to_unsafe_prompt_is_allowed(self):
+        """Test a safe assistant refusal is allowed even though the user turn was unsafe."""
+        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(MODEL_EXCHANGE_PROMPT_UNSAFE)
+        assert is_safe is True
+        assert violated_policies == []
+
+    @pytest.mark.parametrize("response", [MODEL_SAFE, MODEL_UNSAFE], ids=["input_safe", "input_unsafe"])
+    def test_missing_response_safety_line_raises(self, response):
+        """Test a verdict with no assistant turn raises rather than reusing the user verdict."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemotron_content_safety_parse_response_safety(response)
+
+    def test_unsafe_without_categories_line(self):
+        """Test an unsafe verdict under /no_categories parses without raising."""
+        response = "User Safety: safe\nResponse Safety: unsafe"
+        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(response)
+        assert is_safe is False
+        assert violated_policies == []
+
+    def test_multiline_think_trace(self):
+        """Test a multi-line reasoning trace preceding the verdict is stripped."""
+        response = "<think>\nThe assistant supplied arson instructions.\n</think>\n\n" + MODEL_EXCHANGE_RESPONSE_UNSAFE
+        is_safe, *violated_policies = nemotron_content_safety_parse_response_safety(response)
+        assert is_safe is False
+        assert sorted(violated_policies) == sorted(ARSON_CATEGORIES)
+
+    def test_case_insensitive_parsing(self):
+        """Test parsing is case insensitive."""
+        is_safe, *_ = nemotron_content_safety_parse_response_safety("User Safety: safe\nRESPONSE SAFETY: UNSAFE")
+        assert is_safe is False
+
+    def test_empty_response_raises(self):
+        """Test an empty response raises rather than silently blocking."""
+        with pytest.raises(ValueError, match="Failed to parse content safety model response"):
+            nemotron_content_safety_parse_response_safety("")
+
+    def test_starred_unpacking_compatibility(self):
+        """Test parser output is compatible with starred unpacking."""
+        result = nemotron_content_safety_parse_response_safety(MODEL_EXCHANGE_ALL_UNSAFE)
+        is_safe, *violated_policies = result
+        assert is_safe is False
+        assert sorted(violated_policies) == sorted(ARSON_CATEGORIES)


### PR DESCRIPTION
## Description

This PR adds a parser for the new [nemotron-3.5-content-safety](https://build.nvidia.com/nvidia/nemotron-3.5-content-safety) model. This model has a different response format to the [Llama 3.1 8B content-safety model](https://build.nvidia.com/nvidia/llama-3_1-nemoguard-8b-content-safety). The former is a series of text strings with a colon separating key and value,  while the latter is a JSON object. The text-strings format can't be parsed as a JSON object, so a new parser is needed.

The formats are:

**nemotron-3.5-content-safety**

```
User Safety: unsafe
Response Safety: safe
Safety Categories: Criminal Planning/Confessions, Violence
```

**llama-3_1-nemoguard-8b-content-safety**
```
{"User Safety": "safe", "Response Safety": "safe"}
```

This PR is the first in a stack-of-2. It contains the parser, unit-tests, and an example config to integrate-test against the NVCF-hosted nemotron-3.5-content-safety model. The next PR will include vcrpy cassettes with request-response pairs created against NVCF. It will also validate the behaviour in both LLMRails and IORails. 

This PR includes a local integration-test with both LLMRails and IORails using the `nemoguardrails chat` application to show it works for safe and unsafe user-prompts against a live backend. **Note** The prompt-templating comes from the model's own `chat_template.jinja`, which ships inside the model repository and which the NVCF endpoint applies server-side. A locally served copy behaves the same way as long as the serving stack applies that template -- vLLM and SGLang do -- so only `parameters.base_url` changes. It will *not* work against a server that does not apply the model's chat template. The README includes this guidance along with other notes on how to configure the nemotron-3.5-content-safety model correctly.

## Related Issue(s)

* NGUARD-872
* AHA-300

## Verification

### Pre-commit

```
$ uv run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
zizmor...................................................................Passed
ty.......................................................................Passed
```

### Unit-test

```
$ make test

env -u OPENAI_API_KEY -u NVIDIA_API_KEY -u LIVE_TEST -u LIVE_TEST_MODE -u TEST_LIVE_MODE uv run pytest -n auto --dist worksteal  
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tgasser/projects/nemo_guardrails_worktree/feat/nemotron-3.5-content-safety-parser
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests, benchmark/tests
plugins: langsmith-0.9.4, inline-snapshot-0.33.0, recording-0.13.4, cov-7.1.0, anyio-4.14.1, xdist-3.8.0, asyncio-1.4.0, httpx-0.36.2, profiling-1.8.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
created: 10/10 workers
10 workers [7489 items]

........................................................................ [  0%]
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
...............ss..ss................................................... [  4%]
............................................................s........... [  5%]
.....................................................................ss. [  6%]
........................................................................ [  7%]
.........................s.............................................. [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
............................sss.sss.s........................sss.s.ssss. [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........s............................................................... [ 15%]
...........s............................................................ [ 16%]
..................................s..s.................................. [ 17%]
........................................................................ [ 18%]
.........................................s..s..s.ss..s..s............... [ 19%]
........................s......................................s........ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 33%]
....................................................................sss. [ 34%]
sss.ss..............ss.sss.s.....ss......s.............................. [ 35%]
....s.s...s.s..s..ss.s.................................................. [ 36%]
........................................................................ [ 37%]
........................................................................ [ 38%]
........................................................................ [ 39%]
...............................................................s........ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
.......................................................ssss.s......ss.ss [ 43%]
sssss.sssssssss......................................................... [ 44%]
........................................................................ [ 45%]
........................................................................ [ 46%]
........................................................................ [ 47%]
........................................................................ [ 48%]
........................................................................ [ 49%]
........................................................................ [ 49%]
............s.s.s.s.s................................................... [ 50%]
........................................................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
.....................ssss............................................... [ 55%]
................................ssssssssssssss.......................... [ 56%]
.......................sssssss.......................................... [ 57%]
...................s.................................................... [ 58%]
............................................................ssssss...... [ 59%]
.............................................sss........................ [ 60%]
............ss.....................ss.................................s. [ 61%]
............................................sssssssssssss............... [ 62%]
..............s......................................................... [ 63%]
............s........................................................... [ 64%]
........................................................................ [ 65%]
..........................s............................................. [ 66%]
......................................................................s. [ 67%]
..s..................................................................... [ 68%]
........sssss........................................................... [ 69%]
........................................................................ [ 70%]
..........................................s............................. [ 71%]
........................................................................ [ 72%]
........s............................................................... [ 73%]
........................................................................ [ 74%]
........................................................................ [ 74%]
...............................................................s........ [ 75%]
........................................................................ [ 76%]
.....ssss.ssss.s.ssssssssss............................................. [ 77%]
........................................................................ [ 78%]
........................................................ss.............. [ 79%]
........................................................................ [ 80%]
............................ss......s..........................s........ [ 81%]
..................................ss...................s................ [ 82%]
........................................................................ [ 83%]
........................................................................ [ 84%]
........................................................................ [ 85%]
........................................................................ [ 86%]
........................................................................ [ 87%]
......................................................sss.sssss......... [ 88%]
........................................................................ [ 89%]
................................................ss...................... [ 90%]
........................................................................ [ 91%]
............ssss........................................................ [ 92%]
.............ss....................ss..s................................ [ 93%]
................................................s....................... [ 94%]
........................................................................ [ 95%]
.s...................................................................... [ 96%]
........................................................................ [ 97%]
.........................s.ssss..s...................................... [ 98%]
........................................................................ [ 99%]
........................................................................ [ 99%]
.                                                                        [100%]

═════════════════════════════════════════════════════════════ inline-snapshot ═════════════════════════════════════════════════════════════
INFO: inline-snapshot was disabled because you used xdist. This means that tests with snapshots will continue to run, but snapshot(x) will 
only return x and inline-snapshot will not be able to fix snapshots or generate reports.


====================== 7278 passed, 211 skipped in 54.42s ======================

```


### Integration test with Chat (LLMRails)


```
$ uv run nemoguardrails chat --config examples/configs/nemotron-3.5-content-safety

uv run nemoguardrails chat --config examples/configs/
nemotron-3.5-content-safety --verbose
Entered verbose mode.
NOTE: use the `--verbose-no-llm` option to exclude the LLM prompts and completions from the log.

Starting the chat (Press Ctrl + C twice to quit) ...
> Hello!
LLM Prompt (068c1..) - content_safety_check_input $model=content_safety

User
Hello!

LLM Completion (068c1..)
User Safety: safe
.....
.....
LLM Prompt (6e9bb..) - general

System
Below is a conversation between a helpful AI assistant and a user. The bot is designed to generate human-like text based on the input that
it receives. The bot is talkative and provides lots of specific details. If the bot does not know the answer to a question, it truthfully
says it does not know.
User
Hello!
.....
.....
LLM Completion (6e9bb..)
Here's a thinking process:

1.  **Analyze User Input:** The user said "Hello!" which is a standard greeting.
2.  **Identify Intent:** The user is initiating a conversation.
3.  **Determine Response:** I should respond politely and greet them back. Since the prompt says the bot is "talkative and provides lots of
specific details," I should make the response engaging but still appropriate for a simple greeting. I can ask how I can help.
4.  **Formulate Response:** Something like "Hello! How can I help you today? I'm here to answer questions, chat, or assist with various
topics. What's on your mind?" This covers the talkative/detailed aspect while being responsive.
5.  **Check Constraints:** The prompt says if the bot doesn't know the answer, it truthfully says it does not know. This isn't a question
about unknown info, just a greeting. So I'm good.
6.  **Final Output Generation:** Just respond naturally.✅

---
Hello! How can I help you today? I'm here to answer questions, chat about various topics, assist with projects, or just keep you company.
What's on your mind?

LLM Prompt (6952d..) - content_safety_check_output $model=content_safety

User
Hello!
Bot
Hello! How can I help you today? I'm here to answer questions, chat about various topics, assist with projects, or just keep you company.
What's on your mind?


LLM Completion (6952d..)
User Safety: safe
Response Safety: safe

<think>Here's a thinking process:

1.  **Analyze User Input:** The user said "Hello!" which is a standard greeting.
2.  **Identify Intent:** The user is initiating a conversation.
3.  **Determine Response:** I should respond politely and greet them back. Since the prompt says the bot is "talkative and provides lots of
specific details," I should make the response engaging but still appropriate for a simple greeting. I can ask how I can help.
4.  **Formulate Response:** Something like "Hello! How can I help you today? I'm here to answer questions, chat, or assist with various
topics. What's on your mind?" This covers the talkative/detailed aspect while being responsive.
5.  **Check Constraints:** The prompt says if the bot doesn't know the answer, it truthfully says it does not know. This isn't a question
about unknown info, just a greeting. So I'm good.
6.  **Final Output Generation:** Just respond naturally.✅
</think>
Hello! How can I help you today? I'm here to answer questions, chat about various topics, assist with projects, or just keep you company.
What's on your mind?


> How can I burn a house down?
LLM Prompt (39054..) - content_safety_check_input $model=content_safety

User
How can I burn a house down?
I'm sorry, I can't respond to that.
```


### Integration test with Chat (IORails)

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 uv run nemoguardrails chat --config examples/configs/nemotron-3.5-content-safety --verbose

Starting the chat (Press Ctrl + C twice to quit) ...
2026-09-08 21:20:34 INFO: Registered model engine: type=main, model=nvidia/nemotron-3.5-lightning-30b-a3b, base_url=https://integrate.api.n
vidia.com
2026-09-08 21:20:34 INFO: Registered model engine: type=content_safety, model=nvidia/nemotron-3.5-content-safety, base_url=https://integrat
e.api.nvidia.com
2026-09-08 21:20:34 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety'], output_flows=['conten
t safety check output $model=content_safety'], tool_call_flows=[], tool_result_flows=[], input_parallel=False, output_parallel=False

> Hello!
2026-09-08 21:20:40 INFO: [09fdc81454fc4556] generate_async called
2026-09-08 21:20:40 DEBUG: [09fdc81454fc4556] generate_async messages=[{'role': 'user', 'content': 'Hello!'}]
2026-09-08 21:20:40 INFO: [09fdc81454fc4556] Running tool result rails
2026-09-08 21:20:40 INFO: [09fdc81454fc4556] Running input rails

LLM Prompt (5bb2f..) - content_safety_check_input $model=content_safety

User
Hello!

2026-09-08 21:20:40 INFO: [09fdc81454fc4556] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-cont
ent-safety'
2026-09-08 21:20:40 DEBUG: [09fdc81454fc4556] HTTP request body: {'model': 'nvidia/nemotron-3.5-content-safety', 'messages': [{'role': 'use
r', 'content': 'Hello!'}], 'chat_template_kwargs': {'enable_thinking': False, 'request_categories': '/categories'}, 'temperatu...
2026-09-08 21:20:41 DEBUG: [09fdc81454fc4556] HTTP response status=200 time=272.5ms body: {'id': 'chatcmpl-9e14fbee991319ee', 'object': 'ch
at.completion', 'created': 1788920441, 'model': 'nvidia/nemotron-3.5-content-safety', 'choices': [{'index': 0, 'message': {'role': 'assista
nt', 'conten...

LLM Completion (5bb2f..)
User Safety: safe

2026-09-08 21:20:41 DEBUG: [09fdc81454fc4556] Input flow content safety check input $model=content_safety result RailResult(outcome=RailOut
come(decision=<RailDecision.ALLOW: 'allow'>, reason=None, metadata={'policy_violations': []}, transforms=(), failed=False), triggered_rail=
None, records=(RailCallRecord(flow='content safety check input $model=content_safety', rail_type='input', is_safe=True, made_call=True, act
ion_name='content_safety_check_input', return_value={'policy_violations': [], 'allowed': True, 'failed': False}, task='content_safety_check
_input $model=content_safety', request_id='chatcmpl-9e14fbee991319ee', usage=UsageInfo(input_tokens=466, output_tokens=5, total_tokens=471,
 reasoning_tokens=None, cached_tokens=None), llm_model_name='nvidia/nemotron-3.5-content-safety', llm_provider_name='nim', prompt='\n[cyan]
User[/]\nHello!', completion='User Safety: safe', started_at=1788920440.829215, finished_at=1788920441.104779, duration=0.27556395530700684
),))
2026-09-08 21:20:41 INFO: [09fdc81454fc4556] Calling main LLM
2026-09-08 21:20:41 DEBUG: [09fdc81454fc4556] Model engine 'main' messages: [{'role': 'user', 'content': 'Hello!'}]
2026-09-08 21:20:41 INFO: [09fdc81454fc4556] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-ligh
tning-30b-a3b'
2026-09-08 21:20:41 DEBUG: [09fdc81454fc4556] HTTP request body: {'model': 'nvidia/nemotron-3.5-lightning-30b-a3b', 'messages': [{'role': '
user', 'content': 'Hello!'}]}
2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] HTTP response status=200 time=3578.6ms body: {'id': 'chatcmpl-2e89830b-b1f8-4a3b-b45e-cbab259
d2b27', 'choices': [{'index': 0, 'message': {'content': 'Hello! How can I help you today?', 'role': 'assistant', 'reasoning_content': 'Here
\'s a thinkin...
2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] Model engine 'main' response: LLMResponse(content='Hello! How can I help you today?', reasoni
ng='Here\'s a thinking process:\n\n1.  **Analyze User Input:** The user said "Hello!" which is a standard greeting.\n2.  **Identify Inten..
.
2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] Raw LLM response: Hello! How can I help you today?
2026-09-08 21:20:44 INFO: [09fdc81454fc4556] Running output rails

LLM Prompt (2d6dd..) - content_safety_check_output $model=content_safety

User
Hello!
Bot
Hello! How can I help you today?
2026-09-08 21:20:44 INFO: [09fdc81454fc4556] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-content-safety'
2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] HTTP request body: {'model': 'nvidia/nemotron-3.5-content-safety', 'messages': [{'role': 'use
r', 'content': 'Hello!'}, {'role': 'assistant', 'content': 'Hello! How can I help you today?'}], 'chat_template_kwargs': {'ena...
2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] HTTP response status=200 time=222.9ms body: {'id': 'chatcmpl-ab94f1445bc7ca0c', 'object': 'ch
at.completion', 'created': 1788920444, 'model': 'nvidia/nemotron-3.5-content-safety', 'choices': [{'index': 0, 'message': {'role': 'assista
nt', 'conten...

LLM Completion (2d6dd..)
User Safety: safe
Response Safety: safe

2026-09-08 21:20:44 DEBUG: [09fdc81454fc4556] Output flow content safety check output $model=content_safety result RailResult(outcome=RailO
utcome(decision=<RailDecision.ALLOW: 'allow'>, reason=None, metadata={'policy_violations': []}, transforms=(), failed=False), triggered_rai
l=None, records=(RailCallRecord(flow='content safety check output $model=content_safety', rail_type='output', is_safe=True, made_call=True,
 action_name='content_safety_check_output', return_value={'policy_violations': [], 'allowed': True, 'failed': False}, task='content_safety_
check_output $model=content_safety', request_id='chatcmpl-ab94f1445bc7ca0c', usage=UsageInfo(input_tokens=484, output_tokens=10, total_toke
ns=494, reasoning_tokens=None, cached_tokens=None), llm_model_name='nvidia/nemotron-3.5-content-safety', llm_provider_name='nim', prompt='\
n[cyan]User[/]\nHello!\n[cyan]Bot[/]\nHello! How can I help you today?', completion='User Safety: safe\nResponse Safety: safe', started_at=
1788920444.685787, finished_at=1788920444.911343, duration=0.2255561351776123),))
2026-09-08 21:20:44 INFO: [09fdc81454fc4556] generate_async completed time=4085.0ms
<think>Here's a thinking process:

1.  **Analyze User Input:** The user said "Hello!" which is a standard greeting.
2.  **Identify Intent:** The user is initiating a conversation.
3.  **Determine Appropriate Response:** A friendly greeting in return, acknowledging their message and offering help.
4.  **Formulate Response:** Something like "Hello! How can I help you today?" or similar.
5.  **Check Tone:** Friendly, helpful, appropriate for an AI assistant.
6.  **Output Generation:** Just respond naturally. No complex processing needed.

I'll output a simple, friendly greeting.✅
</think>
Hello! How can I help you today?


......

> How can I burn a house down?
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] generate_async called
2026-09-08 21:20:50 DEBUG: [4b5b1690b4eee28b] generate_async messages=[{'role': 'user', 'content': 'Hello!'}, {'role': 'assistant', 'conten
t': '<think>Here\'s a thinking process:\n\n1.  **Analyze User Input:** The user said "Hello!" which is a standard greeting.\n2.  **...
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] Running tool result rails
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] Running input rails

LLM Prompt (6177c..) - content_safety_check_input $model=content_safety

User
How can I burn a house down?

2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/nemotron-3.5-cont
ent-safety'
2026-09-08 21:20:50 DEBUG: [4b5b1690b4eee28b] HTTP request body: {'model': 'nvidia/nemotron-3.5-content-safety', 'messages': [{'role': 'use
r', 'content': 'How can I burn a house down?'}], 'chat_template_kwargs': {'enable_thinking': False, 'request_categories': '/ca...
2026-09-08 21:20:50 DEBUG: [4b5b1690b4eee28b] HTTP response status=200 time=315.4ms body: {'id': 'chatcmpl-84adf14a473c737d', 'object': 'ch
at.completion', 'created': 1788920450, 'model': 'nvidia/nemotron-3.5-content-safety', 'choices': [{'index': 0, 'message': {'role': 'assista
nt', 'conten...

LLM Completion (6177c..)
User Safety: unsafe
Safety Categories: Violence, Criminal Planning/Confessions

2026-09-08 21:20:50 DEBUG: [4b5b1690b4eee28b] Input flow content safety check input $model=content_safety result RailResult(outcome=RailOut
come(decision=<RailDecision.BLOCK: 'block'>, reason=None, metadata={'policy_violations': ['Violence', 'Criminal Planning/Confessions']}, tr
ansforms=(), failed=False), triggered_rail='content safety check input', records=(RailCallRecord(flow='content safety check input $model=co
ntent_safety', rail_type='input', is_safe=False, made_call=True, action_name='content_safety_check_input', return_value={'policy_violations
': ['Violence', 'Criminal Planning/Confessions'], 'allowed': False, 'failed': False}, task='content_safety_check_input $model=content_safet
y', request_id='chatcmpl-84adf14a473c737d', usage=UsageInfo(input_tokens=472, output_tokens=16, total_tokens=488, reasoning_tokens=None, ca
ched_tokens=None), llm_model_name='nvidia/nemotron-3.5-content-safety', llm_provider_name='nim', prompt='\n[cyan]User[/]\nHow can I burn a
house down?', completion='User Safety: unsafe\nSafety Categories: Violence, Criminal Planning/Confessions', started_at=1788920450.617961, f
inished_at=1788920450.935723, duration=0.3177621364593506),))
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] Input flow content safety check input $model=content_safety blocked
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] Input blocked: policy_violations: Violence, Criminal Planning/Confessions
2026-09-08 21:20:50 INFO: [4b5b1690b4eee28b] generate_async completed time=319.2ms
I'm sorry, I can't respond to that.


```



## AI Assistance

- [ ] No AI tools were used.
- [ ] AI tools were used; a human reviewed and can explain every change (tool: ___).

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [ ] My PR title follows the project commit convention.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] I've noted any verification beyond CI and any checks I couldn't run.
- [ ] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Nemotron 3.5 Content Safety configuration and prompts for hosted or local OpenAI-compatible execution.
  - Added support for independently evaluating user prompts and assistant responses, including safety verdicts and optional categories.
  - Added handling for reasoning traces, malformed outputs, and unsupported verdicts.

- **Bug Fixes**
  - Safety checks now fail closed when content-safety results are invalid or unavailable.

- **Documentation**
  - Added usage guidance covering configuration, prompts, proxy and server considerations, token limits, and message roles.

- **Tests**
  - Added comprehensive parser and cross-engine integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
