### PR TITLE
doc: fix broken Getting Started Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To the best of our knowledge, the NeMo Guardrails library is the only guardrails
 ## Learn More
 
 - [Documentation](https://docs.nvidia.com/nemo/guardrails)
-- [Getting Started Guide](https://docs.nvidia.com/nemo/guardrails/getting-started)
+- [Getting Started Guide](https://docs.nvidia.com/nemo/guardrails/get-started/installation-guide)
 - [Examples](./examples)
 - [FAQs](https://docs.nvidia.com/nemo/guardrails/faqs.html)
 - [Security Guidelines](https://docs.nvidia.com/nemo/guardrails/security/guidelines.html)


### PR DESCRIPTION
Fixes #2381

## What changed

The "Getting Started Guide" link in the root README (Learn More section) pointed at `https://docs.nvidia.com/nemo/guardrails/getting-started`, which now returns **404**:

```
$ curl -s -o /dev/null -w "%{http_code}" -L https://docs.nvidia.com/nemo/guardrails/getting-started
404
```

The docs site reorganized the guide under `/get-started/`. The link now points to the live page:

https://docs.nvidia.com/nemo/guardrails/get-started/installation-guide (returns 200)

> Note: `fern/docs.yml` redirect entries still map `/getting-started` to `latest/getting-started/installation-guide`, which also 404s on the live site. Those redirect destinations look stale too, but I kept this PR scoped to the README fix — happy to update them as a follow-up if maintainers want.

## Verification

- [x] `curl -s -o /dev/null -w "%{http_code}" -L https://docs.nvidia.com/nemo/guardrails/get-started/installation-guide` → `200`
- [x] No other references in `README.md` rely on the removed URL