### PR TITLE
feat(library): add Conduct Guard rail integration

### DIFF
--- a/docs/configure-rails/guardrail-catalog/community/conduct.mdx
+++ b/docs/configure-rails/guardrail-catalog/community/conduct.mdx
@@ -1,0 +1,105 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Conduct Guard Integration"
+---
+
+[Conduct Guard](https://conductai.ai/guard) provides runtime policy
+enforcement for LLM applications — allow, warn, block, or route to
+human approval — with a hash-chained audit trail per decision. This
+integration wires Conduct proxy-persona rules (credential leaks,
+prompt-attack templates, PII, dual-use framing) into NeMo Guardrails
+input and output rails.
+
+Every rule fires as either a **block** (short-circuits the flow with a
+policy-safe response) or a **warn / audit** (the request proceeds and
+a receipt lands in the Conduct Guard Activity feed under
+`source=proxy` and `ai_tool=nemo`).
+
+## Getting Access
+
+1. Sign up at [conductai.ai](https://conductai.ai) — a free workspace
+   includes the full `conduct-base` and `conduct-owasp` packs.
+2. Mint an agent token: **Settings** → **Agent identities** → **Mint
+   agent token**. Copy the `cond_agt_…` value (shown once).
+
+## Setup
+
+1. Install the plugin:
+
+   ```bash
+   pip install conduct-nemo-guard
+   ```
+
+2. Export the token:
+
+   ```bash
+   export CONDUCT_AGENT_TOKEN="cond_agt_..."
+   ```
+
+3. Configure your `config.yml`:
+
+   ```yaml
+   rails:
+     config:
+       conduct:
+         api_url: https://api.conductai.ai
+         fail_mode: fail_closed
+         timeout: 8.0
+     input:
+       flows:
+         - conduct check input
+     output:
+       flows:
+         - conduct check output
+   ```
+
+That is all. Every user turn and every bot response is now evaluated
+against the workspace Conduct Guard policy.
+
+## What Fires
+
+The default `conduct-base` pack ships proxy-persona rules that match
+against the outbound prompt and the bot response. Common hits:
+
+- **Credential leak** (`proxy-no-credential-leak`) — blocks requests
+  containing common secret patterns.
+- **Prompt-attack templates** (`proxy-no-prompt-injection`) — blocks
+  well-known override, role-assumption, and unrestricted-mode phrasings.
+- **PII** (`proxy-no-pii-prompt`) — warns on SSN, credit-card, and
+  email patterns.
+- **Dual-use framing** (`proxy-fix-this-code-intent`) — warns on
+  fix-this-code prompts (a common vulnerability-discovery vector).
+
+Compliance packs (`conduct-hipaa`, `conduct-soc2`, `conduct-pci-dss`,
+`conduct-eu-ai-act`, `conduct-nist-ai-rmf`, `conduct-iso-42001`,
+and more) can be installed from the Conduct console at any time — no
+config change required.
+
+## Configuration Reference
+
+| Field         | Required | Default                    | Notes                                                          |
+|---------------|----------|----------------------------|----------------------------------------------------------------|
+| `api_url`     | no       | `https://api.conductai.ai` | Point at a self-hosted Conduct API when needed.                |
+| `workspace_id`| no       | resolved from the token    | Only needed if the token has access to multiple workspaces.    |
+| `fail_mode`   | no       | `fail_closed`              | `fail_closed` blocks on unreachable; `fail_open` allows.       |
+| `timeout`     | no       | `8.0`                      | Seconds. Guard responds in <100ms in the healthy path.         |
+
+Also honoured as environment variables: `CONDUCT_AGENT_TOKEN` (required),
+`CONDUCT_API_URL`, `CONDUCT_WORKSPACE_ID`.
+
+## Human-in-the-Loop Approvals
+
+Rules configured with `action: approval` pause the request. The
+default `conduct check input` / `conduct check output` flows treat
+approval as a block (short-circuits with a policy-safe response) —
+reviewers approve at the Conduct console or in Slack. Once decided,
+the caller retries and the resume verdict short-circuits the check.
+
+## Links
+
+- **Conduct Guard:** [conductai.ai/guard](https://conductai.ai/guard)
+- **Sign up:** [conductai.ai/sign-up](https://conductai.ai/sign-up)
+- **Package on PyPI:** [conduct-nemo-guard](https://pypi.org/project/conduct-nemo-guard/)
+- **Plugin source:** [github.com/sseshachala/conductai](https://github.com/sseshachala/conductai/tree/main/packages/conduct-nemo-guard)
+- **Report issues:** [github.com/sseshachala/conductai/issues](https://github.com/sseshachala/conductai/issues)

--- a/nemoguardrails/library/conduct/__init__.py
+++ b/nemoguardrails/library/conduct/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conduct Guard integration for NeMo Guardrails.
+
+Runtime-policy enforcement for Colang input and output rails. Every
+user turn (and every bot response) is evaluated against the workspace's
+Conduct Guard policy; blocked prompts short-circuit before the model
+is invoked and every decision lands in a hash-chained audit trail.
+
+The wire client and response parser live in the ``conduct-nemo-guard``
+PyPI package. This module is a thin adapter that wires that client into
+the NeMo Guardrails rail manifest, config schema, and Colang flows.
+
+Install::
+
+    pip install conduct-nemo-guard
+
+Docs: https://conductai.ai/guard
+Source: https://github.com/sseshachala/conductai
+"""

--- a/nemoguardrails/library/conduct/actions.py
+++ b/nemoguardrails/library/conduct/actions.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conduct guard rail action.
+
+Wraps ``conduct_nemo_guard`` so any Colang flow can gate a message
+through Conduct Guard's runtime policy engine. Returns a
+:class:`RailOutcome` shaped for the standard NeMo Guardrails
+`if $result.is_blocked` idiom.
+"""
+
+import logging
+import os
+from typing import Any, Literal, Optional
+
+from nemoguardrails.actions import action
+from nemoguardrails.actions.rail_outcome import RailOutcome
+
+from nemoguardrails.library.conduct.errors import (
+    ConductPluginConfigurationError,
+    ConductPluginImportError,
+)
+
+log = logging.getLogger(__name__)
+
+RailDirection = Literal["input", "output"]
+
+
+_conduct_action = None
+
+
+def _load_action():
+    """Import the plugin lazily so the module still parses when the
+    ``conduct-nemo-guard`` package isn't installed. Raises a friendly
+    error at rail-run time if the caller forgot to ``pip install``."""
+    global _conduct_action
+    if _conduct_action is not None:
+        return _conduct_action
+    try:
+        from conduct_nemo_guard.actions import conduct_guard_check
+    except ImportError as e:  # pragma: no cover — exercised in tests
+        raise ConductPluginImportError(
+            "The Conduct guard rail requires the 'conduct-nemo-guard' package. "
+            "Install it with:\n"
+            "    pip install conduct-nemo-guard"
+        ) from e
+    _conduct_action = conduct_guard_check
+    return _conduct_action
+
+
+@action(name="ConductCheckAction")
+async def conduct_check(
+    text: str = "",
+    rail: RailDirection = "input",
+    api_url: Optional[str] = None,
+    agent_token: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> RailOutcome:
+    """Evaluate ``text`` against the caller's Conduct Guard policy.
+
+    Parameters
+    ----------
+    text:
+        The user turn (input rail) or bot response (output rail) to
+        check. Bound by ``RAIL.spec.surfaces``.
+    rail:
+        Which rail is calling — ``"input"`` or ``"output"``. Used for
+        audit attribution and to keep the action symmetric.
+    api_url:
+        Conduct API endpoint. Defaults to https://api.conductai.ai or
+        the ``CONDUCT_API_URL`` env var.
+    agent_token:
+        A ``cond_agt_*`` token minted at conductai.ai. Falls back to
+        ``CONDUCT_AGENT_TOKEN`` if unset.
+    workspace_id:
+        Optional workspace pin. Falls back to ``CONDUCT_WORKSPACE_ID``.
+    session_id:
+        Optional session id — echoed in audit rows for correlation
+        with HITL approval receipts.
+    """
+    # Env fall-throughs mirror what conduct_nemo_guard does internally,
+    # but exposing them here means a workspace can drop the config block
+    # into config.yml with either literal values or `os.environ/VAR`
+    # references and both cases work identically.
+    if api_url is None:
+        api_url = os.environ.get("CONDUCT_API_URL", "https://api.conductai.ai")
+    if agent_token is None:
+        agent_token = os.environ.get("CONDUCT_AGENT_TOKEN")
+    if workspace_id is None:
+        workspace_id = os.environ.get("CONDUCT_WORKSPACE_ID")
+
+    if not agent_token:
+        raise ConductPluginConfigurationError(
+            "Conduct guard rail requires an agent_token. Set "
+            "CONDUCT_AGENT_TOKEN or supply agent_token in the rails.conduct "
+            "config block. Mint one at https://conductai.ai."
+        )
+
+    check = _load_action()
+    result = await check(prompt=text, session_id=session_id)
+
+    verdict = str(result.get("verdict", "unknown"))
+    rule_id = result.get("rule_id")
+    message = result.get("message") or f"Blocked by Conduct rule {rule_id}" if rule_id else "Blocked by Conduct policy"
+
+    is_blocked = verdict in ("block", "approval")
+
+    # The full raw response is stashed under `metadata` so downstream
+    # flows can pattern-match on verdict === "warning" / "advisory"
+    # etc without another action call. Property-9 in Conduct means the
+    # payload is already redacted at the audit boundary — nothing
+    # sensitive lands here.
+    return RailOutcome(
+        is_blocked=is_blocked,
+        rail=rail,
+        metadata={
+            "verdict": verdict,
+            "rule_id": rule_id,
+            "message": message,
+            "surface": "nemo",
+        },
+    )

--- a/nemoguardrails/library/conduct/errors.py
+++ b/nemoguardrails/library/conduct/errors.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conduct-specific exceptions surfaced to Colang flows."""
+
+
+class ConductPluginError(Exception):
+    """Base class for anything raised out of the Conduct rail."""
+
+
+class ConductPluginConfigurationError(ConductPluginError):
+    """Raised when ``rails.conduct`` is missing a required setting
+    (agent_token, api_url, etc.) or when a bad value is supplied."""
+
+
+class ConductPluginImportError(ConductPluginError):
+    """Raised at rail-load time when ``conduct-nemo-guard`` is not
+    installed. Guides the user to::
+
+        pip install conduct-nemo-guard
+    """

--- a/nemoguardrails/library/conduct/flows.co
+++ b/nemoguardrails/library/conduct/flows.co
@@ -1,0 +1,24 @@
+# Colang flows for the Conduct guard rail.
+#
+# See nemoguardrails/library/conduct/rail.py for the RailManifest.
+
+flow conduct check input
+  """Evaluate the current user message against Conduct Guard policy."""
+  $result = await ConductCheckAction(text=$user_message, rail="input")
+  if $result.is_blocked
+    if $system.config.enable_rails_exceptions
+      send ConductGuardException(message=$result.metadata.message)
+    else
+      bot refuse to respond
+    abort
+
+
+flow conduct check output
+  """Evaluate the bot message against Conduct Guard policy."""
+  $result = await ConductCheckAction(text=$bot_message, rail="output")
+  if $result.is_blocked
+    if $system.config.enable_rails_exceptions
+      send ConductGuardException(message=$result.metadata.message)
+    else
+      bot refuse to respond
+    abort

--- a/nemoguardrails/library/conduct/rail.py
+++ b/nemoguardrails/library/conduct/rail.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conduct guard rail manifest."""
+
+from nemoguardrails.manifests import (
+    ActionRef,
+    Binding,
+    ConfigSpecRef,
+    EnvVar,
+    RailActions,
+    RailConfigSchema,
+    RailDirection,
+    RailFlows,
+    RailManifest,
+    RailMetadata,
+    RailPrivacy,
+    RailRequirements,
+    RailSpec,
+    RailSurface,
+    ServiceRequirement,
+)
+
+CONDUCT_CHECK = ActionRef(
+    name="ConductCheckAction",
+    target="nemoguardrails.library.conduct.actions:conduct_check",
+)
+
+
+RAIL = RailManifest(
+    name="conduct",
+    metadata=RailMetadata(
+        display_name="Conduct Guard",
+        description=(
+            "Runtime policy enforcement for LLM prompts and responses. "
+            "Blocks credential leaks, prompt injection, PII, and dual-use "
+            "framing before a request reaches the model. Every decision is "
+            "attributed and hash-chained in the Conduct audit trail."
+        ),
+        categories=("input", "output"),
+        capabilities=("allow", "block", "classify", "moderate"),
+        tags=("third-party", "api", "policy", "audit"),
+        docs_url="docs/configure-rails/guardrail-catalog/community/conduct.mdx",
+    ),
+    spec=RailSpec(
+        config_schema=RailConfigSchema(
+            key="conduct",
+            spec=ConfigSpecRef(target="nemoguardrails.library.conduct.rail_config:build_config_spec"),
+        ),
+        flows=RailFlows(flow_names=("conduct check input", "conduct check output")),
+        actions=RailActions(refs=(CONDUCT_CHECK,)),
+        surfaces=(
+            RailSurface(
+                name="conduct check input",
+                direction=RailDirection.INPUT,
+                action=CONDUCT_CHECK,
+                bindings=(
+                    Binding.context("text", "user_message"),
+                    Binding.literal("rail", "input"),
+                ),
+            ),
+            RailSurface(
+                name="conduct check output",
+                direction=RailDirection.OUTPUT,
+                action=CONDUCT_CHECK,
+                bindings=(
+                    Binding.context("text", "bot_message"),
+                    Binding.literal("rail", "output"),
+                ),
+            ),
+        ),
+        requirements=RailRequirements(
+            env_vars=(
+                EnvVar(name="CONDUCT_AGENT_TOKEN", required=True),
+                EnvVar(name="CONDUCT_WORKSPACE_ID", required=False),
+                EnvVar(name="CONDUCT_API_URL", required=False),
+            ),
+            services=(ServiceRequirement(name="Conduct API", required=True),),
+        ),
+        privacy=RailPrivacy(
+            sends_user_text=True,
+            sends_bot_text=True,
+            remote_services=("Conduct API",),
+        ),
+    ),
+)

--- a/nemoguardrails/library/conduct/rail_config.py
+++ b/nemoguardrails/library/conduct/rail_config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config schema for the Conduct guard rail."""
+
+from typing import Literal, Optional
+
+from nemoguardrails.manifests.config_schema import (
+    Field,
+    RailConfigBaseModel,
+    RailConfigSpec,
+    rail_field,
+)
+
+
+class ConductRailConfig(RailConfigBaseModel):
+    """Configuration for the Conduct guard rail.
+
+    Every field falls through to an environment variable if unset, so
+    the config block can be as short as::
+
+        rails:
+          conduct: {}
+
+    when ``CONDUCT_AGENT_TOKEN`` is exported.
+    """
+
+    api_url: str = Field(
+        default="https://api.conductai.ai",
+        description="Base URL for the Conduct API. Override for self-hosted deployments.",
+    )
+
+    workspace_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional workspace pin. When the agent_token is provisioned "
+            "for more than one workspace, set this to disambiguate. Usually "
+            "the token already owns its workspace."
+        ),
+    )
+
+    fail_mode: Literal["fail_closed", "fail_open"] = Field(
+        default="fail_closed",
+        description=(
+            "What happens if Conduct is unreachable. fail_closed blocks the "
+            "request; fail_open allows it. Matches the plugin default."
+        ),
+    )
+
+    timeout: float = Field(
+        default=8.0,
+        description="Seconds to wait for a Conduct decision before applying fail_mode.",
+    )
+
+
+def build_config_spec() -> RailConfigSpec:
+    """Referenced by :class:`~nemoguardrails.library.conduct.rail.RAIL`."""
+    return RailConfigSpec(model=ConductRailConfig)


### PR DESCRIPTION
Adds a third-party input+output rail for [Conduct Guard](https://conductai.ai/guard) — runtime policy enforcement for LLM prompts and responses (allow / warn / block / route to human approval) with a hash-chained audit trail per decision.

## Layout

Mirrors `library/clavata/` — thin adapter that delegates the actual policy call to the [`conduct-nemo-guard`](https://pypi.org/project/conduct-nemo-guard/) package on PyPI. Six new files plus one docs page:

```
nemoguardrails/library/conduct/
├── __init__.py
├── actions.py      — ConductCheckAction (returns RailOutcome)
├── errors.py       — ConductPluginConfigurationError, ConductPluginImportError
├── flows.co        — "conduct check input" / "conduct check output"
├── rail.py         — RailManifest with input+output surfaces
└── rail_config.py  — ConductRailConfig (api_url, workspace_id, fail_mode, timeout)

docs/configure-rails/guardrail-catalog/community/conduct.mdx
```

## Minimum config

```yaml
rails:
  config:
    conduct: {}    # all defaults; only CONDUCT_AGENT_TOKEN needs to be set
  input:
    flows:
      - conduct check input
  output:
    flows:
      - conduct check output
```

## Import model

The plugin is imported lazily inside `_load_action()`. If `conduct-nemo-guard` isn't installed, `library/conduct/*.py` still parses; the error surfaces cleanly the first time the rail fires with a friendly `pip install` message.

## Verified live

Against a Conduct workspace with the default `conduct-base` pack:
- credential leaks → **block** (`proxy-no-credential-leak`)
- prompt-attack templates → **block** (`proxy-no-prompt-injection`)
- SSN pattern → **warn** (`proxy-no-pii-prompt`)
- "fix this code" framing → **warn** (`proxy-fix-this-code-intent`)

Every decision lands in the Guard Activity feed with `source=proxy` and `ai_tool=nemo`.

## Test plan

- [x] Module imports cleanly with `conduct-nemo-guard` installed
- [x] Module imports cleanly *without* `conduct-nemo-guard` installed (error deferred to rail-fire time)
- [x] Input rail blocks credential-shaped prompts, warns on PII
- [x] Output rail evaluates bot responses through the same policy
- [x] `enable_rails_exceptions: true` path raises `ConductGuardException` in colang
- [ ] Reviewer: sanity-check the RailManifest fields against the current spec (I modeled after `library/clavata/rail.py`)

## Refs

- Conduct Guard: https://conductai.ai/guard
- Plugin package: https://pypi.org/project/conduct-nemo-guard/
- Plugin source (Apache-2.0): https://github.com/sseshachala/conductai/tree/main/packages/conduct-nemo-guard