### PR TITLE
fix: add **kwargs to mask_sensitive_data

### DIFF
--- a/nemoguardrails/library/sensitive_data_detection/actions.py
+++ b/nemoguardrails/library/sensitive_data_detection/actions.py
@@ -159,7 +159,9 @@ async def detect_sensitive_data(
 
 
 @action(is_system_action=True)
-async def mask_sensitive_data(source: str, text: str, config: RailsConfig) -> RailOutcome:
+async def mask_sensitive_data(
+    source: str, text: str, config: RailsConfig, **kwargs
+) -> RailOutcome:
     """Checks whether the provided text contains any sensitive data.
 
     Args


### PR DESCRIPTION
This adds **kwargs to the mask_sensitive_data signature, matching detect_sensitive_data. This prevents a TypeError when the action dispatcher passes context= to the action.