### PR TITLE
fix(rails): load config.py for combined configurations

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1258,8 +1258,10 @@ class RailsConfig(BaseModel):
 
         Supports loading a from a single file, or from a directory.
         """
-        if "," in config_path:
-            raise ValueError(f"Invalid config path {config_path}. Commas are not supported.")
+        if "," in config_path or config_path != config_path.strip():
+            raise ValueError(
+                f"Invalid config path {config_path!r}. Paths cannot contain commas or begin or end with whitespace."
+            )
 
         # If the config path is a file, we load the YAML content.
         # Otherwise, if it's a folder, we iterate through all files.

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1258,6 +1258,9 @@ class RailsConfig(BaseModel):
 
         Supports loading a from a single file, or from a directory.
         """
+        if "," in config_path:
+            raise ValueError(f"Invalid config path {config_path}. Commas are not supported.")
+
         # If the config path is a file, we load the YAML content.
         # Otherwise, if it's a folder, we iterate through all files.
         if os.path.isfile(config_path) and config_path.endswith((".yaml", ".yml")):

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -360,19 +360,34 @@ class LLMRails(BaseGuardrails):
                 flow_config["is_subflow"] = True
 
         # We check if the configuration or any of the imported ones have config.py modules.
-        config_modules = []
-        for _path in list(self.config.imported_paths.values() if self.config.imported_paths else []) + [
-            self.config.config_path
-        ]:
-            if _path:
-                filepath = os.path.join(_path, "config.py")
-                if os.path.exists(filepath):
+        config_paths = list(self.config.imported_paths.values() if self.config.imported_paths else [])
+        if self.config.config_path:
+            if os.path.exists(self.config.config_path):
+                config_paths.append(self.config.config_path)
+            else:
+                config_paths.extend(path.strip() for path in self.config.config_path.split(",") if path.strip())
+
+        config_modules: List[Tuple[Any, str]] = []
+        loaded_config_paths = set()
+        for _path in config_paths:
+            canonical_path = os.path.realpath(_path)
+            if canonical_path in loaded_config_paths:
+                continue
+            loaded_config_paths.add(canonical_path)
+
+            filepath = os.path.join(_path, "config.py")
+            if os.path.exists(filepath):
+                try:
                     filename = os.path.basename(filepath)
                     spec = importlib.util.spec_from_file_location(filename, filepath)
-                    if spec and spec.loader:
-                        config_module = importlib.util.module_from_spec(spec)
-                        spec.loader.exec_module(config_module)
-                        config_modules.append(config_module)
+                    if not spec or not spec.loader:
+                        raise ImportError("Could not create a module loader.")
+
+                    config_module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(config_module)
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to load configuration module at {filepath}.") from exc
+                config_modules.append((config_module, filepath))
 
         colang_version_to_runtime: Dict[str, Type[Runtime]] = {
             "1.0": RuntimeV1_0,
@@ -389,9 +404,12 @@ class LLMRails(BaseGuardrails):
         # If we have a config_modules with an `init` function, we call it.
         # We need to call this here because the `init` might register additional
         # LLM providers.
-        for config_module in config_modules:
+        for config_module, filepath in config_modules:
             if hasattr(config_module, "init"):
-                config_module.init(self)
+                try:
+                    config_module.init(self)
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to initialize configuration module at {filepath}.") from exc
 
         # If we have a customized embedding model, we'll use it.
         for model in self.config.models:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -362,10 +362,7 @@ class LLMRails(BaseGuardrails):
         # We check if the configuration or any of the imported ones have config.py modules.
         config_paths = list(self.config.imported_paths.values() if self.config.imported_paths else [])
         if self.config.config_path:
-            if os.path.exists(self.config.config_path):
-                config_paths.append(self.config.config_path)
-            else:
-                config_paths.extend(path.strip() for path in self.config.config_path.split(",") if path.strip())
+            config_paths.extend(path.strip() for path in self.config.config_path.split(",") if path.strip())
 
         config_modules: List[Tuple[Any, str]] = []
         loaded_config_paths = set()

--- a/tests/rails/llm/test_config.py
+++ b/tests/rails/llm/test_config.py
@@ -20,6 +20,34 @@ from pydantic import ValidationError
 from nemoguardrails.rails.llm.config import Model, RailsConfig, RailsConfigData, TaskPrompt
 
 
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        pytest.param("config,comma", id="comma"),
+        pytest.param(" config", id="leading-space"),
+        pytest.param("config ", id="trailing-space"),
+        pytest.param("\tconfig", id="leading-tab"),
+        pytest.param("config\n", id="trailing-newline"),
+    ],
+)
+def test_from_path_rejects_ambiguous_path_characters(config_path):
+    with pytest.raises(
+        ValueError,
+        match="Paths cannot contain commas or begin or end with whitespace",
+    ):
+        RailsConfig.from_path(config_path)
+
+
+def test_from_path_allows_internal_spaces(tmp_path):
+    config_path = tmp_path / "config with spaces"
+    config_path.mkdir()
+    (config_path / "config.yml").write_text("models: []\n", encoding="utf-8")
+
+    config = RailsConfig.from_path(str(config_path))
+
+    assert config.config_path == str(config_path)
+
+
 def test_task_prompt_valid_content():
     prompt = TaskPrompt(task="example_task", content="This is a valid prompt.")
     assert prompt.task == "example_task"

--- a/tests/server/test_guardrail_checks.py
+++ b/tests/server/test_guardrail_checks.py
@@ -21,8 +21,11 @@ pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
 from nemoguardrails.exceptions import RailTypeNotConfiguredError
+from nemoguardrails.rails import LLMRails
+from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import RailsResult, RailStatus, RailType
 from nemoguardrails.server import api
+from nemoguardrails.testing.fake_model import FakeLLMModel
 
 client = TestClient(api.app)
 
@@ -129,6 +132,90 @@ def test_config_id_resolves():
 
     assert resp.status_code == 200
     mock_get.assert_called_once_with(["my_config"], model_name="test")
+
+
+def test_config_py_parser_has_library_and_service_parity_for_single_and_multiple_configs(tmp_path, monkeypatch):
+    first_config_path = tmp_path / "first"
+    first_config_path.mkdir()
+    (first_config_path / "config.yml").write_text(
+        """
+models: []
+rails:
+  input:
+    flows:
+      - self check input
+prompts:
+  - task: self_check_input
+    content: "{{ user_input }}"
+    output_parser: policy_parser
+""",
+        encoding="utf-8",
+    )
+    (first_config_path / "config.py").write_text(
+        """
+def parse_policy_output(_response):
+    return [False]
+
+def init(app):
+    app.register_output_parser(parse_policy_output, "policy_parser")
+    app.register_action_param("first_config_initialized", True)
+""",
+        encoding="utf-8",
+    )
+
+    second_config_path = tmp_path / "second"
+    second_config_path.mkdir()
+    (second_config_path / "config.yml").write_text("models: []\n", encoding="utf-8")
+    (second_config_path / "config.py").write_text(
+        """
+def init(app):
+    app.register_action_param("second_config_initialized", True)
+""",
+        encoding="utf-8",
+    )
+
+    library_rails = LLMRails(
+        RailsConfig.from_path(str(first_config_path)),
+        llm=FakeLLMModel(responses=["unparsed output"]),
+    )
+    library_result = library_rails.check(
+        messages=[{"role": "user", "content": "hello"}],
+        rail_types=[RailType.INPUT],
+    )
+
+    created_rails = []
+
+    def create_service_rails(config, verbose=False):
+        rails = LLMRails(config, llm=FakeLLMModel(responses=["unparsed output"]), verbose=verbose)
+        created_rails.append(rails)
+        return rails
+
+    monkeypatch.setattr(api.app, "rails_config_path", str(tmp_path))
+    monkeypatch.setattr(api.app, "single_config_mode", False)
+    monkeypatch.setattr(api, "LLMRails", create_service_rails)
+
+    single_response = _post(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "guardrails": {"config_id": "first", "rail_types": ["input"]},
+        }
+    )
+    multiple_response = _post(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "guardrails": {"config_ids": ["first", "second"], "rail_types": ["input"]},
+        }
+    )
+
+    assert library_result.status is RailStatus.BLOCKED
+    assert single_response.status_code == 200
+    assert single_response.json()["status"] == library_result.status.value
+    assert multiple_response.status_code == 200
+    assert multiple_response.json()["status"] == RailStatus.BLOCKED.value
+    assert created_rails[1].runtime.registered_action_params["first_config_initialized"] is True
+    assert created_rails[1].runtime.registered_action_params["second_config_initialized"] is True
 
 
 def test_default_config_used_when_none_specified():

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -77,20 +77,6 @@ def init(app):
     assert rails.runtime.llm_task_manager.output_parsers["policy_parser"]("raw output") == [False]
 
 
-def test_config_path_containing_comma_is_rejected(tmp_path):
-    config_path = tmp_path / "config,with-comma"
-    _write_config(
-        config_path,
-        """
-def init(app):
-    app.register_action_param("config_initialized", True)
-""",
-    )
-
-    with pytest.raises(ValueError, match="Commas are not supported"):
-        RailsConfig.from_path(str(config_path))
-
-
 def test_custom_init_deduplicates_imported_and_combined_config(tmp_path):
     imported_config_path = tmp_path / "imported"
     _write_config(

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -14,8 +14,12 @@
 # limitations under the License.
 
 import os
+import re
 
-from nemoguardrails import RailsConfig
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.testing.fake_model import FakeLLMModel
 from tests.utils import TestChat
 
 CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
@@ -32,3 +36,96 @@ def test_custom_init():
 
     chat >> "hi"
     chat << "John"
+
+
+def _write_config(config_path, config_module, config_content="models: []\n"):
+    config_path.mkdir()
+    (config_path / "config.yml").write_text(config_content, encoding="utf-8")
+    return (config_path / "config.py").write_text(config_module, encoding="utf-8")
+
+
+def test_custom_init_runs_for_each_combined_config(tmp_path):
+    first_config_path = tmp_path / "first"
+    second_config_path = tmp_path / "second"
+    _write_config(
+        first_config_path,
+        """
+def parse_policy_output(_response):
+    return [False]
+
+def init(app):
+    app.register_output_parser(parse_policy_output, "policy_parser")
+    app.register_action_param("first_config_initialized", True)
+""",
+    )
+    _write_config(
+        second_config_path,
+        """
+def init(app):
+    app.register_action_param("second_config_initialized", True)
+""",
+    )
+
+    config = RailsConfig.from_path(str(first_config_path)) + RailsConfig.from_path(str(second_config_path))
+    rails = LLMRails(config, llm=FakeLLMModel(responses=[]))
+
+    assert rails.runtime.registered_action_params["first_config_initialized"] is True
+    assert rails.runtime.registered_action_params["second_config_initialized"] is True
+    assert rails.runtime.llm_task_manager.output_parsers["policy_parser"]("raw output") == [False]
+
+
+def test_custom_init_preserves_single_config_path_containing_comma(tmp_path):
+    config_path = tmp_path / "config,with-comma"
+    _write_config(
+        config_path,
+        """
+def init(app):
+    app.register_action_param("config_initialized", True)
+""",
+    )
+
+    rails = LLMRails(RailsConfig.from_path(str(config_path)), llm=FakeLLMModel(responses=[]))
+
+    assert rails.runtime.registered_action_params["config_initialized"] is True
+
+
+def test_custom_init_deduplicates_imported_and_combined_config(tmp_path):
+    imported_config_path = tmp_path / "imported"
+    _write_config(
+        imported_config_path,
+        """
+def init(app):
+    params = app.runtime.registered_action_params
+    app.register_action_param("init_count", params.get("init_count", 0) + 1)
+""",
+    )
+    importing_config_path = tmp_path / "importing"
+    _write_config(
+        importing_config_path,
+        "",
+        f'models: []\nimport_paths:\n  - "{imported_config_path}"\n',
+    )
+
+    config = RailsConfig.from_path(str(importing_config_path)) + RailsConfig.from_path(str(imported_config_path))
+    rails = LLMRails(config, llm=FakeLLMModel(responses=[]))
+
+    assert rails.runtime.registered_action_params["init_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("config_module", "error_message"),
+    [
+        ('raise ValueError("load failed")\n', "Failed to load configuration module"),
+        ('def init(_app):\n    raise ValueError("init failed")\n', "Failed to initialize configuration module"),
+    ],
+)
+def test_custom_init_failure_names_config_file(tmp_path, config_module, error_message):
+    config_path = tmp_path / "broken"
+    _write_config(config_path, config_module)
+    config_file = config_path / "config.py"
+    config = RailsConfig.from_path(str(config_path))
+
+    with pytest.raises(RuntimeError, match=rf"{error_message} at {re.escape(str(config_file))}") as exc_info:
+        LLMRails(config, llm=FakeLLMModel(responses=[]))
+
+    assert isinstance(exc_info.value.__cause__, ValueError)

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -117,3 +117,19 @@ def test_custom_init_failure_names_config_file(tmp_path, config_module, error_me
         LLMRails(config, llm=FakeLLMModel(responses=[]))
 
     assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_custom_init_failure_when_module_loader_is_unavailable(tmp_path, monkeypatch):
+    config_path = tmp_path / "broken"
+    _write_config(config_path, "")
+    config_file = config_path / "config.py"
+    config = RailsConfig.from_path(str(config_path))
+    monkeypatch.setattr("nemoguardrails.rails.llm.llmrails.importlib.util.spec_from_file_location", lambda *_args: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match=rf"Failed to load configuration module at {re.escape(str(config_file))}",
+    ) as exc_info:
+        LLMRails(config, llm=FakeLLMModel(responses=[]))
+
+    assert isinstance(exc_info.value.__cause__, ImportError)

--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -15,6 +15,7 @@
 
 import os
 import re
+from pathlib import Path
 
 import pytest
 
@@ -44,9 +45,10 @@ def _write_config(config_path, config_module, config_content="models: []\n"):
     return (config_path / "config.py").write_text(config_module, encoding="utf-8")
 
 
-def test_custom_init_runs_for_each_combined_config(tmp_path):
-    first_config_path = tmp_path / "first"
-    second_config_path = tmp_path / "second"
+def test_custom_init_runs_for_each_combined_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    first_config_path = Path("first")
+    second_config_path = Path("second")
     _write_config(
         first_config_path,
         """
@@ -65,6 +67,7 @@ def init(app):
     app.register_action_param("second_config_initialized", True)
 """,
     )
+    Path("first,second").mkdir()
 
     config = RailsConfig.from_path(str(first_config_path)) + RailsConfig.from_path(str(second_config_path))
     rails = LLMRails(config, llm=FakeLLMModel(responses=[]))
@@ -74,7 +77,7 @@ def init(app):
     assert rails.runtime.llm_task_manager.output_parsers["policy_parser"]("raw output") == [False]
 
 
-def test_custom_init_preserves_single_config_path_containing_comma(tmp_path):
+def test_config_path_containing_comma_is_rejected(tmp_path):
     config_path = tmp_path / "config,with-comma"
     _write_config(
         config_path,
@@ -84,9 +87,8 @@ def init(app):
 """,
     )
 
-    rails = LLMRails(RailsConfig.from_path(str(config_path)), llm=FakeLLMModel(responses=[]))
-
-    assert rails.runtime.registered_action_params["config_initialized"] is True
+    with pytest.raises(ValueError, match="Commas are not supported"):
+        RailsConfig.from_path(str(config_path))
 
 
 def test_custom_init_deduplicates_imported_and_combined_config(tmp_path):


### PR DESCRIPTION
## Description

Load and initialize each policy's `config.py` when the server combines multiple configurations. Reject unsupported literal config paths containing commas or leading/trailing whitespace so they cannot be confused with or altered by merged-path parsing; internal spaces remain supported. The change also avoids duplicate initialization through imports and reports the failing file when loading or initialization raises an error.





## Verification

- server smoke test: single and multi-policy `/v1/checks` requests returned HTTP 200 with `blocked`; logs showed both policy `config.py` initializers for the combined request.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] This PR links to a triaged issue assigned to me.
- [x] My PR title follows the project commit convention.
- [x] I've updated the documentation if applicable (not applicable; this restores documented behavior).
- [x] I've added tests if applicable.
- [x] I've noted any verification beyond CI and any checks I couldn't run.
- [x] I did not update generated changelog files manually.
- [ ] I addressed all CodeRabbit, Greptile, and other review comments, or replied with why no change is needed.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration modules can now be loaded from imported paths and from directories or comma-separated configuration paths.
  * Duplicate configuration paths are automatically removed, including overlaps between imported and combined configurations.
  * Configuration modules retain their source paths for clearer initialization diagnostics.

* **Bug Fixes**
  * Improved error messages for configuration module loading, execution, and initialization failures, including the affected source path and underlying cause.
  * Ensured consistent custom configuration behavior across library-created and service-created rails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->