### PR TITLE
test: make config path fixture portable

### DIFF
--- a/tests/test_custom_init.py
+++ b/tests/test_custom_init.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.testing.fake_model import FakeLLMModel
@@ -91,7 +92,10 @@ def init(app):
     _write_config(
         importing_config_path,
         "",
-        f'models: []\nimport_paths:\n  - "{imported_config_path}"\n',
+        yaml.safe_dump(
+            {"models": [], "import_paths": [str(imported_config_path)]},
+            sort_keys=False,
+        ),
     )
 
     config = RailsConfig.from_path(str(importing_config_path)) + RailsConfig.from_path(str(imported_config_path))


### PR DESCRIPTION
## Description

Fix the [Windows test failure](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/34447752616/job/102776211013) by serializing the generated configuration with `yaml.safe_dump()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated custom initialization tests to generate configuration files using YAML serialization.
  - Added YAML support required by the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->