### PR TITLE
doc: Broken 'Getting Started Guide' link in root README

### DIFF
--- a/docs/configure-rails/colang/colang-1/tutorials/1-hello-world/hello-world.ipynb
+++ b/docs/configure-rails/colang/colang-1/tutorials/1-hello-world/hello-world.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Hello World\n",
         "\n",
-        "This guide shows you how to create a \"Hello World\" guardrails configuration that controls the greeting behavior. Before you begin, make sure you have [installed NeMo Guardrails](../../getting-started/installation-guide.md)."
+        "This guide shows you how to create a \"Hello World\" guardrails configuration that controls the greeting behavior. Before you begin, make sure you have [installed NeMo Guardrails](../../get-started/installation-guide.md)."
       ]
     },
     {


### PR DESCRIPTION
Fixes #2381

This corrects `getting-started` to `get-started` in `docs/configure-rails/colang/colang-1/tutorials/1-hello-world/hello-world.ipynb`, as reported in #2381.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #2381