### PR TITLE
feat(library): restore and migrate Zscaler AI Guard integration

### DIFF
--- a/docs/configure-rails/guardrail-catalog/community/zscaler-aiguard.md
+++ b/docs/configure-rails/guardrail-catalog/community/zscaler-aiguard.md
@@ -1,0 +1,93 @@
+# Zscaler AI Guard Integration
+
+The Zscaler AI Guard guardrail uses the [Zscaler AI Guard](https://help.zscaler.com/ai-guard) API to scan prompts and LLM responses for security threats, including:
+
+- **Credentials and secrets** - API keys, tokens, passwords, and cloud credentials
+- **PII (Personally Identifiable Information)** - Names, emails, phone numbers, SSNs, and other personal data
+- **Toxicity** - Violent, abusive, hateful, or harmful content
+- **Prompt injection** - Adversarial prompts designed to manipulate AI behavior or bypass security controls
+- **Malicious URLs** - Known malicious URLs and domains
+- **Policy violations** - Custom content policy violations configured in the AI Guard console
+
+The integration uses the [zscaler-sdk-python](https://pypi.org/project/zscaler-sdk-python/) SDK and implements **fail-closed** semantics: if the API call fails or returns an unexpected result, the integration blocks the content by default.
+
+The following environment variables are required:
+
+- `AIGUARD_API_KEY`: Zscaler AI Guard API key (Bearer token). To obtain this key, go to **AI Guard Console** > **Private AI Apps** > **Applications** > **API Keys**.
+- `AIGUARD_CLOUD`: Cloud region. Options: `us1` (default), `us2`, `eu1`, `eu2`.
+
+To use a specific policy instead of automatic resolution, set the following optional variable:
+
+- `AIGUARD_POLICY_ID`: Integer policy ID. When set, the integration calls `execute-policy` with the specified ID instead of `resolve-and-execute-policy`.
+
+## Setup
+
+### Colang v1
+
+```yaml
+# config.yml
+
+# Optional: show detailed block messages (severity, policy name, detectors)
+enable_rails_exceptions: true
+
+rails:
+  input:
+    flows:
+      - zscaler aiguard moderation on input
+
+  output:
+    flows:
+      - zscaler aiguard moderation on output
+```
+
+### Colang v2
+
+```yaml
+# config.yml
+
+colang_version: "2.x"
+```
+
+```text
+# rails.co
+
+import guardrails
+import nemoguardrails.library.zscaler_aiguard
+
+flow input rails $input_text
+    zscaler aiguard moderation on input
+
+flow output rails $output_text
+    zscaler aiguard moderation on output
+```
+
+## How It Works
+
+1. **Input scanning**: Before user prompts reach the LLM, the `zscaler aiguard moderation on input` flow sends the prompt to the AI Guard API with `direction="IN"`.
+2. **Output scanning**: After the LLM generates a response, the `zscaler aiguard moderation on output` flow sends the response to the AI Guard API with `direction="OUT"`.
+3. **Policy selection**: By default, the integration calls `resolve-and-execute-policy`, which automatically selects the appropriate policy. If `AIGUARD_POLICY_ID` is set, the integration calls `execute-policy` with the specified policy ID instead.
+4. **Verdict handling**: If the API returns an `action` of `BLOCK`, the flow aborts and the bot refuses to respond. If the API returns `ALLOW` or `DETECT`, the content passes through normally.
+5. **Rails exceptions**: Setting `enable_rails_exceptions: true` at the top level of the config causes blocked requests to emit a `ZscalerAiguardInputRailException` or `ZscalerAiguardOutputRailException`. The exception message contains the severity, policy name, blocking detectors, and transaction ID.
+6. **Fail-closed**: If the API call fails (network error, timeout, or authentication failure), the action returns `action: BLOCK` by default to prevent potentially unsafe content from passing through.
+
+## Detectors
+
+The AI Guard policy engine evaluates all configured detectors and returns a single `ALLOW` / `BLOCK` / `DETECT` verdict. Available detectors include:
+
+- `toxicity` - Toxic or harmful language
+- `pii` - Personally identifiable information
+- `personalData` - Personal data patterns
+- `piiDeepscan` - Deep PII scanning
+- `secrets` - Credentials, API keys, tokens
+- `promptInjection` - Prompt injection attempts
+- `maliciousUrl` - Malicious URL detection
+
+Configure detectors in the [Zscaler AI Guard console](https://help.zscaler.com/aiguard), not in the NeMo Guardrails configuration.
+
+## Dependencies
+
+Install the required SDK:
+
+```bash
+pip install zscaler-sdk-python
+```

--- a/docs/configure-rails/guardrail-catalog/community/zscaler-aiguard.mdx
+++ b/docs/configure-rails/guardrail-catalog/community/zscaler-aiguard.mdx
@@ -1,4 +1,6 @@
-# Zscaler AI Guard Integration
+---
+title: "Zscaler AI Guard Integration"
+---
 
 The Zscaler AI Guard guardrail uses the [Zscaler AI Guard](https://help.zscaler.com/ai-guard) API to scan prompts and LLM responses for security threats, including:
 
@@ -11,10 +13,16 @@ The Zscaler AI Guard guardrail uses the [Zscaler AI Guard](https://help.zscaler.
 
 The integration uses the [zscaler-sdk-python](https://pypi.org/project/zscaler-sdk-python/) SDK and implements **fail-closed** semantics: if the API call fails or returns an unexpected result, the integration blocks the content by default.
 
-The following environment variables are required:
+## Data handling
 
-- `AIGUARD_API_KEY`: Zscaler AI Guard API key (Bearer token). To obtain this key, go to **AI Guard Console** > **Private AI Apps** > **Applications** > **API Keys**.
-- `AIGUARD_CLOUD`: Cloud region. Options: `us1` (default), `us2`, `eu1`, `eu2`.
+The input rail sends the full user message to the Zscaler AI Guard API. The output rail sends the full bot response. Review Zscaler's applicable privacy and data retention terms before enabling the integration in production.
+
+## Configuration
+
+Configure the integration with the following environment variables:
+
+- `AIGUARD_API_KEY`: Required Zscaler AI Guard API key (Bearer token). To obtain this key, go to **AI Guard Console** > **Private AI Apps** > **Applications** > **API Keys**.
+- `AIGUARD_CLOUD`: Optional cloud region. Options include `us1` (default), `us2`, `eu1`, and `eu2`.
 
 To use a specific policy instead of automatic resolution, set the following optional variable:
 

--- a/docs/configure-rails/guardrail-catalog/third-party.mdx
+++ b/docs/configure-rails/guardrail-catalog/third-party.mdx
@@ -283,7 +283,7 @@ For more details, check out the [Cisco AI Defense Integration](/configure-guardr
 
 The NeMo Guardrails library supports using [Zscaler AI Guard](https://www.zscaler.com/platform/ai-guard) for input and output content moderation through the `zscaler-sdk-python` SDK. It detects credentials, PII, toxicity, prompt injection, malicious URLs, and policy violations.
 
-To activate the protection, you need to set the `AIGUARD_API_KEY` and `AIGUARD_CLOUD` environment variables.
+To activate the protection, set the `AIGUARD_API_KEY` environment variable. You can optionally set `AIGUARD_CLOUD` to select a cloud region.
 
 ### Example usage
 

--- a/docs/configure-rails/guardrail-catalog/third-party.mdx
+++ b/docs/configure-rails/guardrail-catalog/third-party.mdx
@@ -279,6 +279,26 @@ rails:
 
 For more details, check out the [Cisco AI Defense Integration](/configure-guardrails/guardrail-catalog/third-party/ai-defense) page.
 
+## Zscaler AI Guard
+
+The NeMo Guardrails library supports using [Zscaler AI Guard](https://www.zscaler.com/platform/ai-guard) for input and output content moderation through the `zscaler-sdk-python` SDK. It detects credentials, PII, toxicity, prompt injection, malicious URLs, and policy violations.
+
+To activate the protection, you need to set the `AIGUARD_API_KEY` and `AIGUARD_CLOUD` environment variables.
+
+### Example usage
+
+```yaml
+rails:
+  input:
+    flows:
+      - zscaler aiguard moderation on input
+  output:
+    flows:
+      - zscaler aiguard moderation on output
+```
+
+For more details, check out the [Zscaler AI Guard Integration](/configure-guardrails/guardrail-catalog/third-party/zscaler-aiguard) page.
+
 ## HuggingFace Classifier
 
 The NeMo Guardrails library supports using HuggingFace text classification models for fast, prompt-free content moderation on input, output, and retrieval flows. Classifiers can run locally via `transformers` or connect to remote inference servers (vLLM, KServe, FMS).

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -206,6 +206,9 @@ navigation:
               - page: Trend Micro
                 path: configure-rails/guardrail-catalog/community/trend-micro.mdx
                 slug: trend-micro
+              - page: Zscaler AI Guard
+                path: configure-rails/guardrail-catalog/community/zscaler-aiguard.mdx
+                slug: zscaler-aiguard
       - section: Custom Actions
         path: configure-rails/actions/index.mdx
         slug: actions

--- a/docs/reference/rail-engine-support.mdx
+++ b/docs/reference/rail-engine-support.mdx
@@ -9,13 +9,13 @@ content:
   type: "reference"
 ---
 
-The NVIDIA NeMo Guardrails library ships 33 built-in rails under `nemoguardrails/library`.
+The NVIDIA NeMo Guardrails library ships 34 built-in rails under `nemoguardrails/library`.
 Each rail declares its behavior in a [rail manifest](/reference/rail-manifests), and each manifest exposes one or more *surfaces*.
 A surface is the flow name you list under `rails.input.flows`, `rails.output.flows`, or `rails.retrieval.flows` in `config.yml`.
 
-The 33 manifests declare 78 surfaces in total.
-`LLMRails` runs all 78 through its Colang runtime, in both Colang 1.0 and Colang 2.x.
-`IORails` runs 59 of them by compiling the manifest directly, without Colang.
+The 34 manifests declare 80 surfaces in total.
+`LLMRails` runs all 80 through its Colang runtime, in both Colang 1.0 and Colang 2.x.
+`IORails` runs 61 of them by compiling the manifest directly, without Colang.
 
 This page lists every surface and the engine that can run it.
 For capability areas that are not tied to a specific rail, such as streaming, observability, and the generation API, refer to [Engine Feature Support](/reference/engine-feature-support).
@@ -37,10 +37,10 @@ The following table summarizes surface support by direction:
 
 | Direction | Surfaces | LLMRails | IORails |
 |---|---:|---:|---:|
-| Input | 32 | 32 | 31 |
-| Output | 35 | 35 | 28 |
+| Input | 33 | 33 | 32 |
+| Output | 36 | 36 | 29 |
 | Retrieval | 11 | 11 | 0 |
-| **Total** | **78** | **78** | **59** |
+| **Total** | **80** | **80** | **61** |
 
 `IORails` does not accept a `rails.retrieval` section at all, so every retrieval surface is an `LLMRails` capability.
 A configuration that declares one routes to `LLMRails` by default.
@@ -86,6 +86,7 @@ The following table lists the input surfaces:
 | `mask sensitive data on input` | Sensitive Data Detection | ✓ | ✓ | Rewrites `user_message` |
 | `topic safety check input` | Topic Safety | ✓ | ✓ | |
 | `trend ai guard input` | Trend Micro Vision One AI Guard | ✓ | ✓ | |
+| `zscaler aiguard moderation on input` | Zscaler AI Guard | ✓ | ✓ | |
 
 ### Output Surfaces
 
@@ -128,6 +129,7 @@ The following table lists the output surfaces:
 | `detect sensitive data on output` | Sensitive Data Detection | ✓ | ✓ | |
 | `mask sensitive data on output` | Sensitive Data Detection | ✓ | ✓ | Rewrites `bot_message` |
 | `trend ai guard output` | Trend Micro Vision One AI Guard | ✓ | ✓ | |
+| `zscaler aiguard moderation on output` | Zscaler AI Guard | ✓ | ✓ | |
 
 ### Retrieval Surfaces
 
@@ -223,6 +225,7 @@ The rails that declare an optional dependency are the following:
 | Injection Detection | `yara-python` | |
 | Jailbreak Detection | `torch`, `transformers` | |
 | Sensitive Data Detection | `presidio-analyzer`, `presidio-anonymizer`, `spacy` | `sdd` |
+| Zscaler AI Guard | `zscaler-sdk-python` | |
 
 Hugging Face Classifier and Jailbreak Detection each offer an in-process backend and a remote endpoint.
 `IORails` enforces the dependency only when the configuration selects the in-process backend.

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -43,7 +43,7 @@ In this context, a *session* is the lifetime of a single Python process running 
 
 Each value identifies a built-in library feature. The built-in rail manifests are the authoritative source. Related manifests can share a stable feature identifier so telemetry remains comparable across releases.
 
-`activefence`, `ai_defense`, `autoalign`, `clavata`, `cleanlab`, `content_safety`, `context_bloat_detection`, `crowdstrike_aidr`, `f5`, `factchecking`, `fiddler`, `gcp_moderate_text`, `gliner`, `guardrails_ai`, `hallucination`, `hf_classifier`, `injection_detection`, `jailbreak_detection`, `llama_guard`, `pangea`, `patronusai`, `policyai`, `polygraf`, `prompt_security`, `regex`, `self_check`, `sensitive_data_detection`, `topic_safety`, `trend_micro`.
+`activefence`, `ai_defense`, `autoalign`, `clavata`, `cleanlab`, `content_safety`, `context_bloat_detection`, `crowdstrike_aidr`, `f5`, `factchecking`, `fiddler`, `gcp_moderate_text`, `gliner`, `guardrails_ai`, `hallucination`, `hf_classifier`, `injection_detection`, `jailbreak_detection`, `llama_guard`, `pangea`, `patronusai`, `policyai`, `polygraf`, `prompt_security`, `regex`, `self_check`, `sensitive_data_detection`, `topic_safety`, `trend_micro`, `zscaler_aiguard`.
 
 ## Data Not Collected by Telemetry
 

--- a/nemoguardrails/library/zscaler_aiguard/__init__.py
+++ b/nemoguardrails/library/zscaler_aiguard/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/zscaler_aiguard/actions.py
+++ b/nemoguardrails/library/zscaler_aiguard/actions.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Zscaler AI Guard integration for NeMo Guardrails.
+
+Scans prompts and LLM responses using the Zscaler AI Guard DAS API
+via the zscaler-sdk-python SDK.
+
+By default, uses resolve-and-execute-policy (automatic policy selection).
+Set AIGUARD_POLICY_ID to use execute-policy with a specific policy.
+
+Required environment variables:
+    AIGUARD_API_KEY  - Zscaler AI Guard API key (Bearer token)
+    AIGUARD_CLOUD    - Cloud region, e.g. us1, us2, eu1 (default: us1)
+
+Optional environment variables:
+    AIGUARD_POLICY_ID - Specific policy ID to use (default: auto-resolved)
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+
+from nemoguardrails.actions import action
+
+log = logging.getLogger(__name__)
+
+_sdk_client = None
+_sdk_client_cloud = None
+
+
+def _get_sdk_client():
+    """Lazily initialise the Zscaler AI Guard SDK client."""
+    global _sdk_client, _sdk_client_cloud
+
+    cloud = os.environ.get("AIGUARD_CLOUD", "us1")
+
+    if _sdk_client is None or _sdk_client_cloud != cloud:
+        try:
+            from zscaler.zaiguard.legacy import LegacyZGuardClientHelper
+        except ImportError:
+            raise ImportError(
+                "zscaler-sdk-python is required for the Zscaler AI Guard integration. "
+                "Install it with: pip install zscaler-sdk-python"
+            )
+
+        if not os.environ.get("AIGUARD_API_KEY"):
+            raise EnvironmentError(
+                "AIGUARD_API_KEY environment variable is required for the Zscaler AI Guard integration."
+            )
+
+        _sdk_client = LegacyZGuardClientHelper(cloud=cloud)
+        _sdk_client_cloud = cloud
+    return _sdk_client
+
+
+def _get_attr(obj, name, default=None):
+    """Access an attribute by name from either a dict or an object."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _scan_sync(content: str, direction: str, policy_id: Optional[int] = None):
+    """Call the AI Guard API synchronously (wrapped with asyncio.to_thread)."""
+    client = _get_sdk_client()
+
+    if policy_id is not None:
+        result, _response, error = client.policy_detection.execute_policy(
+            content=content,
+            direction=direction,
+            policy_id=policy_id,
+        )
+    else:
+        result, _response, error = client.policy_detection.resolve_and_execute_policy(
+            content=content,
+            direction=direction,
+        )
+
+    if error:
+        raise RuntimeError(f"AI Guard API error: {error}")
+    return result
+
+
+def _build_block_message(
+    direction: str,
+    severity: str,
+    policy_name: str,
+    blocking_detectors: list,
+    transaction_id: Optional[str] = None,
+) -> str:
+    """Build a human-readable block message with full context."""
+    target = "user prompt" if direction == "IN" else "LLM response"
+    parts = [f"Zscaler AI Guard blocked the {target}."]
+    parts.append(f"Severity: {severity}.")
+    parts.append(f"Policy: {policy_name}.")
+    if blocking_detectors:
+        parts.append(f"Detectors: {', '.join(blocking_detectors)}.")
+    if transaction_id:
+        parts.append(f"Transaction: {transaction_id}.")
+    return " ".join(parts)
+
+
+@action(is_system_action=True)
+async def call_zscaler_aiguard_api(
+    text: Optional[str] = None,
+    direction: str = "IN",
+    policy_id: Optional[int] = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """
+    Scan content using Zscaler AI Guard.
+
+    Args:
+        text: Content to scan (user prompt or bot response).
+        direction: "IN" for user prompts, "OUT" for bot responses.
+        policy_id: Optional policy ID. If provided, calls execute_policy
+            instead of resolve_and_execute_policy. Can also be set via
+            AIGUARD_POLICY_ID environment variable.
+
+    Returns:
+        Dict containing:
+            action       - Policy verdict (ALLOW / BLOCK / DETECT)
+            severity     - Severity level of the detection
+            policy_name  - Name of the policy that was evaluated
+            transaction_id - Unique transaction ID for debugging
+            detectors    - Dict of detector names to their verdicts
+            message      - Pre-built human-readable message for exceptions
+    """
+    if not text:
+        return {
+            "action": "ALLOW",
+            "severity": "NONE",
+            "policy_name": "none",
+            "transaction_id": None,
+            "detectors": {},
+            "blocking_detectors": [],
+            "message": "",
+        }
+
+    effective_policy_id = policy_id
+    if effective_policy_id is None:
+        env_policy_id = os.environ.get("AIGUARD_POLICY_ID")
+        if env_policy_id:
+            try:
+                effective_policy_id = int(env_policy_id)
+            except ValueError:
+                raise ValueError(
+                    f"AIGUARD_POLICY_ID={env_policy_id!r} is not a valid integer. "
+                    "Fix the environment variable or remove it to use automatic policy resolution."
+                )
+
+    log.debug("AI Guard scanning %s content (%d chars)", direction, len(text))
+
+    try:
+        result = await asyncio.to_thread(_scan_sync, text, direction, effective_policy_id)
+
+        if result is None:
+            log.warning("AI Guard returned None — blocking by default")
+            return {
+                "action": "BLOCK",
+                "severity": "UNKNOWN",
+                "policy_name": "unknown",
+                "transaction_id": None,
+                "detectors": {},
+                "blocking_detectors": [],
+                "message": _build_block_message(direction, "UNKNOWN", "unknown", []),
+            }
+
+        action_val = str(_get_attr(result, "action", "BLOCK")).upper()
+        severity = _get_attr(result, "severity", "unknown")
+        policy_name = _get_attr(result, "policy_name") or _get_attr(result, "policyName", "unknown")
+        transaction_id = _get_attr(result, "transaction_id") or _get_attr(result, "transactionId")
+
+        detector_responses = _get_attr(result, "detector_responses") or _get_attr(result, "detectorResponses") or {}
+        detectors = {}
+        blocking_detectors = []
+        if not isinstance(detector_responses, dict):
+            log.warning(
+                "AI Guard returned non-dict detector_responses (%s) — skipping detector parsing",
+                type(detector_responses).__name__,
+            )
+            detector_responses = {}
+        for name, det in detector_responses.items():
+            det_action = str(_get_attr(det, "action", "unknown")).upper()
+            det_triggered = _get_attr(det, "triggered", False)
+            detectors[name] = {
+                "action": det_action,
+                "triggered": det_triggered,
+                "severity": _get_attr(det, "severity"),
+            }
+            if det_action == "BLOCK":
+                blocking_detectors.append(name)
+
+        if action_val == "BLOCK":
+            message = _build_block_message(direction, severity, policy_name, blocking_detectors, transaction_id)
+            log.info("AI Guard BLOCKED: %s", message)
+        elif action_val != "ALLOW":
+            message = ""
+            log.info(
+                "AI Guard %s [txn=%s, policy=%s, severity=%s]",
+                action_val,
+                transaction_id,
+                policy_name,
+                severity,
+            )
+        else:
+            message = ""
+            log.debug(
+                "AI Guard ALLOWED [txn=%s, policy=%s]",
+                transaction_id,
+                policy_name,
+            )
+
+        return {
+            "action": action_val,
+            "severity": severity,
+            "policy_name": policy_name,
+            "transaction_id": transaction_id,
+            "detectors": detectors,
+            "blocking_detectors": blocking_detectors,
+            "message": message,
+        }
+
+    except (ImportError, EnvironmentError, ValueError):
+        raise
+    except Exception as e:
+        log.error("AI Guard scan failed: %s — %s", type(e).__name__, e)
+        message = _build_block_message(direction, "UNKNOWN", "unknown", [])
+        return {
+            "action": "BLOCK",
+            "severity": "UNKNOWN",
+            "policy_name": "unknown",
+            "transaction_id": None,
+            "detectors": {},
+            "blocking_detectors": [],
+            "error": str(e),
+            "message": message,
+        }

--- a/nemoguardrails/library/zscaler_aiguard/actions.py
+++ b/nemoguardrails/library/zscaler_aiguard/actions.py
@@ -36,6 +36,7 @@ import os
 from typing import Any, Optional
 
 from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
 
 log = logging.getLogger(__name__)
 
@@ -115,13 +116,33 @@ def _build_block_message(
     return " ".join(parts)
 
 
-@action(is_system_action=True)
+def _outcome_metadata(
+    action_value: str,
+    severity: str,
+    policy_name: str,
+    transaction_id: Optional[str],
+    detectors: dict[str, Any],
+    blocking_detectors: list[str],
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "action": action_value,
+        "severity": severity,
+        "policy_name": policy_name,
+        "transaction_id": transaction_id,
+        "detectors": detectors,
+        "blocking_detectors": blocking_detectors,
+        **extra,
+    }
+
+
+@action(name="call_zscaler_aiguard_api", is_system_action=True)
 async def call_zscaler_aiguard_api(
     text: Optional[str] = None,
     direction: str = "IN",
     policy_id: Optional[int] = None,
     **kwargs,
-) -> dict[str, Any]:
+) -> RailOutcome:
     """
     Scan content using Zscaler AI Guard.
 
@@ -133,24 +154,10 @@ async def call_zscaler_aiguard_api(
             AIGUARD_POLICY_ID environment variable.
 
     Returns:
-        Dict containing:
-            action       - Policy verdict (ALLOW / BLOCK / DETECT)
-            severity     - Severity level of the detection
-            policy_name  - Name of the policy that was evaluated
-            transaction_id - Unique transaction ID for debugging
-            detectors    - Dict of detector names to their verdicts
-            message      - Pre-built human-readable message for exceptions
+        The rail decision with the parsed AI Guard response as metadata.
     """
     if not text:
-        return {
-            "action": "ALLOW",
-            "severity": "NONE",
-            "policy_name": "none",
-            "transaction_id": None,
-            "detectors": {},
-            "blocking_detectors": [],
-            "message": "",
-        }
+        return RailOutcome.allow(metadata=_outcome_metadata("ALLOW", "NONE", "none", None, {}, []))
 
     effective_policy_id = policy_id
     if effective_policy_id is None:
@@ -171,15 +178,10 @@ async def call_zscaler_aiguard_api(
 
         if result is None:
             log.warning("AI Guard returned None — blocking by default")
-            return {
-                "action": "BLOCK",
-                "severity": "UNKNOWN",
-                "policy_name": "unknown",
-                "transaction_id": None,
-                "detectors": {},
-                "blocking_detectors": [],
-                "message": _build_block_message(direction, "UNKNOWN", "unknown", []),
-            }
+            return RailOutcome.block(
+                reason=_build_block_message(direction, "UNKNOWN", "unknown", []),
+                metadata=_outcome_metadata("BLOCK", "UNKNOWN", "unknown", None, {}, []),
+            )
 
         action_val = str(_get_attr(result, "action", "BLOCK")).upper()
         severity = _get_attr(result, "severity", "unknown")
@@ -206,48 +208,55 @@ async def call_zscaler_aiguard_api(
             if det_action == "BLOCK":
                 blocking_detectors.append(name)
 
+        metadata = _outcome_metadata(
+            action_val,
+            severity,
+            policy_name,
+            transaction_id,
+            detectors,
+            blocking_detectors,
+        )
         if action_val == "BLOCK":
             message = _build_block_message(direction, severity, policy_name, blocking_detectors, transaction_id)
-            log.info("AI Guard BLOCKED: %s", message)
-        elif action_val != "ALLOW":
-            message = ""
             log.info(
-                "AI Guard %s [txn=%s, policy=%s, severity=%s]",
+                "AI Guard blocked content: direction=%s severity=%s detector_count=%d",
+                direction,
+                severity,
+                len(blocking_detectors),
+            )
+            return RailOutcome.block(reason=message, metadata=metadata)
+        if action_val == "DETECT":
+            log.info(
+                "AI Guard returned a non-blocking verdict: action=%s direction=%s severity=%s",
                 action_val,
-                transaction_id,
-                policy_name,
+                direction,
                 severity,
             )
-        else:
-            message = ""
-            log.debug(
-                "AI Guard ALLOWED [txn=%s, policy=%s]",
-                transaction_id,
-                policy_name,
-            )
+            return RailOutcome.allow(metadata=metadata)
+        if action_val == "ALLOW":
+            log.debug("AI Guard allowed content: direction=%s", direction)
+            return RailOutcome.allow(metadata=metadata)
 
-        return {
-            "action": action_val,
-            "severity": severity,
-            "policy_name": policy_name,
-            "transaction_id": transaction_id,
-            "detectors": detectors,
-            "blocking_detectors": blocking_detectors,
-            "message": message,
-        }
+        log.warning("AI Guard returned an unknown action; blocking by default")
+        return RailOutcome.block(
+            reason=_build_block_message(direction, severity, policy_name, blocking_detectors, transaction_id),
+            metadata=metadata,
+        )
 
     except (ImportError, EnvironmentError, ValueError):
         raise
     except Exception as e:
-        log.error("AI Guard scan failed: %s — %s", type(e).__name__, e)
+        log.error("AI Guard scan failed: error_type=%s", type(e).__name__)
         message = _build_block_message(direction, "UNKNOWN", "unknown", [])
-        return {
-            "action": "BLOCK",
-            "severity": "UNKNOWN",
-            "policy_name": "unknown",
-            "transaction_id": None,
-            "detectors": {},
-            "blocking_detectors": [],
-            "error": str(e),
-            "message": message,
-        }
+        return RailOutcome.block(
+            reason=message,
+            metadata=_outcome_metadata(
+                "BLOCK",
+                "UNKNOWN",
+                "unknown",
+                None,
+                {},
+                [],
+                error_type=type(e).__name__,
+            ),
+        )

--- a/nemoguardrails/library/zscaler_aiguard/flows.co
+++ b/nemoguardrails/library/zscaler_aiguard/flows.co
@@ -1,0 +1,25 @@
+# INPUT RAILS
+
+flow zscaler aiguard moderation on input
+  $result = await CallZscalerAiguardApiAction(text=$user_message, direction="IN")
+
+  if $result.action == "BLOCK"
+    if $system.config.enable_rails_exceptions
+      $msg = $result["message"]
+      send ZscalerAiguardInputRailException(message=$msg)
+    else
+      bot inform answer unknown
+    abort
+
+# OUTPUT RAILS
+
+flow zscaler aiguard moderation on output
+  $result = await CallZscalerAiguardApiAction(text=$bot_message, direction="OUT")
+
+  if $result.action == "BLOCK"
+    if $system.config.enable_rails_exceptions
+      $msg = $result["message"]
+      send ZscalerAiguardOutputRailException(message=$msg)
+    else
+      bot inform answer unknown
+    abort

--- a/nemoguardrails/library/zscaler_aiguard/flows.co
+++ b/nemoguardrails/library/zscaler_aiguard/flows.co
@@ -3,10 +3,10 @@
 flow zscaler aiguard moderation on input
   $result = await CallZscalerAiguardApiAction(text=$user_message, direction="IN")
 
-  if $result.action == "BLOCK"
+  if $result.is_blocked
     if $system.config.enable_rails_exceptions
-      $msg = $result["message"]
-      send ZscalerAiguardInputRailException(message=$msg)
+      $message = $result.reason
+      send ZscalerAiguardInputRailException(message=$message)
     else
       bot inform answer unknown
     abort
@@ -16,10 +16,10 @@ flow zscaler aiguard moderation on input
 flow zscaler aiguard moderation on output
   $result = await CallZscalerAiguardApiAction(text=$bot_message, direction="OUT")
 
-  if $result.action == "BLOCK"
+  if $result.is_blocked
     if $system.config.enable_rails_exceptions
-      $msg = $result["message"]
-      send ZscalerAiguardOutputRailException(message=$msg)
+      $message = $result.reason
+      send ZscalerAiguardOutputRailException(message=$message)
     else
       bot inform answer unknown
     abort

--- a/nemoguardrails/library/zscaler_aiguard/flows.v1.co
+++ b/nemoguardrails/library/zscaler_aiguard/flows.v1.co
@@ -1,0 +1,25 @@
+# INPUT RAILS
+
+define subflow zscaler aiguard moderation on input
+  $result = execute call_zscaler_aiguard_api(text=$user_message, direction="IN")
+
+  if $result.action == "BLOCK"
+    if $config.enable_rails_exceptions
+      $msg = $result["message"]
+      create event ZscalerAiguardInputRailException(message=$msg)
+    else
+      bot inform answer unknown
+    stop
+
+# OUTPUT RAILS
+
+define subflow zscaler aiguard moderation on output
+  $result = execute call_zscaler_aiguard_api(text=$bot_message, direction="OUT")
+
+  if $result.action == "BLOCK"
+    if $config.enable_rails_exceptions
+      $msg = $result["message"]
+      create event ZscalerAiguardOutputRailException(message=$msg)
+    else
+      bot inform answer unknown
+    stop

--- a/nemoguardrails/library/zscaler_aiguard/flows.v1.co
+++ b/nemoguardrails/library/zscaler_aiguard/flows.v1.co
@@ -3,10 +3,10 @@
 define subflow zscaler aiguard moderation on input
   $result = execute call_zscaler_aiguard_api(text=$user_message, direction="IN")
 
-  if $result.action == "BLOCK"
+  if $result.is_blocked
     if $config.enable_rails_exceptions
-      $msg = $result["message"]
-      create event ZscalerAiguardInputRailException(message=$msg)
+      $message = $result.reason
+      create event ZscalerAiguardInputRailException(message=$message)
     else
       bot inform answer unknown
     stop
@@ -16,10 +16,10 @@ define subflow zscaler aiguard moderation on input
 define subflow zscaler aiguard moderation on output
   $result = execute call_zscaler_aiguard_api(text=$bot_message, direction="OUT")
 
-  if $result.action == "BLOCK"
+  if $result.is_blocked
     if $config.enable_rails_exceptions
-      $msg = $result["message"]
-      create event ZscalerAiguardOutputRailException(message=$msg)
+      $message = $result.reason
+      create event ZscalerAiguardOutputRailException(message=$message)
     else
       bot inform answer unknown
     stop

--- a/nemoguardrails/library/zscaler_aiguard/rail.py
+++ b/nemoguardrails/library/zscaler_aiguard/rail.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.manifests import (
+    ActionRef,
+    Binding,
+    EnvVar,
+    RailActions,
+    RailDirection,
+    RailFlows,
+    RailManifest,
+    RailMetadata,
+    RailPrivacy,
+    RailRequirements,
+    RailSpec,
+    RailSurface,
+    ServiceRequirement,
+)
+
+CALL_ZSCALER_AIGUARD_API = ActionRef(
+    name="call_zscaler_aiguard_api",
+    target="nemoguardrails.library.zscaler_aiguard.actions:call_zscaler_aiguard_api",
+)
+
+RAIL = RailManifest(
+    name="zscaler_aiguard",
+    metadata=RailMetadata(
+        display_name="Zscaler AI Guard",
+        description="Moderates input and output text with the Zscaler AI Guard API.",
+        categories=("input", "output"),
+        capabilities=("allow", "block", "classify", "content_safety", "detect_pii", "moderate"),
+        tags=("third-party", "api", "security"),
+        docs_url="docs/configure-rails/guardrail-catalog/community/zscaler-aiguard.mdx",
+    ),
+    spec=RailSpec(
+        flows=RailFlows(
+            flow_names=(
+                "zscaler aiguard moderation on input",
+                "zscaler aiguard moderation on output",
+            ),
+        ),
+        actions=RailActions(refs=(CALL_ZSCALER_AIGUARD_API,)),
+        surfaces=(
+            RailSurface(
+                name="zscaler aiguard moderation on input",
+                direction=RailDirection.INPUT,
+                action=CALL_ZSCALER_AIGUARD_API,
+                bindings=(
+                    Binding.context("text", "user_message"),
+                    Binding.literal("direction", "IN"),
+                ),
+            ),
+            RailSurface(
+                name="zscaler aiguard moderation on output",
+                direction=RailDirection.OUTPUT,
+                action=CALL_ZSCALER_AIGUARD_API,
+                bindings=(
+                    Binding.context("text", "bot_message"),
+                    Binding.literal("direction", "OUT"),
+                ),
+            ),
+        ),
+        requirements=RailRequirements(
+            env_vars=(
+                EnvVar(name="AIGUARD_API_KEY", required=True),
+                EnvVar(name="AIGUARD_CLOUD", required=False),
+                EnvVar(name="AIGUARD_POLICY_ID", required=False),
+            ),
+            services=(ServiceRequirement(name="Zscaler AI Guard API", required=True),),
+            optional_dependencies=("zscaler-sdk-python",),
+        ),
+        privacy=RailPrivacy(
+            sends_user_text=True,
+            sends_bot_text=True,
+            remote_services=("Zscaler AI Guard API",),
+        ),
+    ),
+)

--- a/tests/guardrails/test_compiled_rail.py
+++ b/tests/guardrails/test_compiled_rail.py
@@ -536,7 +536,7 @@ class TestSurfacesOutsideTheTier:
             assert declared_context - supported_context
 
     def test_the_input_output_tier_splits_into_servable_and_refused(self):
-        """59 servable against the eight refused surfaces, pinned by name.
+        """61 servable against the eight refused surfaces, pinned by name.
 
         A predicate would follow the code it is checking; a new manifest surface fails here.
         """
@@ -548,7 +548,7 @@ class TestSurfacesOutsideTheTier:
             bucket.append((direction, name))
 
         assert sorted(refused) == sorted(UNSUPPORTED_CONTEXT_SURFACES | UNSUPPORTED_RAIL_SURFACES)
-        assert len(servable) == 59
+        assert len(servable) == 61
 
     def test_the_rewriting_surfaces_are_all_servable(self):
         """The eighteen this work exists for, nine each way, with no direction half-enabled."""

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -2191,6 +2191,7 @@ class TestScopeGateCharacterization:
             ("input", "self check input"),
             ("input", "topic safety check input"),
             ("input", "trend ai guard input"),
+            ("input", "zscaler aiguard moderation on input"),
             ("output", "activefence moderation on output"),
             ("output", "ai defense inspect response"),
             ("output", "autoalign check output"),
@@ -2219,6 +2220,7 @@ class TestScopeGateCharacterization:
             ("output", "regex check output"),
             ("output", "self check output"),
             ("output", "trend ai guard output"),
+            ("output", "zscaler aiguard moderation on output"),
         }
     )
 

--- a/tests/rails/llm/test_config.py
+++ b/tests/rails/llm/test_config.py
@@ -150,6 +150,7 @@ def test_builtin_rails_config_fields_canonical_set_and_legacy_exports():
         "self_check.input_check",
         "self_check.output_check",
         "topic_safety",
+        "zscaler_aiguard",
     }
     expected_config_keys = {
         "ai_defense",

--- a/tests/test_runtime_flow_gate_equivalence.py
+++ b/tests/test_runtime_flow_gate_equivalence.py
@@ -712,6 +712,20 @@ F5_OUTPUT = RailSpec(
     action="f5_guardrails_scan",
 )
 
+ZSCALER_AIGUARD_INPUT = RailSpec(
+    name="zscaler_aiguard_input",
+    flow="zscaler aiguard moderation on input",
+    direction="input",
+    action="call_zscaler_aiguard_api",
+)
+
+ZSCALER_AIGUARD_OUTPUT = RailSpec(
+    name="zscaler_aiguard_output",
+    flow="zscaler aiguard moderation on output",
+    direction="output",
+    action="call_zscaler_aiguard_api",
+)
+
 ACTIVEFENCE_INPUT = RailSpec(
     name="activefence_input",
     flow="activefence moderation on input",
@@ -2204,6 +2218,20 @@ FIXTURES = [
         F5_OUTPUT,
         allow_return=RailOutcome.allow(metadata={"result": {"outcome": "cleared"}}),
         block_return=RailOutcome.block(metadata={"result": {"outcome": "flagged"}}),
+        include_exception_case=True,
+    ),
+    *_rail_outcome_cases(
+        ZSCALER_AIGUARD_INPUT,
+        allow_return=RailOutcome.allow(metadata={"action": "ALLOW"}),
+        block_return=RailOutcome.block(reason="Zscaler AI Guard blocked the user prompt."),
+        block_observable=ObservableOutcome.ANSWER_UNKNOWN,
+        include_exception_case=True,
+    ),
+    *_rail_outcome_cases(
+        ZSCALER_AIGUARD_OUTPUT,
+        allow_return=RailOutcome.allow(metadata={"action": "ALLOW"}),
+        block_return=RailOutcome.block(reason="Zscaler AI Guard blocked the LLM response."),
+        block_observable=ObservableOutcome.ANSWER_UNKNOWN,
         include_exception_case=True,
     ),
     _case(

--- a/tests/test_zscaler_aiguard.py
+++ b/tests/test_zscaler_aiguard.py
@@ -1,0 +1,665 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+input_rail_config = RailsConfig.from_content(
+    yaml_content="""
+        models: []
+        rails:
+          input:
+            flows:
+              - zscaler aiguard moderation on input
+    """
+)
+
+output_rail_config = RailsConfig.from_content(
+    yaml_content="""
+        models: []
+        rails:
+          output:
+            flows:
+              - zscaler aiguard moderation on output
+    """
+)
+
+both_rails_config = RailsConfig.from_content(
+    yaml_content="""
+        models: []
+        rails:
+          input:
+            flows:
+              - zscaler aiguard moderation on input
+          output:
+            flows:
+              - zscaler aiguard moderation on output
+    """
+)
+
+exceptions_config = RailsConfig.from_content(
+    yaml_content="""
+        models: []
+        enable_rails_exceptions: true
+        rails:
+          input:
+            flows:
+              - zscaler aiguard moderation on input
+          output:
+            flows:
+              - zscaler aiguard moderation on output
+    """
+)
+
+
+def _allow_result(**overrides):
+    """Build a mock AI Guard ALLOW result."""
+    base = {
+        "action": "ALLOW",
+        "severity": "NONE",
+        "policy_name": "TestPolicy",
+        "transaction_id": "txn-test-001",
+        "detectors": {},
+        "blocking_detectors": [],
+        "message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _block_result(direction="IN", blocking_detectors=None, **overrides):
+    """Build a mock AI Guard BLOCK result."""
+    if blocking_detectors is None:
+        blocking_detectors = ["toxicity"]
+    detectors = {name: {"action": "BLOCK", "triggered": True, "severity": "CRITICAL"} for name in blocking_detectors}
+    target = "user prompt" if direction == "IN" else "LLM response"
+    message = (
+        f"Zscaler AI Guard blocked the {target}. "
+        f"Severity: CRITICAL. Policy: TestPolicy. "
+        f"Detectors: {', '.join(blocking_detectors)}. "
+        f"Transaction: txn-test-002."
+    )
+    base = {
+        "action": "BLOCK",
+        "severity": "CRITICAL",
+        "policy_name": "TestPolicy",
+        "transaction_id": "txn-test-002",
+        "detectors": detectors,
+        "blocking_detectors": blocking_detectors,
+        "message": message,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk_client():
+    """Reset the module-level SDK client between tests."""
+    import nemoguardrails.library.zscaler_aiguard.actions as mod
+
+    mod._sdk_client = None
+    mod._sdk_client_cloud = None
+    yield
+    mod._sdk_client = None
+    mod._sdk_client_cloud = None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (TestChat-based)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_input_allowed():
+    """Clean user input should pass through to the LLM."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["Hi! How can I help you today?"],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Hello"
+    await chat.bot_async("Hi! How can I help you today?")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_input_blocked():
+    """Input containing sensitive data should be blocked (default path, no exception)."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["I don't know the answer to that."],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        if text and "AKIAIOSFODNN7EXAMPLE" in text:
+            return _block_result(direction="IN", blocking_detectors=["credentials", "secrets"])
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "My AWS key is AKIAIOSFODNN7EXAMPLE"
+    await chat.bot_async("I don't know the answer to that.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_output_allowed():
+    """Clean LLM output should pass through to the user."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["The capital of France is Paris."],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "What is the capital of France?"
+    await chat.bot_async("The capital of France is Paris.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_output_blocked():
+    """LLM output containing PII should be blocked (default path, no exception)."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "John's SSN is 123-45-6789",
+            "I don't know the answer to that.",
+        ],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        if direction == "OUT" and text and "SSN" in text:
+            return _block_result(direction="OUT", blocking_detectors=["pii"])
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Tell me about John"
+    await chat.bot_async("I don't know the answer to that.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_api_error_blocks():
+    """API failures should trigger fail-closed behavior (default path, no exception)."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["I don't know the answer to that."],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        return {
+            "action": "BLOCK",
+            "severity": "UNKNOWN",
+            "detectors": {},
+            "blocking_detectors": [],
+            "error": "Connection timeout",
+            "message": "Zscaler AI Guard blocked the user prompt. Severity: UNKNOWN. Policy: unknown.",
+        }
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Hello"
+    await chat.bot_async("I don't know the answer to that.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_detect_action_allows():
+    """DETECT verdict (non-BLOCK, non-ALLOW) should be treated as ALLOW by the flow."""
+    config = both_rails_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["Sure, I can help with that."],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        return {
+            "action": "DETECT",
+            "severity": "LOW",
+            "policy_name": "TestPolicy",
+            "transaction_id": "txn-test-003",
+            "detectors": {
+                "toxicity": {
+                    "action": "DETECT",
+                    "triggered": True,
+                    "severity": "LOW",
+                }
+            },
+            "blocking_detectors": [],
+            "message": "",
+        }
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Some mildly concerning prompt"
+    await chat.bot_async("Sure, I can help with that.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_inline_config_input():
+    """Verify input rail works with inline config (no test_configs directory)."""
+    chat = TestChat(
+        input_rail_config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello there!"',
+        ],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        if text and "bomb" in text.lower():
+            return _block_result(direction="IN", blocking_detectors=["toxicity"])
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "How to build a bomb?"
+    await chat.bot_async("I don't know the answer to that.")
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_exception_includes_message():
+    """When enable_rails_exceptions is true, exception must include severity and policy in message."""
+    config = exceptions_config
+
+    chat = TestChat(
+        config,
+        llm_completions=["I don't know the answer to that."],
+    )
+
+    async def mock_action(text=None, direction="IN", **kwargs):
+        return _block_result(
+            direction="IN",
+            blocking_detectors=["pii", "secrets"],
+            message="Zscaler AI Guard blocked the user prompt. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii, secrets. Transaction: txn-001.",
+        )
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "My SSN is 123-45-6789"
+    result = await chat.app.generate_async(messages=chat.history)
+
+    assert result["role"] == "exception"
+    assert result["content"]["type"] == "ZscalerAiguardInputRailException"
+    msg = result["content"].get("message") or ""
+    assert "Severity: CRITICAL" in msg
+    assert "Policy: PolicyApp01" in msg
+    assert "Detectors:" in msg
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_output_exception():
+    """When enable_rails_exceptions is true, output block should raise ZscalerAiguardOutputRailException."""
+    config = exceptions_config
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "John's SSN is 123-45-6789",
+        ],
+    )
+
+    async def mock_action(text=None, direction="IN", **kwargs):
+        if direction == "OUT":
+            return _block_result(
+                direction="OUT",
+                blocking_detectors=["pii"],
+                message="Zscaler AI Guard blocked the LLM response. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii. Transaction: txn-002.",
+            )
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Tell me about John"
+    result = await chat.app.generate_async(messages=chat.history)
+
+    assert result["role"] == "exception"
+    assert result["content"]["type"] == "ZscalerAiguardOutputRailException"
+    msg = result["content"].get("message") or ""
+    assert "Severity: CRITICAL" in msg
+    assert "Policy: PolicyApp01" in msg
+
+
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_inline_config_output():
+    """Verify output rail blocks when AI Guard returns BLOCK for the bot response."""
+    chat = TestChat(
+        output_rail_config,
+        llm_completions=[
+            "  express greeting",
+            '  "Here is some content"',
+        ],
+    )
+
+    async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
+        if direction == "OUT":
+            return _block_result(direction="OUT", blocking_detectors=["secrets"])
+        return _allow_result()
+
+    chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
+
+    chat >> "Give me a secret key"
+    await chat.bot_async("I don't know the answer to that.")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_zscaler_aiguard_get_attr_dict():
+    """_get_attr should work with both dicts and objects."""
+    from nemoguardrails.library.zscaler_aiguard.actions import _get_attr
+
+    assert _get_attr({"key": "value"}, "key") == "value"
+    assert _get_attr({"key": "value"}, "missing", "default") == "default"
+
+    class SimpleObj:
+        pass
+
+    obj = SimpleObj()
+    obj.key = "value"
+    assert _get_attr(obj, "key") == "value"
+    assert _get_attr(obj, "missing", "default") == "default"
+
+
+@pytest.mark.unit
+def test_zscaler_aiguard_build_block_message():
+    """_build_block_message should produce a readable message with all context."""
+    from nemoguardrails.library.zscaler_aiguard.actions import _build_block_message
+
+    msg = _build_block_message(
+        direction="IN",
+        severity="CRITICAL",
+        policy_name="PolicyApp01",
+        blocking_detectors=["pii", "secrets"],
+        transaction_id="txn-abc-123",
+    )
+    assert "Zscaler AI Guard blocked the user prompt." in msg
+    assert "Severity: CRITICAL." in msg
+    assert "Policy: PolicyApp01." in msg
+    assert "Detectors: pii, secrets." in msg
+    assert "Transaction: txn-abc-123." in msg
+
+    msg_out = _build_block_message(
+        direction="OUT",
+        severity="HIGH",
+        policy_name="OutputPolicy",
+        blocking_detectors=["toxicity"],
+    )
+    assert "Zscaler AI Guard blocked the LLM response." in msg_out
+    assert "Severity: HIGH." in msg_out
+    assert "Policy: OutputPolicy." in msg_out
+    assert "Detectors: toxicity." in msg_out
+    assert "Transaction:" not in msg_out
+
+    msg_no_detectors = _build_block_message(
+        direction="IN",
+        severity="UNKNOWN",
+        policy_name="unknown",
+        blocking_detectors=[],
+    )
+    assert "Detectors:" not in msg_no_detectors
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_empty_text():
+    """Action should return ALLOW for empty text without calling the API."""
+    from nemoguardrails.library.zscaler_aiguard.actions import (
+        call_zscaler_aiguard_api,
+    )
+
+    result = await call_zscaler_aiguard_api(text=None, direction="IN")
+    assert result["action"] == "ALLOW"
+    assert result["message"] == ""
+
+    result = await call_zscaler_aiguard_api(text="", direction="IN")
+    assert result["action"] == "ALLOW"
+    assert result["message"] == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_scan_success():
+    """Action should correctly parse an ALLOW result from the SDK."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.return_value = {
+            "action": "ALLOW",
+            "severity": "NONE",
+            "policyName": "DefaultPolicy",
+            "transactionId": "txn-abc-123",
+            "detectorResponses": {
+                "toxicity": {
+                    "action": "ALLOW",
+                    "triggered": False,
+                    "severity": "NONE",
+                },
+                "pii": {
+                    "action": "ALLOW",
+                    "triggered": False,
+                    "severity": "NONE",
+                },
+            },
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Hello world", direction="IN")
+
+        assert result["action"] == "ALLOW"
+        assert result["policy_name"] == "DefaultPolicy"
+        assert result["transaction_id"] == "txn-abc-123"
+        assert "toxicity" in result["detectors"]
+        assert "pii" in result["detectors"]
+        assert result["blocking_detectors"] == []
+        assert result["message"] == ""
+        mock_scan.assert_called_once_with("Hello world", "IN", None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_scan_block():
+    """Action should correctly parse a BLOCK result from the SDK."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.return_value = {
+            "action": "BLOCK",
+            "severity": "CRITICAL",
+            "policyName": "StrictPolicy",
+            "transactionId": "txn-xyz-789",
+            "detectorResponses": {
+                "credentials": {
+                    "action": "BLOCK",
+                    "triggered": True,
+                    "severity": "CRITICAL",
+                },
+                "toxicity": {
+                    "action": "ALLOW",
+                    "triggered": False,
+                    "severity": "NONE",
+                },
+            },
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="My key is AKIAIOSFODNN7EXAMPLE", direction="IN")
+
+        assert result["action"] == "BLOCK"
+        assert result["severity"] == "CRITICAL"
+        assert result["blocking_detectors"] == ["credentials"]
+        assert result["detectors"]["credentials"]["triggered"] is True
+        assert result["detectors"]["toxicity"]["triggered"] is False
+        assert "Severity: CRITICAL" in result["message"]
+        assert "Policy: StrictPolicy" in result["message"]
+        assert "Detectors: credentials" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_exception_fail_closed():
+    """Action should return BLOCK when the SDK raises an exception (fail-closed)."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.side_effect = RuntimeError("Connection refused")
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Hello", direction="IN")
+
+        assert result["action"] == "BLOCK"
+        assert result["severity"] == "UNKNOWN"
+        assert result["policy_name"] == "unknown"
+        assert result["transaction_id"] is None
+        assert "Connection refused" in result["error"]
+        assert "message" in result
+        assert result["message"] != ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_none_result_blocks():
+    """Action should return BLOCK when the SDK returns None (fail-closed)."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.return_value = None
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Hello", direction="IN")
+
+        assert result["action"] == "BLOCK"
+        assert result["severity"] == "UNKNOWN"
+        assert result["policy_name"] == "unknown"
+        assert result["transaction_id"] is None
+        assert "message" in result
+        assert result["message"] != ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_policy_id_param():
+    """Action should pass policy_id to _scan_sync when provided."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.return_value = {
+            "action": "ALLOW",
+            "severity": "NONE",
+            "policyName": "CustomPolicy",
+            "transactionId": "txn-policy-001",
+            "detectorResponses": {},
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Test content", direction="IN", policy_id=900)
+
+        assert result["action"] == "ALLOW"
+        mock_scan.assert_called_once_with("Test content", "IN", 900)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_policy_id_env():
+    """Action should read AIGUARD_POLICY_ID from environment when no param given."""
+    with (
+        patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan,
+        patch.dict(os.environ, {"AIGUARD_POLICY_ID": "1234"}),
+    ):
+        mock_scan.return_value = {
+            "action": "ALLOW",
+            "severity": "NONE",
+            "policyName": "EnvPolicy",
+            "transactionId": "txn-env-001",
+            "detectorResponses": {},
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Test content", direction="IN")
+
+        assert result["action"] == "ALLOW"
+        mock_scan.assert_called_once_with("Test content", "IN", 1234)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_policy_id_param_overrides_env():
+    """Explicit policy_id param should take precedence over env var."""
+    with (
+        patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan,
+        patch.dict(os.environ, {"AIGUARD_POLICY_ID": "1234"}),
+    ):
+        mock_scan.return_value = {
+            "action": "ALLOW",
+            "severity": "NONE",
+            "policyName": "ParamPolicy",
+            "transactionId": "txn-override-001",
+            "detectorResponses": {},
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Test content", direction="IN", policy_id=5678)
+
+        assert result["action"] == "ALLOW"
+        mock_scan.assert_called_once_with("Test content", "IN", 5678)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_invalid_policy_id_env():
+    """Invalid AIGUARD_POLICY_ID env var should raise ValueError (fail-closed)."""
+    with patch.dict(os.environ, {"AIGUARD_POLICY_ID": "not-a-number"}):
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        with pytest.raises(ValueError, match="AIGUARD_POLICY_ID"):
+            await call_zscaler_aiguard_api(text="Test content", direction="IN")

--- a/tests/test_zscaler_aiguard.py
+++ b/tests/test_zscaler_aiguard.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.actions.rail_outcome import RailDecision, RailOutcome
 from tests.utils import TestChat
 
 input_rail_config = RailsConfig.from_content(
@@ -70,7 +71,7 @@ exceptions_config = RailsConfig.from_content(
 )
 
 
-def _allow_result(**overrides):
+def _allow_result(**overrides) -> RailOutcome:
     """Build a mock AI Guard ALLOW result."""
     base = {
         "action": "ALLOW",
@@ -79,13 +80,12 @@ def _allow_result(**overrides):
         "transaction_id": "txn-test-001",
         "detectors": {},
         "blocking_detectors": [],
-        "message": "",
     }
     base.update(overrides)
-    return base
+    return RailOutcome.allow(metadata=base)
 
 
-def _block_result(direction="IN", blocking_detectors=None, **overrides):
+def _block_result(direction="IN", blocking_detectors=None, reason=None, **overrides) -> RailOutcome:
     """Build a mock AI Guard BLOCK result."""
     if blocking_detectors is None:
         blocking_detectors = ["toxicity"]
@@ -104,10 +104,9 @@ def _block_result(direction="IN", blocking_detectors=None, **overrides):
         "transaction_id": "txn-test-002",
         "detectors": detectors,
         "blocking_detectors": blocking_detectors,
-        "message": message,
     }
     base.update(overrides)
-    return base
+    return RailOutcome.block(reason=reason or message, metadata=base)
 
 
 @pytest.fixture(autouse=True)
@@ -221,14 +220,16 @@ async def test_zscaler_aiguard_api_error_blocks():
     )
 
     async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
-        return {
-            "action": "BLOCK",
-            "severity": "UNKNOWN",
-            "detectors": {},
-            "blocking_detectors": [],
-            "error": "Connection timeout",
-            "message": "Zscaler AI Guard blocked the user prompt. Severity: UNKNOWN. Policy: unknown.",
-        }
+        return RailOutcome.block(
+            reason="Zscaler AI Guard blocked the user prompt. Severity: UNKNOWN. Policy: unknown.",
+            metadata={
+                "action": "BLOCK",
+                "severity": "UNKNOWN",
+                "detectors": {},
+                "blocking_detectors": [],
+                "error_type": "TimeoutError",
+            },
+        )
 
     chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
 
@@ -247,21 +248,22 @@ async def test_zscaler_aiguard_detect_action_allows():
     )
 
     async def mock_action(text: Optional[str] = None, direction: str = "IN", **kwargs):
-        return {
-            "action": "DETECT",
-            "severity": "LOW",
-            "policy_name": "TestPolicy",
-            "transaction_id": "txn-test-003",
-            "detectors": {
-                "toxicity": {
-                    "action": "DETECT",
-                    "triggered": True,
-                    "severity": "LOW",
-                }
-            },
-            "blocking_detectors": [],
-            "message": "",
-        }
+        return RailOutcome.allow(
+            metadata={
+                "action": "DETECT",
+                "severity": "LOW",
+                "policy_name": "TestPolicy",
+                "transaction_id": "txn-test-003",
+                "detectors": {
+                    "toxicity": {
+                        "action": "DETECT",
+                        "triggered": True,
+                        "severity": "LOW",
+                    }
+                },
+                "blocking_detectors": [],
+            }
+        )
 
     chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
 
@@ -305,7 +307,7 @@ async def test_zscaler_aiguard_exception_includes_message():
         return _block_result(
             direction="IN",
             blocking_detectors=["pii", "secrets"],
-            message="Zscaler AI Guard blocked the user prompt. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii, secrets. Transaction: txn-001.",
+            reason="Zscaler AI Guard blocked the user prompt. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii, secrets. Transaction: txn-001.",
         )
 
     chat.app.register_action(mock_action, "call_zscaler_aiguard_api")
@@ -338,7 +340,7 @@ async def test_zscaler_aiguard_output_exception():
             return _block_result(
                 direction="OUT",
                 blocking_detectors=["pii"],
-                message="Zscaler AI Guard blocked the LLM response. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii. Transaction: txn-002.",
+                reason="Zscaler AI Guard blocked the LLM response. Severity: CRITICAL. Policy: PolicyApp01. Detectors: pii. Transaction: txn-002.",
             )
         return _allow_result()
 
@@ -446,12 +448,14 @@ async def test_zscaler_aiguard_action_empty_text():
     )
 
     result = await call_zscaler_aiguard_api(text=None, direction="IN")
-    assert result["action"] == "ALLOW"
-    assert result["message"] == ""
+    assert result.decision is RailDecision.ALLOW
+    assert result.metadata["action"] == "ALLOW"
+    assert result.reason is None
 
     result = await call_zscaler_aiguard_api(text="", direction="IN")
-    assert result["action"] == "ALLOW"
-    assert result["message"] == ""
+    assert result.decision is RailDecision.ALLOW
+    assert result.metadata["action"] == "ALLOW"
+    assert result.reason is None
 
 
 @pytest.mark.unit
@@ -484,13 +488,14 @@ async def test_zscaler_aiguard_action_scan_success():
 
         result = await call_zscaler_aiguard_api(text="Hello world", direction="IN")
 
-        assert result["action"] == "ALLOW"
-        assert result["policy_name"] == "DefaultPolicy"
-        assert result["transaction_id"] == "txn-abc-123"
-        assert "toxicity" in result["detectors"]
-        assert "pii" in result["detectors"]
-        assert result["blocking_detectors"] == []
-        assert result["message"] == ""
+        assert result.decision is RailDecision.ALLOW
+        assert result.metadata["action"] == "ALLOW"
+        assert result.metadata["policy_name"] == "DefaultPolicy"
+        assert result.metadata["transaction_id"] == "txn-abc-123"
+        assert "toxicity" in result.metadata["detectors"]
+        assert "pii" in result.metadata["detectors"]
+        assert result.metadata["blocking_detectors"] == []
+        assert result.reason is None
         mock_scan.assert_called_once_with("Hello world", "IN", None)
 
 
@@ -524,14 +529,38 @@ async def test_zscaler_aiguard_action_scan_block():
 
         result = await call_zscaler_aiguard_api(text="My key is AKIAIOSFODNN7EXAMPLE", direction="IN")
 
-        assert result["action"] == "BLOCK"
-        assert result["severity"] == "CRITICAL"
-        assert result["blocking_detectors"] == ["credentials"]
-        assert result["detectors"]["credentials"]["triggered"] is True
-        assert result["detectors"]["toxicity"]["triggered"] is False
-        assert "Severity: CRITICAL" in result["message"]
-        assert "Policy: StrictPolicy" in result["message"]
-        assert "Detectors: credentials" in result["message"]
+        assert result.decision is RailDecision.BLOCK
+        assert result.metadata["action"] == "BLOCK"
+        assert result.metadata["severity"] == "CRITICAL"
+        assert result.metadata["blocking_detectors"] == ["credentials"]
+        assert result.metadata["detectors"]["credentials"]["triggered"] is True
+        assert result.metadata["detectors"]["toxicity"]["triggered"] is False
+        assert "Severity: CRITICAL" in result.reason
+        assert "Policy: StrictPolicy" in result.reason
+        assert "Detectors: credentials" in result.reason
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zscaler_aiguard_action_unknown_verdict_blocks():
+    """An unrecognized vendor verdict should fail closed."""
+    with patch("nemoguardrails.library.zscaler_aiguard.actions._scan_sync") as mock_scan:
+        mock_scan.return_value = {
+            "action": "REVIEW",
+            "severity": "UNKNOWN",
+            "policyName": "DefaultPolicy",
+            "transactionId": "txn-review-001",
+            "detectorResponses": {},
+        }
+
+        from nemoguardrails.library.zscaler_aiguard.actions import (
+            call_zscaler_aiguard_api,
+        )
+
+        result = await call_zscaler_aiguard_api(text="Hello", direction="IN")
+
+        assert result.decision is RailDecision.BLOCK
+        assert result.metadata["action"] == "REVIEW"
 
 
 @pytest.mark.unit
@@ -547,13 +576,13 @@ async def test_zscaler_aiguard_action_exception_fail_closed():
 
         result = await call_zscaler_aiguard_api(text="Hello", direction="IN")
 
-        assert result["action"] == "BLOCK"
-        assert result["severity"] == "UNKNOWN"
-        assert result["policy_name"] == "unknown"
-        assert result["transaction_id"] is None
-        assert "Connection refused" in result["error"]
-        assert "message" in result
-        assert result["message"] != ""
+        assert result.decision is RailDecision.BLOCK
+        assert result.metadata["action"] == "BLOCK"
+        assert result.metadata["severity"] == "UNKNOWN"
+        assert result.metadata["policy_name"] == "unknown"
+        assert result.metadata["transaction_id"] is None
+        assert result.metadata["error_type"] == "RuntimeError"
+        assert result.reason
 
 
 @pytest.mark.unit
@@ -569,12 +598,12 @@ async def test_zscaler_aiguard_action_none_result_blocks():
 
         result = await call_zscaler_aiguard_api(text="Hello", direction="IN")
 
-        assert result["action"] == "BLOCK"
-        assert result["severity"] == "UNKNOWN"
-        assert result["policy_name"] == "unknown"
-        assert result["transaction_id"] is None
-        assert "message" in result
-        assert result["message"] != ""
+        assert result.decision is RailDecision.BLOCK
+        assert result.metadata["action"] == "BLOCK"
+        assert result.metadata["severity"] == "UNKNOWN"
+        assert result.metadata["policy_name"] == "unknown"
+        assert result.metadata["transaction_id"] is None
+        assert result.reason
 
 
 @pytest.mark.unit
@@ -596,7 +625,7 @@ async def test_zscaler_aiguard_action_policy_id_param():
 
         result = await call_zscaler_aiguard_api(text="Test content", direction="IN", policy_id=900)
 
-        assert result["action"] == "ALLOW"
+        assert result.decision is RailDecision.ALLOW
         mock_scan.assert_called_once_with("Test content", "IN", 900)
 
 
@@ -622,7 +651,7 @@ async def test_zscaler_aiguard_action_policy_id_env():
 
         result = await call_zscaler_aiguard_api(text="Test content", direction="IN")
 
-        assert result["action"] == "ALLOW"
+        assert result.decision is RailDecision.ALLOW
         mock_scan.assert_called_once_with("Test content", "IN", 1234)
 
 
@@ -648,7 +677,7 @@ async def test_zscaler_aiguard_action_policy_id_param_overrides_env():
 
         result = await call_zscaler_aiguard_api(text="Test content", direction="IN", policy_id=5678)
 
-        assert result["action"] == "ALLOW"
+        assert result.decision is RailDecision.ALLOW
         mock_scan.assert_called_once_with("Test content", "IN", 5678)
 
 


### PR DESCRIPTION
Restores the Zscaler AI Guard integration originally contributed by @willguibr in #1710. Although #1710 was merged, its merge commit subsequently became unreachable from `develop` after the branch history was rewritten.


The restored implementation remains attributed to @willguibr. 

Follow-up commits migrate the integration to the current [rail manifest contract](https://github.com/NVIDIA-NeMo/Guardrails/pull/2157) and [`RailOutcome` contract](https://github.com/NVIDIA-NeMo/Guardrails/pull/2150), update the documentation and engine-support matrix, and align the tests with the current architecture.